### PR TITLE
fix: harden console command and utility edge cases

### DIFF
--- a/packages/@ralphschuler/screeps-layouts/src/blueprints/constants.ts
+++ b/packages/@ralphschuler/screeps-layouts/src/blueprints/constants.ts
@@ -6,6 +6,8 @@
  * Get structure limits per RCL
  */
 export function getStructureLimits(rcl: number): Record<BuildableStructureConstant, number> {
+  const finiteRcl = Number.isFinite(rcl) ? rcl : 1;
+  const normalizedRcl = Math.min(8, Math.max(1, Math.floor(finiteRcl)));
   const limits: Record<number, Partial<Record<BuildableStructureConstant, number>>> = {
     1: { spawn: 1, extension: 0, road: 2500, constructedWall: 0 },
     2: { spawn: 1, extension: 5, road: 2500, constructedWall: 2500, rampart: 2500, container: 5 },
@@ -80,5 +82,5 @@ export function getStructureLimits(rcl: number): Record<BuildableStructureConsta
     }
   };
 
-  return (limits[rcl] ?? limits[1]) as Record<BuildableStructureConstant, number>;
+  return limits[normalizedRcl] as Record<BuildableStructureConstant, number>;
 }

--- a/packages/@ralphschuler/screeps-layouts/test/blueprintSelector.test.ts
+++ b/packages/@ralphschuler/screeps-layouts/test/blueprintSelector.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+
+describe("Blueprint selector", () => {
+  before(() => {
+    Object.assign(globalThis, {
+      STRUCTURE_EXTENSION: "extension",
+      STRUCTURE_SPAWN: "spawn",
+      STRUCTURE_ROAD: "road",
+      STRUCTURE_TOWER: "tower",
+      STRUCTURE_STORAGE: "storage",
+      STRUCTURE_TERMINAL: "terminal",
+      STRUCTURE_FACTORY: "factory",
+      STRUCTURE_LAB: "lab",
+      STRUCTURE_NUKER: "nuker",
+      STRUCTURE_OBSERVER: "observer",
+      STRUCTURE_POWER_SPAWN: "powerSpawn",
+      STRUCTURE_LINK: "link",
+      STRUCTURE_RAMPART: "rampart"
+    });
+  });
+
+  it("clamps invalid high RCL values to RCL 8 structure limits", async () => {
+    const { getStructuresForRCL } = await import("../src/blueprints/selector.ts");
+    const { EARLY_COLONY_BLUEPRINT } = await import("../src/blueprints/definitions/early-colony.ts");
+
+    const structures = getStructuresForRCL(EARLY_COLONY_BLUEPRINT, 9);
+
+    expect(structures.filter(s => s.structureType === "extension")).to.have.length(60);
+    expect(structures.filter(s => s.structureType === "spawn")).to.have.length(1);
+  });
+
+  it("clamps invalid low RCL values to RCL 1 structure limits", async () => {
+    const { getStructuresForRCL } = await import("../src/blueprints/selector.ts");
+    const { EARLY_COLONY_BLUEPRINT } = await import("../src/blueprints/definitions/early-colony.ts");
+
+    const structures = getStructuresForRCL(EARLY_COLONY_BLUEPRINT, 0);
+
+    expect(structures.filter(s => s.structureType === "extension")).to.have.length(0);
+    expect(structures.filter(s => s.structureType === "spawn")).to.have.length(1);
+  });
+
+  it("treats non-finite RCL values as RCL 1 structure limits", async () => {
+    const { getStructuresForRCL } = await import("../src/blueprints/selector.ts");
+    const { EARLY_COLONY_BLUEPRINT } = await import("../src/blueprints/definitions/early-colony.ts");
+
+    const structures = getStructuresForRCL(EARLY_COLONY_BLUEPRINT, Number.NaN);
+
+    expect(structures.filter(s => s.structureType === "extension")).to.have.length(0);
+    expect(structures.filter(s => s.structureType === "spawn")).to.have.length(1);
+  });
+});

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/actionExecutionPolicy.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/actionExecutionPolicy.ts
@@ -21,7 +21,8 @@ export function shouldClearStateForActionResult(
   return (
     result === ERR_FULL ||
     result === ERR_NOT_ENOUGH_RESOURCES ||
-    result === ERR_INVALID_TARGET
+    result === ERR_INVALID_TARGET ||
+    result === ERR_NO_BODYPART
   );
 }
 

