### PR TITLE
[codex] Reuse defense assist wave start

### DIFF
--- a/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
@@ -79,7 +79,7 @@ function pruneExpiredDefenseAssistWaves(now: number): void {
   if (Object.keys(states).length === 0) delete memory.defenseAssistWaves;
 }
 
-function getDefenseAssistWaveId(homeRoom: string, request: DefenseAssistRequestMemory): number {
+function getDefenseAssistWave(homeRoom: string, request: DefenseAssistRequestMemory): DefenseAssistWaveState {
   const states = getDefenseAssistWaveState();
   const key = getDefenseAssistWaveKey(homeRoom, request.roomName);
   const now = Game.time;
@@ -90,15 +90,12 @@ function getDefenseAssistWaveId(homeRoom: string, request: DefenseAssistRequestM
   const existing = states[key];
   if (existing && now - existing.seenAt <= DEFENSE_ASSIST_WAVE_TTL) {
     existing.seenAt = now;
-    return existing.createdAt;
+    return existing;
   }
 
-  states[key] = { createdAt: requestedAt, seenAt: now };
-  return requestedAt;
-}
-
-function getDefenseAssistSquadKey(homeRoom: string, request: DefenseAssistRequestMemory): number {
-  return getDefenseAssistWaveId(homeRoom, request);
+  const wave = { createdAt: requestedAt, seenAt: now };
+  states[key] = wave;
+  return wave;
 }
 
 function getDefenseRoleNeed(request: DefenseAssistRequestMemory, role: string): number {
@@ -251,13 +248,8 @@ function canSpawnDefenseAssistFrom(room: Room): boolean {
   return getActualHostileCreeps(room).length === 0;
 }
 
-function getDefenseAssistCreatedAt(_request: DefenseAssistRequestMemory): number {
-  return Game.time;
-}
-
-function createDefenseAssistSquadId(homeRoom: string, request: DefenseAssistRequestMemory): string {
-  const squadKey = getDefenseAssistSquadKey(homeRoom, request);
-  return `defenseAssist:${homeRoom}:${request.roomName}:${squadKey}`;
+function createDefenseAssistSquadId(homeRoom: string, request: DefenseAssistRequestMemory, waveCreatedAt: number): string {
+  return `defenseAssist:${homeRoom}:${request.roomName}:${waveCreatedAt}`;
 }
 
 function createDefenseAssistSpawnAssignment(
@@ -265,13 +257,14 @@ function createDefenseAssistSpawnAssignment(
   home: Room,
   request: DefenseAssistRequestMemory
 ): DefenseAssistSpawnAssignment {
+  const wave = getDefenseAssistWave(homeRoom, request);
   return {
     targetRoom: request.roomName,
     task: DEFENSE_ASSIST_TASK,
     priority: (request.urgency ?? 1) >= 2 ? SpawnPriority.EMERGENCY : SpawnPriority.HIGH,
-    defenseSquadId: createDefenseAssistSquadId(homeRoom, request),
+    defenseSquadId: createDefenseAssistSquadId(homeRoom, request, wave.createdAt),
     defenseSquadSize: getDefenseAssistSquadSizeForHelper(request, home),
-    defenseSquadCreatedAt: getDefenseAssistCreatedAt(request)
+    defenseSquadCreatedAt: wave.createdAt
   };
 }
 

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -224,11 +224,11 @@ describe("defense spawn throttling", () => {
     );
     for (const request of assistRequests) {
       assert.equal(request.additionalMemory?.defenseSquadSize, 3);
-      assert.equal(request.additionalMemory?.defenseSquadCreatedAt, Game.time);
+      assert.equal(request.additionalMemory?.defenseSquadCreatedAt, 990);
     }
   });
 
-  it("keeps helper defense-assist wave ids stable across planning ticks", () => {
+  it("keeps helper defense-assist wave ids and staging start stable across planning ticks", () => {
     const helper = createRoom([], "W17S29", 1800, 1800);
     const attacked = createRoom([createHostile([ATTACK, RANGED_ATTACK, HEAL, MOVE])], "W19S28");
     Game.rooms.W17S29 = helper;
@@ -259,8 +259,8 @@ describe("defense spawn throttling", () => {
 
     assert.equal(firstRequest?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:900");
     assert.equal(secondRequest?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:900");
-    assert.equal(firstRequest?.additionalMemory?.defenseSquadCreatedAt, 1000);
-    assert.equal(secondRequest?.additionalMemory?.defenseSquadCreatedAt, 1005);
+    assert.equal(firstRequest?.additionalMemory?.defenseSquadCreatedAt, 900);
+    assert.equal(secondRequest?.additionalMemory?.defenseSquadCreatedAt, 900);
   });
 
   it("stabilizes wave IDs across request refreshes", () => {
@@ -322,6 +322,9 @@ describe("defense spawn throttling", () => {
     assert.equal(initial?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:1000");
     assert.equal(refreshed?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:1000");
     assert.equal(newWave?.additionalMemory?.defenseSquadId, "defenseAssist:W17S29:W19S28:2405");
+    assert.equal(initial?.additionalMemory?.defenseSquadCreatedAt, 1000);
+    assert.equal(refreshed?.additionalMemory?.defenseSquadCreatedAt, 1000);
+    assert.equal(newWave?.additionalMemory?.defenseSquadCreatedAt, 2405);
   });
 
   it("uses aggregate parity squad size instead of role count for hard defense assists", () => {


### PR DESCRIPTION
## Summary

Reuse the stable defense-assist wave start tick as `defenseSquadCreatedAt` for helper-room combat creeps.

## Linked issue

Closes #3206
Related: #3196

## Changes

- Changed defense-assist spawn assignment to resolve one stable wave object per helper+target request.
- Use the wave `createdAt` for both `defenseSquadId` and `defenseSquadCreatedAt`.
- Updated spawn tests to prove wave staging start stays stable across planning ticks/request refreshes and resets after TTL expiry.

## Validation

- ✅ `npm run test:spawn` — 127 passing.
- ✅ `npm run build:spawn`.
- ✅ `npm run lint:spawn`.
- ✅ `npm run check:alliance-safety`.
- ✅ `npm run build`.
- ✅ `npm run test:roles` — 119 passing.
- ✅ `npm run test:server:smoke` — passed; 49/49 screepsmod-testing assertions passed.

## Deployment impact

Runtime spawn-planning change for Screeps.com `main` after merge/deploy. Later helper defense-assist creeps in an existing wave inherit the already-waited wave age, allowing hard-threat staging/trickle release to proceed without a fresh per-creep 750-tick delay.

## Live bot evidence

Live shard1 scan at `2026-07-03T08:27Z` (`artifacts/live-analysis-20260703T082748Z-cycle/postdeploy-summary.json`) showed `W18S28` still owned RCL5 with `spawns=0`, `towers=0`, friendly creeps `0`, hostiles `3`, and spawn construction site present. Neighbor `W18S27` had newly spawned low-energy rangers while no friendly creeps had reached `W18S28`.

## Follow-up issues

- #3196 remains the parent live spawnless recovery issue.
- #3193 tracks defense-assist accounting cache/performance.
- #3200 tracks defense-assist queue/staging telemetry.
