### PR TITLE
fix(intel): ignore configured ally creeps in threats

### DIFF
--- a/packages/@ralphschuler/screeps-remote-mining/test/remotePathSearch.test.ts
+++ b/packages/@ralphschuler/screeps-remote-mining/test/remotePathSearch.test.ts
@@ -142,7 +142,7 @@ describe("remotePathSearch", () => {
 
     (global as unknown as Record<string, number>).FIND_STRUCTURES = 107;
     (global as unknown as Record<string, number>).FIND_CREEPS = 101;
-    (global as unknown as Record<string, number>).FIND_HOSTILE_STRUCTURES = 108;
+    (global as unknown as Record<string, number>).FIND_HOSTILE_STRUCTURES = 109;
     (global as unknown as Record<string, string>).STRUCTURE_ROAD = "road";
     (global as unknown as Record<string, string>).STRUCTURE_TOWER = "tower";
     (global as unknown as Record<string, string>).STRUCTURE_CONTROLLER = "controller";

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5065,7 +5065,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -42363,9 +42363,13 @@ P && !P.done && (d = N.return) && d.call(N);
 if (m) throw m.error;
 }
 }
-}, e.prototype.isConfiguredAllyStructure = function(e) {
+}, e.prototype.isConfiguredAllyOwned = function(e) {
 var t, r = null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 return "string" == typeof r && this.config.allies.includes(r);
+}, e.prototype.isConfiguredAllyStructure = function(e) {
+return this.isConfiguredAllyOwned(e);
+}, e.prototype.isConfiguredAllyCreep = function(e) {
+return this.isConfiguredAllyOwned(e);
 }, e.prototype.isAggressiveCreep = function(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 2;
 }, e.prototype.detectThreats = function() {
@@ -42375,7 +42379,9 @@ var o = Game.rooms[r];
 if (o) {
 var n = t.knownRooms[r];
 if (n) {
-var a = V(o), i = a.filter(function(t) {
+var a = V(o).filter(function(t) {
+return !e.isConfiguredAllyCreep(t);
+}), i = a.filter(function(t) {
 return e.isAggressiveCreep(t);
 }), s = o.find(FIND_NUKES), c = 0;
 s.length > 0 ? (c = 3, A.warn("Nuke detected in ".concat(r, ", ").concat(s.length, " incoming"), {

--- a/packages/screeps-bot/src/empire/intelScanner.ts
+++ b/packages/screeps-bot/src/empire/intelScanner.ts
@@ -347,11 +347,19 @@ export class IntelScanner {
   }
 
   /**
-   * Check whether a structure belongs to a configured (non-permanent) ally.
+   * Check whether an owned entity belongs to a configured (non-permanent) ally.
    */
-  private isConfiguredAllyStructure(structure: Structure): boolean {
-    const owner = (structure as { owner?: { username?: string } }).owner?.username;
+  private isConfiguredAllyOwned(entity: { owner?: { username?: string } }): boolean {
+    const owner = entity.owner?.username;
     return typeof owner === "string" && this.config.allies.includes(owner);
+  }
+
+  private isConfiguredAllyStructure(structure: Structure): boolean {
+    return this.isConfiguredAllyOwned(structure as { owner?: { username?: string } });
+  }
+
+  private isConfiguredAllyCreep(creep: Creep): boolean {
+    return this.isConfiguredAllyOwned(creep);
   }
 
   /**
@@ -378,7 +386,7 @@ export class IntelScanner {
       const intel = empire.knownRooms[roomName];
       if (!intel) continue;
 
-      const hostileCreeps = getActualHostileCreeps(room);
+      const hostileCreeps = getActualHostileCreeps(room).filter(c => !this.isConfiguredAllyCreep(c));
       const aggressiveHostiles = hostileCreeps.filter(c => this.isAggressiveCreep(c));
 
       // Detect incoming nukes

--- a/packages/screeps-bot/test/unit/intelScanner.test.ts
+++ b/packages/screeps-bot/test/unit/intelScanner.test.ts
@@ -6,6 +6,14 @@ function ownedStructure(structureType: StructureConstant, owner: string): Struct
   return { structureType, owner: { username: owner } } as unknown as Structure;
 }
 
+function aggressiveCreep(owner: string): Creep {
+  return {
+    owner: { username: owner },
+    body: [{ type: ATTACK }],
+    getActiveBodyparts: (part: BodyPartConstant) => (part === ATTACK ? 1 : 0)
+  } as unknown as Creep;
+}
+
 function createVisibleRoom(
   structures: Structure[],
   hostileStructures: Structure[],
@@ -86,5 +94,63 @@ describe("IntelScanner", () => {
       towerCount: 0,
       spawnCount: 0
     });
+  });
+
+  it("does not raise room threat for configured ally creeps", () => {
+    const globals = global as unknown as Record<string, unknown>;
+    const previousGlobals = {
+      ATTACK: globals.ATTACK,
+      RANGED_ATTACK: globals.RANGED_ATTACK,
+      WORK: globals.WORK,
+      FIND_HOSTILE_CREEPS: globals.FIND_HOSTILE_CREEPS,
+      FIND_NUKES: globals.FIND_NUKES,
+      Game: globals.Game,
+      Memory: globals.Memory
+    };
+
+    try {
+      globals.ATTACK = "attack";
+      globals.RANGED_ATTACK = "ranged_attack";
+      globals.WORK = "work";
+      globals.FIND_HOSTILE_CREEPS = 103;
+      globals.FIND_NUKES = 117;
+
+      const empire = createDefaultEmpireMemory();
+      empire.knownRooms.W2N2 = {
+        name: "W2N2",
+        lastSeen: 1,
+        sources: 2,
+        controllerLevel: 8,
+        threatLevel: 0,
+        scouted: true,
+        terrain: "plains",
+        isHighway: false,
+        isSK: false
+      };
+      const configuredAlly = aggressiveCreep("FriendlyNeighbor");
+      const room = {
+        name: "W2N2",
+        find: (type: FindConstant) => {
+          if (type === FIND_HOSTILE_CREEPS) return [configuredAlly];
+          if (type === FIND_NUKES) return [];
+          return [];
+        }
+      } as unknown as Room;
+      (global as unknown as { Game: Partial<Game> }).Game = { rooms: { W2N2: room }, time: 100 };
+      (global as unknown as { Memory: Memory }).Memory = { empire } as Memory;
+      const scanner = new IntelScanner({ allies: ["FriendlyNeighbor"] });
+
+      (scanner as unknown as { detectThreats(): void }).detectThreats();
+
+      expect(empire.knownRooms.W2N2.threatLevel).to.equal(0);
+    } finally {
+      for (const [key, value] of Object.entries(previousGlobals)) {
+        if (value === undefined) {
+          delete globals[key];
+        } else {
+          globals[key] = value;
+        }
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- filter configured ally creeps out of IntelScanner room threat detection
- add regression coverage for configured ally aggressive creeps
- align remote-mining test constant with @types/screeps FIND_HOSTILE_STRUCTURES = 109

## Validation
- npm run test:unit -w screeps-typescript-starter -- --grep IntelScanner
- npm run lint -w screeps-typescript-starter -- --max-warnings=0
- npm run build:bot
- npm run test:unit -w screeps-typescript-starter
- npm test -w @ralphschuler/screeps-remote-mining
- npm run check:alliance-safety
- git diff --check