### PR TITLE
[codex] Fix deploy workflow hostname fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,25 +14,31 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy (${{ matrix.environment }})
+    name: Deploy (${{ matrix.target.environment }})
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    environment: ${{ matrix.environment }}
+    environment: ${{ matrix.target.environment }}
     strategy:
       fail-fast: false
       matrix:
-        environment:
-          - sim.screeps.com
-          - season.screeps.com
-          - ptr.screeps.com
-          - screeps.com
-          - screeps.nyphon.de
-          - screeps.newbieland.net
+        target:
+          - environment: sim.screeps.com
+            hostname: screeps.com
+          - environment: season.screeps.com
+            hostname: season.screeps.com
+          - environment: ptr.screeps.com
+            hostname: ptr.screeps.com
+          - environment: screeps.com
+            hostname: screeps.com
+          - environment: screeps.nyphon.de
+            hostname: screeps.nyphon.de
+          - environment: screeps.newbieland.net
+            hostname: screeps.newbieland.net
     env:
       CI: true
       SCREEPS_USER: ${{ vars.SCREEPS_USER }}
       SCREEPS_PROTOCOL: ${{ vars.SCREEPS_PROTOCOL }}
-      SCREEPS_HOSTNAME: ${{ vars.SCREEPS_HOSTNAME }}
+      SCREEPS_HOSTNAME: ${{ vars.SCREEPS_HOSTNAME || matrix.target.hostname }}
       SCREEPS_PORT: ${{ vars.SCREEPS_PORT }}
       SCREEPS_PATH: ${{ vars.SCREEPS_PATH }}
       SCREEPS_BRANCH: ${{ vars.SCREEPS_BRANCH }}

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -50,12 +50,12 @@ Required environment variables/secrets:
 - `SCREEPS_PASS` (secret, when using password auth)
 - `SCREEPS_TOKEN` (secret, preferred)
 - `SCREEPS_PROTOCOL`
-- `SCREEPS_HOSTNAME`
+- `SCREEPS_HOSTNAME` (optional in GitHub Actions; the workflow falls back to its target hostname)
 - `SCREEPS_PORT`
 - `SCREEPS_PATH`
 - `SCREEPS_BRANCH`
 
-Configured environments include official and private servers such as `screeps.com`, `season.screeps.com`, `ptr.screeps.com`, and private-server targets.
+Configured environments include official and private servers such as `screeps.com`, `season.screeps.com`, `ptr.screeps.com`, and private-server targets. The deploy workflow provides a non-empty default hostname for each matrix target (`sim.screeps.com` uses `screeps.com` as the API host); environment variables can still override that hostname when needed.
 
 ## Branch/environment mapping
 


### PR DESCRIPTION
## Summary
- Add a per-target default hostname to the Deploy workflow matrix.
- Fall back from `vars.SCREEPS_HOSTNAME` to that matrix hostname so deploy jobs do not pass an empty host.
- Document the GitHub Actions hostname fallback.

## Linked issue
Closes #3106

## Changes
- Workflow: `.github/workflows/deploy.yml` now uses `matrix.target.environment` plus `matrix.target.hostname`.
- Docs: `docs/deployment/README.md` explains the hostname fallback and `sim.screeps.com` API host mapping.

## Validation
- ✅ `python3` YAML parse of `.github/workflows/deploy.yml`
- ✅ Deploy workflow text fallback check
- ✅ `SCREEPS_HOSTNAME=screeps.com SCREEPS_BRANCH=main npm run build:bot`
- ✅ Missing-host guard still fails as expected with `DEPLOY=true` and no `SCREEPS_HOSTNAME`

## Deployment impact
Fixes GitHub Actions deploy jobs that were failing before upload because `SCREEPS_HOSTNAME` was empty. Does not change local deploy guard behavior or credentials handling.

## Live bot evidence
Pre-work live analysis used read-only Screeps API. Runtime issues were filed/updated separately; this PR addresses the current P0 deploy blocker.

## Follow-up issues
- #3107
- #3108
