### PR TITLE
chore: fix Dependabot Docker package directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,7 @@ updates:
 
   # Docker images
   - package-ecosystem: "docker"
-    directory: "/packages/screeps-grafana-exporter"
+    directory: "/packages/screeps-graphite-exporter"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
@@ -82,7 +82,7 @@ updates:
     open-pull-requests-limit: 1
 
   - package-ecosystem: "docker"
-    directory: "/packages/screeps-types-mcp"
+    directory: "/packages/screeps-typescript-mcp"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

Fix stale Dependabot Docker package directories so dependency scans target existing packages.

## Changes

- Replace `/packages/screeps-grafana-exporter` with existing `/packages/screeps-graphite-exporter`.
- Replace `/packages/screeps-types-mcp` with existing `/packages/screeps-typescript-mcp`.

## Validation

- Verified target package directories exist in the repository.
- Config-only change; no runtime tests run.

## Risks/Rollback

- Low risk. Revert this commit if Dependabot should stop scanning those Dockerfiles.

## Related Issues

- None.

## Conversation Context

While auditing open Dependabot PRs, the Docker update configuration was found to reference stale package directories. This PR updates the configuration to the current package names.
