### PR TITLE
[codex] Prevent worker-bodied claimers

### DIFF
--- a/packages/screeps-bot/test/unit/spawnIntentCompiler.test.ts
+++ b/packages/screeps-bot/test/unit/spawnIntentCompiler.test.ts
@@ -357,7 +357,12 @@ describe("spawn intent compiler", () => {
       Harvester1: { memory: { role: "harvester", homeRoom: "W1N1" }, spawning: false },
       Hauler1: { memory: { role: "hauler", homeRoom: "W1N1" }, spawning: false },
       Upgrader1: { memory: { role: "upgrader", homeRoom: "W1N1" }, spawning: false },
-      Claimer1: { memory: { role: "claimer", homeRoom: "W1N1", targetRoom: "W2N1", task: "claim" }, spawning: false }
+      Claimer1: {
+        memory: { role: "claimer", homeRoom: "W1N1", targetRoom: "W2N1", task: "claim" },
+        spawning: false,
+        body: [{ type: CLAIM, hits: 100 }, { type: MOVE, hits: 100 }],
+        getActiveBodyparts: (part: BodyPartConstant) => (part === CLAIM ? 1 : 0)
+      }
     } as unknown as typeof Game.creeps;
 
     const request = createSpawnPlan(room, createSwarm(["W2N1"]))

--- a/packages/screeps-spawn/src/bodyOptimizer.ts
+++ b/packages/screeps-spawn/src/bodyOptimizer.ts
@@ -318,6 +318,7 @@ export function optimizeBody(options: BodyOptimizationOptions): BodyTemplate {
     case "interShardScout":
       return { parts: [MOVE], cost: 50, minCapacity: 50 };
 
+    case "claimer":
     case "interShardClaimer":
       return { parts: [CLAIM, MOVE], cost: 650, minCapacity: 650 };
 

--- a/packages/screeps-spawn/src/spawn-demand/claimerDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/claimerDemand.ts
@@ -37,10 +37,18 @@ function isRoomRecoveryReclaimEnabled(): boolean {
   return mem.spawnSettings?.roomRecoveryReclaim !== false;
 }
 
+function hasActiveClaimPart(creep: Creep): boolean {
+  if (typeof creep.getActiveBodyparts === "function") {
+    return creep.getActiveBodyparts(CLAIM) > 0;
+  }
+
+  return creep.body?.some(part => part.type === CLAIM && part.hits > 0) ?? false;
+}
+
 function hasAssignedClaimer(targetRoom: string, task: ClaimerTask): boolean {
   const activeClaimer = Object.values(Game.creeps).some(creep => {
     const memory = creep.memory as unknown as SwarmCreepMemory;
-    return memory.role === "claimer" && memory.targetRoom === targetRoom && memory.task === task;
+    return memory.role === "claimer" && memory.targetRoom === targetRoom && memory.task === task && hasActiveClaimPart(creep);
   });
   if (activeClaimer) return true;
 
@@ -48,7 +56,8 @@ function hasAssignedClaimer(targetRoom: string, task: ClaimerTask): boolean {
     const queuedClaimer = spawnQueue.getPendingRequests(roomName).some(request =>
       request.role === "claimer" &&
       request.targetRoom === targetRoom &&
-      request.additionalMemory?.task === task
+      request.additionalMemory?.task === task &&
+      request.body.parts.includes(CLAIM)
     );
     if (queuedClaimer) return true;
   }

--- a/packages/screeps-spawn/src/spawnIntentCompiler.ts
+++ b/packages/screeps-spawn/src/spawnIntentCompiler.ts
@@ -266,7 +266,9 @@ export function compileSpawnDemandToRequest(room: Room, demand: SpawnDemand): Sp
       });
     const maxBodyEnergy = demand.bodyOverride || defenseAssistBody ? maxEnergy : effectiveMaxEnergy;
 
-    if (!body || body.cost > maxBodyEnergy) return null;
+    if (!body) return null;
+    if (demand.roleName === "claimer" && !body.parts.includes(CLAIM)) return null;
+    if (body.cost > maxBodyEnergy) return null;
 
     const additionalMemory = {
       ...(demand.task ? { task: demand.task } : {}),

--- a/packages/screeps-spawn/test/bodyOptimizer.test.ts
+++ b/packages/screeps-spawn/test/bodyOptimizer.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { calculateBodyCost } from "../src/bodyUtils";
-import { optimizeBuilderBody, optimizeUpgraderBody } from "../src/bodyOptimizer";
+import { optimizeBody, optimizeBuilderBody, optimizeUpgraderBody } from "../src/bodyOptimizer";
 
 function expectTemplate(parts: BodyPartConstant[], expectedParts: BodyPartConstant[]): void {
   expect(parts).to.deep.equal(expectedParts);
@@ -24,6 +24,16 @@ describe("Body Optimizer", () => {
       expectTemplate(template.parts, [WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE]);
       expect(template.cost).to.equal(calculateBodyCost(template.parts));
       expect(template.minCapacity).to.equal(template.cost);
+    });
+  });
+
+  describe("optimizeBody", () => {
+    it("keeps claimers on a CLAIM-capable body instead of falling back to a worker body", () => {
+      const template = optimizeBody({ role: "claimer", maxEnergy: 300 });
+
+      expectTemplate(template.parts, [CLAIM, MOVE]);
+      expect(template.cost).to.equal(650);
+      expect(template.minCapacity).to.equal(650);
     });
   });
 });

