### PR TITLE
fix(ci): align Node 24 types and Screeps API harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "@types/sinon": "^21.0.1",
         "ajv": "^8.20.0",
@@ -1939,13 +1939,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -8116,9 +8116,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8638,7 +8638,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8674,7 +8674,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8702,7 +8702,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8730,7 +8730,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8764,7 +8764,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8796,7 +8796,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8824,7 +8824,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8855,7 +8855,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8889,7 +8889,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8922,7 +8922,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8955,7 +8955,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -8989,7 +8989,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9027,7 +9027,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9058,7 +9058,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9089,7 +9089,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9120,7 +9120,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9181,7 +9181,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "@types/sinon": "^21.0.1",
         "@types/sinon-chai": "^4.0.0",
@@ -9521,7 +9521,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9559,7 +9559,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9595,7 +9595,7 @@
         "@types/chai": "^5.2.3",
         "@types/lz-string": "^1.5.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9624,7 +9624,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9653,7 +9653,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "@types/sinon": "^21.0.1",
         "@types/sinon-chai": "^4.0.0",
@@ -9752,7 +9752,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9785,7 +9785,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -9811,7 +9811,7 @@
       "version": "1.0.0",
       "license": "Unlicense",
       "devDependencies": {
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "typescript": "^5.4.3"
       }
     }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "@types/sinon": "^21.0.1",
     "ajv": "^8.20.0",

--- a/packages/@ralphschuler/screeps-cache/package.json
+++ b/packages/@ralphschuler/screeps-cache/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-clusters/package.json
+++ b/packages/@ralphschuler/screeps-clusters/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-console/package.json
+++ b/packages/@ralphschuler/screeps-console/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-core/package.json
+++ b/packages/@ralphschuler/screeps-core/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-empire/package.json
+++ b/packages/@ralphschuler/screeps-empire/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-intershard/package.json
+++ b/packages/@ralphschuler/screeps-intershard/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-kernel/package-lock.json
+++ b/packages/@ralphschuler/screeps-kernel/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.2",
         "@types/screeps": "^3.4.0",
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
@@ -144,13 +144,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/screeps": {
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/@ralphschuler/screeps-kernel/package.json
+++ b/packages/@ralphschuler/screeps-kernel/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-layouts/package.json
+++ b/packages/@ralphschuler/screeps-layouts/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-memory/package.json
+++ b/packages/@ralphschuler/screeps-memory/package.json
@@ -31,7 +31,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-pathfinding/package.json
+++ b/packages/@ralphschuler/screeps-pathfinding/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-pheromones/package.json
+++ b/packages/@ralphschuler/screeps-pheromones/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-remote-mining/package.json
+++ b/packages/@ralphschuler/screeps-remote-mining/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-roles/package.json
+++ b/packages/@ralphschuler/screeps-roles/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-standards/package.json
+++ b/packages/@ralphschuler/screeps-standards/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-stats/package.json
+++ b/packages/@ralphschuler/screeps-stats/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/@ralphschuler/screeps-visuals/package.json
+++ b/packages/@ralphschuler/screeps-visuals/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screeps-bot/package.json
+++ b/packages/screeps-bot/package.json
@@ -42,7 +42,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "@types/sinon": "^21.0.1",
     "@types/sinon-chai": "^4.0.0",

--- a/packages/screeps-chemistry/package.json
+++ b/packages/screeps-chemistry/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screeps-defense/package.json
+++ b/packages/screeps-defense/package.json
@@ -45,7 +45,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screeps-economy/package.json
+++ b/packages/screeps-economy/package.json
@@ -43,7 +43,7 @@
     "@types/chai": "^5.2.3",
     "@types/lz-string": "^1.5.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screeps-posis/package.json
+++ b/packages/screeps-posis/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screeps-server/package.json
+++ b/packages/screeps-server/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "@types/sinon": "^21.0.1",
     "@types/sinon-chai": "^4.0.0",

--- a/packages/screeps-server/scripts/private-server-harness.d.ts
+++ b/packages/screeps-server/scripts/private-server-harness.d.ts
@@ -22,6 +22,8 @@ export interface HarnessOptions {
   repoRoot?: string;
 }
 
