### PR TITLE
[codex] Detect global heap switches

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -9,6 +9,7 @@ Operate the bot with CPU, bucket, spawn health, room survival, and error rate as
 - Grafana dashboards linked from the root README when available.
 - Private-server artifacts under `packages/screeps-server/artifacts/<mode>/`.
 - GitHub Actions validation artifacts for duplication, complexity, coverage, and smoke tests.
+- [Global runtime diagnostics](global-runtime-diagnostics.md) for global resets and stale heap switches.
 
 ## Key health checks
 
@@ -56,6 +57,7 @@ Treat these as failures: no tick progression, bot upload failure, missing test m
 - **Deploy says credentials valid but no upload:** confirm `DEPLOY=true` path via `npm run push`, not `npm run build`.
 - **Private-server ports busy:** harness auto-selects alternate ports; stale containers can be stopped with server package scripts.
 - **Global reset loop:** inspect first thrown error in console/harness logs, then add a regression test around initialization.
+- **Global heap switch:** check `Memory.runtimeDiagnostics.global.switchCount`; repeated increments mean heap globals may be stale.
 - **Bucket drain:** disable expensive visuals/planning first, then profile process metrics and hot path pathfinding.
 - **Allied target risk:** use shared alliance helpers from core/defense and add tests for `TooAngel`/`TedRoastBeef`.
 

--- a/docs/operations/global-runtime-diagnostics.md
+++ b/docs/operations/global-runtime-diagnostics.md
@@ -1,0 +1,33 @@
+# Global runtime diagnostics
+
+The bot records lightweight diagnostics for Screeps global resets and stale heap switches.
+
+## Why this exists
+
+Screeps normally runs consecutive ticks in the same JavaScript heap until a global reset. During server instability, the runtime can also alternate between older heaps. A stale heap switch means global variables may contain values from several ticks ago.
+
+## Runtime behavior
+
+`packages/screeps-bot/src/core/globalRuntimeDiagnostics.ts` runs at the top of `main.loop`.
+
+It records:
+
+- `Memory.__globalResetCount` — backward-compatible reset counter used by private-server runtime assertions.
+- `Memory.runtimeDiagnostics.global.resetCount` — number of observed new heaps/global resets.
+- `Memory.runtimeDiagnostics.global.switchCount` — number of observed stale heap switches.
+- `Memory.runtimeDiagnostics.global.lastTick` — last tick observed by diagnostics.
+- `Memory.runtimeDiagnostics.global.lastResetTick` — last new-heap tick.
+- `Memory.runtimeDiagnostics.global.lastSwitchTick` — last detected stale-heap tick.
+- `Memory.runtimeDiagnostics.global.lastSwitchPreviousTick` — stale heap's previous tick marker.
+
+Global switches are logged with throttling. The diagnostic does not clear heap state or skip ticks; it only makes the condition visible.
+
+## Triage
+
+Investigate when:
+
+- `switchCount` increases repeatedly.
+- `__globalResetCount` climbs quickly in private-server smoke or live stats.
+- Console logs show `Global heap switch detected` near runtime anomalies.
+
+Use this signal before enabling any Memory/RawMemory hack that relies on heap continuity.

