### PR TITLE
[codex] Escalate ranged-heal defense attacks

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -5913,6 +5913,7 @@ y > 0 && (c.guards = Math.ceil(1.5 * c.guards), c.rangers = Math.ceil(1.5 * c.ra
 c.healers = Math.ceil(1.5 * c.healers), c.urgency = 2, c.reasons.push("".concat(y, " boosted enemies (high threat)"))),
 (l.length >= 2 || y > 0 || p > 0 || f > 0) && (c.guards = Math.max(c.guards, 2),
 c.rangers = Math.max(c.rangers, 2)), l.length >= 3 && (c.healers = Math.max(c.healers, 1)),
+l.length >= 2 && d >= 8 && p >= 4 && (c.urgency = Math.max(c.urgency, 2), c.reasons.push("".concat(l.length, " hostiles with ").concat(d, " ranged/").concat(p, " heal parts (coordinated ranged-heal attack)"))),
 l.length >= 5 && (c.urgency = Math.max(c.urgency, 1.5), c.reasons.push("".concat(l.length, " hostiles (large attack)"))),
 e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -12072,18 +12073,18 @@ subsystem: "Defense"
 }, e.prototype.calculateEmergencyLevel = function(e, t) {
 var r = j(e);
 if (0 === t.danger && 0 === r.length) return Pa.NONE;
-var o = fr(e), n = vr(e);
+var o = fr(e), n = vr(e), a = Br(e);
 if (e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
 }
 }).length > 0) return Pa.CRITICAL;
-var a = r.filter(function(e) {
+var i = r.filter(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && e.boost;
 });
-}), i = Math.max(0, o.guards - n.guards) + Math.max(0, o.rangers - n.rangers) + Math.max(0, o.healers - n.healers);
-return a.length > 0 && i >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers ? Pa.HIGH : t.danger >= 2 && i >= 1 ? Pa.MEDIUM : t.danger >= 1 || r.length > 0 ? Pa.LOW : Pa.NONE;
+}), s = Math.max(0, o.guards - n.guards) + Math.max(0, o.rangers - n.rangers) + Math.max(0, o.healers - n.healers);
+return i.length > 0 && s >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers || a.dangerLevel >= 2 && s >= 2 ? Pa.HIGH : (t.danger >= 2 || a.dangerLevel >= 2) && s >= 1 ? Pa.MEDIUM : t.danger >= 1 || r.length > 0 ? Pa.LOW : Pa.NONE;
 }, e.prototype.executeEmergencyResponse = function(e, t, r) {
 r.level >= Pa.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
 r.level >= Pa.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),

--- a/packages/screeps-defense/src/analysis/defenderNeeds.ts
+++ b/packages/screeps-defense/src/analysis/defenderNeeds.ts
@@ -10,6 +10,9 @@ import type { SwarmState } from "@ralphschuler/screeps-memory";
 import { getActualHostileCreeps } from "../alliance/nonAggressionPact";
 
 const DEFENSE_ASSIST_THREAT_PARTS = new Set<BodyPartConstant>([ATTACK, RANGED_ATTACK, WORK, HEAL, CLAIM]);
