### PR TITLE
Persist moveTo targets without object IDs

### DIFF
--- a/packages/screeps-bot/src/memory/schemas.ts
+++ b/packages/screeps-bot/src/memory/schemas.ts
@@ -515,6 +515,8 @@ export interface CreepState {
   action: string;
   /** Target object ID for the action */
   targetId?: Id<_HasId>;
+  /** Serialized target position for actions without a persistent object */
+  targetPos?: { x: number; y: number; roomName: string };
   /** Room name target (for moveToRoom actions) */
   targetRoom?: string;
   /** Tick when this state was entered */


### PR DESCRIPTION
## Summary
- store serialized positions for moveTo actions so states can be reconstructed without object IDs
- allow moveTo state completion checks to use stored positions when targets lack IDs
- document the new stored position field in creep state memory

## Testing
- npm test *(fails: existing mocha setup expects CommonJS; `require` is not available in ES module scope)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb7c359008320aa56f8a0827cd1fe)