--- a/packages/screeps-bot/src/core/globalRuntimeDiagnostics.ts
+++ b/packages/screeps-bot/src/core/globalRuntimeDiagnostics.ts
@@ -1,0 +1,225 @@
+/**
+ * Detect Screeps global resets and stale heap switches.
+ *
+ * Screeps can occasionally alternate between more than one VM heap for the same
+ * shard. Heap/global state then appears to jump backwards relative to Game.time.
+ * This diagnostic keeps a tiny per-heap tick marker and compact Memory counters
+ * so the bot can observe the condition without clearing heap state or skipping
+ * ticks.
+ */
+
+const GLOBAL_STATE_KEY = "__screepsGlobalRuntimeDiagnostics";
+const DEFAULT_SWITCH_LOG_THROTTLE_TICKS = 100;
+
+export interface GlobalRuntimeDiagnosticsMemory {
+  heapId: string;
+  resetCount: number;
+  switchCount: number;
+  lastTick: number;
+  lastResetTick: number;
+  lastSwitchTick?: number;
+  lastSwitchPreviousTick?: number;
+  lastWarningTick?: number;
+}
+
+interface GlobalRuntimeState {
+  heapId: string;
+  lastTick: number;
+}
+
+interface GlobalRuntimeStateOwner {
+  [GLOBAL_STATE_KEY]?: GlobalRuntimeState;
+}
+
+export interface GlobalRuntimeDiagnosticsLogger {
+  info(message: string, context?: unknown): void;
+  warn(message: string, context?: unknown): void;
+}
+
+export type GlobalRuntimeDiagnosticsEventType = "reset" | "switch" | "steady";
+
+export interface GlobalRuntimeDiagnosticsEvent {
+  type: GlobalRuntimeDiagnosticsEventType;
+  heapId: string;
+  currentTick: number;
+  previousTick?: number;
+  resetCount: number;
+  switchCount: number;
+}
+
+export interface GlobalRuntimeDiagnosticsOptions {
+  logger?: GlobalRuntimeDiagnosticsLogger;
+  createHeapId?: () => string;
+  switchLogThrottleTicks?: number;
+}
+
+declare global {
+  interface Memory {
+    /** Backward-compatible counter consumed by private-server runtime assertions. */
+    __globalResetCount?: number;
+    /** Compact diagnostics for global resets and stale heap switches. */
+    runtimeDiagnostics?: {
+      global?: GlobalRuntimeDiagnosticsMemory;
+    };
+  }
+}
+
+function getGlobalStateOwner(): GlobalRuntimeStateOwner {
+  return globalThis as GlobalRuntimeStateOwner;
+}
+
+function createDefaultHeapId(): string {
+  const shardName = typeof Game.shard?.name === "string" ? Game.shard.name : "shard";
+  const randomPart = Math.floor(Math.random() * 0xffffffff).toString(16).padStart(8, "0");
+  return `${shardName}:${Game.time}:${randomPart}`;
+}
+
+function asNonNegativeFiniteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function asFiniteTick(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asOptionalFiniteTick(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function ensureDiagnosticsMemory(heapId: string): GlobalRuntimeDiagnosticsMemory {
+  Memory.runtimeDiagnostics ??= {};
+
+  const existing = Memory.runtimeDiagnostics.global as Partial<GlobalRuntimeDiagnosticsMemory> | undefined;
+  if (existing && typeof existing === "object") {
+    const normalized: GlobalRuntimeDiagnosticsMemory = {
+      heapId: typeof existing.heapId === "string" && existing.heapId.length > 0 ? existing.heapId : heapId,
+      resetCount: asNonNegativeFiniteNumber(existing.resetCount, Math.max(0, Memory.__globalResetCount ?? 0)),
+      switchCount: asNonNegativeFiniteNumber(existing.switchCount, 0),
+      lastTick: asFiniteTick(existing.lastTick, Game.time),
+      lastResetTick: asFiniteTick(existing.lastResetTick, Game.time),
+      lastSwitchTick: asOptionalFiniteTick(existing.lastSwitchTick),
+      lastSwitchPreviousTick: asOptionalFiniteTick(existing.lastSwitchPreviousTick),
+      lastWarningTick: asOptionalFiniteTick(existing.lastWarningTick)
+    };
+
+    Memory.runtimeDiagnostics.global = normalized;
+    return normalized;
+  }
+
+  const resetCount = Math.max(0, Memory.__globalResetCount ?? 0);
+  const diagnostics: GlobalRuntimeDiagnosticsMemory = {
+    heapId,
+    resetCount,
+    switchCount: 0,
+    lastTick: Game.time,
+    lastResetTick: Game.time
+  };
+
+  Memory.runtimeDiagnostics.global = diagnostics;
+  return diagnostics;
+}
+
+function recordReset(heapId: string, logger?: GlobalRuntimeDiagnosticsLogger): GlobalRuntimeDiagnosticsEvent {
+  const diagnostics = ensureDiagnosticsMemory(heapId);
+  const nextResetCount = Math.max(diagnostics.resetCount, Memory.__globalResetCount ?? 0) + 1;
+
+  diagnostics.heapId = heapId;
+  diagnostics.resetCount = nextResetCount;
+  diagnostics.lastResetTick = Game.time;
+  diagnostics.lastTick = Game.time;
+  Memory.__globalResetCount = nextResetCount;
+
+  logger?.info("Global reset detected", {
+    meta: {
+      heapId,
+      resetCount: nextResetCount,
+      tick: Game.time
+    }
+  });
+
+  return {
+    type: "reset",
+    heapId,
+    currentTick: Game.time,
+    resetCount: nextResetCount,
+    switchCount: diagnostics.switchCount
+  };
+}
+
+function recordSwitch(
+  state: GlobalRuntimeState,
+  previousTick: number,
+  logger: GlobalRuntimeDiagnosticsLogger | undefined,
+  throttleTicks: number
+): GlobalRuntimeDiagnosticsEvent {
+  const diagnostics = ensureDiagnosticsMemory(state.heapId);
+  diagnostics.switchCount += 1;
+  diagnostics.heapId = state.heapId;
+  diagnostics.lastSwitchTick = Game.time;
+  diagnostics.lastSwitchPreviousTick = previousTick;
+  diagnostics.lastTick = Game.time;
+
+  const lastWarningTick = diagnostics.lastWarningTick ?? -Infinity;
+  if (Game.time - lastWarningTick >= throttleTicks) {
+    diagnostics.lastWarningTick = Game.time;
+    logger?.warn("Global heap switch detected", {
+      meta: {
+        heapId: state.heapId,
+        previousTick,
+        currentTick: Game.time,
+        skippedTicks: Math.max(0, Game.time - previousTick - 1),
+        switchCount: diagnostics.switchCount
+      }
+    });
+  }
+
+  return {
+    type: "switch",
+    heapId: state.heapId,
+    currentTick: Game.time,
+    previousTick,
+    resetCount: diagnostics.resetCount,
+    switchCount: diagnostics.switchCount
+  };
+}
+
+export function resetGlobalRuntimeDiagnosticsForTests(): void {
+  delete getGlobalStateOwner()[GLOBAL_STATE_KEY];
+}
+
+export function runGlobalRuntimeDiagnostics(options: GlobalRuntimeDiagnosticsOptions = {}): GlobalRuntimeDiagnosticsEvent {
+  const owner = getGlobalStateOwner();
+  const createHeapId = options.createHeapId ?? createDefaultHeapId;
+  const throttleTicks = options.switchLogThrottleTicks ?? DEFAULT_SWITCH_LOG_THROTTLE_TICKS;
+  let state = owner[GLOBAL_STATE_KEY];
+
+  if (!state) {
+    state = {
+      heapId: createHeapId(),
+      lastTick: Game.time
+    };
+    owner[GLOBAL_STATE_KEY] = state;
+    return recordReset(state.heapId, options.logger);
+  }
+
+  const previousTick = state.lastTick;
+  state.lastTick = Game.time;
+
+  if (previousTick + 1 !== Game.time) {
+    return recordSwitch(state, previousTick, options.logger, throttleTicks);
+  }
+
+  const diagnostics = ensureDiagnosticsMemory(state.heapId);
+  diagnostics.heapId = state.heapId;
+  diagnostics.lastTick = Game.time;
+  Memory.__globalResetCount = Math.max(Memory.__globalResetCount ?? 0, diagnostics.resetCount);
+
+  return {
+    type: "steady",
+    heapId: state.heapId,
+    currentTick: Game.time,
+    previousTick,
+    resetCount: diagnostics.resetCount,
+    switchCount: diagnostics.switchCount
+  };
+}

--- a/packages/screeps-bot/src/main.ts
+++ b/packages/screeps-bot/src/main.ts
@@ -1,6 +1,7 @@
 import "./visuals/roomVisualExtensions";
 import { getConfig } from "./config";
 import { registerAllConsoleCommands } from "./core/consoleCommands";
+import { runGlobalRuntimeDiagnostics } from "./core/globalRuntimeDiagnostics";
 import { createLogger } from "./core/logger";
 import { loop as swarmLoop } from "./SwarmBot";
 
@@ -146,6 +147,7 @@ registerAllConsoleCommands(config.lazyLoadConsoleCommands);
 
 export const loop = (): void => {
   try {
+    runGlobalRuntimeDiagnostics({ logger });
     swarmLoop();
   } catch (error) {
     logger.error(`Critical error in main loop: ${String(error)}`, {

--- a/packages/screeps-bot/test/unit/globalRuntimeDiagnostics.test.ts
+++ b/packages/screeps-bot/test/unit/globalRuntimeDiagnostics.test.ts
@@ -1,0 +1,176 @@
+import { assert } from "chai";
+import {
+  resetGlobalRuntimeDiagnosticsForTests,
+  runGlobalRuntimeDiagnostics
+} from "../../src/core/globalRuntimeDiagnostics";
+
+function setTick(tick: number): void {
+  (global as any).Game.time = tick;
+}
+
+function createLoggerSpy() {
+  const infoMessages: unknown[] = [];
+  const warnMessages: unknown[] = [];
+  return {
+    infoMessages,
+    warnMessages,
+    logger: {
+      info: (message: string, context?: unknown) => infoMessages.push({ message, context }),
+      warn: (message: string, context?: unknown) => warnMessages.push({ message, context })
+    }
+  };
+}
+
+describe("global runtime diagnostics", () => {
+  let previousGame: unknown;
+  let previousMemory: unknown;
+
+  beforeEach(() => {
+    previousGame = (global as any).Game;
+    previousMemory = (global as any).Memory;
+    resetGlobalRuntimeDiagnosticsForTests();
+    (global as any).Game = {
+      ...(previousGame as Record<string, unknown>),
+      time: 100,
+      shard: { name: "shard0" }
+    };
+    (global as any).Memory = {};
+  });
+
+  afterEach(() => {
+    resetGlobalRuntimeDiagnosticsForTests();
+    (global as any).Game = previousGame;
+    (global as any).Memory = previousMemory;
+    previousGame = undefined;
+    previousMemory = undefined;
+  });
+
+  it("records a compact Memory counter on global reset", () => {
+    const { logger, infoMessages } = createLoggerSpy();
+
+    const event = runGlobalRuntimeDiagnostics({ logger, createHeapId: () => "heap-a" });
+
+    assert.deepInclude(event, {
+      type: "reset",
+      heapId: "heap-a",
+      currentTick: 100,
+      resetCount: 1,
+      switchCount: 0
+    });
+    assert.equal((global as any).Memory.__globalResetCount, 1);
+    assert.deepInclude((global as any).Memory.runtimeDiagnostics.global, {
+      heapId: "heap-a",
+      resetCount: 1,
+      switchCount: 0,
+      lastTick: 100,
+      lastResetTick: 100
+    });
+    assert.lengthOf(infoMessages, 1);
+  });
+
+  it("does not increment counters during consecutive ticks on the same heap", () => {
+    runGlobalRuntimeDiagnostics({ createHeapId: () => "heap-a" });
+    setTick(101);
+
+    const event = runGlobalRuntimeDiagnostics({ createHeapId: () => "heap-a" });
+
+    assert.deepInclude(event, {
+      type: "steady",
+      heapId: "heap-a",
+      currentTick: 101,
+      previousTick: 100,
+      resetCount: 1,
+      switchCount: 0
+    });
+    assert.equal((global as any).Memory.__globalResetCount, 1);
+    assert.equal((global as any).Memory.runtimeDiagnostics.global.switchCount, 0);
+  });
+
+  it("detects stale heap switches when Game.time jumps ahead", () => {
+    const { logger, warnMessages } = createLoggerSpy();
+    runGlobalRuntimeDiagnostics({ logger, createHeapId: () => "heap-a" });
+    setTick(110);
+
+    const event = runGlobalRuntimeDiagnostics({ logger, createHeapId: () => "heap-a" });
+
+    assert.deepInclude(event, {
+      type: "switch",
+      heapId: "heap-a",
+      currentTick: 110,
+      previousTick: 100,
+      resetCount: 1,
+      switchCount: 1
+    });
+    assert.deepInclude((global as any).Memory.runtimeDiagnostics.global, {
+      switchCount: 1,
+      lastSwitchTick: 110,
+      lastSwitchPreviousTick: 100,
+      lastTick: 110
+    });
+    assert.lengthOf(warnMessages, 1);
+  });
+
+  it("normalizes corrupt persisted diagnostics before updating counters", () => {
+    (global as any).Memory = {
+      __globalResetCount: 4,
+      runtimeDiagnostics: {
+        global: {
+          heapId: "",
+          resetCount: Number.NaN,
+          switchCount: -1,
+          lastTick: Number.NaN,
+          lastResetTick: undefined
+        }
+      }
+    };
+
+    const event = runGlobalRuntimeDiagnostics({ createHeapId: () => "heap-a" });
+
+    assert.deepInclude(event, {
+      type: "reset",
+      heapId: "heap-a",
+      currentTick: 100,
+      resetCount: 5,
+      switchCount: 0
+    });
+    assert.deepInclude((global as any).Memory.runtimeDiagnostics.global, {
+      heapId: "heap-a",
+      resetCount: 5,
+      switchCount: 0,
+      lastTick: 100,
+      lastResetTick: 100
+    });
+    assert.equal((global as any).Memory.__globalResetCount, 5);
+  });
+
+  it("throttles repeated switch warnings but keeps counting switches", () => {
+    const { logger, warnMessages } = createLoggerSpy();
+    runGlobalRuntimeDiagnostics({ logger, createHeapId: () => "heap-a", switchLogThrottleTicks: 50 });
+
+    setTick(110);
+    runGlobalRuntimeDiagnostics({ logger, switchLogThrottleTicks: 50 });
+    setTick(120);
+    runGlobalRuntimeDiagnostics({ logger, switchLogThrottleTicks: 50 });
+
+    assert.equal((global as any).Memory.runtimeDiagnostics.global.switchCount, 2);
+    assert.lengthOf(warnMessages, 1);
+  });
+
+  it("counts a new global reset when heap state is absent again", () => {
+    runGlobalRuntimeDiagnostics({ createHeapId: () => "heap-a" });
+    resetGlobalRuntimeDiagnosticsForTests();
+    setTick(101);
+
+    const event = runGlobalRuntimeDiagnostics({ createHeapId: () => "heap-b" });
+
+    assert.deepInclude(event, {
+      type: "reset",
+      heapId: "heap-b",
+      currentTick: 101,
+      resetCount: 2,
+      switchCount: 0
+    });
+    assert.equal((global as any).Memory.__globalResetCount, 2);
+    assert.equal((global as any).Memory.runtimeDiagnostics.global.heapId, "heap-b");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a top-of-loop runtime diagnostic for Screeps global resets and stale heap / multiple-global switches.

## Linked issue
Closes #3090

## What changed
- Added `runGlobalRuntimeDiagnostics()` in `packages/screeps-bot/src/core/globalRuntimeDiagnostics.ts`.
- Records compact counters in `Memory.__globalResetCount` and `Memory.runtimeDiagnostics.global`.
- Logs reset/switch events with switch warning throttling.
- Runs the diagnostic before `swarmLoop()`.
- Added unit tests for reset, steady tick, switch, throttling, corrupt Memory normalization, and test isolation.
- Documented operational triage in `docs/operations/global-runtime-diagnostics.md`.

## Why it changed
Screeps can occasionally alternate between stale JS heaps. This makes global variables appear to jump backward. The bot now detects and persists that signal without clearing heap state or skipping ticks.

## Tests run
- `npm ci --ignore-scripts`
- `npm run build:framework`
- `npm run test:unit -w screeps-typescript-starter -- --grep "global runtime diagnostics"`
- `npm run lint -w screeps-typescript-starter`
- `npm run build -w screeps-typescript-starter`
- `npm run check-versions`
- `npm run sync:deps:check`
- `npm run check:alliance-safety`
- `npm run typecheck`
- `npm run test:unit -w screeps-typescript-starter` (2333 passing)
- `npm run test:server:smoke` (passed; 49/49 screepsmod-testing assertions)
- `npm run build:docs`

## Deployment impact
Low runtime overhead. Adds one lightweight check at the top of every tick and no behavior change beyond logs/Memory counters. `npm run push` rebuilds the bundle before Screeps upload; tracked `dist/main.js` was intentionally not committed to keep the PR reviewable.

## Follow-up issues created
None.
