### PR TITLE
[codex] Suppress peaceful RCL2 guard reserve

### DIFF
--- a/packages/screeps-server/scripts/private-server-harness.js
+++ b/packages/screeps-server/scripts/private-server-harness.js
@@ -2,12 +2,27 @@ import net from "node:net";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
-import { ScreepsAPI } from "screeps-api";
 import { appendCpuBenchmarkSample } from "./cpu-benchmark-model.js";
 import { ensureLiveCloneAuth, seedLiveCloneSnapshot } from "./live-clone-seeder.js";
 import { createServerControlPlane, parseTickRate } from "./server-control-plane.js";
+
+const legacyApiRequire = createRequire(new URL("../../../package.json", import.meta.url));
+const ScreepsAPI = resolveScreepsApiConstructor(legacyApiRequire("screeps-api"));
+
+export function resolveScreepsApiConstructor(moduleNamespace) {
+  const candidates = [
+    moduleNamespace?.ScreepsAPI,
+    moduleNamespace?.default?.ScreepsAPI,
+    moduleNamespace?.default,
+    moduleNamespace
+  ];
+  const constructor = candidates.find((candidate) => typeof candidate === "function");
+  if (!constructor) throw new TypeError("screeps-api module did not expose a ScreepsAPI constructor");
+  return constructor;
+}
 
 const DEFAULT_RUNTIME_WARMUP_TICKS = 100;
 const DEFAULT_SMOKE_DURATION_MINUTES = 15;

