### PR TITLE
[codex] Continue layout construction queue after rejected sites

### DIFF
--- a/packages/@ralphschuler/screeps-layouts/src/blueprints/constructionQueue.ts
+++ b/packages/@ralphschuler/screeps-layouts/src/blueprints/constructionQueue.ts
@@ -129,11 +129,13 @@ export function issueConstructionSites(room: Room, plan: BlueprintPlan, maxSites
   if (globalExistingSites >= globalSiteCap) return 0;
 
   const existing = roomExistingKeys(room);
+  // Build the full queue: the highest-scoring planned tiles can be rejected by
+  // live Screeps validation, so slicing to maxSitesPerTick candidates can starve
+  // lower-scored mandatory structures such as extension fallback sites.
   const queue = buildConstructionQueue(plan, {
     existingStructureKeys: existing.structures,
     existingSiteKeys: existing.sites,
-    currentRcl: room.controller?.level ?? plan.rcl,
-    maxItems: Math.min(maxSitesPerTick, globalSiteCap - globalExistingSites)
+    currentRcl: room.controller?.level ?? plan.rcl
   });
 
   let created = 0;

--- a/packages/@ralphschuler/screeps-layouts/test/stampPlanner.test.ts
+++ b/packages/@ralphschuler/screeps-layouts/test/stampPlanner.test.ts
@@ -33,7 +33,9 @@ function installScreepsConstants(): void {
     STRUCTURE_EXTRACTOR: EXTRACTOR,
     STRUCTURE_CONTAINER: "container",
     TERRAIN_MASK_WALL: 1,
-    MAX_CONSTRUCTION_SITES: 100
+    MAX_CONSTRUCTION_SITES: 100,
+    OK: 0,
+    ERR_INVALID_TARGET: -7
   });
 }
 
@@ -250,6 +252,51 @@ describe("stamp blueprint planner", () => {
 
     try {
       expect(issueConstructionSites(room, plan, 3)).to.equal(0);
+    } finally {
+      (globalThis as { Game?: unknown }).Game = oldGame;
+    }
+  });
+
+  it("continues past rejected high-priority construction candidates", async () => {
+    const { issueConstructionSites } = await import("../src/blueprints/constructionQueue.ts");
+    const oldGame = (globalThis as { Game?: unknown }).Game;
+    const calls: Array<{ x: number; y: number; structureType: BuildableStructureConstant }> = [];
+    const plan: BlueprintPlan = {
+      roomName: "W1N1",
+      rcl: 5,
+      anchor: { x: 25, y: 25 },
+      structures: [
+        { x: 10, y: 10, structureType: EXTENSION, minRcl: 2, priority: 300, source: "blocked-1", placedBy: "stamp" },
+        { x: 11, y: 10, structureType: EXTENSION, minRcl: 2, priority: 299, source: "blocked-2", placedBy: "stamp" },
+        { x: 12, y: 10, structureType: EXTENSION, minRcl: 2, priority: 298, source: "blocked-3", placedBy: "stamp" },
+        { x: 13, y: 10, structureType: EXTENSION, minRcl: 2, priority: 297, source: "valid-extension", placedBy: "stamp" }
+      ],
+      roads: [],
+      ramparts: [],
+      unplaced: [],
+      errors: [],
+      stamps: [],
+      version: "test"
+    };
+    const room = {
+      controller: { level: 5 },
+      find: () => [],
+      createConstructionSite: (x: number, y: number, structureType: BuildableStructureConstant) => {
+        calls.push({ x, y, structureType });
+        return x === 13 && y === 10 ? OK : ERR_INVALID_TARGET;
+      }
+    } as unknown as Room;
+
+    (globalThis as { Game?: unknown }).Game = { constructionSites: {} };
+
+    try {
+      expect(issueConstructionSites(room, plan, 1)).to.equal(1);
+      expect(calls.map(call => `${call.structureType}:${call.x},${call.y}`)).to.deep.equal([
+        "extension:10,10",
+        "extension:11,10",
+        "extension:12,10",
+        "extension:13,10"
+      ]);
     } finally {
       (globalThis as { Game?: unknown }).Game = oldGame;
     }

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -34428,8 +34428,7 @@ sites: s
 }(e), d = ma(t, {
 existingStructureKeys: m.structures,
 existingSiteKeys: m.sites,
-currentRcl: null !== (i = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== i ? i : t.rcl,
-maxItems: Math.min(3, u - l)
+currentRcl: null !== (i = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== i ? i : t.rcl
 }), p = 0;
 try {
 for (var f = a(d), y = f.next(); !y.done; y = f.next()) {


### PR DESCRIPTION
## Summary

Fixes the stamp construction queue so rejected high-priority construction candidates no longer starve lower-scored mandatory sites.

## Linked issue

Closes #3107

## Changes

- Builds the full blueprint construction queue before issuing sites.
- Keeps `maxSitesPerTick` as a creation limit, not a candidate-scan limit.
- Adds regression coverage where rejected extension candidates are skipped until a later valid extension site is created.
- Regenerates `packages/screeps-bot/dist/main.js`.

## Validation

- `npm run test:layouts` — pass, 52 passing
- `npm run build:layouts` — pass
- `npm run build:bot` — pass
- `npm run lint -w @ralphschuler/screeps-layouts` — pass
- `git diff --check` — pass

## Deployment impact

Runtime layout construction behavior changes on screeps.com. Rooms with mandatory structure demand should continue scanning planned sites after live API rejects earlier candidates, improving odds of extension fallback placement.

## Live bot evidence

Live `shard1/W18S28` remained RCL5 with 1 completed extension and 0 extension construction sites after PR #3142 deploy. The room had open global/site capacity but many non-extension sites, matching a starvation mode where earlier candidates can prevent later mandatory extensions from being attempted.

## Follow-up issues

- #3143 tracks stale shard3 Memory.stats diagnostics discovered during live analysis.
