### PR TITLE
Expose swarm brain metrics in Grafana

### DIFF
--- a/packages/screeps-influx-exporter/README.md
+++ b/packages/screeps-influx-exporter/README.md
@@ -8,6 +8,7 @@ Exports Screeps stats to InfluxDB from either `Memory.stats` or console log outp
 - Uses InfluxDB v2 line protocol via the official client library.
 - Supports nested stats objects with automatic flattening.
 - Extracts room and subsystem information from metric keys for better tagging.
+- Optional full-memory export for deep debugging/visualization use-cases.
 
 ## Configuration
 All configuration is provided via environment variables. Authentication requires either `SCREEPS_TOKEN` or the combination of `SCREEPS_USERNAME` and `SCREEPS_PASSWORD`.
@@ -17,6 +18,7 @@ All configuration is provided via environment variables. Authentication requires
 | `EXPORTER_MODE` | `memory` | Set to `memory` or `console`. |
 | `EXPORTER_POLL_INTERVAL_MS` | `15000` | Poll interval for memory mode. |
 | `EXPORTER_MEMORY_PATH` | `stats` | Memory path to read stats from. |
+| `EXPORTER_MEMORY_FULL` | `false` | When `true`, flatten the entire Memory payload instead of only `Memory.stats`. |
 | `EXPORTER_SHARD` | `shard0` | Shard to read from when polling memory. |
 | `INFLUXDB_URL` | `http://localhost:8086` | InfluxDB server URL. |
 | `INFLUXDB_TOKEN` | _none_ | InfluxDB authentication token (required). |

--- a/packages/screeps-influx-exporter/src/config.ts
+++ b/packages/screeps-influx-exporter/src/config.ts
@@ -4,6 +4,7 @@ export interface ExporterConfig {
   mode: ExporterMode;
   pollIntervalMs: number;
   memoryPath: string;
+  exportFullMemory: boolean;
   shard: string;
   protocol: string;
   hostname: string;
@@ -48,6 +49,7 @@ export function loadConfig(): ExporterConfig {
     mode,
     pollIntervalMs: parseNumber(process.env.EXPORTER_POLL_INTERVAL_MS, 15000),
     memoryPath: process.env.EXPORTER_MEMORY_PATH ?? 'stats',
+    exportFullMemory: (process.env.EXPORTER_MEMORY_FULL ?? 'false').toLowerCase() === 'true',
     shard: process.env.EXPORTER_SHARD ?? 'shard0',
     protocol: process.env.SCREEPS_PROTOCOL ?? 'https',
     hostname: process.env.SCREEPS_HOST ?? 'screeps.com',

--- a/packages/screeps-influx-exporter/src/memoryCollector.ts
+++ b/packages/screeps-influx-exporter/src/memoryCollector.ts
@@ -118,7 +118,7 @@ export async function startMemoryCollector(
     try {
       const rawMemory = await api.memory.get(config.memoryPath, config.shard);
       const decoded = decodeMemory(rawMemory, logger);
-      const stats = decoded?.stats ?? decoded;
+      const stats = config.exportFullMemory ? decoded : decoded?.stats ?? decoded;
 
       if (stats && typeof stats === 'object') {
         // Flatten the entire stats object and ingest all metrics

--- a/packages/screeps-server/grafana/provisioning/dashboards/screeps-ant-swarm.json
+++ b/packages/screeps-server/grafana/provisioning/dashboards/screeps-ant-swarm.json
@@ -213,7 +213,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 4,
         "x": 12,
         "y": 1
       },
@@ -322,8 +322,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
+        "w": 4,
+        "x": 16,
         "y": 1
       },
       "id": 4,
@@ -394,6 +394,107 @@
       ],
       "title": "CPU Usage %",
       "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "screeps",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"stat\"] == \"cpu.limit\")\n  |> last()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "stat::tag",
+              "operator": "=",
+              "value": "data.cpu.limit"
+            }
+          ]
+        }
+      ],
+      "title": "CPU Limit",
+      "type": "stat"
     },
     {
       "collapsed": false,
@@ -1414,7 +1515,7 @@
           "measurement": "screeps",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"stat\"] == \"tick\")\n  |> last()",
+          "query": "from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"stat\"] == \"system.tick\")\n  |> last()",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -1773,7 +1874,7 @@
           "measurement": "screeps",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"screeps\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"category\"] == \"room\")\n  |> filter(fn: (r) => r[\"stat\"] =~ /controller\\.progressPercent$/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"Controller Progress\")",
+          "query": "from(bucket: \"screeps\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"category\"] == \"room\")\n  |> filter(fn: (r) => r[\"stat\"] =~ /controller\\.progress_percent$/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"Controller Progress\")",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -1802,6 +1903,758 @@
       ],
       "title": "Room Controller Progress",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Exporter Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Success",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"screeps\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"type\"] == \"scrape_success\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"Scrape Success\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Exporter Scrape Success",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 59