--- a/packages/@ralphschuler/screeps-roles/test/actionExecutionPolicy.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/actionExecutionPolicy.test.ts
@@ -13,6 +13,7 @@ describe("Action Execution Policy", () => {
       true,
     );
     expect(shouldClearStateForActionResult(ERR_INVALID_TARGET)).to.equal(true);
+    expect(shouldClearStateForActionResult(ERR_NO_BODYPART)).to.equal(true);
   });
 
   it("should retain state for successful and retryable action results", () => {

--- a/packages/screeps-bot/src/core/uiCommands.ts
+++ b/packages/screeps-bot/src/core/uiCommands.ts
@@ -38,6 +38,7 @@ export class UICommands {
     if (!room) {
       return colorful(`Room ${roomName} not found or not visible`, "red", true);
     }
+    const roomNameLiteral = JSON.stringify(roomName);
 
     return createElement.form(
       "spawnCreep",
@@ -65,7 +66,7 @@ export class UICommands {
       {
         content: "Spawn Creep",
         command: `({role, name}) => {
-        const room = Game.rooms['${roomName}'];
+        const room = Game.rooms[${roomNameLiteral}];
         if (!room) return 'Room not found';
         const spawns = room.find(FIND_MY_SPAWNS);
         if (spawns.length === 0) return 'No spawns found';
@@ -91,6 +92,7 @@ export class UICommands {
     if (!room) {
       return colorful(`Room ${roomName} not found or not visible`, "red", true);
     }
+    const roomNameLiteral = JSON.stringify(roomName);
 
     let html = `<div style="background: #2b2b2b; padding: 10px; margin: 5px;">`;
     html += `<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: ${roomName}</h3>`;
@@ -122,11 +124,11 @@ export class UICommands {
     html += createElement.button({
       content: "📊 Room Stats",
       command: `() => {
-        const room = Game.rooms['${roomName}'];
+        const room = Game.rooms[${roomNameLiteral}];
         if (!room) return 'Room not found';
         let stats = '=== Room Stats ===\\n';
         stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';
-        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === '${roomName}').length + '\\n';
+        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ${roomNameLiteral}).length + '\\n';
         if (room.controller) {
           stats += 'RCL: ' + room.controller.level + '\\n';
           stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';

--- a/packages/screeps-bot/test/unit/uiCommands.test.ts
+++ b/packages/screeps-bot/test/unit/uiCommands.test.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+import { UICommands } from "../../src/core/uiCommands";
+
+describe("UICommands", () => {
+  beforeEach(() => {
+    (global as any).Game = {
+      time: 1234,
+      rooms: {},
+      creeps: {}
+    };
+  });
+
+  it("escapes room names embedded in spawn form commands", () => {
+    const roomName = "W1N1']; return 'owned'; //";
+    (global as any).Game.rooms[roomName] = {
+      find: () => [],
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    };
+
+    const output = new UICommands().spawnForm(roomName);
+
+    const escapedRoomLiteral = JSON.stringify(roomName).replace(/"/g, "&quot;");
+
+    expect(output).to.include(escapedRoomLiteral);
+    expect(output).to.not.include(`Game.rooms['${roomName}']`);
+  });
+});

--- a/packages/screeps-server/scripts/private-server-harness.js
+++ b/packages/screeps-server/scripts/private-server-harness.js
@@ -397,11 +397,14 @@ async function writeSummary(options, summary, status) {
   );
 }
 
+export function createPollingDeadline(options, now = Date.now()) {
+  return now + options.durationMinutes * 60 * 1000;
+}
+
 export async function runPrivateServerTest(options = parseHarnessArgs()) {
   fs.mkdirSync(options.artifactsDir, { recursive: true });
   const summary = createInitialSummary(options);
   const log = createLogger(options);
-  const endAt = Date.now() + options.durationMinutes * 60 * 1000;
 
   try {
     await runShell("npm", ["run", "build:mod"], options, log, {
@@ -418,6 +421,7 @@ export async function runPrivateServerTest(options = parseHarnessArgs()) {
     const api = await createApi(options, summary);
     await uploadBot(options, summary, api);
 
+    const endAt = createPollingDeadline(options);
     let polls = 0;
     while (Date.now() < endAt && polls < options.maxTicks) {
       await queueInlineAssertions(options, summary, api);

--- a/packages/screeps-server/test/scripts/private-server-harness.test.ts
+++ b/packages/screeps-server/test/scripts/private-server-harness.test.ts
@@ -3,6 +3,7 @@ import zlib from "node:zlib";
 import {
   buildEnsureBotUserCommand,
   createInitialSummary,
+  createPollingDeadline,
   decodeMemoryData,
   inspectMemorySnapshot,
   parseHarnessArgs,
@@ -65,6 +66,15 @@ describe("private-server harness module", () => {
     expect(summary.checks).to.deep.equal({});
     expect(summary.metrics).to.deep.equal({});
     expect(summary.errors).to.deep.equal([]);
+  });
+
+  it("starts the polling deadline after server setup finishes", () => {
+    const options = parseHarnessArgs(["--durationMinutes=5"], {});
+    const setupFinishedAt = new Date("2026-05-09T00:10:00.000Z").getTime();
+
+    expect(createPollingDeadline(options, setupFinishedAt)).to.equal(
+      new Date("2026-05-09T00:15:00.000Z").getTime(),
+    );
   });
 
   it("decodes plain, object, empty, and gzipped Memory payloads", () => {

--- a/packages/screeps-utils/src/console/ui.ts
+++ b/packages/screeps-utils/src/console/ui.ts
@@ -56,8 +56,16 @@ export function createLink(content: string, url: string, newTab: boolean = true)
  * @param command - The command to execute in the console
  * @returns JavaScript code to execute the command
  */
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function sendCommandToConsole(command: string): string {
-  return `angular.element(document.body).injector().get('Console').sendCommand('(${command})()', 1)`;
+  return `angular.element(document.body).injector().get('Console').sendCommand(${JSON.stringify(`(${command})()`)}, 1)`;
 }
 
 /**
@@ -161,7 +169,7 @@ export const createElement = {
    * @returns HTML button element
    */
   button(detail: ButtonDetail): string {
-    return `<button onclick="${sendCommandToConsole(detail.command)}">${detail.content}</button>`;
+    return `<button onclick="${escapeHtmlAttribute(sendCommandToConsole(detail.command))}">${detail.content}</button>`;
   },
 
   /**
@@ -207,7 +215,7 @@ export const createElement = {
     })()`;
 
     // Add submit button
-    parts.push(`<button type="button" onclick="${commandWrap.replace(/\n/g, ';')}">${buttonDetail.content}</button>`);
+    parts.push(`<button type="button" onclick="${escapeHtmlAttribute(commandWrap.replace(/\n/g, ';'))}">${buttonDetail.content}</button>`);
     parts.push(`</form>`);
 
     // Compress to single line

--- a/packages/screeps-utils/src/optimization/cpuEfficiency.ts
+++ b/packages/screeps-utils/src/optimization/cpuEfficiency.ts
@@ -2,12 +2,18 @@
  * CPU efficiency utilities with throttled execution and lazy evaluation.
  */
 
+/** Normalize throttle intervals to avoid modulo edge cases. */
+function normalizeInterval(interval: number): number {
+  if (!Number.isFinite(interval) || interval < 1) return 1;
+  return Math.floor(interval);
+}
+
 /**
  * Execute a function only every N ticks.
  * @param offset - Optional offset to spread load across ticks
  */
 export function throttle<T>(fn: () => T, interval: number, offset = 0): T | undefined {
-  if ((Game.time + offset) % interval === 0) {
+  if ((Game.time + offset) % normalizeInterval(interval) === 0) {
     return fn();
   }
   return undefined;
@@ -20,7 +26,7 @@ export function throttleWithDefault<T>(
   defaultValue: T,
   offset = 0
 ): T {
-  if ((Game.time + offset) % interval === 0) {
+  if ((Game.time + offset) % normalizeInterval(interval) === 0) {
     return fn();
   }
   return defaultValue;

--- a/packages/screeps-utils/test/console/ui.test.ts
+++ b/packages/screeps-utils/test/console/ui.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { createElement } from "../../src/console/ui.ts";
+
+describe("Console UI helpers", () => {
+  beforeEach(() => {
+    (globalThis as { Game?: { time: number } }).Game = { time: 1234 };
+  });
+
+  it("escapes button onclick command attributes while preserving executable command text", () => {
+    const command = `() => Game.rooms["W1N1"].name + ' ok'`;
+
+    const html = createElement.button({ content: "Run", command });
+
+    expect(html).to.include("\\&quot;W1N1\\&quot;");
+    expect(html).to.include("' ok'");
+    expect(html).to.not.include('Game.rooms["W1N1"]');
+  });
+
+  it("escapes form onclick attributes generated from command wrappers", () => {
+    const html = createElement.form(
+      "testForm",
+      [{ type: "input", name: "name", label: "Name" }],
+      { content: "Submit", command: `({name}) => "hello " + name` }
+    );
+
+    expect(html).to.include("onclick=");
+    expect(html).to.include("&quot;hello &quot;");
+    expect(html).to.not.include('({name}) => "hello " + name');
+  });
+});

--- a/packages/screeps-utils/test/optimization/cpuEfficiency.test.ts
+++ b/packages/screeps-utils/test/optimization/cpuEfficiency.test.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { throttle, throttleWithDefault } from "../../src/optimization/cpuEfficiency.ts";
+
+describe("CPU efficiency utilities", () => {
+  beforeEach(() => {
+    (globalThis as { Game?: { time: number } }).Game = { time: 7 };
+  });
+
+  it("treats non-positive throttle intervals as every tick", () => {
+    let calls = 0;
+
+    const result = throttle(() => {
+      calls++;
+      return "ran";
+    }, 0);
+
+    expect(result).to.equal("ran");
+    expect(calls).to.equal(1);
+  });
+
+  it("treats non-finite throttle intervals as every tick", () => {
+    let calls = 0;
+
+    const result = throttleWithDefault(() => {
+      calls++;
+      return "ran";
+    }, Number.NaN, "default");
+
+    expect(result).to.equal("ran");
+    expect(calls).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary

Harden console command generation and utility edge cases found during the bounded `/loop` workflow.

## Changes

- Escape generated console `onclick` command attributes and use JSON command strings for safer Screeps console controls.
- Embed room names as JavaScript string literals in UI commands to avoid malformed commands for quote-containing room keys.
- Clamp layout RCL limit lookup to finite Screeps RCL range `1..8`.
- Normalize invalid throttle intervals to one tick to avoid modulo `0`/`NaN` skip bugs.
- Clear action execution state when `ERR_NO_BODYPART` makes a retained target impossible.
- Add regression tests for each hardening slice.

## Validation

- `npm test -w @ralphschuler/screeps-utils -- --grep "Console UI|CPU efficiency"` → 4 passing
- `npm test -w @ralphschuler/screeps-layouts -- --grep "Blueprint selector"` → 3 passing
- `npm test -w @ralphschuler/screeps-roles -- --grep "Action Execution Policy"` → 4 passing
- `npm run test:unit -w screeps-typescript-starter -- --grep "UICommands"` → 1 passing

## Risks/Rollback

Low-risk isolated hardening. Roll back by reverting commit `1bb3caa`.

## Related Issues

None.

## Conversation Context

Created from bounded `/loop` hardening work. A reviewer pass found an HTML attribute escaping regression risk in UI command hardening; fixed before force-updating this PR branch onto `origin/main` to resolve merge conflicts.