--- a/packages/screeps-server/scripts/setup-bot-arena.js
+++ b/packages/screeps-server/scripts/setup-bot-arena.js
@@ -5,8 +5,23 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import { ScreepsAPI } from 'screeps-api';
+
+const legacyApiRequire = createRequire(new URL('../../../package.json', import.meta.url));
+const ScreepsAPI = resolveScreepsApiConstructor(legacyApiRequire('screeps-api'));
+
+function resolveScreepsApiConstructor(moduleNamespace) {
+  const candidates = [
+    moduleNamespace?.ScreepsAPI,
+    moduleNamespace?.default?.ScreepsAPI,
+    moduleNamespace?.default,
+    moduleNamespace
+  ];
+  const constructor = candidates.find((candidate) => typeof candidate === 'function');
+  if (!constructor) throw new TypeError('screeps-api module did not expose a ScreepsAPI constructor');
+  return constructor;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/screeps-server/test/scripts/private-server-harness.test.ts
+++ b/packages/screeps-server/test/scripts/private-server-harness.test.ts
@@ -16,6 +16,7 @@ import {
   parseTickRate,
   prepareArtifactsDir,
   resolveAvailablePorts,
+  resolveScreepsApiConstructor,
   restartScreepsRuntime,
   shouldContinuePolling,
   summarizeServerLogDiagnostics,
@@ -24,6 +25,18 @@ import {
 } from "../../scripts/private-server-harness.js";
 
 describe("private-server harness module", () => {
+  it("resolves screeps-api constructors from CommonJS and ESM namespace shapes", () => {
+    class Api {}
+
+    expect(resolveScreepsApiConstructor({ ScreepsAPI: Api })).to.equal(Api);
+    expect(resolveScreepsApiConstructor({ default: { ScreepsAPI: Api } })).to.equal(Api);
+    expect(resolveScreepsApiConstructor({ default: Api })).to.equal(Api);
+    expect(resolveScreepsApiConstructor(Api)).to.equal(Api);
+    expect(() => resolveScreepsApiConstructor({ ScreepsAPI: {} })).to.throw(
+      "screeps-api module did not expose a ScreepsAPI constructor",
+    );
+  });
+
   it("parses smoke defaults into a stable run contract", () => {
     const options = parseHarnessArgs([], {});
 

--- a/packages/screeps-spawn/src/militarySpawnPolicy.ts
+++ b/packages/screeps-spawn/src/militarySpawnPolicy.ts
@@ -13,7 +13,12 @@ export function shouldLimitIdleLocalMilitary(def: Pick<RoleSpawnDef, "family" | 
   return def.family === "military" && visibleHostiles === 0 && !def.remoteRole;
 }
 
-export function canSpawnIdleLocalMilitary(role: string, counts: Map<string, number>): boolean {
-  if (countLocalMilitaryCreeps(counts) >= IDLE_MILITARY_RESERVE) return false;
+export function canSpawnIdleLocalMilitary(
+  role: string,
+  counts: Map<string, number>,
+  reserveLimit = IDLE_MILITARY_RESERVE
+): boolean {
+  if (reserveLimit <= 0) return false;
+  if (countLocalMilitaryCreeps(counts) >= reserveLimit) return false;
   return role === "guard";
 }

--- a/packages/screeps-spawn/src/spawnNeedsAnalyzer.ts
+++ b/packages/screeps-spawn/src/spawnNeedsAnalyzer.ts
@@ -13,7 +13,11 @@ import { type CrossShardTransferRequest, resourceTransferCoordinator } from "./b
 import { countCreepsByRole, countCreepsOfRole, countRemoteCreepsByTargetRoom } from "./creepCounts";
 import { memoryManager } from "@ralphschuler/screeps-memory";
 import type { SwarmCreepMemory, SwarmState } from "@ralphschuler/screeps-memory";
-import { canSpawnIdleLocalMilitary, shouldLimitIdleLocalMilitary } from "./militarySpawnPolicy";
+import {
+  canSpawnIdleLocalMilitary,
+  IDLE_MILITARY_RESERVE,
+  shouldLimitIdleLocalMilitary
+} from "./militarySpawnPolicy";
 import { ROLE_DEFINITIONS } from "./roleDefinitions";
 import {
   getRemoteRoleMaxPerRemote,
@@ -86,6 +90,16 @@ function isRemoteEligibleForDefense(roomName: string): boolean {
 }
 
 export { countCreepsByRole, countCreepsOfRole, countRemoteCreepsByTargetRoom } from "./creepCounts";
+
+/** Peaceful early rooms should spend spawn time on economy before idle deterrence. */
+function getPeacefulIdleLocalMilitaryReserve(room: Room | undefined, swarm: SwarmState, isBootstrapMode: boolean): number {
+  const isCalmEconomy = swarm.danger === 0 && swarm.posture !== "war" && swarm.posture !== "siege";
+  const rcl = room?.controller?.level ?? 0;
+  if (isCalmEconomy && (isBootstrapMode || (rcl > 0 && rcl <= 2))) {
+    return 0;
+  }
+  return IDLE_MILITARY_RESERVE;
+}
 
 /** Return the target creep count for one home-room role under the current swarm state. */
 export function getRoleTargetCount(roomName: string, role: string, swarm: SwarmState): number {
@@ -192,8 +206,11 @@ export function needsRole(roomName: string, role: string, swarm: SwarmState, isB
   // are exempt because they are gated by visible remote-room threats below.
   const room = Game.rooms[roomName];
   const visibleHostiles = room ? getActualHostileCreeps(room).length : 0;
-  if (shouldLimitIdleLocalMilitary(def, visibleHostiles) && !canSpawnIdleLocalMilitary(role, countCreepsByRole(roomName))) {
-    return false;
+  if (shouldLimitIdleLocalMilitary(def, visibleHostiles)) {
+    const reserveLimit = getPeacefulIdleLocalMilitaryReserve(room, swarm, isBootstrapMode);
+    if (!canSpawnIdleLocalMilitary(role, countCreepsByRole(roomName), reserveLimit)) {
+      return false;
+    }
   }
 
   // SPECIAL: larvaWorker should ONLY be spawned during bootstrap/emergency

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -18,13 +18,19 @@ import { SpawnPriority, spawnQueue } from "../src/spawnQueue.ts";
 
 declare const require: NodeRequire;
 
-function createRoom(hostiles: Creep[] = [], name = "W1N1", energyCapacity = 800, energyAvailable = energyCapacity): Room {
+function createRoom(
+  hostiles: Creep[] = [],
+  name = "W1N1",
+  energyCapacity = 800,
+  energyAvailable = energyCapacity,
+  controllerLevel = 3
+): Room {
   const spawn = { id: `${name}-spawn`, spawning: false };
   return {
     name,
     energyAvailable,
     energyCapacityAvailable: energyCapacity,
-    controller: { my: true, level: 3 },
+    controller: { my: true, level: controllerLevel },
     find: (type: number) => {
       if (type === FIND_HOSTILE_CREEPS) return hostiles;
       if (type === FIND_MY_SPAWNS) return [spawn];
@@ -117,6 +123,38 @@ describe("defense spawn throttling", () => {
     assert.equal(countLocalMilitaryCreeps(counts), 0);
     assert.isTrue(shouldLimitIdleLocalMilitary(ROLE_DEFINITIONS.guard, 0));
     assert.isTrue(canSpawnIdleLocalMilitary("guard", counts));
+  });
+
+  it("suppresses peaceful idle guard demand in RCL2 bootstrap rooms", () => {
+    const room = createRoom([], "W19S26", 300, 300, 2);
+    Game.rooms.W19S26 = room;
+    Game.creeps = {
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W19S26" } },
+      harvester2: { spawning: false, memory: { role: "harvester", homeRoom: "W19S26" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W19S26" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W19S26" } }
+    } as unknown as typeof Game.creeps;
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const plan = createSpawnPlan(room, { danger: 0, posture: "eco" } as any);
+
+    assert.isUndefined(plan.requests.find(request => request.role === "guard"));
+  });
+
+  it("keeps one peaceful idle guard reserve after early bootstrap", () => {
+    const room = createRoom([], "W1N1", 800, 800, 3);
+    Game.rooms.W1N1 = room;
+    Game.creeps = {
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W1N1" } },
+      harvester2: { spawning: false, memory: { role: "harvester", homeRoom: "W1N1" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W1N1" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W1N1" } }
+    } as unknown as typeof Game.creeps;
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const plan = createSpawnPlan(room, { danger: 0, posture: "eco" } as any);
+
+    assert.exists(plan.requests.find(request => request.role === "guard"));
   });
 
   it("spawns helper-room defense assists for visible attacked rooms even when the helper is peaceful", () => {


### PR DESCRIPTION
## Summary
- Suppresses peaceful idle local military reserve in RCL1/RCL2 and bootstrap-mode rooms.
- Keeps the existing one-guard idle reserve for calm RCL3+ rooms.
- Adds live-inspired spawn-plan coverage for the W19S26-style RCL2 guard over-spawn case.
- Fixes the required private-server smoke CI module-interop blocker for `screeps-api` on Node 24.

## Linked issues
Closes #3108
Closes #3117

## Changes
- `packages/screeps-spawn/src/spawnNeedsAnalyzer.ts`: calculates an early-room reserve limit before allowing idle local military demand.
- `packages/screeps-spawn/src/militarySpawnPolicy.ts`: accepts an explicit reserve limit.
- `packages/screeps-spawn/test/defenseSpawning.test.ts`: covers RCL2 suppression and RCL3 preserve behavior.
- `packages/screeps-server/scripts/private-server-harness.js` and `setup-bot-arena.js`: load `screeps-api` through `createRequire()` for Node 24 compatibility.

## Validation
- ✅ `npm run test:spawn -- --grep "peaceful idle guard"` (spawn suite ran; 116 passing)
- ✅ `npm run build:spawn`
- ✅ `npm run lint:spawn`
- ✅ `npm run build`
- ✅ `npm run test:spawn`
- ✅ `npm run check:alliance-safety`
- ✅ `node -e "import('./packages/screeps-server/scripts/private-server-harness.js').then(()=>console.log('private-server-harness import ok'))"`
- ✅ `npm run test:server:packages`
- ✅ `git diff --check`

## Deployment impact
Affects spawn demand policy. After deploy, peaceful RCL2 rooms should stop replacing idle local guards; existing extra guards age out naturally. CI smoke harness now loads under Node 24.

## Live bot evidence
Read-only Screeps API recheck at shard1 tick `72029115` showed `W19S26` at RCL2, danger `0`, hostiles `0`, defense requests `0`, with multiple guards and active bootstrap construction backlog.

## Follow-up issues
- #3115 tracks the separate live layout issue: `W19S26` has no RCL2 extensions or extension sites.
