### PR TITLE
Fix creep context logger usage

### DIFF
--- a/packages/screeps-bot/src/roles/behaviors/context.ts
+++ b/packages/screeps-bot/src/roles/behaviors/context.ts
@@ -450,7 +450,6 @@ export function createContext(creep: Creep): CreepContext {
   if (memory.working === undefined) {
     memory.working = creep.store.getUsedCapacity() > 0;
     logger.debug(`${creep.name} initialized working=${memory.working} from carry state`, {
-      subsystem: "CreepContext",
       creep: creep.name
     });
   }


### PR DESCRIPTION
## Summary
- adjust creep context debug logging to use the logger helper’s expected context shape

## Testing
- npm test -- --runInBand *(fails: performanceBenchmarks.test expectation for benchmark ratio > 1)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ca09324c88320abe6138773122168)