+export function resolveScreepsApiConstructor(moduleNamespace: any): any;
+export function createLegacyScreepsApiAdapter(ScreepsHttpClient: any): any;
 export function parseScenarioList(rawValue?: unknown, defaults?: string[]): string[];
 export function parseTickRate(rawValue: unknown): number;
 export function parseRuntimeWarmupTicks(rawValue?: unknown, configPath?: string | URL, env?: Record<string, string | undefined>): number;

--- a/packages/screeps-server/scripts/private-server-harness.js
+++ b/packages/screeps-server/scripts/private-server-harness.js
@@ -13,15 +13,48 @@ const legacyApiRequire = createRequire(new URL("../../../package.json", import.m
 const ScreepsAPI = resolveScreepsApiConstructor(legacyApiRequire("screeps-api"));
 
 export function resolveScreepsApiConstructor(moduleNamespace) {
-  const candidates = [
+  const legacyCandidates = [
     moduleNamespace?.ScreepsAPI,
     moduleNamespace?.default?.ScreepsAPI,
     moduleNamespace?.default,
     moduleNamespace
   ];
-  const constructor = candidates.find((candidate) => typeof candidate === "function");
-  if (!constructor) throw new TypeError("screeps-api module did not expose a ScreepsAPI constructor");
-  return constructor;
+  const legacyConstructor = legacyCandidates.find((candidate) => typeof candidate === "function");
+  if (legacyConstructor) return legacyConstructor;
+
+  const httpClientConstructor = [
+    moduleNamespace?.ScreepsHttpClient,
+    moduleNamespace?.default?.ScreepsHttpClient,
+  ].find((candidate) => typeof candidate === "function");
+  if (httpClientConstructor) return createLegacyScreepsApiAdapter(httpClientConstructor);
+
+  throw new TypeError("screeps-api module did not expose a supported Screeps API constructor");
+}
+
+export function createLegacyScreepsApiAdapter(ScreepsHttpClient) {
+  return class LegacyScreepsApiAdapter {
+    constructor(options) {
+      this.client = new ScreepsHttpClient(options);
+      this.http = this.client._http;
+      this.raw = {
+        game: {
+          time: (shard) => this.client.gameTime(shard),
+        },
+        user: {
+          code: {
+            set: (branch, modules) => this.client.userCodeSet({ branch, modules }),
+          },
+        },
+      };
+      this.memory = {
+        get: (path, shard) => this.client.userMemoryGet(path, shard),
+      };
+    }
+
+    auth() {
+      return this.client.auth();
+    }
+  };
 }
 
 const DEFAULT_RUNTIME_WARMUP_TICKS = 100;

--- a/packages/screeps-server/test/scripts/private-server-harness.test.ts
+++ b/packages/screeps-server/test/scripts/private-server-harness.test.ts
@@ -33,8 +33,66 @@ describe("private-server harness module", () => {
     expect(resolveScreepsApiConstructor({ default: Api })).to.equal(Api);
     expect(resolveScreepsApiConstructor(Api)).to.equal(Api);
     expect(() => resolveScreepsApiConstructor({ ScreepsAPI: {} })).to.throw(
-      "screeps-api module did not expose a ScreepsAPI constructor",
+      "screeps-api module did not expose a supported Screeps API constructor",
     );
+  });
+
+  it("adapts screeps-api v2 ScreepsHttpClient to the legacy harness contract", async () => {
+    class ScreepsHttpClient {
+      config: unknown;
+      _http = { defaults: { headers: { common: {} } } };
+
+      constructor(config: unknown) {
+        this.config = config;
+      }
+
+      auth() {
+        return Promise.resolve({ ok: 1, token: "token" });
+      }
+
+      gameTime(shard: string) {
+        return Promise.resolve({ time: 123, shard });
+      }
+
+      userCodeSet(params: unknown) {
+        return Promise.resolve({ ok: 1, params });
+      }
+
+      userMemoryGet(path: string, shard: string) {
+        return Promise.resolve({ data: { path, shard } });
+      }
+    }
+
+    const Api = resolveScreepsApiConstructor({ ScreepsHttpClient });
+    const api = new Api({
+      email: "swarm-bot",
+      password: "ci-password",
+      protocol: "http",
+      hostname: "127.0.0.1",
+      port: 21025,
+      path: "/",
+    });
+
+    api.http.defaults.headers.common["X-Server-Password"] = "server-password";
+
+    expect(api.client.config).to.deep.include({
+      email: "swarm-bot",
+      password: "ci-password",
+      protocol: "http",
+      hostname: "127.0.0.1",
+      port: 21025,
+      path: "/",
+    });
+    expect(api.http.defaults.headers.common["X-Server-Password"]).to.equal("server-password");
+    expect(await api.auth()).to.deep.equal({ ok: 1, token: "token" });
+    expect(await api.raw.game.time("shard0")).to.deep.equal({ time: 123, shard: "shard0" });
+    expect(await api.raw.user.code.set("$activeWorld", { main: "code" })).to.deep.equal({
+      ok: 1,
+      params: { branch: "$activeWorld", modules: { main: "code" } },
+    });
+    expect(await api.memory.get("", "shard0")).to.deep.equal({
+      data: { path: "", shard: "shard0" },
+    });
   });
 
   it("parses smoke defaults into a stable run contract", () => {

--- a/packages/screeps-spawn/package.json
+++ b/packages/screeps-spawn/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screeps-utils/package.json
+++ b/packages/screeps-utils/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.4.0",
     "chai": "^6.2.2",
     "mocha": "^11.7.6",

--- a/packages/screepsmod-testing/package.json
+++ b/packages/screepsmod-testing/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "Unlicense",
   "devDependencies": {
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.13.2",
     "typescript": "^5.4.3"
   },
   "screepsmod": {

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -13,11 +13,12 @@
  * TODO(P3): STYLE - Convert to TypeScript for consistency with the rest of the codebase
  * All other source files are TypeScript
  * TODO(P3): FEATURE - Add support for more complex semver ranges (e.g., ^, ~, ||)
- * Current implementation only handles >= and <= operators
+ * Current implementation handles simple whitespace-separated comparators: >=, >, <=, <, and exact.
  */
 
 import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const { engines } = require('../package.json');
@@ -34,40 +35,52 @@ const colors = {
  * Simple version comparison function
  * Returns true if current satisfies the requirement
  */
-function satisfiesVersion(current, required) {
+export function satisfiesVersion(current, required) {
   // Remove 'v' prefix if present
   current = current.replace(/^v/, '');
-  
-  // Parse requirement (e.g., ">=16.0.0 <=20.x")
-  const parts = required.split(/\s+/);
-  
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (part.startsWith('>=')) {
-      const minVersion = part.substring(2);
-      if (!compareVersions(current, minVersion, '>=')) return false;
-    } else if (part.startsWith('<=')) {
-      const maxVersion = part.substring(2).replace(/\.x$/, '.999');
-      if (!compareVersions(current, maxVersion, '<=')) return false;
+
+  // Parse requirement (e.g., ">=24 <25" or ">=16.0.0 <=20.x")
+  const parts = required.trim().split(/\s+/).filter(Boolean);
+
+  for (const part of parts) {
+    const match = /^(>=|<=|>|<|=)?(.+)$/.exec(part);
+    if (!match) {
+      continue;
     }
+
+    const operator = match[1] || '=';
+    const requiredVersion = match[2];
+    if (!compareVersions(current, requiredVersion, operator)) return false;
   }
-  
+
   return true;
 }
 
-function compareVersions(version1, version2, operator) {
-  const v1Parts = version1.split('.').map(Number);
-  const v2Parts = version2.split('.').map(Number);
-  
+export function compareVersions(version1, version2, operator) {
+  const v1Parts = parseVersionParts(version1, 0);
+  const v2Parts = parseVersionParts(version2, operator === '<=' ? 999 : 0);
+
   for (let i = 0; i < 3; i++) {
     const v1 = v1Parts[i] || 0;
     const v2 = v2Parts[i] || 0;
-    
+
     if (v1 > v2) return operator === '>=' || operator === '>';
     if (v1 < v2) return operator === '<=' || operator === '<';
   }
-  
-  return operator === '>=' || operator === '<=';
+
+  return operator === '>=' || operator === '<=' || operator === '=';
+}
+
+function parseVersionParts(version, wildcardValue) {
+  return version
+    .replace(/^v/, '')
+    .split('.')
+    .slice(0, 3)
+    .map((part) => {
+      if (part === 'x' || part === 'X' || part === '*') return wildcardValue;
+      const match = /^\d+/.exec(part);
+      return match ? Number(match[0]) : 0;
+    });
 }
 
 function checkVersion(name, current, required) {
@@ -127,4 +140,6 @@ ${colors.reset}`);
   console.log(`${colors.green}✅ All version checks passed!${colors.reset}\n`);
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -56,7 +56,7 @@ cat > "${PACKAGE_DIR}/package.json" << EOF
   "devDependencies": {
     "@types/chai": "^4.1.6",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.13.2",
     "@types/screeps": "^3.3.8",
     "chai": "^4.2.0",
     "mocha": "^11.7.5",

--- a/scripts/shared-dependencies.json
+++ b/scripts/shared-dependencies.json
@@ -4,7 +4,7 @@
     "devDependencies": {
       "@types/chai": "^5.2.3",
       "@types/mocha": "^10.0.10",
-      "@types/node": "^25.9.1",
+      "@types/node": "^24.13.2",
       "@types/screeps": "^3.4.0",
       "chai": "^6.2.2",
       "mocha": "^11.7.6",

--- a/scripts/test/check-versions.test.mjs
+++ b/scripts/test/check-versions.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function runVersionHelper(expression) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `import { satisfiesVersion } from './scripts/check-versions.js';\nconsole.log(${expression});`,
+    ],
+    {
+      cwd: new URL("../..", import.meta.url),
+      encoding: "utf8",
+    },
+  );
+
+  return result;
+}
+
+test("Node engine range accepts Node 24 and rejects neighboring majors", () => {
+  const result = runVersionHelper(
+    `JSON.stringify([\n` +
+      `  satisfiesVersion('24.0.0', '>=24 <25'),\n` +
+      `  satisfiesVersion('24.13.2', '>=24 <25'),\n` +
+      `  satisfiesVersion('23.11.0', '>=24 <25'),\n` +
+      `  satisfiesVersion('25.0.0', '>=24 <25')\n` +
+      `])`,
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [true, true, false, false]);
+});
+
+test("version helper supports upper-bound semver operators", () => {
+  const result = runVersionHelper(
+    `JSON.stringify([\n` +
+      `  satisfiesVersion('24.9.0', '<25'),\n` +
+      `  satisfiesVersion('25.0.0', '<25'),\n` +
+      `  satisfiesVersion('25.0.1', '>25'),\n` +
+      `  satisfiesVersion('25.0.0', '>25')\n` +
+      `])`,
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [true, false, true, false]);
+});


### PR DESCRIPTION
## Overview

Fixes #3128 by aligning Node typings with the repository's Node 24 runtime and teaching the version guard to enforce the active `>=24 <25` engine range.

Also repairs the private-server harness after root `screeps-api@2` ownership: v2 exports `ScreepsHttpClient` instead of the legacy `ScreepsAPI` constructor, so the harness now adapts v2 to its existing auth/upload/time/memory contract.

## Changes

- Constrain `@types/node` to `^24.13.2` across root, workspaces, shared dependency config, package template, and tracked locks.
- Export/test `scripts/check-versions.js` semver helpers.
- Add simple comparator support for `>`, `<`, and exact versions while preserving `>=`/`<=`.
- Add `node:test` coverage proving Node 24 passes and Node 23/25 fail for `>=24 <25`.
- Add a minimal `ScreepsHttpClient` legacy adapter for private-server CI smoke usage.
- Add harness tests covering v2 auth, code upload, game time, Memory reads, and server-password header forwarding.

## Validation

- ✅ `node --input-type=module --eval "import './packages/screeps-server/scripts/private-server-harness.js'; console.log('harness import ok')"`
- ✅ `npm run test:scripts`
- ✅ `npm run test:packages -w @ralphschuler/screeps-server`
- ✅ `npm run sync:deps:check`
- ✅ `npm run check-versions` under Node `v24.18.0`
- ✅ `npm ls @types/node --all` shows `@types/node@24.13.2` deduped
- ✅ `npm run build:framework`
- ✅ `npm run typecheck`

## Risk / rollback

Low CI/dependency/runtime-harness compatibility change. Roll back by reverting these commits to restore `@types/node@25.x`, prior version-guard behavior, and pre-v2 harness resolution.
