### PR TITLE
[codex] Scope deploy secrets to Screeps push step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,6 @@ jobs:
     env:
       CI: true
       SCREEPS_USER: ${{ vars.SCREEPS_USER }}
-      SCREEPS_PASS: ${{ secrets.SCREEPS_PASS }}
-      SCREEPS_TOKEN: ${{ secrets.SCREEPS_TOKEN }}
       SCREEPS_PROTOCOL: ${{ vars.SCREEPS_PROTOCOL }}
       SCREEPS_HOSTNAME: ${{ vars.SCREEPS_HOSTNAME }}
       SCREEPS_PORT: ${{ vars.SCREEPS_PORT }}
@@ -53,5 +51,10 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # Keep deploy credentials scoped to the upload step so dependency installation
+      # and package lifecycle scripts cannot read Screeps secrets.
       - name: Push to Screeps
+        env:
+          SCREEPS_PASS: ${{ secrets.SCREEPS_PASS }}
+          SCREEPS_TOKEN: ${{ secrets.SCREEPS_TOKEN }}
         run: npm run push


### PR DESCRIPTION
## Summary
- Scope Screeps deploy credentials to the upload step only.
- Keep install using `npm ci --ignore-scripts` without `SCREEPS_PASS`/`SCREEPS_TOKEN` in job env.

## Linked issue
Closes #3047

## Changes
- Removed `SCREEPS_PASS` and `SCREEPS_TOKEN` from job-level deploy env.
- Added the secrets only to the `Push to Screeps` step.
- Added an inline workflow comment documenting why secrets are step-scoped.

## Validation
- `npm ci --ignore-scripts` ✅ (Node 22 emitted expected engine warning; repo requires Node 24)
- `grep -nE 'SCREEPS_PASS|SCREEPS_TOKEN|ignore-scripts|Push to Screeps|Install dependencies' .github/workflows/deploy.yml` ✅
- `git diff --check` ✅
- `npm run build` ✅

## Deployment impact
Deploy behavior should remain unchanged for the upload step. Dependency installation no longer receives Screeps deploy credentials.

## Follow-up issues
None.
