### PR TITLE
Avoid blocking moving creeps in cost matrix

### DIFF
--- a/packages/screeps-bot/src/utils/movement.ts
+++ b/packages/screeps-bot/src/utils/movement.ts
@@ -705,7 +705,8 @@ function generateCostMatrix(
   allowHostileRooms = false,
   allowSK = false,
   preferHighway = false,
-  highwayBias = 2.5
+  highwayBias = 2.5,
+  origin?: RoomPosition
 ): CostMatrix | false {
   const costs = new PathFinder.CostMatrix();
   const room = Game.rooms[roomName];
@@ -785,10 +786,12 @@ function generateCostMatrix(
   if (avoidCreeps) {
     const creeps = room.find(FIND_CREEPS);
     for (const creep of creeps) {
+      if (origin && origin.isEqualTo(creep.pos)) continue; // Don't block the moving creep
       costs.set(creep.pos.x, creep.pos.y, 255);
     }
     const powerCreeps = room.find(FIND_POWER_CREEPS);
     for (const pc of powerCreeps) {
+      if (origin && origin.isEqualTo(pc.pos)) continue; // Don't block the moving creep
       costs.set(pc.pos.x, pc.pos.y, 255);
     }
   }
@@ -877,13 +880,14 @@ function findPath(origin: RoomPosition, target: RoomPosition | MoveTarget, opts:
         return false;
       }
       return generateCostMatrix(
-        roomName, 
-        opts.avoidCreeps ?? true, 
-        roadCost, 
+        roomName,
+        opts.avoidCreeps ?? true,
+        roadCost,
         allowHostileRooms,
         allowSK,
         preferHighway,
-        highwayBias
+        highwayBias,
+        origin
       );
     }
   });
@@ -915,13 +919,14 @@ function findPath(origin: RoomPosition, target: RoomPosition | MoveTarget, opts:
             return false;
           }
           return generateCostMatrix(
-            roomName, 
-            opts.avoidCreeps ?? true, 
-            roadCost, 
+            roomName,
+            opts.avoidCreeps ?? true,
+            roadCost,
             allowHostileRooms,
             allowSK,
             preferHighway,
-            highwayBias
+            highwayBias,
+            origin
           );
         }
       });
@@ -956,13 +961,14 @@ function findFleePath(origin: RoomPosition, threats: RoomPosition[], range: numb
     flee: true,
     roomCallback: (roomName: string) => {
       return generateCostMatrix(
-        roomName, 
-        opts.avoidCreeps ?? true, 
-        roadCost, 
+        roomName,
+        opts.avoidCreeps ?? true,
+        roadCost,
         allowHostileRooms,
         allowSK,
         preferHighway,
-        highwayBias
+        highwayBias,
+        origin
       );
     }
   });


### PR DESCRIPTION
## Summary
- pass the moving creep's position into movement cost matrix generation
- avoid marking the acting creep as an obstacle when avoidCreeps is enabled
- use the adjusted cost matrix in both approach and flee pathfinding

## Testing
- npx mocha --no-opts --no-config -r ts-node/register -r tsconfig-paths/register --reporter dot test/unit/movement.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ca4196d5483208bc0a0fcb7b78880)