### PR TITLE
[codex] Guard unified stats room retention by ownership

### DIFF
--- a/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
+++ b/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
@@ -121,6 +121,8 @@ export interface SwarmCreepMemory {
   defenseSquadSize?: number;
   /** Tick when the defense assist wave was requested/spawned. */
   defenseSquadCreatedAt?: number;
+  /** Tick when this creep was released from defense-assist staging. */
+  defenseAssistReleasedAt?: number;
   /** Boosted flag */
   boosted?: boolean;
   /** Boost requirements (for spawning with boost intentions) */

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/military.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/military.ts
@@ -30,6 +30,7 @@ const logger = createLogger("MilitaryBehaviors");
 const DEFENSE_ASSIST_SQUAD_STAGE_TIMEOUT = 250;
 const DEFENSE_ASSIST_HARD_THREAT_STAGE_TIMEOUT = 750;
 const DEFENSE_ASSIST_HARD_THREAT_RELEASE_QUORUM = 5;
+const DEFENSE_ASSIST_HARD_THREAT_TRICKLE_INTERVAL = 50;
 const DEFENSE_ASSIST_TASK = "defenseAssist";
 
 type DefenseAssistRole = "guard" | "ranger" | "healer";
@@ -47,6 +48,10 @@ interface MemoryWithDefenseRequests {
   defenseRequests?: DefenseAssistRequestMemory[] | Record<string, DefenseAssistRequestMemory>;
 }
 
+interface MemoryWithDefenseAssistTrickleReleases {
+  defenseAssistTrickleReleases?: Record<string, number>;
+}
+
 function getDefenseAssistTargetRoom(mem: Partial<SwarmCreepMemory>): string | undefined {
   return mem.assistTarget ?? (mem.task === DEFENSE_ASSIST_TASK ? mem.targetRoom : undefined);
 }
@@ -56,6 +61,7 @@ function clearDefenseAssistAssignment(mem: SwarmCreepMemory): void {
   delete mem.defenseSquadId;
   delete mem.defenseSquadSize;
   delete mem.defenseSquadCreatedAt;
+  delete mem.defenseAssistReleasedAt;
   if (mem.task === DEFENSE_ASSIST_TASK) {
     delete mem.task;
     delete mem.targetRoom;
@@ -70,6 +76,10 @@ function isDefenseAssistSquadStagingExpired(mem: SwarmCreepMemory, hardThreat: b
   if (mem.defenseSquadCreatedAt === undefined) return true;
   const timeout = hardThreat ? DEFENSE_ASSIST_HARD_THREAT_STAGE_TIMEOUT : DEFENSE_ASSIST_SQUAD_STAGE_TIMEOUT;
   return Game.time - mem.defenseSquadCreatedAt >= timeout;
+}
+
+function markDefenseAssistReleased(mem: SwarmCreepMemory): void {
+  mem.defenseAssistReleasedAt ??= Game.time;
 }
 
 function emptyCombatPower(): CombatPower {
@@ -148,15 +158,18 @@ function isReadyDefenseAssistTargetMember(creep: Creep, assistTarget: string, ho
   );
 }
 
-function countReadyDefenseAssistTargetMembers(assistTarget: string, homeRoom: string): number {
+function getReadyDefenseAssistTargetMembers(assistTarget: string, homeRoom: string): Creep[] {
   return Object.values(Game.creeps).filter(creep =>
     isReadyDefenseAssistTargetMember(creep, assistTarget, homeRoom)
-  ).length;
+  );
+}
+
+function countReadyDefenseAssistTargetMembers(assistTarget: string, homeRoom: string): number {
+  return getReadyDefenseAssistTargetMembers(assistTarget, homeRoom).length;
 }
 
 function calculateReadyDefenseAssistTargetPower(assistTarget: string, homeRoom: string): CombatPower {
-  return Object.values(Game.creeps)
-    .filter(creep => isReadyDefenseAssistTargetMember(creep, assistTarget, homeRoom))
+  return getReadyDefenseAssistTargetMembers(assistTarget, homeRoom)
     .reduce((total, creep) => {
       const activeBody = creep.body.filter(part => part.hits > 0);
       return addCombatPower(total, calculateCombatPower(activeBody));
@@ -237,25 +250,87 @@ function countReadyDefenseAssistSquadMembers(mem: SwarmCreepMemory, homeRoom: st
   ).length;
 }
 
+function getDefenseAssistTrickleKey(homeRoom: string, assistTarget: string): string {
+  return `${homeRoom}:${assistTarget}`;
+}
+
+function getDefenseAssistTricklePriority(creep: Creep): number {
+  const activeDamage = creep.body.some(part =>
+    part.hits > 0 && (part.type === ATTACK || part.type === RANGED_ATTACK || part.type === WORK)
+  );
+  if (activeDamage) return 0;
+
+  const activeHeal = creep.body.some(part => part.hits > 0 && part.type === HEAL);
+  return activeHeal ? 1 : 2;
+}
+
+function chooseDefenseAssistTrickleMember(readyMembers: Creep[]): Creep | null {
+  return [...readyMembers].sort((a, b) => {
+    const priorityDelta = getDefenseAssistTricklePriority(a) - getDefenseAssistTricklePriority(b);
+    if (priorityDelta !== 0) return priorityDelta;
+    return a.name.localeCompare(b.name);
+  })[0] ?? null;
+}
+
+function canReleaseHardThreatTrickle(creep: Creep, homeRoom: string, assistTarget: string, readyMembers: Creep[]): boolean {
+  if (chooseDefenseAssistTrickleMember(readyMembers)?.name !== creep.name) return false;
+
+  const memory = Memory as unknown as MemoryWithDefenseAssistTrickleReleases;
+  const releases = memory.defenseAssistTrickleReleases ??= {};
+  const key = getDefenseAssistTrickleKey(homeRoom, assistTarget);
+  const lastReleasedAt = releases[key];
+  if (lastReleasedAt !== undefined && Game.time - lastReleasedAt < DEFENSE_ASSIST_HARD_THREAT_TRICKLE_INTERVAL) {
+    return false;
+  }
+
+  releases[key] = Game.time;
+  return true;
+}
+
 function getDefenseAssistSquadStagingAction(ctx: CreepContext, mem: SwarmCreepMemory): CreepAction | null {
   if (!isDefenseAssistSquadConfigured(mem)) return null;
   if (ctx.creep.room.name !== ctx.homeRoom) return null;
 
   const assistTarget = getDefenseAssistTargetRoom(mem);
   if (!assistTarget) return null;
+  if (mem.defenseAssistReleasedAt !== undefined) return null;
 
   const threatProfile = getVisibleDefenseAssistThreatProfile(assistTarget);
   const hardThreat = isDefenseAssistThreatProfileHard(threatProfile);
-  const readyMembers = hardThreat
-    ? countReadyDefenseAssistTargetMembers(assistTarget, ctx.homeRoom)
-    : countReadyDefenseAssistSquadMembers(mem, ctx.homeRoom);
+  const readyTargetMembers = hardThreat ? getReadyDefenseAssistTargetMembers(assistTarget, ctx.homeRoom) : [];
+  const readyMembers = hardThreat ? readyTargetMembers.length : countReadyDefenseAssistSquadMembers(mem, ctx.homeRoom);
+
+  const releaseQuorum = getDefenseAssistSquadReleaseQuorum(mem, hardThreat);
+  const stagingExpired = isDefenseAssistSquadStagingExpired(mem, hardThreat);
 
   if (threatProfile) {
-    if (hasReadyDefenseAssistParity(assistTarget, ctx.homeRoom, threatProfile)) return null;
+    if (hasReadyDefenseAssistParity(assistTarget, ctx.homeRoom, threatProfile)) {
+      markDefenseAssistReleased(mem);
+      return null;
+    }
+    if (readyMembers >= releaseQuorum) {
+      markDefenseAssistReleased(mem);
+      return null;
+    }
+    if (stagingExpired) {
+      if (!hardThreat) {
+        markDefenseAssistReleased(mem);
+        return null;
+      }
+      if (canReleaseHardThreatTrickle(ctx.creep, ctx.homeRoom, assistTarget, readyTargetMembers)) {
+        markDefenseAssistReleased(mem);
+        return null;
+      }
+    }
   } else {
-    if (readyMembers >= getDefenseAssistSquadReleaseQuorum(mem, hardThreat)) return null;
-    if (!hardThreat && isDefenseAssistSquadStagingExpired(mem, false)) return null;
-    if (hardThreat && isDefenseAssistSquadStagingExpired(mem, true)) return null;
+    if (readyMembers >= releaseQuorum) {
+      markDefenseAssistReleased(mem);
+      return null;
+    }
+    if (stagingExpired) {
+      markDefenseAssistReleased(mem);
+      return null;
+    }
   }
 
   const collectionPoint = getCollectionPoint(ctx.room.name);

--- a/packages/@ralphschuler/screeps-roles/test/militaryAssistance.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/militaryAssistance.test.ts
@@ -125,6 +125,7 @@ describe("military assistance behavior", () => {
   beforeEach(() => {
     resetMockGame();
     delete (Memory as unknown as { defenseRequests?: unknown }).defenseRequests;
+    delete (Memory as unknown as { defenseAssistTrickleReleases?: unknown }).defenseAssistTrickleReleases;
   });
 
   it("assigns an idle guard to a visible active defense request", () => {
@@ -188,26 +189,28 @@ describe("military assistance behavior", () => {
     expect((ctx.creep.memory as { assistTarget?: string }).assistTarget).to.equal(undefined);
   });
 
-  it("does not acquire defense assist for allied creeps in the target room", () => {
-    const ally = { owner: { username: "TooAngel" }, body: [{ type: ATTACK, hits: 100 }] } as unknown as Creep;
-    const target = createMockRoom("W2N1");
-    (target as any).find = (type: number) => (type === FIND_HOSTILE_CREEPS ? [ally] : []);
-    Game.rooms.W2N1 = target;
-    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
-      { roomName: "W2N1", guardsNeeded: 1, rangersNeeded: 0, healersNeeded: 0, urgency: 2, createdAt: Game.time }
-    ];
-    const ctx = createAssistContext("guard", [], { roomName: "W1N1" });
-    delete (ctx.creep.memory as { assistTarget?: string }).assistTarget;
-    (ctx.room as any).getTerrain = () => ({ get: () => 0 });
-    Game.creeps[ctx.creep.name] = ctx.creep;
+  for (const allyName of ["TooAngel", "TedRoastBeef"]) {
+    it(`does not acquire defense assist for allied ${allyName} creeps in the target room`, () => {
+      const ally = { owner: { username: allyName }, body: [{ type: ATTACK, hits: 100 }] } as unknown as Creep;
+      const target = createMockRoom("W2N1");
+      (target as any).find = (type: number) => (type === FIND_HOSTILE_CREEPS ? [ally] : []);
+      Game.rooms.W2N1 = target;
+      (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+        { roomName: "W2N1", guardsNeeded: 1, rangersNeeded: 0, healersNeeded: 0, urgency: 2, createdAt: Game.time }
+      ];
+      const ctx = createAssistContext("guard", [], { roomName: "W1N1" });
+      delete (ctx.creep.memory as { assistTarget?: string }).assistTarget;
+      (ctx.room as any).getTerrain = () => ({ get: () => 0 });
+      Game.creeps[ctx.creep.name] = ctx.creep;
 
-    const action = guard(ctx);
+      const action = guard(ctx);
 
-    expect((ctx.creep.memory as { assistTarget?: string }).assistTarget).to.equal(undefined);
-    expect(action.type).to.not.equal("moveToRoom");
-  });
+      expect((ctx.creep.memory as { assistTarget?: string }).assistTarget).to.equal(undefined);
+      expect(action.type).to.not.equal("moveToRoom");
+    });
+  }
 
-  it("keeps hard-threat assistance staged when quorum lacks aggregate parity", () => {
+  it("releases hard-threat assistance when cross-wave staging quorum is ready", () => {
     createHardThreatRoom("W2N1");
     const ctx = createAssistContext("guard", [], {
       roomName: "W1N1",
@@ -235,7 +238,7 @@ describe("military assistance behavior", () => {
 
     const action = guard(ctx);
 
-    expect(action.type).to.equal("wait");
+    expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
   });
 
   it("stages guard assistance at home until its squad quorum is ready", () => {
@@ -400,7 +403,7 @@ describe("military assistance behavior", () => {
     expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
   });
 
-  it("keeps visible hard-threat defense assists staged after the extended timeout without parity", () => {
+  it("releases visible hard-threat defense assists after the extended timeout without parity", () => {
     createHardThreatRoom("W2N1");
     const ctx = createAssistContext("healer", [], {
       roomName: "W1N1",
@@ -415,10 +418,10 @@ describe("military assistance behavior", () => {
 
     const action = healer(ctx);
 
-    expect(action.type).to.equal("wait");
+    expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
   });
 
-  it("keeps expired aggregate hard-threat assists staged until same-home parity is ready", () => {
+  it("releases expired aggregate hard-threat assists as a bounded trickle", () => {
     createAggregateHardThreatRoom("W2N1");
     const ctx = createAssistContext("guard", [], {
       roomName: "W1N1",
@@ -433,7 +436,51 @@ describe("military assistance behavior", () => {
 
     const action = guard(ctx);
 
-    expect(action.type).to.equal("wait");
+    expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+  });
+
+  it("limits expired hard-threat trickle release to one member per interval", () => {
+    createHardThreatRoom("W2N1");
+    const squadId = "assist:W1N1:W2N1:hard-trickle";
+    const ctx = createAssistContext("guard", [], {
+      roomName: "W1N1",
+      assistTarget: "W2N1",
+      extraMemory: {
+        defenseSquadId: squadId,
+        defenseSquadSize: 13,
+        defenseSquadCreatedAt: Game.time - 760
+      }
+    });
+    const guard2 = createMockCreep("guard2", {
+      room: ctx.room,
+      memory: {
+        role: "guard",
+        family: "military",
+        homeRoom: "W1N1",
+        assistTarget: "W2N1",
+        defenseSquadId: squadId,
+        defenseSquadSize: 13,
+        defenseSquadCreatedAt: Game.time - 760
+      },
+      body: [{ type: ATTACK, hits: 100 }, { type: MOVE, hits: 100 }]
+    });
+    const guard2Ctx = { ...ctx, creep: guard2, memory: guard2.memory as CreepContext["memory"] };
+    Game.creeps = { [ctx.creep.name]: ctx.creep, [guard2.name]: guard2 } as typeof Game.creeps;
+
+    const firstAction = guard(ctx);
+    const firstReleaseTick = Game.time;
+    Game.time += 1;
+    const releasedCreepNextTickAction = guard(ctx);
+    const sameIntervalAction = guard(guard2Ctx);
+    delete Game.creeps[ctx.creep.name];
+    Game.time += 49;
+    const nextIntervalAction = guard(guard2Ctx);
+
+    expect(firstAction).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+    expect((ctx.creep.memory as { defenseAssistReleasedAt?: number }).defenseAssistReleasedAt).to.equal(firstReleaseTick);
+    expect(releasedCreepNextTickAction).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+    expect(sameIntervalAction.type).to.equal("wait");
+    expect(nextIntervalAction).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
   });
 
   it("defends the home room before staging for another room", () => {
@@ -468,7 +515,7 @@ describe("military assistance behavior", () => {
     expect(action).to.deep.equal({ type: "attack", target: localHostile });
   });
 
-  it("keeps hard-threat defense assists staged when staged quorum lacks parity", () => {
+  it("releases hard-threat defense assists once the bounded staging quorum is ready", () => {
     createHardThreatRoom("W2N1");
     const squadId = "assist:W1N1:W2N1:hard";
     const ctx = createAssistContext("guard", [], {
@@ -489,7 +536,7 @@ describe("military assistance behavior", () => {
 
     const action = guard(ctx);
 
-    expect(action.type).to.equal("wait");
+    expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
   });
 
   it("releases healer assistance after the squad staging timeout", () => {

--- a/packages/@ralphschuler/screeps-stats/src/unifiedStats.ts
+++ b/packages/@ralphschuler/screeps-stats/src/unifiedStats.ts
@@ -129,10 +129,11 @@ export class UnifiedStatsManager {
    * This method ensures room stats persist across ticks even when rooms don't execute.
    *
    * Stale data cleanup:
-   * - Only preserve stats for rooms that are still present in Game.rooms
-   * - This prevents unbounded accumulation of stats for lost or invisible rooms
+   * - Only preserve stats for rooms that are currently visible and owned.
+   *   This prevents stale entries for lost rooms from staying in Memory.stats.
    *
-   * @returns Room stats object from previous snapshot (filtered to current rooms), or empty object if none exists
+   * @returns Room stats object from previous snapshot (filtered to visible-owned rooms),
+   * or empty object if none exists
    */
   private preserveRoomStats(): Record<string, RoomStatsEntry> {
     const previousRooms = this.currentSnapshot?.rooms;
@@ -142,12 +143,16 @@ export class UnifiedStatsManager {
 
     const filteredRooms: Record<string, RoomStatsEntry> = {};
     for (const roomName in previousRooms) {
-      if (Object.prototype.hasOwnProperty.call(previousRooms, roomName) && Game.rooms[roomName]) {
+      if (Object.prototype.hasOwnProperty.call(previousRooms, roomName) && this.isOwnedRoom(roomName)) {
         filteredRooms[roomName] = previousRooms[roomName];
       }
     }
 
     return filteredRooms;
+  }
+
+  private isOwnedRoom(roomName: string): boolean {
+    return Boolean(Game.rooms[roomName]?.controller?.my);
   }
 
   /**

--- a/packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts
+++ b/packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts
@@ -21,6 +21,8 @@ describe("UnifiedStatsManager", () => {
         lastUpdate: 1234
       }
     };
+    (Game as unknown as { rooms: Record<string, unknown> }).rooms = {};
+    (Game as unknown as { creeps: Record<string, unknown> }).creeps = {};
   });
 
   it("preserves profiler memory when publishing stats to Memory", () => {
@@ -30,6 +32,136 @@ describe("UnifiedStatsManager", () => {
 
     const profiler = (Memory as unknown as { stats: { profiler?: { rooms: Record<string, { samples: number }> } } }).stats.profiler;
     expect(profiler?.rooms.W17S29.samples).to.equal(42);
+  });
+
+  it("drops stale room stats when room ownership is lost", () => {
+    const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
+    const state = manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } };
+
+    state.currentSnapshot.rooms = {
+      W12S8: {
+        name: "W12S8",
+        rcl: 4,
+        energy: {
+          available: 300,
+          capacity: 300,
+          storage: 200,
+          terminal: 0
+        },
+        controller: {
+          progress: 100,
+          progressTotal: 200,
+          progressPercent: 50,
+          ticksToDowngrade: 1000,
+          downgradeRisk: false
+        },
+        creeps: 5,
+        hostiles: 0,
+        brain: {
+          danger: 0,
+          postureCode: 0,
+          colonyLevelCode: 0
+        },
+        pheromones: {},
+        metrics: {
+          energyHarvested: 0,
+          energySpawning: 0,
+          energyConstruction: 0,
+          energyRepair: 0,
+          energyTower: 0,
+          energyAvailableForSharing: 0,
+          energyCapacityTotal: 0,
+          energyNeed: 0,
+          controllerProgress: 0,
+          hostileCount: 0,
+          damageReceived: 0,
+          constructionSites: 0
+        },
+        profiler: {
+          avgCpu: 0,
+          peakCpu: 0,
+          samples: 1
+        }
+      } as Record<string, unknown>
+    };
+
+    (Game as unknown as { rooms: Record<string, unknown> }).rooms = {
+      W12S8: {
+        name: "W12S8",
+        controller: {
+          my: false
+        }
+      } as Record<string, unknown>
+    };
+
+    manager.startTick();
+
+    expect((manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } }).currentSnapshot.rooms.W12S8).to.equal(undefined);
+  });
+
+  it("retains room stats for still-owned visible rooms", () => {
+    const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
+    const state = manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } };
+
+    state.currentSnapshot.rooms = {
+      W1N1: {
+        name: "W1N1",
+        rcl: 1,
+        energy: {
+          available: 300,
+          capacity: 300,
+          storage: 0,
+          terminal: 0
+        },
+        controller: {
+          progress: 0,
+          progressTotal: 100,
+          progressPercent: 0,
+          ticksToDowngrade: 999,
+          downgradeRisk: false
+        },
+        creeps: 2,
+        hostiles: 0,
+        brain: {
+          danger: 0,
+          postureCode: 0,
+          colonyLevelCode: 0
+        },
+        pheromones: {},
+        metrics: {
+          energyHarvested: 0,
+          energySpawning: 0,
+          energyConstruction: 0,
+          energyRepair: 0,
+          energyTower: 0,
+          energyAvailableForSharing: 0,
+          energyCapacityTotal: 300,
+          energyNeed: 0,
+          controllerProgress: 0,
+          hostileCount: 0,
+          damageReceived: 0,
+          constructionSites: 0
+        },
+        profiler: {
+          avgCpu: 0,
+          peakCpu: 0,
+          samples: 1
+        }
+      } as Record<string, unknown>
+    };
+
+    (Game as unknown as { rooms: Record<string, unknown> }).rooms = {
+      W1N1: {
+        name: "W1N1",
+        controller: {
+          my: true
+        }
+      } as Record<string, unknown>
+    };
+
+    manager.startTick();
+
+    expect((manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } }).currentSnapshot.rooms.W1N1).to.exist;
   });
 
   it("captures gated CPU detail samples and auto-disables after TTL", () => {

--- a/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
@@ -198,8 +198,12 @@ function getDefenseAssistCreatedAt(_request: DefenseAssistRequestMemory): number
   return Game.time;
 }
 
+function getDefenseAssistWaveIdTick(request: DefenseAssistRequestMemory): number {
+  return typeof request.createdAt === "number" && Number.isFinite(request.createdAt) ? request.createdAt : Game.time;
+}
+
 function createDefenseAssistSquadId(homeRoom: string, request: DefenseAssistRequestMemory): string {
-  return `defenseAssist:${homeRoom}:${request.roomName}:${getDefenseAssistCreatedAt(request)}`;
+  return `defenseAssist:${homeRoom}:${request.roomName}:${getDefenseAssistWaveIdTick(request)}`;
 }
 
 function createDefenseAssistSpawnAssignment(

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -174,7 +174,7 @@ describe("defense spawn throttling", () => {
         rangersNeeded: 0,
         healersNeeded: 0,
         urgency: 3,
-        createdAt: Game.time - 2000,
+        createdAt: Game.time,
         threat: "visible hostile dismantler"
       }
     ];
@@ -220,12 +220,47 @@ describe("defense spawn throttling", () => {
     assert.sameMembers(assistRequests.map(request => request.role), ["guard", "ranger", "healer"]);
     assert.deepEqual(
       [...new Set(assistRequests.map(request => request.additionalMemory?.defenseSquadId))],
-      ["defenseAssist:W17S29:W19S28:1000"]
+      ["defenseAssist:W17S29:W19S28:990"]
     );
     for (const request of assistRequests) {
       assert.equal(request.additionalMemory?.defenseSquadSize, 3);
       assert.equal(request.additionalMemory?.defenseSquadCreatedAt, Game.time);
     }
+  });
+
+  it("keeps helper defense-assist wave ids stable across planning ticks", () => {
+    const helper = createRoom([], "W17S29", 1800, 1800);
+    const attacked = createRoom([createHostile([ATTACK, RANGED_ATTACK, HEAL, MOVE])], "W19S28");
+    Game.rooms.W17S29 = helper;
+    Game.rooms.W19S28 = attacked;
+    Game.creeps = {
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W17S29" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W17S29" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W17S29" } }
+    } as unknown as typeof Game.creeps;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W19S28",
+        guardsNeeded: 1,
+        rangersNeeded: 0,
+        healersNeeded: 0,
+        urgency: 3,
+        createdAt: 900,
+        threat: "visible mixed assault"
+      }
+    ];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const firstRequest = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests
+      .find(request => request.additionalMemory?.task === "defenseAssist");
+    Game.time = 1005;
+    const secondRequest = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests
+      .find(request => request.additionalMemory?.task === "defenseAssist");
+
+    assert.equal(firstRequest?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:900");
+    assert.equal(secondRequest?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:900");
+    assert.equal(firstRequest?.additionalMemory?.defenseSquadCreatedAt, 1000);
+    assert.equal(secondRequest?.additionalMemory?.defenseSquadCreatedAt, 1005);
   });
 
   it("uses aggregate parity squad size instead of role count for hard defense assists", () => {


### PR DESCRIPTION
## Summary

- Fixed stale unified-stats room retention for owned-room telemetry.
- `UnifiedStatsManager` now preserves prior room stats only when the room is currently visible and owned (`controller.my`).
- Added regression tests for stale-owner room dropping and ownership-retained room persistence.

## Changes

- `packages/@ralphschuler/screeps-stats/src/unifiedStats.ts`
  - Updated `preserveRoomStats()` to filter preserved room entries with a new `isOwnedRoom()` helper.
  - Removed stale preserved entries for rooms no longer owned.
- `packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts`
  - Added `beforeEach` cleanup for `Game.rooms`/`Game.creeps` test isolation.
  - Added tests:
    - drops stale room stats when room ownership is lost
    - retains room stats for still-owned visible rooms

## Validation

- `npm test -w @ralphschuler/screeps-stats`
- `npm run build -w @ralphschuler/screeps-stats`
- `npm run lint -w @ralphschuler/screeps-stats`

## Linked issue

Closes #3143

## Follow-up

- Add optional stale-tick metadata in live diagnostics payloads to explicitly surface outdated `Memory.stats` snapshots.