+const COORDINATED_RANGED_HEAL_MIN_HOSTILES = 2;
+const COORDINATED_RANGED_HEAL_MIN_RANGED_PARTS = 8;
+const COORDINATED_RANGED_HEAL_MIN_HEAL_PARTS = 4;
 
 function hasVisibleDefenseThreat(room: Room): boolean {
   return getActualHostileCreeps(room).some(hostile =>
@@ -141,6 +144,17 @@ export function analyzeDefenderNeeds(room: Room): DefenderRequirement {
 
   if (hostiles.length >= 3) {
     result.healers = Math.max(result.healers, 1);
+  }
+
+  if (
+    hostiles.length >= COORDINATED_RANGED_HEAL_MIN_HOSTILES &&
+    rangedCount >= COORDINATED_RANGED_HEAL_MIN_RANGED_PARTS &&
+    healerCount >= COORDINATED_RANGED_HEAL_MIN_HEAL_PARTS
+  ) {
+    result.urgency = Math.max(result.urgency, 2.0);
+    result.reasons.push(
+      `${hostiles.length} hostiles with ${rangedCount} ranged/${healerCount} heal parts (coordinated ranged-heal attack)`
+    );
   }
 
   if (hostiles.length >= 5) {

--- a/packages/screeps-defense/src/emergency/emergencyResponse.ts
+++ b/packages/screeps-defense/src/emergency/emergencyResponse.ts
@@ -29,6 +29,7 @@ import {
   needsDefenseAssistance
 } from "../analysis/defenderNeeds";
 import { getActualHostileCreeps } from "../alliance/nonAggressionPact";
+import { assessThreat } from "../threat/threatAssessment";
 
 /**
  * Emergency response levels
@@ -137,6 +138,7 @@ export class EmergencyResponseManager {
 
     const needs = analyzeDefenderNeeds(room);
     const current = getCurrentDefenders(room);
+    const threat = assessThreat(room);
 
     // Critical: Critical structures heavily damaged or about to be destroyed
     const criticalStructures = room.find(FIND_MY_STRUCTURES, {
@@ -167,8 +169,13 @@ export class EmergencyResponseManager {
       return EmergencyLevel.HIGH;
     }
 
+    // High: live threat analysis already sees active-attack/siege pressure and the room lacks defenders.
+    if (threat.dangerLevel >= 2 && defenderDeficit >= 2) {
+      return EmergencyLevel.HIGH;
+    }
+
     // Medium: Significant threat with defender deficit
-    if (swarm.danger >= 2 && defenderDeficit >= 1) {
+    if ((swarm.danger >= 2 || threat.dangerLevel >= 2) && defenderDeficit >= 1) {
       return EmergencyLevel.MEDIUM;
     }
 

--- a/packages/screeps-defense/test/defenderNeeds.test.ts
+++ b/packages/screeps-defense/test/defenderNeeds.test.ts
@@ -81,6 +81,37 @@ describe("defense assistance needs", () => {
     expect((Memory as any).defenseRequests?.[0]?.roomName).to.equal("W1N1");
   });
 
+  it("escalates clustered ranged-heal owned-room attacks above low alert", () => {
+    const manager = new EmergencyResponseManager();
+    const swarm = {
+      danger: 0,
+      posture: "eco",
+      pheromones: { defense: 0, war: 0, siege: 0 }
+    } as any;
+    const rangedHealBody = [
+      ...repeatedParts(RANGED_ATTACK, 14),
+      ...repeatedParts(MOVE, 25),
+      ...repeatedParts(HEAL, 11),
+    ];
+    const room = createRoom([
+      createHostile(rangedHealBody),
+      createHostile(rangedHealBody),
+      createHostile(rangedHealBody),
+      createHostile(rangedHealBody),
+    ], 5, 1);
+
+    const needs = analyzeDefenderNeeds(room);
+    const state = manager.assess(room, swarm);
+    const request = (Memory as any).defenseRequests?.[0];
+
+    expect(needs.urgency).to.be.at.least(2);
+    expect(needs.reasons.join("; ")).to.include("coordinated ranged-heal attack");
+    expect(state.level).to.equal(EmergencyLevel.HIGH);
+    expect(request?.urgency).to.be.at.least(2);
+    expect(request?.rangersNeeded).to.be.greaterThan(0);
+    expect(request?.healersNeeded).to.be.greaterThan(0);
+  });
+
   it("refreshes an active defense request when the visible attack force grows", () => {
     const manager = new EmergencyResponseManager();
     const swarm = {


### PR DESCRIPTION
## Summary

Escalates live owned-room ranged/heal attack groups from low alert to high defense response.

## Linked issue

Closes #3190

## Changes

- Adds a defense-package ranged/heal group urgency heuristic for clustered attacks.
- Uses live threat analysis in emergency response so active-attack/siege threats with defender deficits become HIGH/MEDIUM emergencies even before swarm danger propagates.
- Adds regression coverage using the W18S28 live pattern: four ranged/heal hostiles with limited local defense.
- Updates tracked bot bundle.

## Validation

- `npm test -w @ralphschuler/screeps-defense -- --grep "clustered ranged-heal"` — passed after expected red failure.
- `npm test -w @ralphschuler/screeps-defense` — passed.
- `npm run build:defense && npm run lint:defense` — passed.
- `npm run build && npm run test:defense && npm run check:alliance-safety` — passed.

## Deployment impact

Runtime defense behavior changes: active ranged/heal groups in owned rooms should raise defense posture and request urgency sooner. Deploy path still builds.

## Live bot evidence

Read-only Screeps API sample `artifacts/live-analysis-20260703T010948Z/live-summary.json` showed shard1 `W18S28` at RCL5 with 4 `Tigga` ranged/heal hostiles, 1 tower with 800 energy, 2 ramparts, and 11 friendly creeps.

## Follow-up issues

- #3191 tracks bounded spawn routing/capping for high-urgency defense requests.
