### PR TITLE
fix(layout): clamp unsafe blueprint anchors

### DIFF
--- a/packages/@ralphschuler/screeps-layouts/src/blueprints/planner.ts
+++ b/packages/@ralphschuler/screeps-layouts/src/blueprints/planner.ts
@@ -39,6 +39,12 @@ import {
 } from "./definitions/stamps";
 
 const PLAN_VERSION = "stamp-v1";
+const BUILDABLE_ROOM_MIN = 1;
+const BUILDABLE_ROOM_MAX = 48;
+// Extension pods can place members up to eight tiles from the core anchor.
+const MAX_CORE_STAMP_OFFSET = 8;
+const SAFE_ANCHOR_MIN = BUILDABLE_ROOM_MIN + MAX_CORE_STAMP_OFFSET;
+const SAFE_ANCHOR_MAX = BUILDABLE_ROOM_MAX - MAX_CORE_STAMP_OFFSET;
 
 export interface BlueprintPlannerOptions {
   anchor?: BlueprintPoint;
@@ -60,8 +66,15 @@ export interface StampPlacementResult {
   missing: UnplacedDemand[];
 }
 
-function clampRoomCoordinate(value: number): number {
-  return Math.max(5, Math.min(44, Math.round(value)));
+function clampAnchorCoordinate(value: number): number {
+  return Math.max(SAFE_ANCHOR_MIN, Math.min(SAFE_ANCHOR_MAX, Math.round(value)));
+}
+
+function clampAnchor(point: BlueprintPoint): BlueprintPoint {
+  return {
+    x: clampAnchorCoordinate(point.x),
+    y: clampAnchorCoordinate(point.y)
+  };
 }
 
 function pointRange(a: BlueprintPoint, b: BlueprintPoint): number {
@@ -69,13 +82,13 @@ function pointRange(a: BlueprintPoint, b: BlueprintPoint): number {
 }
 
 function createDefaultAnchor(facts: BlueprintRoomFacts): BlueprintPoint {
-  if (facts.anchor) return { x: facts.anchor.x, y: facts.anchor.y };
+  if (facts.anchor) return clampAnchor(facts.anchor);
 
   const existingStorage = facts.existingStructures?.find(structure => structure.structureType === STRUCTURE_TYPES.storage);
-  if (existingStorage) return { x: existingStorage.x, y: existingStorage.y };
+  if (existingStorage) return clampAnchor(existingStorage);
 
   const existingSpawn = facts.existingStructures?.find(structure => structure.structureType === STRUCTURE_TYPES.spawn);
-  if (existingSpawn) return { x: existingSpawn.x + 2, y: existingSpawn.y };
+  if (existingSpawn) return clampAnchor({ x: existingSpawn.x + 2, y: existingSpawn.y });
 
   const points = [...(facts.sources ?? [])];
   if (facts.controller) points.push(facts.controller);
@@ -84,7 +97,7 @@ function createDefaultAnchor(facts: BlueprintRoomFacts): BlueprintPoint {
   if (points.length === 0) return { x: 25, y: 25 };
 
   const total = points.reduce((sum, point) => ({ x: sum.x + point.x, y: sum.y + point.y }), { x: 0, y: 0 });
-  return { x: clampRoomCoordinate(total.x / points.length), y: clampRoomCoordinate(total.y / points.length) };
+  return clampAnchor({ x: total.x / points.length, y: total.y / points.length });
 }
 
 function countStructure(state: MutablePlanState, structureType: BuildableStructureConstant): number {

--- a/packages/@ralphschuler/screeps-layouts/test/stampPlanner.test.ts
+++ b/packages/@ralphschuler/screeps-layouts/test/stampPlanner.test.ts
@@ -69,6 +69,15 @@ function positionsOf(plan: BlueprintPlan, structureType: BuildableStructureConst
     .map(structure => `${structure.x},${structure.y}`);
 }
 
+function expectPlanPositionsInsidePlannerBounds(plan: BlueprintPlan): void {
+  for (const collection of [plan.structures, plan.roads, plan.ramparts]) {
+    for (const position of collection) {
+      expect(position.x).to.be.within(1, 48);
+      expect(position.y).to.be.within(1, 48);
+    }
+  }
+}
+
 describe("stamp blueprint planner", () => {
   before(installScreepsConstants);
 
@@ -171,6 +180,27 @@ describe("stamp blueprint planner", () => {
 
     expect(plan.anchor).to.deep.equal({ x: 30, y: 31 });
     expect(plan.structures.some(structure => structure.source.startsWith("HUB_CORE") && structure.x === 30 && structure.y === 31)).to.equal(true);
+  });
+
+  it("clamps explicit planner anchors into the safe buildable stamp area", async () => {
+    const { planRoomBlueprint } = await import("../src/blueprints/planner.ts");
+    const plan = planRoomBlueprint(makeFacts(8, { anchor: { x: 25, y: 25 } }), 8, { anchor: { x: 1, y: 1 } });
+
+    expect(plan.anchor).to.deep.equal({ x: 9, y: 9 });
+    expect(plan.errors).to.deep.equal([]);
+    expect(count(plan, EXTENSION)).to.equal(60);
+    expectPlanPositionsInsidePlannerBounds(plan);
+  });
+
+  it("clamps existing-spawn-derived anchors near room edges", async () => {
+    const { planRoomBlueprint } = await import("../src/blueprints/planner.ts");
+    const existingStructures = [{ x: 47, y: 47, structureType: SPAWN }];
+    const plan = planRoomBlueprint(makeFacts(8, { anchor: undefined, existingStructures }));
+
+    expect(plan.anchor).to.deep.equal({ x: 40, y: 40 });
+    expect(count(plan, SPAWN)).to.equal(3);
+    expect(plan.structures.some(structure => structure.structureType === SPAWN && structure.x === 47 && structure.y === 47 && structure.placedBy === "fixed")).to.equal(true);
+    expectPlanPositionsInsidePlannerBounds(plan);
   });
 
   it("adopts an existing offset spawn instead of requiring duplicate spawn1 placement", async () => {


### PR DESCRIPTION
## Overview

Fixes #3114 by normalizing all stamp blueprint anchor sources through one safety clamp.

## Changes

- Clamp explicit anchors and existing storage/spawn-derived anchors to the safe stamp planning band.
- Use a stricter core-anchor band (`9..40`) so extension pod geometry remains inside planner buildable bounds (`1..48`).
- Add regression tests for explicit `{ x: 1, y: 1 }` anchors and existing spawns near room edges.

## Validation

- ✅ `npm test -w @ralphschuler/screeps-layouts` (51 passing)
- ✅ `npm run build -w @ralphschuler/screeps-layouts`
- ✅ `npm run lint -w @ralphschuler/screeps-layouts` (existing module-type warning only)
- ✅ `git diff --check`

## Risk / rollback

Low-risk layout-only change. Roll back by reverting commit `67f3fbe` if edge-anchor behavior needs a diagnostic instead of clamping.
