### PR TITLE
fix: add ally-safe guards for harmful action execution

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
@@ -28,6 +28,7 @@ import { moveTo, clearCachedPath, isExit } from "screeps-cartographer";
 import { clearClosestCache as clearAllCachedTargets } from "../cache";
 import { createLogger } from "@ralphschuler/screeps-core";
 import * as metrics from "@ralphschuler/screeps-stats";
+import { isKnownAllyOwned } from "@ralphschuler/screeps-defense";
 import { applyOpportunisticActions } from "../economy/opportunisticActions";
 import { getCollectionPoint } from "../utils/common";
 import { taskBoard } from "../tasks";
@@ -53,6 +54,34 @@ export type RemoteMoveHandler = (
 type MetricsCreepMemory = CreepMemory & { _metrics?: metrics.CreepMetrics };
 
 let remoteMoveHandler: RemoteMoveHandler | undefined;
+
+function shouldBlockHarmfulActionAgainstAlly(
+  ctx: CreepContext,
+  actionType: string,
+  target: RoomObject,
+): boolean {
+  if (!isKnownAllyOwned(target as unknown as Structure)) {
+    return false;
+  }
+
+  logger.warn("Refusing harmful action against known ally target", {
+    room: ctx.creep.pos.roomName,
+    creep: ctx.creep.name,
+    meta: {
+      action: actionType,
+      target: (target as { id?: string }).id,
+      owner: (target as { owner?: { username?: string } }).owner?.username,
+    },
+  });
+
+  delete ctx.memory.state;
+  if ((ctx.creep as Creep).id) {
+    clearCachedPath(ctx.creep);
+    clearAllCachedTargets(ctx.creep);
+  }
+  taskBoard.releaseCreep(ctx.creep.name, ctx.creep.room.name);
+  return true;
+}
 
 export function setRemoteMoveHandler(
   handler: RemoteMoveHandler | undefined,
@@ -221,7 +250,12 @@ export function executeAction(
       );
       break;
 
-    case "dismantle":
+    case "dismantle": {
+      if (shouldBlockHarmfulActionAgainstAlly(ctx, optimizedAction.type, optimizedAction.target)) {
+        shouldClearState = true;
+        break;
+      }
+
       shouldClearState = executeWithRange(
         creep,
         () => creep.dismantle(optimizedAction.target),
@@ -230,9 +264,15 @@ export function executeAction(
         optimizedAction.type,
       );
       break;
+    }
 
     // Combat
-    case "attack":
+    case "attack": {
+      if (shouldBlockHarmfulActionAgainstAlly(ctx, optimizedAction.type, optimizedAction.target)) {
+        shouldClearState = true;
+        break;
+      }
+
       executeWithRange(
         creep,
         () => creep.attack(optimizedAction.target),
@@ -241,8 +281,14 @@ export function executeAction(
         optimizedAction.type,
       );
       break;
+    }
 
-    case "rangedAttack":
+    case "rangedAttack": {
+      if (shouldBlockHarmfulActionAgainstAlly(ctx, optimizedAction.type, optimizedAction.target)) {
+        shouldClearState = true;
+        break;
+      }
+
       executeWithRange(
         creep,
         () => creep.rangedAttack(optimizedAction.target),
@@ -251,6 +297,7 @@ export function executeAction(
         optimizedAction.type,
       );
       break;
+    }
 
     case "heal":
       executeWithRange(
@@ -296,7 +343,12 @@ export function executeAction(
       );
       break;
 
-    case "attackController":
+    case "attackController": {
+      if (shouldBlockHarmfulActionAgainstAlly(ctx, optimizedAction.type, optimizedAction.target)) {
+        shouldClearState = true;
+        break;
+      }
+
       executeWithRange(
         creep,
         () => creep.attackController(optimizedAction.target),
@@ -305,6 +357,7 @@ export function executeAction(
         optimizedAction.type,
       );
       break;
+    }
 
     // Movement
     case "moveTo": {

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/power.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/power.ts
@@ -6,14 +6,21 @@
  */
 
 import type { SwarmCreepMemory } from "../memory/schemas";
-import { getActualHostileCreeps, getActualHostileStructures } from "@ralphschuler/screeps-defense";
+import {
+  getActualHostileCreeps,
+  getActualHostileStructures,
+  isKnownAllyOwned,
+} from "@ralphschuler/screeps-defense";
+import { createLogger } from "@ralphschuler/screeps-core";
 import { moveTo } from "screeps-cartographer";
 import type { CreepAction, CreepContext } from "./types";
 import {
   cachedRoomFind,
   cachedFindMyStructures,
-  cachedFindDroppedResources
+  cachedFindDroppedResources,
 } from "../cache";
+
+const logger = createLogger("PowerExecutor");
 
 // =============================================================================
 // Regular Creep Power Roles
@@ -487,12 +494,35 @@ export function powerWarrior(ctx: PowerCreepContext): PowerCreepAction {
   return { type: "idle" };
 }
 
+const DISRUPT_POWER_ACTIONS: ReadonlySet<PowerConstant> = new Set([
+  PWR_DISRUPT_SPAWN,
+  PWR_DISRUPT_TOWER,
+  PWR_DISRUPT_TERMINAL,
+]);
+
+function isDisruptivePowerAgainstAlly(power: PowerConstant, target?: RoomObject): boolean {
+  return Boolean(target && DISRUPT_POWER_ACTIONS.has(power) && isKnownAllyOwned(target as unknown as Structure));
+}
+
 /**
  * Execute a Power Creep action.
  */
 export function executePowerCreepAction(powerCreep: PowerCreep, action: PowerCreepAction): void {
   switch (action.type) {
     case "usePower": {
+      if (isDisruptivePowerAgainstAlly(action.power, action.target)) {
+        logger.warn("Refusing disruptive power action against known ally target", {
+          creep: powerCreep.name,
+          room: powerCreep.pos?.roomName,
+          meta: {
+            power: action.power,
+            target: action.target && (action.target as { id?: string }).id,
+            owner: (action.target as { owner?: { username?: string } } | undefined)?.owner?.username,
+          },
+        });
+        break;
+      }
+
       const result = action.target
         ? powerCreep.usePower(action.power, action.target)
         : powerCreep.usePower(action.power);

--- a/packages/@ralphschuler/screeps-roles/test/executorSafety.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/executorSafety.test.ts
@@ -1,0 +1,167 @@
+import { expect } from "chai";
+import { executeAction, executePowerCreepAction, type CreepContext } from "../src/index";
+import { createMockCreep, createMockRoom, resetMockGame } from "./setup";
+
+describe("Action execution ally-safety guard", () => {
+  beforeEach(() => {
+    resetMockGame();
+  });
+
+  function createTestContext(creep: Creep, room: Room): CreepContext {
+    return {
+      creep,
+      room,
+      memory: creep.memory as CreepContext["memory"],
+      swarmState: undefined,
+      squadMemory: undefined,
+      homeRoom: room.name,
+      isInHomeRoom: true,
+      isFull: false,
+      isEmpty: true,
+      isWorking: false,
+      assignedSource: null,
+      assignedMineral: null,
+      energyAvailable: false,
+      nearbyEnemies: false,
+      constructionSiteCount: 0,
+      damagedStructureCount: 0,
+      droppedResources: [],
+      containers: [],
+      depositContainers: [],
+      spawnStructures: [],
+      towers: [],
+      storage: undefined,
+      terminal: undefined,
+      hostiles: [],
+      damagedAllies: [],
+      prioritizedSites: [],
+      repairTargets: [],
+      labs: [],
+      factory: undefined,
+      tombstones: [],
+      mineralContainers: [],
+    };
+  }
+
+  it("blocks creep attack actions against known allies", () => {
+    const room = createMockRoom("W1N1");
+    let attackCalled = false;
+
+    const creep = createMockCreep("guard1", {
+      room,
+      memory: {
+        role: "soldier",
+        homeRoom: room.name,
+        working: false,
+        state: { action: "attack", targetId: "ally01", startTick: Game.time, timeout: 25 },
+      },
+    });
+    (creep as any).attack = () => {
+      attackCalled = true;
+      return OK;
+    };
+
+    const allyCreep = {
+      id: "ally01",
+      owner: { username: "TooAngel" },
+      pos: new RoomPosition(10, 10, room.name),
+    } as unknown as Creep;
+
+    Game.creeps[creep.name] = creep;
+    Game.rooms[room.name] = room;
+
+    executeAction(creep, { type: "attack", target: allyCreep }, createTestContext(creep, room));
+
+    expect(attackCalled).to.equal(false);
+    expect(creep.memory.state).to.equal(undefined);
+  });
+
+  it("allows attack actions against non-ally targets", () => {
+    const room = createMockRoom("W1N1");
+    let attackCalled = false;
+
+    const creep = createMockCreep("guard2", {
+      room,
+      memory: {
+        role: "soldier",
+        homeRoom: room.name,
+        working: false,
+      },
+    });
+    (creep as any).attack = () => {
+      attackCalled = true;
+      return OK;
+    };
+
+    const hostileCreep = {
+      id: "hostile01",
+      owner: { username: "Enemy" },
+      pos: new RoomPosition(10, 10, room.name),
+    } as unknown as Creep;
+
+    Game.creeps[creep.name] = creep;
+    Game.rooms[room.name] = room;
+
+    executeAction(creep, { type: "attack", target: hostileCreep }, createTestContext(creep, room));
+
+    expect(attackCalled).to.equal(true);
+  });
+
+  it("blocks disruptive power actions against known allies", () => {
+    const room = createMockRoom("W1N1");
+    let usePowerCalled = false;
+
+    const powerCreep: PowerCreep = {
+      name: "pc1",
+      pos: {
+        x: 10,
+        y: 10,
+        roomName: room.name,
+        isEqualTo: () => false,
+        isNearTo: () => false,
+        inRangeTo: () => true,
+        getRangeTo: () => 0,
+        findInRange: () => [],
+        findClosestByRange: () => null,
+        findClosestByPath: () => null,
+        lookFor: () => [],
+      } as unknown as RoomPosition,
+      room,
+      getActiveBodyparts: () => 0,
+      usePower: () => {
+        usePowerCalled = true;
+        return OK;
+      },
+      cancelOrder: () => OK,
+      move: () => OK,
+      moveByPath: () => OK,
+      moveByDirection: () => OK,
+      moveTo: () => OK,
+      renew: () => OK,
+      enableRoom: () => OK,
+      say: () => OK,
+      notifyWhenAttacked: () => OK,
+      getOffPath: () => false,
+      drop: () => OK,
+      suicide: () => OK,
+      transfer: () => OK,
+      withdraw: () => OK,
+    } as unknown as PowerCreep;
+
+    const allyTerminal = {
+      id: "ally-term",
+      owner: { username: "TedRoastBeef" },
+      structureType: STRUCTURE_TERMINAL,
+      effects: [],
+      pos: new RoomPosition(10, 10, room.name),
+    } as unknown as StructureTerminal;
+
+    executePowerCreepAction(powerCreep, {
+      type: "usePower",
+      power: PWR_DISRUPT_TERMINAL,
+      target: allyTerminal,
+    });
+
+    expect(usePowerCalled).to.equal(false);
+  });
+});

--- a/packages/@ralphschuler/screeps-roles/test/setup.ts
+++ b/packages/@ralphschuler/screeps-roles/test/setup.ts
@@ -83,6 +83,11 @@
 (global as any).RESOURCE_KEANIUM_BAR = 'keanium_bar';
 (global as any).RESOURCE_OXIDANT = 'oxidant';
 
+// Power constants
+(global as any).PWR_DISRUPT_SPAWN = 9;
+(global as any).PWR_DISRUPT_TOWER = 11;
+(global as any).PWR_DISRUPT_TERMINAL = 15;
+
 // Return codes
 (global as any).OK = 0;
 (global as any).ERR_NOT_OWNER = -1;
@@ -201,6 +206,8 @@ export const MockMemory: {
 /**
  * Create a mock creep for testing
  */
+let mockCreepIdCounter = 0;
+
 export function createMockCreep(name: string, options: {
   room?: any;
   memory?: any;
@@ -211,6 +218,7 @@ export function createMockCreep(name: string, options: {
   const mockRoom = options.room || createMockRoom('W1N1');
   
   const creep = {
+    id: (++mockCreepIdCounter).toString(16).padStart(24, "0"),
     name,
     room: mockRoom,
     pos: options.pos || {


### PR DESCRIPTION
## Summary

Implements issue #3098 hardening for last-mile ally safety:

- Add ally target guard in `behaviors/executor.ts` for harmful creep actions before execution:
  - `attack`
  - `rangedAttack`
  - `dismantle`
  - `attackController`
- Add ally target guard in `behaviors/power.ts` for disruptive power actions:
  - `PWR_DISRUPT_SPAWN`
  - `PWR_DISRUPT_TOWER`
  - `PWR_DISRUPT_TERMINAL`
- Log blocked attempts and clear/flush creep state/task assignment to avoid stuck behavior.
- Add focused unit tests in `test/executorSafety.test.ts`.

## Validation

- `npm test --workspace @ralphschuler/screeps-roles`
- `npm run build --workspace @ralphschuler/screeps-roles`
- `npm run lint --workspace @ralphschuler/screeps-roles`

Closes #3098
