### PR TITLE
fix(economy): balance minerals into zero-stock terminals

### DIFF
--- a/packages/screeps-economy/src/terminals/terminalManager.ts
+++ b/packages/screeps-economy/src/terminals/terminalManager.ts
@@ -505,29 +505,31 @@ export class TerminalManager {
    * Balance minerals between rooms with terminals
    */
   private balanceMinerals(rooms: Room[]): void {
-    // Get mineral distribution across rooms
-    const mineralMap = new Map<MineralConstant, { room: Room; amount: number }[]>();
+    // Discover non-energy resources with stock anywhere, then include every terminal room.
+    // Rooms without that resource are valid deficit targets with amount 0.
+    const resourceTypes = new Set<ResourceConstant>();
 
     for (const room of rooms) {
       const terminal = room.terminal!;
-      
-      // Check each mineral type - only iterate over resources actually in the terminal
       const resources = Object.keys(terminal.store) as ResourceConstant[];
+
       for (const resourceType of resources) {
         if (resourceType === RESOURCE_ENERGY) continue;
-        
-        const amount = terminal.store.getUsedCapacity(resourceType);
-        if (amount === 0) continue;
 
-        if (!mineralMap.has(resourceType as MineralConstant)) {
-          mineralMap.set(resourceType as MineralConstant, []);
+        const amount = terminal.store.getUsedCapacity(resourceType);
+        if (amount > 0) {
+          resourceTypes.add(resourceType);
         }
-        mineralMap.get(resourceType as MineralConstant)!.push({ room, amount });
       }
     }
 
-    // Balance each mineral type
-    for (const [mineralType, roomList] of mineralMap.entries()) {
+    // Balance each resource type
+    for (const resourceType of resourceTypes) {
+      const roomList = rooms.map(room => ({
+        room,
+        amount: room.terminal!.store.getUsedCapacity(resourceType)
+      }));
+
       if (roomList.length < 2) continue;
 
       // Sort by amount
@@ -544,7 +546,7 @@ export class TerminalManager {
       const alreadyQueued = this.transferQueue.some(
         req => req.fromRoom === richest.room.name && 
                req.toRoom === poorest.room.name && 
-               req.resourceType === mineralType
+               req.resourceType === resourceType
       );
       if (alreadyQueued) continue;
 
@@ -560,13 +562,13 @@ export class TerminalManager {
       this.transferQueue.push({
         fromRoom: richest.room.name,
         toRoom: poorest.room.name,
-        resourceType: mineralType,
+        resourceType,
         amount: transferAmount,
         priority: 1
       });
 
       logger.info(
-        `Queued mineral transfer: ${transferAmount} ${mineralType} from ${richest.room.name} to ${poorest.room.name}`,
+        `Queued mineral transfer: ${transferAmount} ${resourceType} from ${richest.room.name} to ${poorest.room.name}`,
         { subsystem: "Terminal" }
       );
     }

--- a/packages/screeps-economy/test/TerminalManager.test.ts
+++ b/packages/screeps-economy/test/TerminalManager.test.ts
@@ -121,4 +121,31 @@ describe("TerminalManager", () => {
 
     expect(sendCount).to.equal(0);
   });
+
+  it("balances minerals to an owned terminal that currently has zero stock", () => {
+    const sends: Array<{ resource: ResourceConstant; amount: number; destination: string }> = [];
+    (Game.market as Market).calcTransactionCost = () => 100;
+    const source = createRoom(
+      "W1N1",
+      createStore({ [RESOURCE_ENERGY]: 10000, [RESOURCE_HYDROGEN]: 12000 }),
+      ((resource, amount, destination) => {
+        sends.push({ resource, amount, destination });
+        return OK;
+      }) as StructureTerminal["send"]
+    );
+    const target = createRoom("W2N2", createStore({ [RESOURCE_ENERGY]: 10000 }));
+    (Game.rooms as Record<string, Room>).W1N1 = source;
+    (Game.rooms as Record<string, Room>).W2N2 = target;
+
+    new TerminalManager({
+      minBucket: 0,
+      energySendThreshold: 999999,
+      energyRequestThreshold: 0,
+      capacityClearanceThreshold: 1.1
+    }).run();
+
+    expect(sends).to.deep.equal([
+      { resource: RESOURCE_HYDROGEN, amount: 6000, destination: "W2N2" }
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- include every owned terminal room when balancing non-energy resources discovered anywhere
- allow rooms with zero stock to receive surplus minerals/compounds
- add regression coverage for zero-stock terminal mineral balancing

## Validation
- npm test -w @ralphschuler/screeps-economy -- --grep "zero stock" (confirmed red before implementation, green after)
- npm test -w @ralphschuler/screeps-economy -- --grep TerminalManager
- npm test -w @ralphschuler/screeps-economy
- npm run build:economy
- npm run lint:economy
- git diff --check
- NODE_PATH=/home/ralph/Github/screeps/node_modules npm run check:alliance-safety

## Notes
- Low-risk economy-only change; no combat targeting or ally behavior touched.