### PR TITLE
Refine memory manager initialization cadence

### DIFF
--- a/packages/screeps-bot/src/memory/manager.ts
+++ b/packages/screeps-bot/src/memory/manager.ts
@@ -31,26 +31,26 @@ const DEAD_CREEP_CLEANUP_INTERVAL = 10;
  * Memory Manager class
  */
 export class MemoryManager {
-  private initialized = false;
+  private lastInitializeTick: number | null = null;
   private lastCleanupTick = 0;
 
   /**
    * Initialize all memory structures
    */
   public initialize(): void {
-    if (this.initialized) return;
+    if (this.lastInitializeTick === Game.time) return;
+
+    this.lastInitializeTick = Game.time;
 
     this.runMemoryMigration();
     this.ensureOvermindMemory();
     this.ensureClustersMemory();
-    
+
     // Only clean dead creeps periodically to save CPU
     if (Game.time - this.lastCleanupTick >= DEAD_CREEP_CLEANUP_INTERVAL) {
       this.cleanDeadCreeps();
       this.lastCleanupTick = Game.time;
     }
-
-    this.initialized = true;
   }
 
   /**

--- a/packages/screeps-bot/test/unit/main.test.ts
+++ b/packages/screeps-bot/test/unit/main.test.ts
@@ -14,9 +14,11 @@ describe("main", () => {
     global.Game = _.clone(Game);
     // @ts-ignore : allow adding Memory to global
     global.Memory = _.clone(Memory);
-    // Reset the memory manager's initialized state
-    // @ts-ignore: Accessing private property for testing
-    memoryManager["initialized"] = false;
+    // Reset the memory manager's per-tick state
+    // @ts-ignore: Accessing private properties for testing
+    memoryManager["lastInitializeTick"] = null;
+    // @ts-ignore: Accessing private properties for testing
+    memoryManager["lastCleanupTick"] = 0;
   });
 
   it("should export a loop function", () => {

--- a/packages/screeps-bot/test/unit/memoryManager.test.ts
+++ b/packages/screeps-bot/test/unit/memoryManager.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "chai";
+import { MemoryManager } from "../../src/memory/manager";
+import { Game as GameMock, Memory as MemoryMock } from "./mock";
+
+// These tests rely on the per-file test setup to provide lodash's _.clone helper.
+
+describe("MemoryManager", () => {
+  let manager: MemoryManager;
+
+  beforeEach(() => {
+    // @ts-ignore: test setup injects lodash-lite clone
+    global.Game = _.clone(GameMock);
+    // @ts-ignore: test setup injects lodash-lite clone
+    global.Memory = _.clone(MemoryMock);
+    manager = new MemoryManager();
+  });
+
+  it("cleans up dead creep memory after the cleanup interval", () => {
+    // @ts-ignore: Assigning to mocked global values
+    global.Game.time = 100;
+    // @ts-ignore: Assigning to mocked global values
+    global.Memory.creeps = { alive: {}, expired: {} };
+    // @ts-ignore: Assigning to mocked global values
+    global.Game.creeps = { alive: {} };
+    // Force the cleanup window to be open
+    // @ts-ignore: Accessing private property for testing
+    manager["lastCleanupTick"] = 89;
+
+    manager.initialize();
+
+    // @ts-ignore: Accessing mocked memory
+    expect(global.Memory.creeps.alive).to.exist;
+    // @ts-ignore: Accessing mocked memory
+    expect(global.Memory.creeps.expired).to.be.undefined;
+  });
+
+  it("reruns migrations when memory version falls behind", () => {
+    manager.initialize();
+    // @ts-ignore: Accessing mocked memory
+    const currentVersion = global.Memory.memoryVersion;
+
+    // Simulate a new tick where memory version regressed
+    // @ts-ignore: Assigning to mocked global values
+    global.Game.time += 1;
+    // @ts-ignore: Accessing mocked memory
+    global.Memory.memoryVersion = (currentVersion as number) - 1;
+    // @ts-ignore: Accessing mocked memory
+    global.Memory.creeps = { needsMigration: {} };
+
+    manager.initialize();
+
+    // @ts-ignore: Accessing mocked memory
+    expect(global.Memory.memoryVersion).to.equal(currentVersion);
+    // @ts-ignore: Accessing mocked memory
+    expect(global.Memory.creeps.needsMigration.version).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the memory manager runs migrations and memory setup every tick while skipping redundant same-tick work
- keep periodic dead-creep cleanup gated by its interval
- add unit coverage for cleanup cadence and rerunning migrations when memory versions regress

## Testing
- npm test *(fails: npm command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ca95175483208418866a09b3ba76)