### PR TITLE
Enable live arbitrage execution and tracking

### DIFF
--- a/packages/screeps-bot/src/memory/schemas.ts
+++ b/packages/screeps-bot/src/memory/schemas.ts
@@ -133,6 +133,32 @@ export interface OrderStats {
 }
 
 /**
+ * Pending arbitrage trade tracking
+ */
+export interface PendingArbitrageTrade {
+  /** Unique trade identifier */
+  id: string;
+  /** Resource being traded */
+  resource: ResourceConstant;
+  /** Amount purchased */
+  amount: number;
+  /** Buy order used */
+  buyOrderId: string;
+  /** Target buy order to sell into */
+  sellOrderId?: string;
+  /** Target sell price if no order is available */
+  targetSellPrice: number;
+  /** Room that executed the purchase */
+  destinationRoom: string;
+  /** Expected tick when transfer is ready */
+  expectedArrival: number;
+  /** Price paid per unit */
+  buyPrice: number;
+  /** Estimated transport cost paid in energy */
+  transportCost: number;
+}
+
+/**
  * Market memory containing all market intelligence
  */
 export interface MarketMemory {
@@ -146,6 +172,12 @@ export interface MarketMemory {
   totalProfit?: number;
   /** Last balance tick */
   lastBalance?: number;
+  /** Pending arbitrage trades */
+  pendingArbitrage?: PendingArbitrageTrade[];
+  /** Number of completed arbitrage cycles */
+  completedArbitrage?: number;
+  /** Profit generated from arbitrage cycles */
+  arbitrageProfit?: number;
 }
 
 /**
@@ -639,7 +671,10 @@ export function createDefaultSwarmState(): SwarmState {
 export function createDefaultMarketMemory(): MarketMemory {
   return {
     resources: {},
-    lastScan: 0
+    lastScan: 0,
+    pendingArbitrage: [],
+    completedArbitrage: 0,
+    arbitrageProfit: 0
   };
 }
 


### PR DESCRIPTION
## Summary
- reinstate arbitrage scanning in MarketManager and respect CPU/bucket and trading credit guards
- add pending arbitrage tracking with arrival metadata and reconcile purchases into outbound sales or sell orders
- capture arbitrage completion logs/metrics in market memory for unified stats

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939704c9cdc8320a9e1b0a881eac051)