### PR TITLE
[codex] Retire invalid no-CLAIM claimers

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
@@ -324,7 +324,7 @@ export function executeAction(
 
     // Controller actions
     case "claim":
-      executeWithRange(
+      shouldClearState = executeWithRange(
         creep,
         () => creep.claimController(optimizedAction.target),
         optimizedAction.target,
@@ -334,7 +334,7 @@ export function executeAction(
       break;
 
     case "reserve":
-      executeWithRange(
+      shouldClearState = executeWithRange(
         creep,
         () => creep.reserveController(optimizedAction.target),
         optimizedAction.target,
@@ -349,7 +349,7 @@ export function executeAction(
         break;
       }
 
-      executeWithRange(
+      shouldClearState = executeWithRange(
         creep,
         () => creep.attackController(optimizedAction.target),
         optimizedAction.target,

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/utility/claimer.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/utility/claimer.ts
@@ -3,6 +3,28 @@ import { isExit } from "screeps-cartographer";
 import type { CreepAction, CreepContext } from "../types";
 import { moveToRoomCenter } from "./navigation";
 
+function retireInvalidClaimer(ctx: CreepContext): CreepAction {
+  delete ctx.memory.state;
+  delete (ctx.memory as typeof ctx.memory & { task?: string }).task;
+
+  const spawn = ctx.spawnStructures.find(
+    (structure): structure is StructureSpawn => structure.structureType === STRUCTURE_SPAWN,
+  );
+  if (!spawn) {
+    ctx.creep.suicide();
+    return { type: "idle" };
+  }
+
+  const recycleResult = spawn.recycleCreep(ctx.creep);
+  if (recycleResult === ERR_NOT_IN_RANGE) {
+    return { type: "moveTo", target: spawn };
+  }
+  if (recycleResult !== OK && recycleResult !== ERR_BUSY) {
+    ctx.creep.suicide();
+  }
+  return { type: "idle" };
+}
+
 /**
  * Claimer - claim, reserve, or attack room controllers.
  *
@@ -10,6 +32,10 @@ import { moveToRoomCenter } from "./navigation";
  * travel/off-exit movement and the final controller action.
  */
 export function claimer(ctx: CreepContext): CreepAction {
+  if (ctx.creep.getActiveBodyparts(CLAIM) === 0) {
+    return retireInvalidClaimer(ctx);
+  }
+
   const targetRoom = ctx.memory.targetRoom;
 
   if (!targetRoom) {

--- a/packages/@ralphschuler/screeps-roles/test/claimerBehavior.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/claimerBehavior.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import { claimer, type CreepContext } from "../src/index";
+import { createMockCreep, createMockRoom, resetMockGame } from "./setup";
+
+function createContext(creep: Creep, room: Room): CreepContext {
+  return {
+    creep,
+    room,
+    memory: creep.memory as CreepContext["memory"],
+    swarmState: undefined,
+    squadMemory: undefined,
+    homeRoom: creep.memory.homeRoom ?? room.name,
+    isInHomeRoom: creep.memory.homeRoom === room.name,
+    isFull: false,
+    isEmpty: true,
+    isWorking: false,
+    assignedSource: null,
+    assignedMineral: null,
+    energyAvailable: false,
+    nearbyEnemies: false,
+    constructionSiteCount: 0,
+    damagedStructureCount: 0,
+    droppedResources: [],
+    containers: [],
+    depositContainers: [],
+    spawnStructures: [],
+    towers: [],
+    storage: undefined,
+    terminal: undefined,
+    hostiles: [],
+    damagedAllies: [],
+    prioritizedSites: [],
+    repairTargets: [],
+    labs: [],
+    factory: undefined,
+    tombstones: [],
+    mineralContainers: [],
+  };
+}
+
+describe("claimer behavior", () => {
+  beforeEach(() => {
+    resetMockGame();
+  });
+
+  it("retires a claimer with no active CLAIM parts instead of attempting controller actions", () => {
+    const controller = {
+      id: "controller1" as Id<StructureController>,
+      pos: new RoomPosition(25, 25, "W2N1"),
+    } as StructureController;
+    const room = createMockRoom("W2N1", { controller });
+    let suicideCalled = false;
+    const creep = createMockCreep("claimer_invalid", {
+      room,
+      memory: {
+        role: "claimer",
+        homeRoom: "W1N1",
+        targetRoom: "W2N1",
+        task: "claim",
+        state: { action: "claim", targetId: controller.id },
+      },
+      body: [
+        { type: WORK, hits: 100 },
+        { type: CARRY, hits: 100 },
+        { type: MOVE, hits: 100 },
+      ],
+    });
+    (creep as unknown as { suicide: () => ScreepsReturnCode }).suicide = () => {
+      suicideCalled = true;
+      return OK;
+    };
+
+    const action = claimer(createContext(creep, room));
+
+    expect(action.type).to.equal("idle");
+    expect(suicideCalled).to.equal(true);
+    expect(creep.memory.state).to.equal(undefined);
+    expect((creep.memory as CreepMemory & { task?: string }).task).to.equal(undefined);
+  });
+
+  it("allows claim-capable claimers to reserve the target room controller", () => {
+    const controller = {
+      id: "controller2" as Id<StructureController>,
+      pos: new RoomPosition(25, 25, "W2N1"),
+    } as StructureController;
+    const room = createMockRoom("W2N1", { controller });
+    let suicideCalled = false;
+    const creep = createMockCreep("claimer_valid", {
+      room,
+      memory: {
+        role: "claimer",
+        homeRoom: "W1N1",
+        targetRoom: "W2N1",
+        task: "reserve",
+      },
+      body: [
+        { type: CLAIM, hits: 100 },
+        { type: MOVE, hits: 100 },
+      ],
+    });
+    (creep as unknown as { suicide: () => ScreepsReturnCode }).suicide = () => {
+      suicideCalled = true;
+      return OK;
+    };
+
+    const action = claimer(createContext(creep, room));
+
+    expect(action.type).to.equal("reserve");
+    expect((action as Extract<typeof action, { type: "reserve" }>).target).to.equal(controller);
+    expect(suicideCalled).to.equal(false);
+  });
+});

--- a/packages/@ralphschuler/screeps-roles/test/executorSafety.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/executorSafety.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { executeAction, executePowerCreepAction, type CreepContext } from "../src/index";
+import { executeAction, executePowerCreepAction, type CreepAction, type CreepContext } from "../src/index";
 import { createMockCreep, createMockRoom, resetMockGame } from "./setup";
 
 describe("Action execution ally-safety guard", () => {
@@ -105,6 +105,43 @@ describe("Action execution ally-safety guard", () => {
     executeAction(creep, { type: "attack", target: hostileCreep }, createTestContext(creep, room));
 
     expect(attackCalled).to.equal(true);
+  });
+
+  it("clears stale controller-action state when the creep has no active CLAIM parts", () => {
+    const room = createMockRoom("W1N1");
+    const controller = {
+      id: "controller1" as Id<StructureController>,
+      pos: new RoomPosition(10, 10, room.name),
+    } as StructureController;
+    const cases: Array<{
+      action: "claim" | "reserve" | "attackController";
+      method: "claimController" | "reserveController" | "attackController";
+    }> = [
+      { action: "claim", method: "claimController" },
+      { action: "reserve", method: "reserveController" },
+      { action: "attackController", method: "attackController" },
+    ];
+
+    for (const { action, method } of cases) {
+      const creep = createMockCreep(`claimer-${action}`, {
+        room,
+        memory: {
+          role: "claimer",
+          homeRoom: room.name,
+          working: false,
+          state: { action, targetId: controller.id, startTick: Game.time, timeout: 25 },
+        },
+        body: [{ type: MOVE, hits: 100 }],
+      });
+      (creep as unknown as Record<typeof method, () => ScreepsReturnCode>)[method] = () => ERR_NO_BODYPART;
+
+      Game.creeps[creep.name] = creep;
+      Game.rooms[room.name] = room;
+
+      executeAction(creep, { type: action, target: controller } as CreepAction, createTestContext(creep, room));
+
+      expect(creep.memory.state, action).to.equal(undefined);
+    }
   });
 
   it("blocks disruptive power actions against known allies", () => {


### PR DESCRIPTION
## Summary

Retires legacy invalid claimers that have no active `CLAIM` parts and clears stale controller-action state when controller actions fail permanently.

## Linked issue

Closes #3168

## Changes

- Add a claimer behavior guard for no-`CLAIM` claimers:
  - clear stale state/task
  - recycle at an available spawn when possible
  - suicide if no recycle path exists
- Make `claim`, `reserve`, and `attackController` executor paths honor `executeWithRange` clear-state decisions.
- Add role behavior and executor regression tests for no-`CLAIM` claimers.

## Validation

- `npm test -w @ralphschuler/screeps-roles -- --grep "claimer behavior|controller-action state"` ✅
- `npm test -w @ralphschuler/screeps-roles` ✅
- `npm run build -w @ralphschuler/screeps-roles` ✅
- `npm run lint -w @ralphschuler/screeps-roles` ✅
- `npm run build:bot` ✅ (known TS2352 warning remains tracked by #3162)
- `npm run check-versions` ✅ under Node 24.18.0
- `npm run sync:deps:check` ✅
- `npm run check:alliance-safety --silent` ✅
- `npm run test:server:smoke` ✅

## Deployment impact

Runtime behavior change in `@ralphschuler/screeps-roles`; deploy required after merge so legacy invalid claimers stop wasting controller actions.

## Live bot evidence

Follow-up to PR #3167 / issue #3166. Earlier live artifacts showed worker-bodied `claimer_*` creeps with no `CLAIM` parts attempting claim/reserve tasks. Current read-only snapshot at `artifacts/autonomous-live-20260702T195920Z/` did not see active `claimer_*` creeps in sampled rooms, but Memory.creeps was rate-limited (#3121), so this PR adds the runtime safety guard.

## Follow-up issues

- #3121 tracks Screeps Memory API rate limits blocking full live verification.
- #3162 tracks the existing deploy build TS2352 warning.
