### PR TITLE
Use centralized logger for SwarmBot notices

### DIFF
--- a/packages/screeps-bot/test/unit/swarmBotLogging.test.ts
+++ b/packages/screeps-bot/test/unit/swarmBotLogging.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { Game as MockGame, Memory as MockMemory } from "./mock";
+
+function reloadSwarmBot() {
+  delete require.cache[require.resolve("../../src/core/kernel")];
+  delete require.cache[require.resolve("../../src/core/logger")];
+  delete require.cache[require.resolve("../../src/core/processRegistry")];
+  delete require.cache[require.resolve("../../src/SwarmBot")];
+
+  return require("../../src/SwarmBot") as typeof import("../../src/SwarmBot");
+}
+
+describe("SwarmBot logging", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // Reset globals to a clean baseline
+    // @ts-ignore: globals provided by test setup
+    global.Game = _.clone(MockGame);
+    // @ts-ignore: globals provided by test setup
+    global.Memory = _.clone(MockMemory);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("logs skipped creeps through the logger", () => {
+    const bot = reloadSwarmBot();
+
+    const loggerModule = require("../../src/core/logger");
+    const warnSpy = sandbox.spy(loggerModule, "warn");
+
+    const processRegistry = require("../../src/core/processRegistry");
+    sandbox.stub(processRegistry, "registerAllProcesses");
+
+    sandbox.stub(bot.kernel, "initialize");
+    sandbox.stub(bot.kernel, "getBucketMode").returns("low");
+    sandbox.stub(bot.kernel, "hasCpuBudget").returns(false);
+    sandbox.stub(bot.roomManager, "run");
+    sandbox.stub(bot.profiler, "measureSubsystem").callsFake((_, fn: () => void) => fn());
+
+    // @ts-ignore: test setup for Game globals
+    global.Game.creeps = {
+      alpha: { memory: { role: "builder" }, spawning: false },
+      beta: { memory: { role: "hauler" }, spawning: false }
+    };
+    // @ts-ignore: test setup for Game globals
+    global.Game.time = 12350; // divisible by 50 to satisfy logging interval
+
+    bot.loop();
+
+    expect(warnSpy).to.have.been.calledWithMatch(
+      sinon.match(/Skipped .* creeps due to CPU/),
+      sinon.match({ subsystem: "SwarmBot" })
+    );
+  });
+
+  it("logs visualization errors through the logger", () => {
+    const bot = reloadSwarmBot();
+
+    const loggerModule = require("../../src/core/logger");
+    const errorSpy = sandbox.spy(loggerModule, "error");
+
+    const processRegistry = require("../../src/core/processRegistry");
+    sandbox.stub(processRegistry, "registerAllProcesses");
+
+    sandbox.stub(bot.kernel, "initialize");
+    sandbox.stub(bot.kernel, "getBucketMode").returns("normal");
+    sandbox.stub(bot.kernel, "hasCpuBudget").returns(true);
+    sandbox.stub(bot.roomManager, "run");
+    sandbox.stub(bot.profiler, "measureSubsystem").callsFake((_, fn: () => void) => fn());
+
+    sandbox.stub(bot.roomVisualizer, "draw").throws(new Error("boom"));
+
+    // @ts-ignore: test setup for Game globals
+    global.Game.rooms = {
+      W1N1: { name: "W1N1", controller: { my: true } }
+    };
+
+    bot.loop();
+
+    expect(errorSpy).to.have.been.calledWithMatch(
+      sinon.match(/Visualization error in W1N1/),
+      sinon.match({ subsystem: "visualizations", room: "W1N1" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- route SwarmBot skip notices, visualization failures, and error handling through the centralized logger with subsystem context
- ensure critical bucket handling and room processing errors respect logger formatting and severity
- add unit coverage to confirm logger usage when creeps are skipped and when visualization drawing throws

## Testing
- npm test (fails: mocha cannot load .ts tests due to ERR_UNKNOWN_FILE_EXTENSION)
- npx mocha --require ts-node/register --require tsconfig-paths/register --require ./test/setup-mocha.js test/unit/**/*.ts (fails: ERR_UNKNOWN_FILE_EXTENSION for TypeScript tests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ca9587c48320ba3f0b892425d6e7)