### PR TITLE
[codex] Record defense assist release contract

### DIFF
--- a/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
+++ b/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
@@ -123,6 +123,12 @@ export interface SwarmCreepMemory {
   defenseSquadCreatedAt?: number;
   /** Tick when this creep was released from defense-assist staging. */
   defenseAssistReleasedAt?: number;
+  /** Release mode used when a defense-assist creep left staging. */
+  defenseAssistReleaseReason?:
+    | "parity-ready"
+    | "squad-quorum"
+    | "expired-staging"
+    | "hard-threat-trickle";
   /** Boosted flag */
   boosted?: boolean;
   /** Boost requirements (for spawning with boost intentions) */

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/military.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/military.ts
@@ -35,6 +35,8 @@ const DEFENSE_ASSIST_TASK = "defenseAssist";
 
 type DefenseAssistRole = "guard" | "ranger" | "healer";
 
+type DefenseAssistReleaseReason = NonNullable<SwarmCreepMemory["defenseAssistReleaseReason"]>;
+
 interface DefenseAssistRequestMemory {
   roomName: string;
   guardsNeeded?: number;
@@ -62,10 +64,16 @@ function clearDefenseAssistAssignment(mem: SwarmCreepMemory): void {
   delete mem.defenseSquadSize;
   delete mem.defenseSquadCreatedAt;
   delete mem.defenseAssistReleasedAt;
+  delete mem.defenseAssistReleaseReason;
   if (mem.task === DEFENSE_ASSIST_TASK) {
     delete mem.task;
     delete mem.targetRoom;
   }
+}
+
+function markDefenseAssistReleased(mem: SwarmCreepMemory, reason: DefenseAssistReleaseReason): void {
+  mem.defenseAssistReleasedAt ??= Game.time;
+  mem.defenseAssistReleaseReason = reason;
 }
 
 function isDefenseAssistSquadConfigured(mem: SwarmCreepMemory): boolean {
@@ -76,10 +84,6 @@ function isDefenseAssistSquadStagingExpired(mem: SwarmCreepMemory, hardThreat: b
   if (mem.defenseSquadCreatedAt === undefined) return true;
   const timeout = hardThreat ? DEFENSE_ASSIST_HARD_THREAT_STAGE_TIMEOUT : DEFENSE_ASSIST_SQUAD_STAGE_TIMEOUT;
   return Game.time - mem.defenseSquadCreatedAt >= timeout;
-}
-
-function markDefenseAssistReleased(mem: SwarmCreepMemory): void {
-  mem.defenseAssistReleasedAt ??= Game.time;
 }
 
 function emptyCombatPower(): CombatPower {
@@ -305,30 +309,30 @@ function getDefenseAssistSquadStagingAction(ctx: CreepContext, mem: SwarmCreepMe
 
   if (threatProfile) {
     if (hasReadyDefenseAssistParity(assistTarget, ctx.homeRoom, threatProfile)) {
-      markDefenseAssistReleased(mem);
+      markDefenseAssistReleased(mem, "parity-ready");
       return null;
     }
     if (readyMembers >= releaseQuorum) {
-      markDefenseAssistReleased(mem);
+      markDefenseAssistReleased(mem, "squad-quorum");
       return null;
     }
     if (stagingExpired) {
       if (!hardThreat) {
-        markDefenseAssistReleased(mem);
+        markDefenseAssistReleased(mem, "expired-staging");
         return null;
       }
       if (canReleaseHardThreatTrickle(ctx.creep, ctx.homeRoom, assistTarget, readyTargetMembers)) {
-        markDefenseAssistReleased(mem);
+        markDefenseAssistReleased(mem, "hard-threat-trickle");
         return null;
       }
     }
   } else {
     if (readyMembers >= releaseQuorum) {
-      markDefenseAssistReleased(mem);
+      markDefenseAssistReleased(mem, "squad-quorum");
       return null;
     }
     if (stagingExpired) {
-      markDefenseAssistReleased(mem);
+      markDefenseAssistReleased(mem, "expired-staging");
       return null;
     }
   }

--- a/packages/@ralphschuler/screeps-roles/test/militaryAssistance.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/militaryAssistance.test.ts
@@ -323,6 +323,8 @@ describe("military assistance behavior", () => {
     const action = guard(ctx);
 
     expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+    expect((ctx.creep.memory as { defenseAssistReleaseReason?: string }).defenseAssistReleaseReason)
+      .to.equal("squad-quorum");
   });
 
   it("keeps hard-threat defense assists staged after the normal timeout until parity is ready", () => {
@@ -419,6 +421,35 @@ describe("military assistance behavior", () => {
     const action = healer(ctx);
 
     expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+    expect((ctx.creep.memory as { defenseAssistReleaseReason?: string }).defenseAssistReleaseReason)
+      .to.equal("hard-threat-trickle");
+  });
+
+  it("stages spawn-produced low-energy hard-threat assists before bounded trickle release", () => {
+    createHardThreatRoom("W2N1");
+    const ctx = createAssistContext("guard", [], {
+      roomName: "W1N1",
+      assistTarget: "W2N1",
+      extraMemory: {
+        task: "defenseAssist",
+        targetRoom: "W2N1",
+        defenseSquadId: "defenseAssist:W1N1:W2N1:1000",
+        defenseSquadSize: 5,
+        defenseSquadCreatedAt: Game.time
+      }
+    });
+    Game.creeps[ctx.creep.name] = ctx.creep;
+
+    const stagedAction = guard(ctx);
+    Game.time += 760;
+    const releasedAction = guard(ctx);
+
+    expect(stagedAction.type).to.equal("wait");
+    expect(releasedAction).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+    expect(ctx.creep.memory.defenseSquadId).to.equal("defenseAssist:W1N1:W2N1:1000");
+    expect(ctx.creep.memory.assistTarget).to.equal("W2N1");
+    expect((ctx.creep.memory as { defenseAssistReleaseReason?: string }).defenseAssistReleaseReason)
+      .to.equal("hard-threat-trickle");
   });
 
   it("releases expired aggregate hard-threat assists as a bounded trickle", () => {
@@ -554,6 +585,8 @@ describe("military assistance behavior", () => {
     const action = healer(ctx);
 
     expect(action).to.deep.equal({ type: "moveToRoom", roomName: "W2N1" });
+    expect((ctx.creep.memory as { defenseAssistReleaseReason?: string }).defenseAssistReleaseReason)
+      .to.equal("expired-staging");
   });
 
   it("keeps guard assistance active and attacks hostile structures when no hostile creeps remain", () => {

--- a/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
@@ -23,6 +23,7 @@ import { getEffectiveRoomEnergyAvailable } from "../roomEnergy";
 import { spawnQueue, SpawnPriority } from "../spawnQueue";
 
 const DEFENSE_ASSIST_REQUEST_TTL = 500;
+const DEFENSE_ASSIST_WAVE_TTL = 1200;
 const DEFENSE_ASSIST_TASK = "defenseAssist";
 const DEFENSE_ASSIST_ROLES = ["guard", "ranger", "healer"] as const;
 
@@ -42,6 +43,62 @@ interface DefenseAssistRequestMemory {
   healersNeeded?: number;
   urgency?: number;
   createdAt?: number;
+}
+
+interface DefenseAssistWaveState {
+  /** Stable wave start tick shared across refreshing requests for this home+target pair */
+  createdAt: number;
+  /** Last tick the wave was referenced while building spawn demand */
+  seenAt: number;
+}
+
+interface DefenseAssistSpawnMemory {
+  defenseAssistWaves?: Record<string, DefenseAssistWaveState>;
+}
+
+function getDefenseAssistWaveState(): Record<string, DefenseAssistWaveState> {
+  const memory = Memory as unknown as DefenseAssistSpawnMemory;
+  return memory.defenseAssistWaves ??= {};
+}
+
+function getDefenseAssistWaveKey(homeRoom: string, targetRoom: string): string {
+  return `${homeRoom}:${targetRoom}`;
+}
+
+function pruneExpiredDefenseAssistWaves(now: number): void {
+  const memory = Memory as unknown as DefenseAssistSpawnMemory;
+  const states = memory.defenseAssistWaves;
+  if (!states) return;
+
+  for (const [key, state] of Object.entries(states)) {
+    if (now - state.seenAt > DEFENSE_ASSIST_WAVE_TTL) {
+      delete states[key];
+    }
+  }
+
+  if (Object.keys(states).length === 0) delete memory.defenseAssistWaves;
+}
+
+function getDefenseAssistWaveId(homeRoom: string, request: DefenseAssistRequestMemory): number {
+  const states = getDefenseAssistWaveState();
+  const key = getDefenseAssistWaveKey(homeRoom, request.roomName);
+  const now = Game.time;
+  const requestedAt =
+    typeof request.createdAt === "number" && Number.isFinite(request.createdAt)
+      ? request.createdAt
+      : now;
+  const existing = states[key];
+  if (existing && now - existing.seenAt <= DEFENSE_ASSIST_WAVE_TTL) {
+    existing.seenAt = now;
+    return existing.createdAt;
+  }
+
+  states[key] = { createdAt: requestedAt, seenAt: now };
+  return requestedAt;
+}
+
+function getDefenseAssistSquadKey(homeRoom: string, request: DefenseAssistRequestMemory): number {
+  return getDefenseAssistWaveId(homeRoom, request);
 }
 
 function getDefenseRoleNeed(request: DefenseAssistRequestMemory, role: string): number {
@@ -198,12 +255,9 @@ function getDefenseAssistCreatedAt(_request: DefenseAssistRequestMemory): number
   return Game.time;
 }
 
-function getDefenseAssistWaveIdTick(request: DefenseAssistRequestMemory): number {
-  return typeof request.createdAt === "number" && Number.isFinite(request.createdAt) ? request.createdAt : Game.time;
-}
-
 function createDefenseAssistSquadId(homeRoom: string, request: DefenseAssistRequestMemory): string {
-  return `defenseAssist:${homeRoom}:${request.roomName}:${getDefenseAssistWaveIdTick(request)}`;
+  const squadKey = getDefenseAssistSquadKey(homeRoom, request);
+  return `defenseAssist:${homeRoom}:${request.roomName}:${squadKey}`;
 }
 
 function createDefenseAssistSpawnAssignment(
@@ -259,6 +313,7 @@ export function getDefenseAssistSpawnAssignment(homeRoom: string, role: string):
 
   const helperEnergyCapacity = home.energyCapacityAvailable;
   const memory = Memory as unknown as { defenseRequests?: DefenseAssistRequestMemory[] };
+  pruneExpiredDefenseAssistWaves(Game.time);
   const candidates = getActiveDefenseAssistRequests(memory)
     .filter(request => request.roomName !== homeRoom)
     .map(request => {

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -263,6 +263,67 @@ describe("defense spawn throttling", () => {
     assert.equal(secondRequest?.additionalMemory?.defenseSquadCreatedAt, 1005);
   });
 
+  it("stabilizes wave IDs across request refreshes", () => {
+    const helper = createRoom([], "W17S29", 1800, 1800);
+    const attacked = createRoom([createHostile([ATTACK, RANGED_ATTACK, HEAL, MOVE])], "W19S28");
+    Game.rooms.W17S29 = helper;
+    Game.rooms.W19S28 = attacked;
+    Game.creeps = {
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W17S29" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W17S29" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W17S29" } }
+    } as unknown as typeof Game.creeps;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W19S28",
+        guardsNeeded: 1,
+        rangersNeeded: 0,
+        healersNeeded: 0,
+        urgency: 3,
+        createdAt: 1000,
+        threat: "visible mixed assault"
+      }
+    ];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const initial = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests
+      .find(request => request.additionalMemory?.task === "defenseAssist");
+
+    Game.time = 1050;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W19S28",
+        guardsNeeded: 1,
+        rangersNeeded: 0,
+        healersNeeded: 0,
+        urgency: 3,
+        createdAt: 1050,
+        threat: "visible mixed assault"
+      }
+    ];
+    const refreshed = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests
+      .find(request => request.additionalMemory?.task === "defenseAssist");
+
+    Game.time = 2405;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W19S28",
+        guardsNeeded: 1,
+        rangersNeeded: 0,
+        healersNeeded: 0,
+        urgency: 3,
+        createdAt: 2405,
+        threat: "visible mixed assault"
+      }
+    ];
+    const newWave = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests
+      .find(request => request.additionalMemory?.task === "defenseAssist");
+
+    assert.equal(initial?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:1000");
+    assert.equal(refreshed?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:1000");
+    assert.equal(newWave?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:2405");
+  });
+
   it("uses aggregate parity squad size instead of role count for hard defense assists", () => {
     const helper = createRoom([], "W17S29", 800, 800);
     const attacked = createRoom([


### PR DESCRIPTION
## Summary

Defines the defense-assist staging/release contract for hard-threat helper waves.

## Linked issue

Closes #3199

## Changes

- Records `defenseAssistReleaseReason` alongside `defenseAssistReleasedAt` for parity, quorum, timeout, and hard-threat trickle releases.
- Keeps same home/target defense-assist waves on stable squad IDs across refreshed defense requests.
- Prunes expired wave state without creating empty Memory keys.
- Adds regression coverage for spawn-produced low-energy hard-threat assists staging, bounded trickle release, release reasons, and refreshed wave IDs.

## Validation

- `npm run test:spawn` ✅
- `npm run test:roles` ✅
- `npm run build:memory` ✅
- `npm run build:spawn` ✅
- `npm run build:roles` ✅
- `npm run lint:spawn` ✅
- `npm run lint:roles` ✅ (Node module-type warning only)
- `npm run check:alliance-safety` ✅
- `npm run build` ✅ (via managed process `full-build-issue-3199`; bundle check passed)

## Deployment impact

Runtime behavior change for defense-assist creeps only. Deploy path still builds; no secrets/config changes.

## Live bot evidence

Current live issue remains W18S28 recovery: read-only scan at shard1 tick `72080310` showed owned RCL5 `W18S28` with `0` completed spawns, `0` towers, `0` friendly creeps, and `6` Tigga hostiles. This PR addresses the helper-wave staging/release contract needed for #3196/#3190 recovery work.

## Follow-up issues

- #3196 remains the P0/P1 parent for spawnless-room cross-room recovery/abandon handling.
- #3121 remains the live Memory API rate-limit diagnostics blocker.
