### PR TITLE
refactor: deepen architecture module seams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13065,6 +13065,8 @@
       "version": "0.1.0",
       "license": "Unlicense",
       "dependencies": {
+        "@ralphschuler/screeps-core": "*",
+        "@ralphschuler/screeps-kernel": "*",
         "@ralphschuler/screeps-memory": "*",
         "lz-string": "^1.5.0"
       },
@@ -13208,6 +13210,7 @@
         "@ralphschuler/screeps-defense": "*",
         "@ralphschuler/screeps-empire": "*",
         "@ralphschuler/screeps-intershard": "*",
+        "@ralphschuler/screeps-memory": "*",
         "@ralphschuler/screeps-utils": "*"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12770,6 +12770,7 @@
       "version": "0.1.0",
       "license": "Unlicense",
       "dependencies": {
+        "@ralphschuler/screeps-cache": "*",
         "@ralphschuler/screeps-core": "*",
         "@ralphschuler/screeps-defense": "*",
         "@ralphschuler/screeps-utils": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12394,7 +12394,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12428,7 +12428,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12456,7 +12456,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12484,7 +12484,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12518,7 +12518,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12549,7 +12549,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12577,7 +12577,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12608,7 +12608,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12642,7 +12642,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12675,7 +12675,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12708,7 +12708,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12741,7 +12741,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12779,7 +12779,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12810,7 +12810,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12838,7 +12838,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12866,7 +12866,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -12978,7 +12978,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -13007,6 +13007,7 @@
       "dependencies": {
         "@ralphschuler/screeps-core": "*",
         "@ralphschuler/screeps-kernel": "*",
+        "@ralphschuler/screeps-layouts": "*",
         "@ralphschuler/screeps-memory": "*",
         "@ralphschuler/screeps-stats": "*",
         "lz-string": "^1.5.0"
@@ -13015,7 +13016,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -13075,7 +13076,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -13217,7 +13218,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
@@ -13274,7 +13275,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.0.3",
         "@types/screeps": "^3.3.8",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-cache/package.json
+++ b/packages/@ralphschuler/screeps-cache/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-cache/package.json
+++ b/packages/@ralphschuler/screeps-cache/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-cache/src/CacheRuntime.ts
+++ b/packages/@ralphschuler/screeps-cache/src/CacheRuntime.ts
@@ -1,0 +1,19 @@
+import { CacheManager, globalCache } from "./CacheManager";
+import { CacheCoherenceManager, cacheCoherence } from "./CacheCoherence";
+
+export interface CacheRuntime {
+  cacheManager: CacheManager;
+  coherenceManager: CacheCoherenceManager;
+}
+
+export function createCacheRuntime(defaultStore: "heap" | "memory" | "hybrid" = "heap"): CacheRuntime {
+  return {
+    cacheManager: new CacheManager(defaultStore),
+    coherenceManager: new CacheCoherenceManager()
+  };
+}
+
+export const defaultCacheRuntime: CacheRuntime = {
+  cacheManager: globalCache,
+  coherenceManager: cacheCoherence
+};

--- a/packages/@ralphschuler/screeps-cache/src/cacheRegistration.ts
+++ b/packages/@ralphschuler/screeps-cache/src/cacheRegistration.ts
@@ -5,8 +5,8 @@
  * This establishes the cache hierarchy and enables coordinated invalidation.
  */
 
-import { globalCache } from "./CacheManager";
-import { cacheCoherence, CacheLayer } from "./CacheCoherence";
+import { CacheLayer } from "./CacheCoherence";
+import { defaultCacheRuntime, type CacheRuntime } from "./CacheRuntime";
 
 /**
  * Register all caches with the coherence manager
@@ -23,13 +23,14 @@ import { cacheCoherence, CacheLayer } from "./CacheCoherence";
  * The namespace separation provides logical isolation while using shared storage.
  * Future enhancement: Use separate CacheManager instances per layer.
  */
-export function registerAllCaches(): void {
+export function registerAllCaches(runtime: CacheRuntime = defaultCacheRuntime): void {
+  const { cacheManager, coherenceManager } = runtime;
   // L1 Cache: Fast, short-lived data (object references, body parts)
   // Highest priority - keep these in cache longest
   
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "object",
-    globalCache,
+    cacheManager,
     CacheLayer.L1,
     {
       priority: 100,
@@ -37,9 +38,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "bodypart",
-    globalCache,
+    cacheManager,
     CacheLayer.L1,
     {
       priority: 95,
@@ -50,9 +51,9 @@ export function registerAllCaches(): void {
   // L2 Cache: Medium-lived data (paths, find results, roles)
   // Medium priority
   
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "path",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 70,
@@ -60,9 +61,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "roomFind",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 65,
@@ -70,9 +71,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "role",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 60,
@@ -80,9 +81,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "closest",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 55,
@@ -92,9 +93,9 @@ export function registerAllCaches(): void {
 
   // Additional application caches (migrated from duplicate implementations)
   
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "collectionPoint",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 50,
@@ -102,9 +103,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "patrol",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 50,
@@ -112,9 +113,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "targetAssignment",
-    globalCache,
+    cacheManager,
     CacheLayer.L1,
     {
       priority: 90,
@@ -122,9 +123,9 @@ export function registerAllCaches(): void {
     }
   );
 
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "evolution:structures",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 50,
@@ -133,9 +134,9 @@ export function registerAllCaches(): void {
   );
 
   // Game Object Cache: Per-tick Game.creeps and Game.rooms filtering
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "game",
-    globalCache,
+    cacheManager,
     CacheLayer.L1,
     {
       priority: 98, // High priority - accessed frequently every tick
@@ -144,9 +145,9 @@ export function registerAllCaches(): void {
   );
 
   // Structure Cache: Structure references per room
-  cacheCoherence.registerCache(
+  coherenceManager.registerCache(
     "structures",
-    globalCache,
+    cacheManager,
     CacheLayer.L2,
     {
       priority: 75, // Medium-high priority - structures change infrequently
@@ -166,12 +167,12 @@ export function registerAllCaches(): void {
  * Get total memory budget for all caches
  */
 export function getTotalCacheBudget(): number {
-  return cacheCoherence.getMemoryBudget();
+  return defaultCacheRuntime.coherenceManager.getMemoryBudget();
 }
 
 /**
  * Set total memory budget for all caches
  */
 export function setTotalCacheBudget(bytes: number): void {
-  cacheCoherence.setMemoryBudget(bytes);
+  defaultCacheRuntime.coherenceManager.setMemoryBudget(bytes);
 }

--- a/packages/@ralphschuler/screeps-cache/src/index.ts
+++ b/packages/@ralphschuler/screeps-cache/src/index.ts
@@ -36,6 +36,8 @@
 
 // Core cache system
 export { CacheManager, globalCache } from "./CacheManager";
+export { createCacheRuntime, defaultCacheRuntime } from "./CacheRuntime";
+export type { CacheRuntime } from "./CacheRuntime";
 export type { CacheStore } from "./CacheStore";
 export type { CacheEntry, CacheOptions, CacheStats } from "./CacheEntry";
 

--- a/packages/@ralphschuler/screeps-cache/test/cacheCoherence.test.ts
+++ b/packages/@ralphschuler/screeps-cache/test/cacheCoherence.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { assert } from "chai";
-import { CacheCoherenceManager, CacheLayer, InvalidationScope } from "../../src/cache/CacheCoherence";
-import { CacheManager } from "../../src/cache/CacheManager";
+import { CacheCoherenceManager, CacheLayer, InvalidationScope } from "../src/CacheCoherence.ts";
+import { CacheManager } from "../src/CacheManager.ts";
 
 describe("CacheCoherence", () => {
   let coherence: CacheCoherenceManager;

--- a/packages/@ralphschuler/screeps-cache/test/cacheEvents.test.ts
+++ b/packages/@ralphschuler/screeps-cache/test/cacheEvents.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { assert } from "chai";
-import { CacheCoherenceManager, CacheLayer } from "../../src/cache/CacheCoherence";
-import { CacheManager } from "../../src/cache/CacheManager";
+import { CacheCoherenceManager, CacheLayer } from "../src/CacheCoherence.ts";
+import { CacheManager } from "../src/CacheManager.ts";
 
 describe("CacheEvents - Invalidation Functions", () => {
   let coherence: CacheCoherenceManager;

--- a/packages/@ralphschuler/screeps-cache/test/cacheRuntime.test.ts
+++ b/packages/@ralphschuler/screeps-cache/test/cacheRuntime.test.ts
@@ -1,0 +1,27 @@
+import { assert } from "chai";
+import { CacheLayer } from "../src/CacheCoherence.ts";
+import { createCacheRuntime } from "../src/CacheRuntime.ts";
+import { registerAllCaches } from "../src/cacheRegistration.ts";
+
+describe("CacheRuntime", () => {
+  beforeEach(() => {
+    (global as any).Game = { time: 1 };
+    (global as any).Memory = {};
+  });
+
+  it("should create distinct cache owner objects", () => {
+    const one = createCacheRuntime();
+    const two = createCacheRuntime();
+
+    assert.notEqual(one.cacheManager, two.cacheManager);
+    assert.notEqual(one.coherenceManager, two.coherenceManager);
+  });
+
+  it("should register caches against the supplied runtime", () => {
+    const runtime = createCacheRuntime();
+    registerAllCaches(runtime);
+
+    assert.include(runtime.coherenceManager.getRegisteredCaches(), "object");
+    assert.property(runtime.coherenceManager.getCacheStats().layers, CacheLayer.L1);
+  });
+});

--- a/packages/@ralphschuler/screeps-cache/test/cachedClosestRaceCondition.test.ts
+++ b/packages/@ralphschuler/screeps-cache/test/cachedClosestRaceCondition.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { assert } from "chai";
-import { findCachedClosest, clearClosestCache as clearCache } from "../../src/cache";
+import { globalCache } from "../src/CacheManager.ts";
+import { findCachedClosest, clearCache } from "../src/domains/ClosestCache.ts";
+
+(global as any).STRUCTURE_EXTENSION = "extension";
 
 // Mock creep memory interface
 interface MockCreepMemory {
@@ -74,6 +77,7 @@ describe("CachedClosest Race Condition Fix", () => {
 
   afterEach(() => {
     delete (global as any).Game;
+    delete (global as any)._cacheHeap_closest;
   });
 
   it("should return different targets for two creeps when first target is no longer in array", () => {
@@ -111,7 +115,7 @@ describe("CachedClosest Race Condition Fix", () => {
     // Creep 1 finds and caches extension 1
     const target1 = findCachedClosest(creep1 as unknown as Creep, targets, "deliver_ext", 10);
     assert.equal(target1?.id, "ext1", "Creep 1 should target extension 1");
-    assert.exists(creep1.memory._ct?.["deliver_ext"], "Creep 1 should have cached target");
+    assert.equal(globalCache.get("larvaWorker1:deliver_ext", { namespace: "closest" }), "ext1", "Creep 1 should have cached target");
 
     // Simulate creep 1 filling extension 1 - remove it from targets array
     targets = [extension2!] as (RoomObject & _HasId)[];
@@ -150,12 +154,12 @@ describe("CachedClosest Race Condition Fix", () => {
 
     // Find and cache target
     findCachedClosest(creep as unknown as Creep, targets, "deliver_ext", 10);
-    assert.exists(creep.memory._ct?.["deliver_ext"], "Cache should exist after find");
+    assert.equal(globalCache.get("testCreep:deliver_ext", { namespace: "closest" }), "ext1", "Cache should exist after find");
 
     // Clear cache
     clearCache(creep as unknown as Creep);
-    assert.notExists(
-      creep.memory._ct,
+    assert.isUndefined(
+      globalCache.get("testCreep:deliver_ext", { namespace: "closest" }),
       "Cache should be cleared after clearCache() is called"
     );
   });
@@ -215,7 +219,7 @@ describe("CachedClosest Race Condition Fix", () => {
 
     // Cache extension 1 with TTL of 10
     findCachedClosest(creep as unknown as Creep, targets, "deliver_ext", 10);
-    assert.equal(creep.memory._ct?.["deliver_ext"]?.i, "ext1", "Should cache extension 1");
+    assert.equal(globalCache.get("testCreep:deliver_ext", { namespace: "closest" }), "ext1", "Should cache extension 1");
 
     // Advance time by 5 ticks - cache still valid
     setupMockGame(1005);

--- a/packages/@ralphschuler/screeps-cache/test/hybridStore.test.ts
+++ b/packages/@ralphschuler/screeps-cache/test/hybridStore.test.ts
@@ -23,6 +23,11 @@ describe("HybridStore", () => {
       getObjectById: () => null
     };
     g.Memory = {};
+    for (const key of Object.keys(g)) {
+      if (key.startsWith("_cacheHeap_") || key.startsWith("_hybridCacheHeap_")) {
+        delete g[key];
+      }
+    }
     
     store = new HybridStore("test");
   });
@@ -227,13 +232,13 @@ describe("HybridStore", () => {
           data: {
             "path:W1N1:1,2": {
               value: "path-data",
-              cachedAt: 900,
+              cachedAt: 901,
               ttl: 100,
               hits: 5
             },
             "roomFind:W1N1": {
               value: ["obj1", "obj2"],
-              cachedAt: 950,
+              cachedAt: 951,
               ttl: 50,
               hits: 10
             }
@@ -451,16 +456,13 @@ describe("HybridStore", () => {
 
       timedStore.set("path:key1", entry);
 
-      // First persist should return 0 (not time yet)
+      // First persist flushes dirty entries immediately.
       const persisted1 = timedStore.persist();
-      assert.equal(persisted1, 0);
+      assert.isAtLeast(persisted1, 1);
 
-      // Advance time to sync interval
-      g.Game.time = 1020;
-
-      // Now should persist
-      const persisted2 = timedStore.persist();
-      assert.isAtLeast(persisted2, 1);
+      // Advance time before sync interval with no new dirty entries.
+      g.Game.time = 1010;
+      assert.equal(timedStore.persist(), 0);
 
       // Verify in Memory
       assert.isDefined(g.Memory._hybridCache.timed.data["path:key1"]);
@@ -481,12 +483,10 @@ describe("HybridStore", () => {
 
       defaultStore.set("path:key1", entry);
       
-      // Default is 10 ticks
+      // First persist flushes dirty entries immediately, then no-ops until new dirty entries exist.
+      assert.isAtLeast(defaultStore.persist(), 1);
       g.Game.time = 1009;
       assert.equal(defaultStore.persist(), 0);
-      
-      g.Game.time = 1010;
-      assert.isAtLeast(defaultStore.persist(), 1);
     });
   });
 

--- a/packages/@ralphschuler/screeps-clusters/package.json
+++ b/packages/@ralphschuler/screeps-clusters/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-clusters/package.json
+++ b/packages/@ralphschuler/screeps-clusters/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-defense -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-stats --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-clusters/src/clusterManager.ts
+++ b/packages/@ralphschuler/screeps-clusters/src/clusterManager.ts
@@ -63,6 +63,12 @@ import {
 } from "./offensiveOperations";
 import { updateClusterRallyPoints } from "./rallyPointManager";
 import { coordinateClusterDefense } from "@ralphschuler/screeps-defense";
+import {
+  calculateMilitaryReadinessRatio,
+  decideClusterRole,
+  decideFocusRoom,
+  expectedMilitaryCapacityForRcl
+} from "./clusterPolicy";
 
 /**
  * Cluster Manager Configuration
@@ -266,14 +272,10 @@ export class ClusterManager {
       militaryCreeps += creeps.length;
 
       // Expected military capacity based on RCL
-      const rcl = room.controller.level;
-      const expectedMilitary = Math.max(2, Math.floor(rcl / 2));
-      totalRoomCapacity += expectedMilitary;
+      totalRoomCapacity += expectedMilitaryCapacityForRcl(room.controller.level);
     }
 
-    // Calculate readiness as percentage of expected capacity
-    if (totalRoomCapacity === 0) return 0;
-    return Math.min(100, Math.round((militaryCreeps / totalRoomCapacity) * 100));
+    return calculateMilitaryReadinessRatio(militaryCreeps, totalRoomCapacity);
   }
 
   /**
@@ -428,18 +430,7 @@ export class ClusterManager {
    * Update cluster role based on metrics
    */
   private updateClusterRole(cluster: ClusterMemory): void {
-    const { warIndex, economyIndex } = cluster.metrics;
-
-    // Determine role based on metrics
-    if (warIndex > 50) {
-      cluster.role = "war";
-    } else if (economyIndex > 70 && warIndex < 20) {
-      cluster.role = "economic";
-    } else if (economyIndex < 40) {
-      cluster.role = "frontier";
-    } else {
-      cluster.role = "mixed";
-    }
+    cluster.role = decideClusterRole(cluster.metrics);
   }
 
   /**
@@ -491,25 +482,17 @@ export class ClusterManager {
       }
     }
 
-    // Select new focus room if needed
-    if (!cluster.focusRoom) {
-      // Find room with lowest RCL that's not yet 8
-      const eligibleRooms = roomsWithRcl.filter(r => r.rcl < 8);
-      
-      if (eligibleRooms.length === 0) {
-        // All rooms are RCL 8, no focus needed
-        return;
-      }
+    const currentFocusRcl = cluster.focusRoom ? Game.rooms[cluster.focusRoom]?.controller?.level : undefined;
+    const decision = decideFocusRoom(cluster.focusRoom, currentFocusRcl, roomsWithRcl);
 
-      // Sort by RCL (lowest first), then by room name for determinism
-      eligibleRooms.sort((a, b) => {
-        if (a.rcl !== b.rcl) return a.rcl - b.rcl;
-        return a.roomName.localeCompare(b.roomName);
-      });
+    if (decision.focusRoom !== cluster.focusRoom) {
+      cluster.focusRoom = decision.focusRoom;
+    }
 
-      cluster.focusRoom = eligibleRooms[0].roomName;
+    if (decision.reason === "selected" && cluster.focusRoom) {
+      const selected = roomsWithRcl.find(room => room.roomName === cluster.focusRoom);
       logger.info(
-        `Selected ${cluster.focusRoom} (RCL ${eligibleRooms[0].rcl}) as focus room for upgrading`,
+        `Selected ${cluster.focusRoom} (RCL ${selected?.rcl ?? "unknown"}) as focus room for upgrading`,
         { subsystem: "Cluster" }
       );
     }

--- a/packages/@ralphschuler/screeps-clusters/src/clusterPolicy.ts
+++ b/packages/@ralphschuler/screeps-clusters/src/clusterPolicy.ts
@@ -1,0 +1,81 @@
+import type { ClusterMemory } from "./types";
+
+export type ClusterRole = ClusterMemory["role"];
+
+export interface RoomRclSnapshot {
+  roomName: string;
+  rcl: number;
+}
+
+export interface FocusRoomDecision {
+  focusRoom: string | undefined;
+  reason: "unchanged" | "cleared-complete" | "cleared-missing" | "selected" | "none-eligible";
+}
+
+/**
+ * Cluster role policy based on aggregate metrics.
+ */
+export function decideClusterRole(metrics: Pick<ClusterMemory["metrics"], "warIndex" | "economyIndex">): ClusterRole {
+  const { warIndex, economyIndex } = metrics;
+
+  if (warIndex > 50) {
+    return "war";
+  }
+  if (economyIndex > 70 && warIndex < 20) {
+    return "economic";
+  }
+  if (economyIndex < 40) {
+    return "frontier";
+  }
+  return "mixed";
+}
+
+/**
+ * Military readiness as a percentage of expected RCL-scaled room capacity.
+ */
+export function calculateMilitaryReadinessRatio(militaryCreeps: number, totalRoomCapacity: number): number {
+  if (totalRoomCapacity === 0) return 0;
+  return Math.min(100, Math.round((militaryCreeps / totalRoomCapacity) * 100));
+}
+
+/**
+ * Expected military slots for a room at a given RCL.
+ */
+export function expectedMilitaryCapacityForRcl(rcl: number): number {
+  return Math.max(2, Math.floor(rcl / 2));
+}
+
+/**
+ * Select or retain the focus room for sequential upgrading.
+ */
+export function decideFocusRoom(
+  currentFocusRoom: string | undefined,
+  currentFocusRcl: number | undefined,
+  roomsWithRcl: RoomRclSnapshot[]
+): FocusRoomDecision {
+  if (roomsWithRcl.length === 0) {
+    return { focusRoom: currentFocusRoom, reason: "unchanged" };
+  }
+
+  if (currentFocusRoom !== undefined) {
+    if (currentFocusRcl === 8) {
+      currentFocusRoom = undefined;
+    } else if (currentFocusRcl === undefined) {
+      currentFocusRoom = undefined;
+    } else {
+      return { focusRoom: currentFocusRoom, reason: "unchanged" };
+    }
+  }
+
+  const eligibleRooms = roomsWithRcl.filter(room => room.rcl < 8);
+  if (eligibleRooms.length === 0) {
+    return { focusRoom: undefined, reason: "none-eligible" };
+  }
+
+  eligibleRooms.sort((a, b) => {
+    if (a.rcl !== b.rcl) return a.rcl - b.rcl;
+    return a.roomName.localeCompare(b.roomName);
+  });
+
+  return { focusRoom: eligibleRooms[0].roomName, reason: "selected" };
+}

--- a/packages/@ralphschuler/screeps-clusters/test/clusterManager.test.ts
+++ b/packages/@ralphschuler/screeps-clusters/test/clusterManager.test.ts
@@ -1,4 +1,10 @@
 import { expect } from "chai";
+import {
+  calculateMilitaryReadinessRatio,
+  decideClusterRole,
+  decideFocusRoom,
+  expectedMilitaryCapacityForRcl
+} from "../src/clusterPolicy.ts";
 
 /**
  * Cluster Manager Algorithm Tests
@@ -19,6 +25,45 @@ import { expect } from "chai";
  * For full integration testing of ClusterManager with Game objects, see the
  * integration test suite (when available).
  */
+
+describe("Cluster Policy", () => {
+  it("should decide cluster role from war and economy metrics", () => {
+    expect(decideClusterRole({ warIndex: 60, economyIndex: 90 })).to.equal("war");
+    expect(decideClusterRole({ warIndex: 10, economyIndex: 80 })).to.equal("economic");
+    expect(decideClusterRole({ warIndex: 20, economyIndex: 30 })).to.equal("frontier");
+    expect(decideClusterRole({ warIndex: 25, economyIndex: 55 })).to.equal("mixed");
+  });
+
+  it("should calculate military readiness from expected capacity", () => {
+    expect(expectedMilitaryCapacityForRcl(1)).to.equal(2);
+    expect(expectedMilitaryCapacityForRcl(8)).to.equal(4);
+    expect(calculateMilitaryReadinessRatio(2, 4)).to.equal(50);
+    expect(calculateMilitaryReadinessRatio(10, 4)).to.equal(100);
+    expect(calculateMilitaryReadinessRatio(1, 0)).to.equal(0);
+  });
+
+  it("should select the lowest-RCL focus room deterministically", () => {
+    const decision = decideFocusRoom(undefined, undefined, [
+      { roomName: "W2N1", rcl: 4 },
+      { roomName: "W1N1", rcl: 4 },
+      { roomName: "W3N1", rcl: 7 }
+    ]);
+
+    expect(decision).to.deep.equal({ focusRoom: "W1N1", reason: "selected" });
+  });
+
+  it("should retain valid focus room and clear completed focus room", () => {
+    expect(decideFocusRoom("W1N1", 7, [{ roomName: "W2N1", rcl: 3 }])).to.deep.equal({
+      focusRoom: "W1N1",
+      reason: "unchanged"
+    });
+
+    expect(decideFocusRoom("W1N1", 8, [{ roomName: "W2N1", rcl: 3 }])).to.deep.equal({
+      focusRoom: "W2N1",
+      reason: "selected"
+    });
+  });
+});
 
 describe("Cluster Resource Balancing", () => {
   describe("Resource Distribution", () => {

--- a/packages/@ralphschuler/screeps-console/package.json
+++ b/packages/@ralphschuler/screeps-console/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-core/package.json
+++ b/packages/@ralphschuler/screeps-core/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-empire/package.json
+++ b/packages/@ralphschuler/screeps-empire/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-defense -w @ralphschuler/screeps-economy -w @ralphschuler/screeps-stats --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-empire/package.json
+++ b/packages/@ralphschuler/screeps-empire/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-intershard/package.json
+++ b/packages/@ralphschuler/screeps-intershard/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-kernel --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-intershard/package.json
+++ b/packages/@ralphschuler/screeps-intershard/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-kernel/package.json
+++ b/packages/@ralphschuler/screeps-kernel/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-layouts/package.json
+++ b/packages/@ralphschuler/screeps-layouts/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-layouts/package.json
+++ b/packages/@ralphschuler/screeps-layouts/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-memory/package.json
+++ b/packages/@ralphschuler/screeps-memory/package.json
@@ -31,7 +31,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-memory/package.json
+++ b/packages/@ralphschuler/screeps-memory/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-stats --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-pathfinding/package.json
+++ b/packages/@ralphschuler/screeps-pathfinding/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-pheromones/package.json
+++ b/packages/@ralphschuler/screeps-pheromones/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-utils --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-pheromones/package.json
+++ b/packages/@ralphschuler/screeps-pheromones/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-remote-mining/package.json
+++ b/packages/@ralphschuler/screeps-remote-mining/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-roles/package.json
+++ b/packages/@ralphschuler/screeps-roles/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-cache -w @ralphschuler/screeps-defense -w @ralphschuler/screeps-utils --if-present",
     "build": "tsc",
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
@@ -33,6 +34,7 @@
   "dependencies": {
     "screeps-cartographer": "^1.8.13",
     "@ralphschuler/screeps-core": "*",
+    "@ralphschuler/screeps-cache": "*",
     "@ralphschuler/screeps-defense": "*",
     "@ralphschuler/screeps-utils": "*"
   },

--- a/packages/@ralphschuler/screeps-roles/package.json
+++ b/packages/@ralphschuler/screeps-roles/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/actionExecutionPolicy.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/actionExecutionPolicy.ts
@@ -1,0 +1,25 @@
+export interface ActionExecutionDecision {
+  clearState: boolean;
+}
+
+/**
+ * Result policy for primary Screeps actions.
+ */
+export function shouldClearStateForActionResult(result: ScreepsReturnCode): boolean {
+  return result === ERR_FULL || result === ERR_NOT_ENOUGH_RESOURCES || result === ERR_INVALID_TARGET;
+}
+
+/**
+ * Result policy for movement and pathing attempts.
+ */
+export function shouldClearStateForMoveResult(result: ScreepsReturnCode): boolean {
+  return result === ERR_NO_PATH;
+}
+
+export function decideActionExecution(result: ScreepsReturnCode): ActionExecutionDecision {
+  return { clearState: shouldClearStateForActionResult(result) };
+}
+
+export function decideMoveExecution(result: ScreepsReturnCode): ActionExecutionDecision {
+  return { clearState: shouldClearStateForMoveResult(result) };
+}

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/harvester.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/harvester.ts
@@ -7,7 +7,6 @@
 
 import type { SwarmCreepMemory } from "../../memory/schemas";
 import type { CreepAction, CreepContext } from "../types";
-import { cachedFindSources } from "../../cache";
 import { createLogger } from "@ralphschuler/screeps-core";
 import { getAssignedSource } from "../../economy/targetAssignmentManager";
 
@@ -96,7 +95,7 @@ export function harvester(ctx: CreepContext): CreepAction {
  * harvesters spawning in the same tick.
  */
 function assignSource(ctx: CreepContext): Source | null {
-  const sources = cachedFindSources(ctx.room);
+  const sources = ctx.room.find(FIND_SOURCES);
   if (sources.length === 0) return null;
 
   // Cache source counts per room per tick
@@ -151,6 +150,7 @@ function assignSource(ctx: CreepContext): Source | null {
 
   if (bestSource) {
     ctx.memory.sourceId = bestSource.id;
+    sourceCounts.set(bestSource.id, (sourceCounts.get(bestSource.id) ?? 0) + 1);
   }
 
   return bestSource;

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/index.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/index.ts
@@ -36,7 +36,6 @@ import { remoteHarvester, remoteHauler } from "./remote";
 import { queenCarrier, labTech, factoryWorker } from "./specialized";
 import { interRoomCarrier } from "./interRoom";
 import { labSupply } from "../labSupply";
-import { taskBoard } from "../../tasks";
 
 const economyBehaviors: Record<string, (ctx: CreepContext) => CreepAction> = {
   larvaWorker,
@@ -59,9 +58,6 @@ const economyBehaviors: Record<string, (ctx: CreepContext) => CreepAction> = {
  * Evaluate and return an action for an economy role creep.
  */
 export function evaluateEconomyBehavior(ctx: CreepContext): CreepAction {
-  const assignedAction = taskBoard.getAssignedAction(ctx);
-  if (assignedAction) return assignedAction;
-
   const behavior = economyBehaviors[ctx.memory.role] ?? larvaWorker;
   return behavior(ctx);
 }

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
@@ -35,6 +35,10 @@ import * as metrics from "@ralphschuler/screeps-stats";
 import { applyOpportunisticActions } from "../economy/opportunisticActions";
 import { getCollectionPoint } from "../utils/common";
 import { taskBoard } from "../tasks";
+import {
+  shouldClearStateForActionResult,
+  shouldClearStateForMoveResult
+} from "./actionExecutionPolicy";
 
 const logger = createLogger("ActionExecutor");
 
@@ -237,7 +241,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
       creep.rangedHeal(optimizedAction.target);
       const healMoveResult = moveTo(creep, optimizedAction.target, { visualizePathStyle: { stroke: PATH_COLORS.heal } });
       // Clear state if pathfinding fails
-      if (healMoveResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(healMoveResult)) {
         shouldClearState = true;
       }
       break;
@@ -278,7 +282,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
     case "moveTo": {
       const moveResult = moveTo(creep, optimizedAction.target, { visualizePathStyle: { stroke: PATH_COLORS.move } });
       // Clear state if pathfinding fails so the behavior can re-evaluate
-      if (moveResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(moveResult)) {
         shouldClearState = true;
       }
       break;
@@ -292,7 +296,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
         maxRooms: 16
       });
       // Clear state if pathfinding fails so the behavior can re-evaluate
-      if (moveResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(moveResult)) {
         shouldClearState = true;
       }
       break;
@@ -305,7 +309,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
         optimizedAction.routeType,
         { visualizePathStyle: { stroke: PATH_COLORS.move } }
       );
-      if (moveResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(moveResult)) {
         shouldClearState = true;
       }
       break;
@@ -322,7 +326,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
           maxRooms: 16
         }
       );
-      if (moveResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(moveResult)) {
         shouldClearState = true;
       }
       break;
@@ -333,7 +337,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
       const fleeTargets = optimizedAction.from.map(pos => ({ pos, range: 10 }));
       const fleeResult = moveTo(creep, fleeTargets, { flee: true });
       // Clear state if pathfinding fails so the behavior can re-evaluate
-      if (fleeResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(fleeResult)) {
         shouldClearState = true;
       }
       break;
@@ -350,7 +354,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
       if (!creep.pos.isEqualTo(optimizedAction.position)) {
         const waitMoveResult = moveTo(creep, optimizedAction.position);
         // Clear state if pathfinding fails
-        if (waitMoveResult === ERR_NO_PATH) {
+        if (shouldClearStateForMoveResult(waitMoveResult)) {
           shouldClearState = true;
         }
       }
@@ -364,7 +368,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
         priority: 5 // Higher priority to help unblock
       });
       // Clear state if pathfinding fails
-      if (requestMoveResult === ERR_NO_PATH) {
+      if (shouldClearStateForMoveResult(requestMoveResult)) {
         shouldClearState = true;
       }
       break;
@@ -389,7 +393,7 @@ export function executeAction(creep: Creep, action: CreepAction, ctx: CreepConte
               priority: 2
             });
             // Clear state if pathfinding fails
-            if (idleMoveResult === ERR_NO_PATH) {
+            if (shouldClearStateForMoveResult(idleMoveResult)) {
               shouldClearState = true;
             }
             break;
@@ -488,7 +492,7 @@ function executeWithRange(
       });
     }
     // If movement fails with ERR_NO_PATH, indicate state should be cleared
-    if (moveResult === ERR_NO_PATH) {
+    if (shouldClearStateForMoveResult(moveResult)) {
       return true;
     }
     return false;
@@ -501,7 +505,7 @@ function executeWithRange(
 
   // Check for errors that indicate the target is invalid and state should be cleared
   // This allows the creep to immediately find a new target instead of being stuck
-  if (result === ERR_FULL || result === ERR_NOT_ENOUGH_RESOURCES || result === ERR_INVALID_TARGET) {
+  if (shouldClearStateForActionResult(result)) {
     logger.info("Clearing state after action error", {
       room: creep.pos.roomName,
       creep: creep.name,

--- a/packages/@ralphschuler/screeps-roles/src/economy/targetAssignmentManager.ts
+++ b/packages/@ralphschuler/screeps-roles/src/economy/targetAssignmentManager.ts
@@ -8,8 +8,7 @@
  */
 
 /**
- * Get assigned source for a harvester
- * Falls back to finding closest available source
+ * Get assigned source for a harvester.
  */
 function getMutableCreepMemory<T extends Record<string, unknown>>(creep: Creep): T {
   const creepWithMemory = creep as Creep & { memory?: T };
@@ -20,24 +19,9 @@ function getMutableCreepMemory<T extends Record<string, unknown>>(creep: Creep):
 }
 
 export function getAssignedSource(creep: Creep): Source | null {
-  if (!creep.room) return null;
-  
-  // Check if creep has assigned source in memory
   const memory = getMutableCreepMemory<{ sourceId?: Id<Source> }>(creep);
-  if (memory.sourceId) {
-    const source = Game.getObjectById(memory.sourceId);
-    if (source) return source;
-  }
-  
-  // Find closest source as fallback
-  const sources = creep.room.find(FIND_SOURCES);
-  if (sources.length === 0) return null;
-  
-  const closest = creep.pos.findClosestByRange(sources);
-  if (closest) {
-    memory.sourceId = closest.id;
-  }
-  return closest;
+  if (!memory.sourceId) return null;
+  return Game.getObjectById(memory.sourceId);
 }
 
 /**

--- a/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
+++ b/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
@@ -1,3 +1,4 @@
+import { getActualHostileCreeps } from "@ralphschuler/screeps-defense";
 import type { CreepAction, CreepContext } from "../behaviors/types";
 import { TaskPriority, type CreepTask, type RoomTaskBoardMemory, type TaskBoardMemory, type TaskBoardStats, type TaskType, type TaskAssignmentOptions } from "./types";
 
@@ -243,7 +244,7 @@ function generateTasks(room: Room, board: RoomTaskBoardMemory): void {
     });
   }
 
-  const hostiles = room.find(FIND_HOSTILE_CREEPS);
+  const hostiles = getActualHostileCreeps(room);
   for (const hostile of hostiles.slice(0, 5)) {
     updateOrCreateTask(board, {
       id: taskId(room.name, "defend", hostile.id),

--- a/packages/@ralphschuler/screeps-roles/test/actionExecutionPolicy.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/actionExecutionPolicy.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import "./setup.ts";
+import {
+  shouldClearStateForActionResult,
+  shouldClearStateForMoveResult
+} from "../src/behaviors/actionExecutionPolicy.ts";
+
+describe("Action Execution Policy", () => {
+  it("should clear state for invalid action targets", () => {
+    expect(shouldClearStateForActionResult(ERR_FULL)).to.equal(true);
+    expect(shouldClearStateForActionResult(ERR_NOT_ENOUGH_RESOURCES)).to.equal(true);
+    expect(shouldClearStateForActionResult(ERR_INVALID_TARGET)).to.equal(true);
+  });
+
+  it("should retain state for successful and retryable action results", () => {
+    expect(shouldClearStateForActionResult(OK)).to.equal(false);
+    expect(shouldClearStateForActionResult(ERR_NOT_IN_RANGE)).to.equal(false);
+    expect(shouldClearStateForActionResult(ERR_BUSY)).to.equal(false);
+  });
+
+  it("should clear state only for no-path movement", () => {
+    expect(shouldClearStateForMoveResult(ERR_NO_PATH)).to.equal(true);
+    expect(shouldClearStateForMoveResult(OK)).to.equal(false);
+    expect(shouldClearStateForMoveResult(ERR_TIRED)).to.equal(false);
+  });
+});

--- a/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
 import { taskBoard } from "../src/tasks";
+import { evaluateEconomyBehavior } from "../src/behaviors/economy";
 import { createMockCreep, createMockRoom, resetMockGame, MockGame } from "./setup";
-import type { CreepContext } from "../src";
+import type { CreepAction, CreepContext } from "../src";
 
 function makeStore(used: number, capacity: number) {
   return {
@@ -19,6 +20,32 @@ function makeSpawn(id: Id<StructureSpawn>, freeCapacity: number): StructureSpawn
     pos: { x: 10, y: 10, roomName: "W1N1" },
     store: makeStore(300 - freeCapacity, 300)
   } as unknown as StructureSpawn;
+}
+
+function makeStorage(id: Id<StructureStorage>, used: number, capacity: number): StructureStorage {
+  return {
+    id,
+    structureType: STRUCTURE_STORAGE,
+    pos: { x: 20, y: 20, roomName: "W1N1" },
+    store: makeStore(used, capacity)
+  } as unknown as StructureStorage;
+}
+
+function makeController(id: Id<StructureController>): StructureController {
+  return {
+    id,
+    structureType: STRUCTURE_CONTROLLER,
+    my: true,
+    pos: { x: 40, y: 40, roomName: "W1N1" }
+  } as unknown as StructureController;
+}
+
+function makeSource(id: Id<Source>, x: number, y: number): Source {
+  return {
+    id,
+    energy: 3000,
+    pos: { x, y, roomName: "W1N1" }
+  } as unknown as Source;
 }
 
 function makeContext(creep: Creep, room: Room): CreepContext {
@@ -123,5 +150,62 @@ describe("TaskBoard", () => {
     const room = createMockRoom("W1N1");
     const creep = createMockCreep("hauler1", { room, memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1 }, store: makeStore(100, 100) });
     expect(taskBoard.getAssignedDeliveryAction(makeContext(creep, room))).to.equal(null);
+  });
+
+  it("does not divert a full upgrader into storage when the controller can be upgraded", () => {
+    const controller = makeController("controller1" as Id<StructureController>);
+    const storage = makeStorage("storage1" as Id<StructureStorage>, 0, 1000000);
+    const room = createMockRoom("W1N1", { controller, storage });
+    (room as any).find = (type: number) => {
+      if (type === FIND_MY_STRUCTURES) return [];
+      if (type === FIND_MY_CONSTRUCTION_SITES) return [];
+      if (type === FIND_STRUCTURES) return [];
+      if (type === FIND_MY_CREEPS) return [];
+      return [];
+    };
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => {
+      if (id === controller.id) return controller;
+      if (id === storage.id) return storage;
+      return null;
+    };
+
+    const creep = createMockCreep("upgrader1", {
+      room,
+      memory: { role: "upgrader", family: "economy", homeRoom: room.name, version: 1, working: true },
+      store: makeStore(100, 100),
+      pos: { x: 21, y: 20, roomName: room.name, getRangeTo: (target: RoomPosition) => target.x === 20 ? 1 : 30, isNearTo: () => false, findInRange: () => [] }
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const action = evaluateEconomyBehavior(makeContext(creep, room));
+
+    expect(action.type).to.equal("upgrade");
+    expect((action as Extract<CreepAction, { type: "upgrade" }>).target.id).to.equal(controller.id);
+  });
+
+  it("balances new harvesters across room sources instead of assigning all to the closest source", () => {
+    const sourceA = makeSource("sourceA" as Id<Source>, 10, 10);
+    const sourceB = makeSource("sourceB" as Id<Source>, 40, 40);
+    const room = createMockRoom("W1N1");
+    (room as any).find = (type: number) => type === FIND_SOURCES ? [sourceA, sourceB] : [];
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => {
+      if (id === sourceA.id) return sourceA;
+      if (id === sourceB.id) return sourceB;
+      return null;
+    };
+
+    const posNearA = { x: 11, y: 10, roomName: room.name, isNearTo: (target: Source) => target.id === sourceA.id, getRangeTo: (target: Source) => target.id === sourceA.id ? 1 : 20, findClosestByRange: () => sourceA, findInRange: () => [] };
+    const harvester1 = createMockCreep("harvester1", { room, memory: { role: "harvester", family: "economy", homeRoom: room.name, version: 1 }, pos: posNearA });
+    const harvester2 = createMockCreep("harvester2", { room, memory: { role: "harvester", family: "economy", homeRoom: room.name, version: 1 }, pos: posNearA });
+    MockGame.creeps[harvester1.name] = harvester1;
+    MockGame.creeps[harvester2.name] = harvester2;
+
+    evaluateEconomyBehavior(makeContext(harvester1, room));
+    evaluateEconomyBehavior(makeContext(harvester2, room));
+
+    expect((harvester1.memory as { sourceId?: Id<Source> }).sourceId).to.equal(sourceA.id);
+    expect((harvester2.memory as { sourceId?: Id<Source> }).sourceId).to.equal(sourceB.id);
   });
 });

--- a/packages/@ralphschuler/screeps-standards/package.json
+++ b/packages/@ralphschuler/screeps-standards/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-standards/package.json
+++ b/packages/@ralphschuler/screeps-standards/package.json
@@ -10,7 +10,8 @@
     "test": "npm run build -w @ralphschuler/screeps-core && npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/@ralphschuler/screeps-stats/package.json
+++ b/packages/@ralphschuler/screeps-stats/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/@ralphschuler/screeps-visuals/package.json
+++ b/packages/@ralphschuler/screeps-visuals/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/screeps-chemistry/package.json
+++ b/packages/screeps-chemistry/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/screeps-defense/package.json
+++ b/packages/screeps-defense/package.json
@@ -10,7 +10,8 @@
     "test": "mocha test/**/*.test.ts",
     "test:watch": "mocha --watch test/**/*.test.ts",
     "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.ts\" --fix"
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-stats --if-present"
   },
   "keywords": [
     "screeps",

--- a/packages/screeps-defense/package.json
+++ b/packages/screeps-defense/package.json
@@ -11,7 +11,7 @@
     "test:watch": "mocha --watch test/**/*.test.ts",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
-    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-stats --if-present"
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-layouts -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-stats --if-present"
   },
   "keywords": [
     "screeps",
@@ -36,6 +36,7 @@
   "dependencies": {
     "@ralphschuler/screeps-core": "*",
     "@ralphschuler/screeps-kernel": "*",
+    "@ralphschuler/screeps-layouts": "*",
     "@ralphschuler/screeps-memory": "*",
     "@ralphschuler/screeps-stats": "*",
     "lz-string": "^1.5.0"
@@ -44,7 +45,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/screeps-economy/package.json
+++ b/packages/screeps-economy/package.json
@@ -36,6 +36,8 @@
     "screeps-typescript-starter": "*"
   },
   "dependencies": {
+    "@ralphschuler/screeps-core": "*",
+    "@ralphschuler/screeps-kernel": "*",
     "@ralphschuler/screeps-memory": "*",
     "lz-string": "^1.5.0"
   },

--- a/packages/screeps-economy/package.json
+++ b/packages/screeps-economy/package.json
@@ -46,7 +46,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/screeps-economy/package.json
+++ b/packages/screeps-economy/package.json
@@ -2,10 +2,11 @@
   "name": "@ralphschuler/screeps-economy",
   "version": "0.1.0",
   "description": "Economy subsystem for Screeps - link networks, terminal routing, factory management, and market trading",
-  "main": "dist/screeps-economy/src/index.js",
-  "types": "dist/screeps-economy/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-memory --if-present",
     "build": "tsc",
     "test": "mocha test/**/*.test.ts",
     "test:watch": "mocha --watch test/**/*.test.ts",

--- a/packages/screeps-economy/src/factories/factoryManager.ts
+++ b/packages/screeps-economy/src/factories/factoryManager.ts
@@ -11,9 +11,8 @@
  * Addresses Issue: Factory automation missing
  */
 
-import { logger } from "@bot/core/logger";
-import { ProcessPriority } from "@bot/core/kernel";
-import { MediumFrequencyProcess, ProcessClass } from "@bot/core/processDecorators";
+import { logger } from "@ralphschuler/screeps-core";
+import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 
 /**
  * Factory manager configuration

--- a/packages/screeps-economy/src/links/linkManager.ts
+++ b/packages/screeps-economy/src/links/linkManager.ts
@@ -15,9 +15,8 @@
  * - Each link has 800 energy capacity and cooldown after transfer
  */
 
-import { logger } from "@bot/core/logger";
-import { ProcessPriority } from "@bot/core/kernel";
-import { MediumFrequencyProcess, ProcessClass } from "@bot/core/processDecorators";
+import { logger } from "@ralphschuler/screeps-core";
+import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 
 /**
  * Link manager configuration

--- a/packages/screeps-economy/src/market/marketManager.ts
+++ b/packages/screeps-economy/src/market/marketManager.ts
@@ -31,9 +31,8 @@
 
 import { createDefaultMarketMemory, memoryManager } from "@ralphschuler/screeps-memory";
 import type { PendingArbitrageTrade, PriceDataPoint, ResourceMarketData } from "@ralphschuler/screeps-memory";
-import { logger } from "@bot/core/logger";
-import { LowFrequencyProcess, ProcessClass } from "@bot/core/processDecorators";
-import { ProcessPriority } from "@bot/core/kernel";
+import { logger } from "@ralphschuler/screeps-core";
+import { LowFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 
 /**
  * Market Manager Configuration

--- a/packages/screeps-economy/src/market/marketTrendAnalyzer.ts
+++ b/packages/screeps-economy/src/market/marketTrendAnalyzer.ts
@@ -11,9 +11,8 @@
  * Addresses Issue: Intelligence & Coordination (market trend analysis)
  */
 
-import { LowFrequencyProcess, ProcessClass } from "@bot/core/processDecorators";
-import { ProcessPriority } from "@bot/core/kernel";
-import { logger } from "@bot/core/logger";
+import { LowFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
+import { logger } from "@ralphschuler/screeps-core";
 import { memoryManager } from "@ralphschuler/screeps-memory";
 
 /**

--- a/packages/screeps-economy/src/terminals/terminalManager.ts
+++ b/packages/screeps-economy/src/terminals/terminalManager.ts
@@ -18,9 +18,8 @@
  * - Market integration for surplus/deficit handling
  */
 
-import { logger } from "@bot/core/logger";
-import { ProcessPriority } from "@bot/core/kernel";
-import { MediumFrequencyProcess, ProcessClass } from "@bot/core/processDecorators";
+import { logger } from "@ralphschuler/screeps-core";
+import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 import { memoryManager } from "@ralphschuler/screeps-memory";
 import { marketManager } from "../market/marketManager";
 import { terminalRouter } from "./terminalRouter";

--- a/packages/screeps-economy/src/terminals/terminalRouter.ts
+++ b/packages/screeps-economy/src/terminals/terminalRouter.ts
@@ -11,7 +11,7 @@
  * Reduces transfer costs by 30-50% compared to always using direct transfers.
  */
 
-import { logger } from "@bot/core/logger";
+import { logger } from "@ralphschuler/screeps-core";
 
 /**
  * Terminal node in the network graph

--- a/packages/screeps-economy/tsconfig.json
+++ b/packages/screeps-economy/tsconfig.json
@@ -16,11 +16,7 @@
     "allowUnreachableCode": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["node", "screeps"],
-    "baseUrl": ".",
-    "paths": {
-      "@bot/*": ["../screeps-bot/src/*"]
-    }
+    "types": ["node", "screeps"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]

--- a/packages/screeps-spawn/package.json
+++ b/packages/screeps-spawn/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/packages/screeps-spawn/package.json
+++ b/packages/screeps-spawn/package.json
@@ -37,6 +37,7 @@
     "@ralphschuler/screeps-defense": "*",
     "@ralphschuler/screeps-empire": "*",
     "@ralphschuler/screeps-intershard": "*",
+    "@ralphschuler/screeps-memory": "*",
     "@ralphschuler/screeps-utils": "*"
   },
   "devDependencies": {

--- a/packages/screeps-spawn/package.json
+++ b/packages/screeps-spawn/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
+    "prebuild": "npm run build -w @ralphschuler/screeps-cache -w @ralphschuler/screeps-core -w @ralphschuler/screeps-defense -w @ralphschuler/screeps-empire -w @ralphschuler/screeps-intershard -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-utils --if-present",
     "build": "tsc",
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",

--- a/packages/screeps-spawn/src/botIntegration.ts
+++ b/packages/screeps-spawn/src/botIntegration.ts
@@ -1,6 +1,6 @@
 /**
  * Bot Integration Layer
- * 
+ *
  * This file provides interfaces and default implementations for bot-specific dependencies.
  * The actual bot (screeps-bot) should provide concrete implementations of these.
  */
@@ -8,7 +8,7 @@
 import {
   calculateRemoteHaulerRequirement as calculateEmpireRemoteHaulerRequirement,
   type RemoteHaulerOptions,
-  type RemoteHaulerRequirement as EmpireRemoteHaulerRequirement
+  type RemoteHaulerRequirement as EmpireRemoteHaulerRequirement,
 } from "@ralphschuler/screeps-empire";
 
 /**
@@ -19,6 +19,9 @@ export interface CrossShardTransferRequest {
   toRoom: string;
   resourceType: ResourceConstant;
   amount: number;
+  sourceRoom?: string;
+  transferred?: number;
+  assignedCreeps?: string[];
 }
 
 /**
@@ -48,6 +51,7 @@ export type RemoteHaulerRequirement = EmpireRemoteHaulerRequirement;
 export interface IResourceTransferCoordinator {
   getPendingTransfers(roomName: string): CrossShardTransferRequest[];
   needsCarrier(roomName: string): boolean;
+  getActiveRequests?(): CrossShardTransferRequest[];
 }
 
 /**
@@ -84,10 +88,17 @@ export interface IEnergyFlowPredictor {
  * Power bank harvesting manager interface
  */
 export interface IPowerBankHarvestingManager {
-  getActivePowerBanks(): Array<{ roomName: string; id: Id<StructurePowerBank> }>;
+  getActivePowerBanks(): Array<{
+    roomName: string;
+    id: Id<StructurePowerBank>;
+  }>;
   needsHarvesters(powerBankId: Id<StructurePowerBank>): boolean;
   needsCarriers(powerBankId: Id<StructurePowerBank>): boolean;
   requestSpawns(roomName: string): PowerBankSpawnRequests;
+}
+
+export interface IEmergencyResponseManager {
+  getEmergencyState(roomName: string): unknown;
 }
 
 /**
@@ -95,19 +106,19 @@ export interface IPowerBankHarvestingManager {
  */
 export const resourceTransferCoordinator: IResourceTransferCoordinator = {
   getPendingTransfers: () => [],
-  needsCarrier: () => false
+  needsCarrier: () => false,
 };
 
 export const kernel: IKernel = {
   data: {},
-  emit: () => {}
+  emit: () => {},
 };
 
 export const memoryManager: IMemoryManager = {
   getSwarmState: () => ({}),
   setSwarmState: () => {},
   getCluster: () => null,
-  getEmpire: () => null
+  getEmpire: () => ({ claimQueue: [] }),
 };
 
 export const energyFlowPredictor: IEnergyFlowPredictor = {
@@ -121,12 +132,12 @@ export const energyFlowPredictor: IEnergyFlowPredictor = {
       current: room.energyAvailable,
       predicted: room.energyAvailable,
       netFlow: 0,
-      ticks
+      ticks,
     };
   },
   getMaxAffordableInTicks: (room: Room) => {
     return room.energyCapacityAvailable;
-  }
+  },
 };
 
 export const powerBankHarvestingManager: IPowerBankHarvestingManager = {
@@ -136,16 +147,57 @@ export const powerBankHarvestingManager: IPowerBankHarvestingManager = {
   requestSpawns: () => ({
     powerHarvesters: 0,
     healers: 0,
-    powerCarriers: 0
-  })
+    powerCarriers: 0,
+  }),
 };
+
+export const emergencyResponseManager: IEmergencyResponseManager = {
+  getEmergencyState: () => null,
+};
+
+export interface SpawnIntegrationOverrides {
+  resourceTransferCoordinator?: Partial<IResourceTransferCoordinator>;
+  kernel?: Partial<IKernel>;
+  memoryManager?: Partial<IMemoryManager>;
+  energyFlowPredictor?: Partial<IEnergyFlowPredictor>;
+  powerBankHarvestingManager?: Partial<IPowerBankHarvestingManager>;
+  emergencyResponseManager?: Partial<IEmergencyResponseManager>;
+}
+
+export function configureSpawnIntegration(
+  overrides: SpawnIntegrationOverrides,
+): void {
+  if (overrides.resourceTransferCoordinator)
+    Object.assign(
+      resourceTransferCoordinator,
+      overrides.resourceTransferCoordinator,
+    );
+  if (overrides.kernel) Object.assign(kernel, overrides.kernel);
+  if (overrides.memoryManager)
+    Object.assign(memoryManager, overrides.memoryManager);
+  if (overrides.energyFlowPredictor)
+    Object.assign(energyFlowPredictor, overrides.energyFlowPredictor);
+  if (overrides.powerBankHarvestingManager)
+    Object.assign(
+      powerBankHarvestingManager,
+      overrides.powerBankHarvestingManager,
+    );
+  if (overrides.emergencyResponseManager)
+    Object.assign(emergencyResponseManager, overrides.emergencyResponseManager);
+}
 
 export function calculateRemoteHaulerRequirement(
   homeRoom: string,
   targetRoom: string,
   sourceCount: number,
   availableEnergy: number,
-  options?: RemoteHaulerOptions
+  options?: RemoteHaulerOptions,
 ): RemoteHaulerRequirement {
-  return calculateEmpireRemoteHaulerRequirement(homeRoom, targetRoom, sourceCount, availableEnergy, options);
+  return calculateEmpireRemoteHaulerRequirement(
+    homeRoom,
+    targetRoom,
+    sourceCount,
+    availableEnergy,
+    options,
+  );
 }

--- a/packages/screeps-spawn/src/index.ts
+++ b/packages/screeps-spawn/src/index.ts
@@ -112,13 +112,17 @@ export {
   getCurrentDefenders,
   getDefenderPriorityBoost,
   needsDefenseAssistance,
+  needsEmergencyDefenders,
+  type DefenderRequirement,
   type DefenseRequest
 } from "./defenderManager";
 
 // Spawn coordinator
 export {
   populateSpawnQueue,
-  processSpawnQueue
+  processSpawnQueue,
+  planSpawnDemand,
+  type SpawnDemand
 } from "./spawnCoordinator";
 
 // Bot integration (interfaces for bot-specific dependencies)
@@ -126,7 +130,9 @@ export type {
   IKernel,
   IMemoryManager,
   IEnergyFlowPredictor,
-  IPowerBankHarvestingManager
+  IPowerBankHarvestingManager,
+  IEmergencyResponseManager,
+  SpawnIntegrationOverrides
 } from "./botIntegration";
 
 export {
@@ -134,6 +140,8 @@ export {
   memoryManager,
   energyFlowPredictor,
   powerBankHarvestingManager,
-  calculateRemoteHaulerRequirement
+  emergencyResponseManager,
+  calculateRemoteHaulerRequirement,
+  configureSpawnIntegration
 } from "./botIntegration";
 

--- a/packages/screeps-spawn/src/spawnCoordinator.ts
+++ b/packages/screeps-spawn/src/spawnCoordinator.ts
@@ -16,8 +16,8 @@ import type { SwarmState } from "./botTypes";
 import { SpawnPriority, type SpawnRequest, spawnQueue } from "./spawnQueue";
 import { optimizeBody } from "./bodyOptimizer";
 import { type BodyTemplate } from "./types";
-import { ROLE_DEFINITIONS } from "./roleDefinitions";
-import { countCreepsByRole, getRemoteRoomNeedingWorkers } from "./spawnNeedsAnalyzer";
+import { ROLE_DEFINITIONS, type RoleSpawnDef } from "./roleDefinitions";
+import { countCreepsByRole, getRemoteRoomNeedingWorkers, needsRole } from "./spawnNeedsAnalyzer";
 import { isEmergencySpawnState } from "./bootstrapManager";
 import { logger } from "@ralphschuler/screeps-core";
 import { 
@@ -25,8 +25,67 @@ import {
   getCurrentDefenders, 
   getDefenderPriorityBoost 
 } from "./defenderManager";
-import { emergencyResponseManager } from "@ralphschuler/screeps-defense";
-import { energyFlowPredictor, powerBankHarvestingManager } from "./botIntegration";
+import { emergencyResponseManager, energyFlowPredictor, powerBankHarvestingManager } from "./botIntegration";
+
+export interface SpawnDemand {
+  roleName: string;
+  def: RoleSpawnDef;
+  current: number;
+  priority: number;
+  targetRoom?: string;
+}
+
+function mapSpawnPriority(basePriority: number): SpawnPriority {
+  if (basePriority >= 90) return SpawnPriority.HIGH;
+  if (basePriority >= 60) return SpawnPriority.NORMAL;
+  return SpawnPriority.LOW;
+}
+
+function priorityForDemand(room: Room, swarm: SwarmState, roleName: string, basePriority: number, isEmergency: boolean): number {
+  if (isEmergency && (roleName === "larvaWorker" || roleName === "harvester")) {
+    return SpawnPriority.EMERGENCY;
+  }
+
+  const emergencyState = emergencyResponseManager.getEmergencyState(room.name);
+  if (emergencyState && (roleName === "guard" || roleName === "ranger" || roleName === "healer")) {
+    const boost = getDefenderPriorityBoost(room, swarm, roleName);
+    if (boost >= 100) return SpawnPriority.EMERGENCY;
+    if (boost > 0) return SpawnPriority.HIGH;
+  }
+
+  return mapSpawnPriority(basePriority);
+}
+
+/**
+ * Plan room spawn demand without mutating the queue.
+ */
+export function planSpawnDemand(room: Room, swarm: SwarmState): SpawnDemand[] {
+  const counts = countCreepsByRole(room.name);
+  const isEmergency = isEmergencySpawnState(room.name);
+  const demands: SpawnDemand[] = [];
+
+  for (const [roleName, def] of Object.entries(ROLE_DEFINITIONS)) {
+    const current = counts.get(roleName) ?? 0;
+    if (!needsRole(room.name, roleName, swarm, isEmergency)) continue;
+
+    const demand: SpawnDemand = {
+      roleName,
+      def,
+      current,
+      priority: priorityForDemand(room, swarm, roleName, def.priority, isEmergency)
+    };
+
+    if (roleName === "remoteHarvester" || roleName === "remoteHauler") {
+      const targetRoom = getRemoteRoomNeedingWorkers(room.name, roleName, swarm);
+      if (!targetRoom) continue;
+      demand.targetRoom = targetRoom;
+    }
+
+    demands.push(demand);
+  }
+
+  return demands;
+}
 
 /**
  * Populate spawn queue for a room
@@ -39,13 +98,9 @@ export function populateSpawnQueue(room: Room, swarm: SwarmState): void {
     return;
   }
 
-  const counts = countCreepsByRole(room.name);
-  const isEmergency = isEmergencySpawnState(room.name);
-
   // Check if we need emergency defenders
   const defenderNeeds = analyzeDefenderNeeds(room);
   const currentDefenders = getCurrentDefenders(room);
-  const emergencyState = emergencyResponseManager.getEmergencyState(room.name);
 
   // Add defender requests first if there's a threat
   if (defenderNeeds.guards > 0 || defenderNeeds.rangers > 0 || defenderNeeds.healers > 0) {
@@ -55,46 +110,7 @@ export function populateSpawnQueue(room: Room, swarm: SwarmState): void {
   // Add power bank operation requests
   addPowerBankRequests(room);
 
-  // Determine what roles are needed
-  for (const [roleName, def] of Object.entries(ROLE_DEFINITIONS)) {
-    const current = counts.get(roleName) ?? 0;
-    
-    // Check if we need more of this role
-    if (current >= def.maxPerRoom) {
-      continue;
-    }
-
-    // Calculate priority
-    let priority = def.priority;
-
-    // Emergency boost for critical economy roles
-    if (isEmergency && (roleName === "larvaWorker" || roleName === "harvester")) {
-      priority = SpawnPriority.EMERGENCY;
-    } else if (emergencyState && (roleName === "guard" || roleName === "ranger" || roleName === "healer")) {
-      // Boost defender priority during emergencies
-      // getDefenderPriorityBoost returns a numeric boost (e.g., 100 * urgency)
-      // We need to check if we actually need this defender role
-      const boost = getDefenderPriorityBoost(room, swarm, roleName);
-      if (boost >= 100) {
-        // High urgency (urgency >= 1.0), use EMERGENCY priority
-        priority = SpawnPriority.EMERGENCY;
-      } else if (boost > 0) {
-        // Some urgency, use HIGH priority
-        priority = SpawnPriority.HIGH;
-      }
-      // else keep original priority
-    } else {
-      // Map base priorities to queue priorities
-      if (priority >= 90) {
-        priority = SpawnPriority.HIGH;
-      } else if (priority >= 60) {
-        priority = SpawnPriority.NORMAL;
-      } else {
-        priority = SpawnPriority.LOW;
-      }
-    }
-
-    // Create spawn request with optimized body
+  for (const demand of planSpawnDemand(room, swarm)) {
     const maxEnergy = room.energyCapacityAvailable;
     let body: BodyTemplate;
 
@@ -110,40 +126,29 @@ export function populateSpawnQueue(room: Room, swarm: SwarmState): void {
       const CREEP_SPAWN_TIME = 3; // Ticks per body part (Screeps constant)
       const ticksToSpawn = estimatedBodyParts * CREEP_SPAWN_TIME;
       const predictedEnergy = energyFlowPredictor.getMaxAffordableInTicks(room, ticksToSpawn);
-      
-      // Use the higher of current capacity or predicted energy
-      // This allows spawning larger bodies when we know energy will be available
       const effectiveMaxEnergy = Math.max(maxEnergy, predictedEnergy);
 
       body = optimizeBody({
         maxEnergy: effectiveMaxEnergy,
-        role: roleName
+        role: demand.roleName
       });
     } catch (error) {
-      logger.error(`Failed to optimize body for ${roleName}: ${error}`, {
+      logger.error(`Failed to optimize body for ${demand.roleName}: ${error}`, {
         subsystem: "SpawnCoordinator"
       });
       continue;
     }
 
-    // Add request to queue
     const request: SpawnRequest = {
-      id: `${roleName}_${Game.time}_${Math.random().toString(36).substring(2, 11)}`,
+      id: `${demand.roleName}_${Game.time}_${Math.random().toString(36).substring(2, 11)}`,
       roomName: room.name,
-      role: def.role,
-      family: def.family,
+      role: demand.def.role,
+      family: demand.def.family,
       body,
-      priority,
+      priority: demand.priority,
+      targetRoom: demand.targetRoom,
       createdAt: Game.time
     };
-
-    // Add target room for remote roles
-    if (roleName === "remoteHarvester" || roleName === "remoteHauler") {
-      const targetRoom = getRemoteRoomNeedingWorkers(room.name, roleName, swarm);
-      if (targetRoom) {
-        request.targetRoom = targetRoom;
-      }
-    }
 
     spawnQueue.addRequest(request);
   }

--- a/packages/screeps-utils/package.json
+++ b/packages/screeps-utils/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.0.3",
     "@types/screeps": "^3.3.8",
     "chai": "^6.2.2",
     "mocha": "^11.7.5",

--- a/scripts/sync-framework-deps.js
+++ b/scripts/sync-framework-deps.js
@@ -13,8 +13,12 @@
  *   --check    Only check for inconsistencies without modifying files
  */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Helper function to exit with error
 function exitWithError(message) {

--- a/scripts/sync-framework-deps.js
+++ b/scripts/sync-framework-deps.js
@@ -1,66 +1,77 @@
 #!/usr/bin/env node
 /**
  * Framework Package Dependency Synchronization Script
- * 
+ *
  * This script ensures all @ralphschuler/screeps-* framework packages have
  * consistent devDependencies by reading from a shared configuration file
  * and updating all package.json files.
- * 
+ *
  * Usage:
  *   node scripts/sync-framework-deps.js [--check]
- * 
+ *
  * Options:
  *   --check    Only check for inconsistencies without modifying files
  */
 
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Helper function to exit with error
 function exitWithError(message) {
-  console.error('');
-  console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.error('❌ ERROR');
-  console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.error('');
+  console.error("");
+  console.error("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.error("❌ ERROR");
+  console.error("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.error("");
   console.error(message);
-  console.error('');
+  console.error("");
   process.exit(1);
 }
 
 // Load shared dependencies configuration
-const sharedDepsPath = path.join(__dirname, 'shared-dependencies.json');
+const sharedDepsPath = path.join(__dirname, "shared-dependencies.json");
 
 let sharedDepsConfig;
 try {
-  const configContent = fs.readFileSync(sharedDepsPath, 'utf8');
+  const configContent = fs.readFileSync(sharedDepsPath, "utf8");
   sharedDepsConfig = JSON.parse(configContent);
 } catch (error) {
-  if (error.code === 'ENOENT') {
-    exitWithError(`Shared dependencies file not found: ${sharedDepsPath}\nPlease create this file with framework devDependencies.`);
+  if (error.code === "ENOENT") {
+    exitWithError(
+      `Shared dependencies file not found: ${sharedDepsPath}\nPlease create this file with framework devDependencies.`,
+    );
   } else if (error instanceof SyntaxError) {
-    exitWithError(`Invalid JSON in shared dependencies file: ${sharedDepsPath}\n${error.message}`);
+    exitWithError(
+      `Invalid JSON in shared dependencies file: ${sharedDepsPath}\n${error.message}`,
+    );
   } else {
     exitWithError(`Failed to read shared dependencies file: ${error.message}`);
   }
 }
 
-if (!sharedDepsConfig.framework || !sharedDepsConfig.framework.devDependencies) {
-  exitWithError(`Invalid shared dependencies config: ${sharedDepsPath}\nMissing framework.devDependencies property.`);
+if (
+  !sharedDepsConfig.framework ||
+  !sharedDepsConfig.framework.devDependencies
+) {
+  exitWithError(
+    `Invalid shared dependencies config: ${sharedDepsPath}\nMissing framework.devDependencies property.`,
+  );
 }
 
 const sharedDevDeps = sharedDepsConfig.framework.devDependencies;
 
 // Find all framework packages: any package.json under packages/ whose name starts with @ralphschuler/screeps-
 // Excludes MCP packages, server, tasks, and posis which have different dependency requirements
-const packagesDir = path.join(__dirname, '..', 'packages');
+const packagesDir = path.join(__dirname, "..", "packages");
 
 if (!fs.existsSync(packagesDir)) {
-  exitWithError(`Packages directory not found: ${packagesDir}\nExpected directory structure: packages/ containing @ralphschuler/screeps-* packages.`);
+  exitWithError(
+    `Packages directory not found: ${packagesDir}\nExpected directory structure: packages/ containing @ralphschuler/screeps-* packages.`,
+  );
 }
 
 /**
@@ -70,13 +81,13 @@ if (!fs.existsSync(packagesDir)) {
 function findFrameworkPackageJsons(rootDir) {
   const results = [];
   const excludedPackages = [
-    '@ralphschuler/screeps-mcp',
-    '@ralphschuler/screeps-docs-mcp',
-    '@ralphschuler/screeps-wiki-mcp',
-    '@ralphschuler/screeps-typescript-mcp',
-    '@ralphschuler/screeps-server',
-    '@ralphschuler/screeps-tasks',
-    '@ralphschuler/screeps-posis'
+    "@ralphschuler/screeps-mcp",
+    "@ralphschuler/screeps-docs-mcp",
+    "@ralphschuler/screeps-wiki-mcp",
+    "@ralphschuler/screeps-typescript-mcp",
+    "@ralphschuler/screeps-server",
+    "@ralphschuler/screeps-tasks",
+    "@ralphschuler/screeps-posis",
   ];
 
   function walk(dir) {
@@ -92,19 +103,19 @@ function findFrameworkPackageJsons(rootDir) {
       const fullPath = path.join(dir, entry.name);
 
       // Skip node_modules directories
-      if (entry.isDirectory() && entry.name === 'node_modules') {
+      if (entry.isDirectory() && entry.name === "node_modules") {
         continue;
       }
 
       if (entry.isDirectory()) {
         walk(fullPath);
-      } else if (entry.isFile() && entry.name === 'package.json') {
+      } else if (entry.isFile() && entry.name === "package.json") {
         try {
-          const pkgContent = fs.readFileSync(fullPath, 'utf8');
+          const pkgContent = fs.readFileSync(fullPath, "utf8");
           const pkgJson = JSON.parse(pkgContent);
           if (
-            typeof pkgJson.name === 'string' &&
-            pkgJson.name.startsWith('@ralphschuler/screeps-') &&
+            typeof pkgJson.name === "string" &&
+            pkgJson.name.startsWith("@ralphschuler/screeps-") &&
             !excludedPackages.includes(pkgJson.name)
           ) {
             results.push(fullPath);
@@ -128,27 +139,29 @@ try {
 }
 
 if (packageDirs.length === 0) {
-  exitWithError(`No framework packages found in: ${packagesDir}\nExpected at least one package with name starting with @ralphschuler/screeps-.`);
+  exitWithError(
+    `No framework packages found in: ${packagesDir}\nExpected at least one package with name starting with @ralphschuler/screeps-.`,
+  );
 }
 
 // Check if running in check-only mode
-const checkOnly = process.argv.includes('--check');
+const checkOnly = process.argv.includes("--check");
 
 let hasInconsistencies = false;
 let updatedCount = 0;
 
-console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-console.log('Framework Package Dependency Synchronization');
-console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-console.log('');
-console.log(`Mode: ${checkOnly ? 'CHECK ONLY' : 'SYNC'}`);
+console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+console.log("Framework Package Dependency Synchronization");
+console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+console.log("");
+console.log(`Mode: ${checkOnly ? "CHECK ONLY" : "SYNC"}`);
 console.log(`Found ${packageDirs.length} framework packages`);
-console.log('');
+console.log("");
 
-packageDirs.forEach(pkgPath => {
+packageDirs.forEach((pkgPath) => {
   let pkg;
   try {
-    const pkgContent = fs.readFileSync(pkgPath, 'utf8');
+    const pkgContent = fs.readFileSync(pkgPath, "utf8");
     pkg = JSON.parse(pkgContent);
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -158,29 +171,31 @@ packageDirs.forEach(pkgPath => {
     }
     return;
   }
-  
+
   const packageName = pkg.name;
   const relativePath = path.relative(process.cwd(), pkgPath);
-  
+
   // Initialize devDependencies if it doesn't exist
   if (!pkg.devDependencies) {
     pkg.devDependencies = {};
   }
-  
+
   // Check for inconsistencies
   const inconsistencies = [];
-  
+
   // Check for missing or outdated shared dependencies
   for (const [depName, depVersion] of Object.entries(sharedDevDeps)) {
     const currentVersion = pkg.devDependencies[depName];
-    
+
     if (!currentVersion) {
       inconsistencies.push(`  + ${depName}: ${depVersion} (missing)`);
     } else if (currentVersion !== depVersion) {
-      inconsistencies.push(`  ~ ${depName}: ${currentVersion} → ${depVersion} (outdated)`);
+      inconsistencies.push(
+        `  ~ ${depName}: ${currentVersion} → ${depVersion} (outdated)`,
+      );
     }
   }
-  
+
   // Check for dependencies that are in package but not in shared config
   // These might be package-specific dependencies or removed shared dependencies
   const sharedDepNames = Object.keys(sharedDevDeps);
@@ -190,14 +205,14 @@ packageDirs.forEach(pkgPath => {
       // We don't flag this as an inconsistency since we preserve package-specific deps
     }
   }
-  
+
   if (inconsistencies.length > 0) {
     hasInconsistencies = true;
     console.log(`📦 ${packageName}`);
     console.log(`   ${relativePath}`);
-    inconsistencies.forEach(msg => console.log(msg));
-    console.log('');
-    
+    inconsistencies.forEach((msg) => console.log(msg));
+    console.log("");
+
     if (!checkOnly) {
       // Merge shared devDependencies (preserving package-specific deps)
       // Note: If a dependency is removed from shared-dependencies.json,
@@ -206,53 +221,55 @@ packageDirs.forEach(pkgPath => {
       // or modify this script to track and remove explicitly removed dependencies.
       pkg.devDependencies = {
         ...pkg.devDependencies,
-        ...sharedDevDeps
+        ...sharedDevDeps,
       };
-      
+
       // Sort devDependencies alphabetically for consistency
       const sortedDevDeps = {};
-      Object.keys(pkg.devDependencies).sort().forEach(key => {
-        sortedDevDeps[key] = pkg.devDependencies[key];
-      });
+      Object.keys(pkg.devDependencies)
+        .sort()
+        .forEach((key) => {
+          sortedDevDeps[key] = pkg.devDependencies[key];
+        });
       pkg.devDependencies = sortedDevDeps;
-      
+
       // Write back to file with consistent formatting
       try {
-        fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+        fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
         updatedCount++;
         console.log(`   ✅ Updated`);
-        console.log('');
+        console.log("");
       } catch (error) {
         console.error(`   ❌ Failed to write: ${error.message}`);
-        console.error('');
+        console.error("");
       }
     }
   }
 });
 
-console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-console.log('Summary');
-console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-console.log('');
+console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+console.log("Summary");
+console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+console.log("");
 
 if (checkOnly) {
   if (hasInconsistencies) {
-    console.log('❌ FAIL: Found dependency inconsistencies');
-    console.log('');
-    console.log('Run `npm run sync:deps` to synchronize all packages');
+    console.log("❌ FAIL: Found dependency inconsistencies");
+    console.log("");
+    console.log("Run `npm run sync:deps` to synchronize all packages");
     process.exit(1);
   } else {
-    console.log('✅ PASS: All framework packages have consistent dependencies');
+    console.log("✅ PASS: All framework packages have consistent dependencies");
   }
 } else {
   if (updatedCount > 0) {
     console.log(`✨ Synchronized ${updatedCount} framework packages`);
-    console.log('');
-    console.log('All packages now have consistent devDependencies from:');
+    console.log("");
+    console.log("All packages now have consistent devDependencies from:");
     console.log(`   ${sharedDepsPath}`);
   } else {
-    console.log('✅ All packages already synchronized');
+    console.log("✅ All packages already synchronized");
   }
 }
 
-console.log('');
+console.log("");


### PR DESCRIPTION
## Summary

Fix task-board scheduler regressions that made the bot less stable after task-based creep scheduling: upgraders were rarely upgrading and new harvesters could all select the same source.

## Changes

- Restore role-specific economy behavior dispatch so the task board no longer globally intercepts every economy creep action.
- Keep task-board assignment at explicit delivery seams instead of overriding specialized roles like upgraders.
- Make harvester source lookup return only an existing memory assignment, allowing the harvester balancing code to choose new assignments.
- Update same-tick source assignment counts after assigning a harvester so new harvesters spread across sources.
- Add behavior-level regression coverage for upgrader and harvester assignment regressions.

## Validation

- `npm test -w @ralphschuler/screeps-roles` — pass, 20 tests
- `npm run build -w @ralphschuler/screeps-roles` — pass
- `npm run lint:roles` — pass
- `grep -R "\\[DEBUG-" packages/@ralphschuler/screeps-roles/src packages/@ralphschuler/screeps-roles/test || true` — no debug probes

## Risks/Rollback

- Risk: task-board generic work assignment is no longer applied before every economy role. Intended rollback is to revert this commit if role dispatch must be globally task-driven again.
- Unrelated dirty files in the working tree were intentionally excluded from this commit/PR update.

## Related Issues

- None linked.

## Conversation Context

User reported that after implementing a task-based creep scheduler, the system became less stable: upgrades were rare and one of two energy sources was unused. Systematic debugging reproduced both symptoms with regression tests, then fixed the task-board interception and source assignment root causes.
