### PR TITLE
[codex] Keep optional deploy targets non-blocking

### DIFF
--- a/.github/ENVIRONMENT_SETUP.md
+++ b/.github/ENVIRONMENT_SETUP.md
@@ -6,16 +6,18 @@ This document explains how to configure GitHub Environments for deploying the Sc
 
 The deploy workflow (`deploy.yml`) uses GitHub Environments to manage server-specific credentials and configuration. Each Screeps server (screeps.com, sim.screeps.com, etc.) needs its own environment configuration.
 
-## Required Environments
+## Deploy Environments
 
 The deploy workflow targets these environments:
 
-- `sim.screeps.com` - Simulation server
-- `season.screeps.com` - Seasonal server
-- `ptr.screeps.com` - Public Test Realm
-- `screeps.com` - Main production server
-- `screeps.nyphon.de` - Private server
-- `screeps.newbieland.net` - Private server
+- `screeps.com` - Main production server (required; gates deploy workflow success)
+- `sim.screeps.com` - Simulation server (optional; non-blocking)
+- `season.screeps.com` - Seasonal server (optional; non-blocking)
+- `ptr.screeps.com` - Public Test Realm (optional; non-blocking)
+- `screeps.nyphon.de` - Private server (optional; non-blocking)
+- `screeps.newbieland.net` - Private server (optional; non-blocking)
+
+Optional targets are still useful when configured, but DNS/auth/server failures there are allowed to fail without marking a successful `screeps.com` production upload as failed.
 
 ## Setting Up an Environment
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,22 +18,32 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment: ${{ matrix.target.environment }}
+    # Only the official production target gates the workflow result. Optional
+    # community/simulation targets are useful when configured, but DNS/auth
+    # outages there must not mark a successful screeps.com upload as failed.
+    continue-on-error: ${{ matrix.target.required != true }}
     strategy:
       fail-fast: false
       matrix:
         target:
           - environment: sim.screeps.com
             hostname: screeps.com
+            required: false
           - environment: season.screeps.com
             hostname: season.screeps.com
+            required: false
           - environment: ptr.screeps.com
             hostname: ptr.screeps.com
+            required: false
           - environment: screeps.com
             hostname: screeps.com
+            required: true
           - environment: screeps.nyphon.de
             hostname: screeps.nyphon.de
+            required: false
           - environment: screeps.newbieland.net
             hostname: screeps.newbieland.net
+            required: false
     env:
       CI: true
       SCREEPS_USER: ${{ vars.SCREEPS_USER }}

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -55,7 +55,7 @@ Required environment variables/secrets:
 - `SCREEPS_PATH`
 - `SCREEPS_BRANCH`
 
-Configured environments include official and private servers such as `screeps.com`, `season.screeps.com`, `ptr.screeps.com`, and private-server targets. The deploy workflow provides a non-empty default hostname for each matrix target (`sim.screeps.com` uses `screeps.com` as the API host); environment variables can still override that hostname when needed.
+Configured environments include official and private servers such as `screeps.com`, `season.screeps.com`, `ptr.screeps.com`, and private-server targets. The deploy workflow provides a non-empty default hostname for each matrix target (`sim.screeps.com` uses `screeps.com` as the API host); environment variables can still override that hostname when needed. Only the production `screeps.com` matrix target is required to pass; optional simulation/community targets are allowed to fail without marking a successful production upload failed.
 
 ## Branch/environment mapping
 

--- a/scripts/test/deploy-workflow.test.mjs
+++ b/scripts/test/deploy-workflow.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../../.github/workflows/deploy.yml", import.meta.url), "utf8");
+
+function parseDeployTargets() {
+  const matrixBlock = workflow.match(/matrix:\n(?<block>[\s\S]*?)\n\s{4}env:/)?.groups?.block;
+  assert.ok(matrixBlock, "deploy workflow should define a matrix before env");
+
+  return [...matrixBlock.matchAll(/^\s{10}- environment: (?<environment>\S+)\n\s{12}hostname: (?<hostname>\S+)\n\s{12}required: (?<required>true|false)$/gm)].map(
+    ({ groups }) => ({
+      environment: groups.environment,
+      hostname: groups.hostname,
+      required: groups.required === "true",
+    }),
+  );
+}
+
+test("deploy workflow keeps screeps.com required and marks optional targets non-blocking", () => {
+  assert.match(
+    workflow,
+    /continue-on-error:\s*\$\{\{\s*matrix\.target\.required\s*!=\s*true\s*\}\}/,
+    "deploy matrix should allow optional target failures without failing the workflow",
+  );
+
+  const targets = parseDeployTargets();
+  assert.deepEqual(
+    targets.map((target) => target.environment).sort(),
+    [
+      "ptr.screeps.com",
+      "screeps.com",
+      "screeps.newbieland.net",
+      "screeps.nyphon.de",
+      "season.screeps.com",
+      "sim.screeps.com",
+    ].sort(),
+  );
+
+  assert.deepEqual(
+    targets.filter((target) => target.required).map((target) => target.environment),
+    ["screeps.com"],
+    "only production screeps.com should be a required deploy target",
+  );
+
+  for (const target of targets) {
+    if (target.environment !== "screeps.com") {
+      assert.equal(target.required, false, `${target.environment} should be optional`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Make the deploy matrix treat only `screeps.com` production upload as required. Optional sim/PTR/community targets now keep their logs but no longer fail the overall Deploy workflow when they are unavailable or unconfigured.

## Linked issue

Closes #3151

## Changes

- Adds `required` metadata to deploy matrix targets.
- Sets job-level `continue-on-error` for optional targets.
- Documents required vs optional deploy environments.
- Adds a script-level regression test for deploy workflow required-target semantics.

## Validation

- `node --test scripts/test/deploy-workflow.test.mjs` — pass
- `npm run test:scripts` — pass
- `npm run sync:deps:check` — pass
- `npm run check-versions` — pass after `nvm use 24` (`node v24.18.0`, `npm 11.16.0`)
- `npm run build` — pass after `nvm use 24`

Note: an initial `npm run check-versions` under the harness default Node v22.22.2 failed as expected; reran under the repo-required Node 24 and passed.

## Deployment impact

Affects GitHub Actions deploy status only. Bot runtime bundle logic unchanged. Production `screeps.com` deploy remains the required target.

## Live bot evidence

Pre-work live analysis completed via read-only Screeps API at `artifacts/live-analysis-20260702T022214Z` and existing live issues were updated (#3118, #3119, #3104, #3143). This PR addresses the separate deployment-status P1.

## Follow-up issues

None created for this scoped deploy-status fix.
