### PR TITLE
[codex] Redact live snapshot API errors

### DIFF
--- a/packages/screeps-server/scripts/export-live-structural-snapshot.js
+++ b/packages/screeps-server/scripts/export-live-structural-snapshot.js
@@ -8,6 +8,7 @@ import {
   safeObject,
   writeJson,
 } from "./cpu-benchmark-model.js";
+import { formatScreepsApiError } from "../../../scripts/live-redaction.mjs";
 
 const require = createRequire(import.meta.url);
 const { ScreepsAPI } = require("screeps-api");
@@ -42,6 +43,10 @@ function unwrapMemory(response) {
   return response;
 }
 
+export function redactedSnapshotError(fields, error) {
+  return { ...fields, message: formatScreepsApiError(error) };
+}
+
 async function fetchMemory(api, shard) {
   const paths = ["stats", "creeps", "rooms", "creepTaskBoard", "defenseRequests", "clusters", "empire"];
   const memory = {};
@@ -50,7 +55,7 @@ async function fetchMemory(api, shard) {
       memory[memoryPath] = unwrapMemory(await api.memory.get(memoryPath, shard));
     } catch (error) {
       memory[memoryPath] = {};
-      memory.__errors = [...(memory.__errors ?? []), { type: "memory", path: memoryPath, message: error instanceof Error ? error.message : String(error) }];
+      memory.__errors = [...(memory.__errors ?? []), redactedSnapshotError({ type: "memory", path: memoryPath }, error)];
     }
   }
   return memory;
@@ -82,14 +87,15 @@ async function exportSnapshot(options) {
     try {
       roomStatus[roomName] = await api.raw.game.roomStatus(roomName, options.shard);
     } catch (error) {
-      roomStatus[roomName] = { ok: 0, error: error instanceof Error ? error.message : String(error) };
-      errors.push({ type: "roomStatus", room: roomName, message: error instanceof Error ? error.message : String(error) });
+      const message = formatScreepsApiError(error);
+      roomStatus[roomName] = { ok: 0, error: message };
+      errors.push(redactedSnapshotError({ type: "roomStatus", room: roomName }, error));
     }
     try {
       roomResponses[roomName] = await api.raw.game.roomObjects(roomName, options.shard);
     } catch (error) {
       roomResponses[roomName] = { objects: [], users: {} };
-      errors.push({ type: "roomObjects", room: roomName, message: error instanceof Error ? error.message : String(error) });
+      errors.push(redactedSnapshotError({ type: "roomObjects", room: roomName }, error));
     }
   }
 

--- a/scripts/live-cpu-profile.mjs
+++ b/scripts/live-cpu-profile.mjs
@@ -4,6 +4,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { redactScreepsApiMessage } from "./live-redaction.mjs";
+
+export { redactScreepsApiMessage };
+
 const DEFAULT_SHARDS = ["shard0", "shard1", "shard2", "shard3"];
 
 export function formatHelp() {
@@ -71,13 +75,6 @@ export function parseArgs(argv) {
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 const isFiniteNumber = value => typeof value === "number" && Number.isFinite(value);
-
-export function redactScreepsApiMessage(message) {
-  return String(message)
-    .replace(/([?&](?:token|access_token|auth)=)[^&#\s)]+/gi, "$1<redacted>")
-    .replace(/(\bX-Token:\s*)[^\s)]+/gi, "$1<redacted>")
-    .replace(/(\bSCREEPS_TOKEN=)[^\s)]+/g, "$1<redacted>");
-}
 
 function addMetric(bucket, key, value, meta = {}) {
   if (!isFiniteNumber(value)) return;

--- a/scripts/live-redaction.mjs
+++ b/scripts/live-redaction.mjs
@@ -1,0 +1,11 @@
+export function redactScreepsApiMessage(message) {
+  return String(message)
+    .replace(/([?&](?:token|access_token|auth)=)[^&#\s)]+/gi, "$1<redacted>")
+    .replace(/(\bX-Token:\s*)[^\s)]+/gi, "$1<redacted>")
+    .replace(/(\bSCREEPS_TOKEN=)[^\s)]+/g, "$1<redacted>");
+}
+
+export function formatScreepsApiError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return redactScreepsApiMessage(message);
+}

--- a/scripts/test/export-live-structural-snapshot-redaction.test.mjs
+++ b/scripts/test/export-live-structural-snapshot-redaction.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { redactedSnapshotError } from "../../packages/screeps-server/scripts/export-live-structural-snapshot.js";
+
+const RATE_LIMIT_MESSAGE = [
+  "Rate limit exceeded, retry after 123ms or disable rate limiting using this link:",
+  "https://screeps.com/a/#!/account/auth-tokens/noratelimit?token=6ea62d57"
+].join(" ");
+
+test("structural snapshot memory errors redact Screeps API token fragments", () => {
+  const entry = redactedSnapshotError({ type: "memory", path: "stats" }, new Error(RATE_LIMIT_MESSAGE));
+
+  assert.equal(entry.type, "memory");
+  assert.equal(entry.path, "stats");
+  assert.equal(entry.message.includes("6ea62d57"), false);
+  assert.equal(entry.message.includes("token=<redacted>"), true);
+});
+
+test("structural snapshot room endpoint errors redact token fragments", () => {
+  for (const fields of [
+    { type: "roomStatus", room: "W1N1" },
+    { type: "roomObjects", room: "W1N1" }
+  ]) {
+    const entry = redactedSnapshotError(fields, `X-Token: abc123 ${RATE_LIMIT_MESSAGE} SCREEPS_TOKEN=secret123`);
+
+    assert.equal(entry.type, fields.type);
+    assert.equal(entry.room, "W1N1");
+    assert.equal(entry.message.includes("abc123"), false);
+    assert.equal(entry.message.includes("secret123"), false);
+    assert.equal(entry.message.includes("6ea62d57"), false);
+    assert.equal(entry.message.includes("token=<redacted>"), true);
+  }
+});


### PR DESCRIPTION
## Summary

Redacts Screeps API error messages before structural snapshot artifacts persist them, and centralizes live-tool API redaction for reuse.

## Linked issue

Closes #3159

## Changes

- Added `scripts/live-redaction.mjs` with shared Screeps API message/error redaction.
- Reused that helper from `scripts/live-cpu-profile.mjs` while preserving its existing export contract.
- Applied redaction to `export-live-structural-snapshot.js` memory, room-status, and room-objects error paths before JSON output.
- Added focused root script tests for structural snapshot redaction.

## Validation

Using Node `v24.18.0` via `nvm use 24`:

- `npm run check-versions` ✅
- `npm run sync:deps:check` ✅
- `npm run test:scripts` ✅
- `npm run build` ✅ (existing Rollup TS2352 warning in `packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts:414`; build passed)
- Live read-only structural snapshot redaction check ✅ (`.tmp/structural-redaction-validation.json` contained no unredacted token-like rate-limit URL)

## Deployment impact

No bot runtime behavior change. Deploy path still builds; this only affects repo live-analysis tooling artifacts.

## Live bot evidence

During 2026-07-02 live analysis, `api.memory.get` rate-limit errors for `shard1`/`shard3` included no-rate-limit URLs before local cleanup. This PR redacts those messages before they are written to structural snapshot JSON.

## Follow-up issues

- #3121 remains the parent blocker for Memory API rate-limited live diagnostics.