+      },
+      "id": 26,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"type\"] == \"scrape_success\")\n  |> group(columns: [\"mode\"], mode: \"by\")\n  |> last()\n  |> keep(columns: [\"_time\", \"mode\", \"_value\"])\n  |> rename(columns: {mode: \"Mode\", _value: \"Status\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Scrape Status",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Economy Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Energy",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"screeps\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"stat\"] =~ /empire\\.energy\\.(available|capacity)$/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"Empire Energy Available\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Empire Energy Available vs Capacity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.75
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 67
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"stat\"] =~ /empire\\.energy\\.(available|capacity)$/)\n  |> last()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"stat\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({ r with utilization: if r[\"empire.energy.capacity\"] == 0.0 then 0.0 else r[\"empire.energy.available\"] / r[\"empire.energy.capacity\"] }))\n  |> keep(columns: [\"_time\", \"utilization\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Energy Utilization",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 67
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "storage = from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"stat\"] == \"empire.energy.storage\")\n  |> last()\n\nterminal = from(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"stat\"] == \"empire.energy.terminal\")\n  |> last()\n\nunion(tables: [storage, terminal])\n  |> group()\n  |> sum(column: \"_value\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> rename(columns: {_value: \"Total Energy\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Stored + Terminal Energy",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 31,
+      "panels": [],
+      "title": "Room Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 32,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "import \"strings\"\n\nfrom(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"category\"] == \"room\")\n  |> filter(fn: (r) => r[\"stat\"] =~ /(rcl|creeps|energy\\.available|energy\\.capacity|storage\\.energy|controller\\.progress_percent)$/)\n  |> last()\n  |> map(fn: (r) => ({ r with metric: strings.replaceAll(v: r.stat, t: \"room.\" + r.sub_category + \".\", u: \"\") }))\n  |> pivot(rowKey: [\"sub_category\"], columnKey: [\"metric\"], valueColumn: \"_value\")\n  |> rename(columns: {sub_category: \"Room\", creeps: \"Creeps\", rcl: \"RCL\", \"energy.available\": \"Energy Available\", \"energy.capacity\": \"Energy Capacity\", \"storage.energy\": \"Storage Energy\", \"controller.progress_percent\": \"Controller %\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Room Snapshot",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 33,
+      "panels": [],
+      "title": "Swarm Brain",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"screeps\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"category\"] == \"room\")\n  |> filter(fn: (r) => r[\"stat\"] =~ /pheromone\\.(expand|harvest|build|upgrade|defense|war|siege|logistics|nukeTarget)$/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"Pheromones\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Pheromone Signals",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Danger"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "orange",
+                      "value": 2
+                    },
+                    {
+                      "color": "red",
+                      "value": 3
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Posture"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "Eco"
+                      },
+                      "1": {
+                        "text": "Expand"
+                      },
+                      "2": {
+                        "text": "Defensive"
+                      },
+                      "3": {
+                        "text": "War"
+                      },
+                      "4": {
+                        "text": "Siege"
+                      },
+                      "5": {
+                        "text": "Evacuate"
+                      },
+                      "6": {
+                        "text": "Nuke Prep"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Colony"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "1": {
+                        "text": "Seed Nest"
+                      },
+                      "2": {
+                        "text": "Foraging Expansion"
+                      },
+                      "3": {
+                        "text": "Mature Colony"
+                      },
+                      "4": {
+                        "text": "Fortified Hive"
+                      },
+                      "5": {
+                        "text": "Empire Dominance"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 35,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "import \"strings\"\n\nfrom(bucket: \"screeps\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r[\"category\"] == \"room\")\n  |> filter(fn: (r) => r[\"stat\"] =~ /(brain\\.danger|brain\\.posture_code|brain\\.colony_level_code|pheromone\\.(expand|defense|war|logistics|upgrade|build|harvest|siege|nukeTarget)|metrics\\.energy\\.harvested|metrics\\.energy\\.spawning|metrics\\.hostile_count)$/)\n  |> last()\n  |> map(fn: (r) => ({ r with metric: strings.replaceAll(v: r.stat, t: \"room.\" + r.sub_category + \".\", u: \"\") }))\n  |> pivot(rowKey: [\"sub_category\"], columnKey: [\"metric\"], valueColumn: \"_value\")\n  |> rename(columns: {sub_category: \"Room\", \"brain.danger\": \"Danger\", \"brain.posture_code\": \"Posture\", \"brain.colony_level_code\": \"Colony\", \"metrics.energy.harvested\": \"Energy Harvested\", \"metrics.energy.spawning\": \"Energy Spawning\", \"metrics.hostile_count\": \"Hostiles\", \"pheromone.expand\": \"P Expand\", \"pheromone.defense\": \"P Defense\", \"pheromone.war\": \"P War\", \"pheromone.logistics\": \"P Logistics\", \"pheromone.harvest\": \"P Harvest\", \"pheromone.build\": \"P Build\", \"pheromone.upgrade\": \"P Upgrade\", \"pheromone.siege\": \"P Siege\", \"pheromone.nukeTarget\": \"P Nuke\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Room Brain Snapshot",
+      "type": "table"
     }
   ],
   "preload": false,
@@ -1838,5 +2691,5 @@
   "timezone": "browser",
   "title": "Screeps Ant Swarm",
   "uid": "screeps-ant-swarm",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
## Summary
- Publish consistent Memory.stats keys for controller progress, system tick, swarm pheromones, posture, and per-room energy metrics to let Grafana surface the bot brain.
- Add an optional EXPORTER_MEMORY_FULL flag and docs so the Influx exporter can flatten the full Memory payload when deeper visibility is needed.
- Extend the Screeps dashboard with new Swarm Brain row, pheromone trend lines, and a room brain snapshot table alongside updated controller/tick queries.

## Testing
- python - <<'PY'
import json
json.load(open('packages/screeps-server/grafana/provisioning/dashboards/screeps-ant-swarm.json'))
print('dashboard ok')
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933bf7e28788320ba000d206b953101)