--- a/packages/screeps-spawn/test/claimerPioneerDemand.test.ts
+++ b/packages/screeps-spawn/test/claimerPioneerDemand.test.ts
@@ -67,6 +67,14 @@ function createDangerousHostile(username = "Invader"): Creep {
   } as Creep;
 }
 
+function createClaimerCreep(targetRoom: string, parts: BodyPartConstant[]): Creep {
+  return {
+    memory: { role: "claimer", targetRoom, task: "claim" },
+    body: parts.map(type => ({ type, hits: 100 })),
+    getActiveBodyparts: (part: BodyPartConstant) => parts.filter(type => type === part).length
+  } as unknown as Creep;
+}
+
 function setEmpireMemory(overrides: Record<string, unknown> = {}): void {
   (global as any).Memory = {
     rooms: {},
@@ -149,6 +157,52 @@ describe("claimer and pioneer demand", () => {
     const assignment = getClaimerSpawnAssignment("E1N1", createSwarm({ remoteAssignments: ["E2N1"] }));
 
     expect(assignment).to.deep.equal({ targetRoom: "E2N1", task: "reserve" });
+  });
+
+  it("ignores active claimers without CLAIM parts when de-duplicating claim targets", () => {
+    Game.rooms.E3N1 = createRoom("E3N1");
+    Game.creeps.invalidClaimer = createClaimerCreep("E3N1", [WORK, CARRY, MOVE]);
+    setEmpireMemory({
+      recoveryRooms: {
+        E3N1: { roomName: "E3N1", lostAt: 10, rcl: 3, role: "core", clusterId: "c1" }
+      }
+    });
+
+    expect(getClaimerSpawnAssignment("E1N1", createSwarm())).to.deep.equal({ targetRoom: "E3N1", task: "claim" });
+  });
+
+  it("treats active CLAIM-bodied claimers as assigned claim targets", () => {
+    Game.rooms.E3N1 = createRoom("E3N1");
+    Game.creeps.validClaimer = createClaimerCreep("E3N1", [CLAIM, MOVE]);
+    setEmpireMemory({
+      recoveryRooms: {
+        E3N1: { roomName: "E3N1", lostAt: 10, rcl: 3, role: "core", clusterId: "c1" }
+      }
+    });
+
+    expect(getClaimerSpawnAssignment("E1N1", createSwarm())).to.equal(null);
+  });
+
+  it("ignores queued claimers without CLAIM parts when de-duplicating claim targets", () => {
+    Game.rooms.E3N1 = createRoom("E3N1");
+    spawnQueue.addRequest({
+      id: "invalid_queued_claimer",
+      roomName: "E1N1",
+      role: "claimer",
+      family: "utility",
+      body: { parts: [WORK, CARRY, MOVE], cost: 200, minCapacity: 200 },
+      priority: 100,
+      targetRoom: "E3N1",
+      additionalMemory: { task: "claim" },
+      createdAt: Game.time
+    });
+    setEmpireMemory({
+      recoveryRooms: {
+        E3N1: { roomName: "E3N1", lostAt: 10, rcl: 3, role: "core", clusterId: "c1" }
+      }
+    });
+
+    expect(getClaimerSpawnAssignment("E1N1", createSwarm())).to.deep.equal({ targetRoom: "E3N1", task: "claim" });
   });
 
   it("skips unsafe recovery and remote reservation targets", () => {

--- a/packages/screeps-spawn/test/spawnIntentCompiler.test.ts
+++ b/packages/screeps-spawn/test/spawnIntentCompiler.test.ts
@@ -1,0 +1,75 @@
+import { expect } from "chai";
+import { compileSpawnDemandToRequest, type SpawnDemand } from "../src/spawnIntentCompiler";
+import { ROLE_DEFINITIONS } from "../src/roleDefinitions";
+import { SpawnPriority } from "../src/spawnQueue";
+
+function createRoom(energyCapacityAvailable: number): Room {
+  return {
+    name: "E1N1",
+    energyAvailable: energyCapacityAvailable,
+    energyCapacityAvailable,
+    controller: { my: true, level: 3 },
+    find: () => []
+  } as unknown as Room;
+}
+
+function createClaimerDemand(overrides: Partial<SpawnDemand> = {}): SpawnDemand {
+  return {
+    roleName: "claimer",
+    def: ROLE_DEFINITIONS.claimer,
+    current: 0,
+    target: 1,
+    missing: 1,
+    priority: SpawnPriority.HIGH,
+    targetRoom: "E2N1",
+    task: "claim",
+    ...overrides
+  };
+}
+
+describe("spawn intent compiler", () => {
+  beforeEach(() => {
+    (globalThis as any).Game = {
+      time: 1000,
+      rooms: {},
+      creeps: {},
+      spawns: {}
+    };
+    (globalThis as any).Memory = {};
+  });
+
+  it("does not compile a low-energy claimer as a worker-bodied fallback", () => {
+    const room = createRoom(300);
+    Game.rooms.E1N1 = room;
+
+    const request = compileSpawnDemandToRequest(room, createClaimerDemand());
+
+    expect(request).to.equal(null);
+  });
+
+  it("compiles affordable claimers with CLAIM parts", () => {
+    const room = createRoom(650);
+    Game.rooms.E1N1 = room;
+
+    const request = compileSpawnDemandToRequest(room, createClaimerDemand());
+
+    expect(request).to.not.equal(null);
+    expect(request!.body.parts).to.deep.equal([CLAIM, MOVE]);
+    expect(request!.targetRoom).to.equal("E2N1");
+    expect(request!.additionalMemory?.task).to.equal("claim");
+  });
+
+  it("rejects claimer body overrides that lack CLAIM parts", () => {
+    const room = createRoom(650);
+    Game.rooms.E1N1 = room;
+
+    const request = compileSpawnDemandToRequest(
+      room,
+      createClaimerDemand({
+        bodyOverride: { parts: [WORK, CARRY, MOVE], cost: 200, minCapacity: 200 }
+      })
+    );
+
+    expect(request).to.equal(null);
+  });
+});


### PR DESCRIPTION
## Summary

Prevents spawn planning from creating or de-duplicating `claimer` creeps that cannot claim/reserve because they lack `CLAIM` body parts.

## Linked issue

Closes #3166

## Changes

- Added explicit `claimer` handling in `@ralphschuler/screeps-spawn` body optimization so fallback bodies stay `CLAIM+MOVE` instead of worker bodies.
- Added a compile guard that rejects `claimer` spawn requests whose selected/override body lacks `CLAIM`.
- Updated claimer de-duplication to ignore active or queued no-`CLAIM` claimers, allowing valid replacements.
- Added spawn-package regression tests and updated a bot integration test fixture to model valid active claimers.

## Validation

- ✅ `npm test -w @ralphschuler/screeps-spawn -- --grep "Body Optimizer|spawn intent compiler"` (RED before implementation: 3 failures)
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm test -w @ralphschuler/screeps-spawn`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run build:spawn`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run lint:spawn`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm test -w screeps-typescript-starter -- --grep "spawn intent compiler|claimer|pioneer"`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run build:bot` (passes with known TS2352 warning tracked in #3162)
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run check-versions && npm run sync:deps:check && npm run check:alliance-safety`
- ⚠️ `npm run build` with default shell Node 22 failed version check; reran version-gated checks under Node 24.
- ⚠️ `npm run build` under bounded 300s tool timeout did not complete; scoped build validation passed and evidence was added to #3103.

## Deployment impact

Affects screeps.com spawn/runtime behavior. Deploy should stop producing new worker-bodied `claimer` creeps and should allow valid replacements when stale invalid claimers exist.

## Live bot evidence

Read-only live snapshot at `artifacts/live-analysis-20260702T090021Z-structural/structural-shard1.json` showed `W19S26` unowned with a visible friendly `claimer_72059440_vxcvgwquw` body `WORK+CARRY+MOVE` and no `CLAIM` part.

## Follow-up issues

- #3103 updated with full-build timeout evidence.
- #3121, #3143, #3105, #3118, and #3161 updated with live-analysis evidence from this run.
