### PR TITLE
[codex] Prioritize spawnless pioneer recovery

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -37197,7 +37197,17 @@ task: "reserve"
 } : null;
 }
 
-function $y(e, t, r) {
+function $y(e) {
+return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
+return e.structureType === STRUCTURE_SPAWN;
+});
+}
+
+function ev(e) {
+return $y(e) ? my.EMERGENCY : my.HIGH;
+}
+
+function tv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
 if (!Qy(e)) return !1;
@@ -37205,11 +37215,11 @@ var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function ev(e, t, r) {
+function rv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return $y(e, t, r);
+return tv(e, t, r);
 }).map(function(t) {
 var r;
 return {
@@ -37222,9 +37232,9 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function tv(e, t) {
+function ov(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !$y(n, e, t)) return null;
+if (!n || !tv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
@@ -37273,9 +37283,7 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
-return e.structureType === STRUCTURE_SPAWN;
-}) ? 3 : 1);
+}(e.name) < ($y(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
@@ -37288,9 +37296,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (ev(u.room, e, t) === e) return {
+if (rv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
-task: "bootstrapSpawn"
+task: "bootstrapSpawn",
+priority: ev(u.room)
 };
 }
 } catch (e) {
@@ -37307,7 +37316,7 @@ if (r) throw r.error;
 return null;
 }
 
-function rv(e, t) {
+function nv(e, t) {
 if (t <= 0) return null;
 try {
 var r = Cy({
@@ -37320,18 +37329,18 @@ return null;
 }
 }
 
-function ov(e, t, r) {
-return "healer" === e || "ranger" === e && Nr(r) ? null : rv(e, t);
+function av(e, t, r) {
+return "healer" === e || "ranger" === e && Nr(r) ? null : nv(e, t);
 }
 
-function nv(e) {
+function iv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function av(e) {
+function sv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37345,7 +37354,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += nv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += iv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37366,7 +37375,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += nv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += iv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37382,23 +37391,23 @@ return i;
 }(e)) : r;
 }
 
-var iv = "defenseAssist", sv = [ "guard", "ranger", "healer" ];
+var cv = "defenseAssist", uv = [ "guard", "ranger", "healer" ];
 
-function cv(e, t) {
+function lv(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function uv(e, t, r, o) {
+function mv(e, t, r, o) {
 void 0 === o && (o = Mr(e.roomName));
-var n = cv(e, t);
+var n = lv(e, t);
 if (!Dr(t)) return n;
 if (!o) return n;
-var i = pv(e.roomName), s = i[t] + Lr(r, o, {
-guard: Math.max(0, cv(e, "guard") - i.guard),
-ranger: Math.max(0, cv(e, "ranger") - i.ranger),
-healer: Math.max(0, cv(e, "healer") - i.healer)
-}, yv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = yv(e.roomName), s = i[t] + Lr(r, o, {
+guard: Math.max(0, lv(e, "guard") - i.guard),
+ranger: Math.max(0, lv(e, "ranger") - i.ranger),
+healer: Math.max(0, lv(e, "healer") - i.healer)
+}, gv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Pr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37413,7 +37422,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && vv(u) && Pr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && hv(u) && Pr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37431,30 +37440,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function lv(e) {
+function dv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function mv(e) {
+function pv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === iv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === cv ? e.targetRoom : void 0;
 }
 
-function dv(e, t) {
-var r = Mr(e.roomName), o = pv(e.roomName), n = Lr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, cv(e, "guard") - o.guard),
-ranger: Math.max(0, cv(e, "ranger") - o.ranger),
-healer: Math.max(0, cv(e, "healer") - o.healer)
-}, yv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function fv(e, t) {
+var r = Mr(e.roomName), o = yv(e.roomName), n = Lr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, lv(e, "guard") - o.guard),
+ranger: Math.max(0, lv(e, "ranger") - o.ranger),
+healer: Math.max(0, lv(e, "healer") - o.healer)
+}, gv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = sv.filter(function(o) {
-return !(uv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Pr(o, t.energyCapacityAvailable, r));
+var i = uv.filter(function(o) {
+return !(mv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Pr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function pv(e) {
+function yv(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37463,7 +37472,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Dr(p) && mv(d) === e && u[p]++;
+Dr(p) && pv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37479,7 +37488,7 @@ if (t) throw t.error;
 for (var f in Game.rooms) try {
 for (var y = (o = void 0, a(by.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Dr(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === iv && g.targetRoom === e) && u[g.role]++;
+Dr(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === cv && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37495,21 +37504,21 @@ if (o) throw o.error;
 return u;
 }
 
-function fv(e, t, r) {
+function vv(e, t, r) {
 var o = xr(r), n = e[t];
 e[t] = n ? wr(n, o) : o;
 }
 
-function yv(e) {
+function gv(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Dr(y) && mv(f) === e) {
+if (Dr(y) && pv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && fv(l, y, v);
+v.length > 0 && vv(l, y, v);
 }
 }
 } catch (e) {
@@ -37526,7 +37535,7 @@ if (t) throw t.error;
 for (var g in Game.rooms) try {
 for (var h = (o = void 0, a(by.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Dr(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === iv && E.targetRoom === e) && fv(l, E.role, E.body.parts);
+Dr(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === cv && E.targetRoom === e) && vv(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37542,27 +37551,27 @@ if (o) throw o.error;
 return l;
 }
 
-function vv(e) {
+function hv(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function gv(e, t, r) {
+function Rv(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function hv(e, t, r, o) {
+function Ev(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && ov("guard", av(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && av("guard", sv(r), o) ? 1 : 0;
 }
 
-function Rv(e, t) {
+function Tv(e, t) {
 var r;
 if (!function(e) {
 return Dr(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !vv(o)) return null;
+if (!o || !hv(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -37587,7 +37596,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(lv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(dv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -37595,15 +37604,15 @@ return t.roomName !== e;
 var r = Mr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(uv(e, t, n, r), hv(e, t, o, r))
+helperNeed: Math.max(mv(e, t, n, r), Ev(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return lv(e.request);
+return dv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Dr(t) ? pv(e)[t] : 0;
+return Dr(t) ? yv(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37628,26 +37637,26 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: iv,
+task: cv,
 priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? my.EMERGENCY : my.HIGH,
-defenseSquadId: gv(e, r, n.createdAt),
-defenseSquadSize: dv(r, t),
+defenseSquadId: Rv(e, r, n.createdAt),
+defenseSquadSize: fv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-function Ev(e) {
+function Cv(e) {
 var t = Game.rooms[e];
 return t ? !!t.controller && !qy(t.controller) && !zy(t) : !jy(e);
 }
 
-function Tv(e) {
+function Sv(e) {
 var t = Game.rooms[e];
 return (null == t ? void 0 : t.controller) ? !qy(t.controller) : !jy(e);
 }
 
-function Cv(e, t, r) {
+function xv(e, t, r) {
 var o = vy[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
@@ -37660,13 +37669,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Sv(e, t, r) {
+function wv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Ev(l) && Dy(e, t, l) < Hy(e, l, t, Game.rooms[l])) return l;
+if (Cv(l) && Dy(e, t, l) < Hy(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37682,7 +37691,7 @@ if (o) throw o.error;
 return null;
 }
 
-function xv(e, t, r, o) {
+function bv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
 var p = vy[t];
@@ -37717,14 +37726,14 @@ var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
 return _y.set(r, n), n;
-}(e, t) >= Cv(e, t, r)) && null !== Sv(e, t, r);
+}(e, t) >= xv(e, t, r)) && null !== wv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Tv(R)) {
+if (Sv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -37750,7 +37759,7 @@ if (n) throw n.error;
 return !1;
 }
 var C = null !== (u = Ly(e).get(t)) && void 0 !== u ? u : 0;
-if (C >= Cv(e, t, r)) return !1;
+if (C >= xv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -37770,7 +37779,7 @@ return !1;
 }(e));
 }
 if ("claimer" === t) return null !== Jy(0, r);
-if ("pioneer" === t) return null !== tv(e, r);
+if ("pioneer" === t) return null !== ov(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var x = f.find(FIND_MINERALS)[0];
@@ -37834,16 +37843,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function wv(e) {
+function Ov(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function bv(e) {
-return 0 === wv(Ly(e, !0));
+function Mv(e) {
+return 0 === Ov(Ly(e, !0));
 }
 
-function Ov(e) {
+function Av(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -37866,14 +37875,14 @@ minCount: 1
 } ];
 }
 
-function Mv(e, t) {
+function kv(e, t) {
 var r, o, n, i, s = Ly(e, !0);
-if (0 === wv(s)) return !0;
+if (0 === Ov(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Ly(e, !1), u = Ov(t);
+var c = Ly(e, !1), u = Av(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -37893,19 +37902,19 @@ if (r) throw r.error;
 return !1;
 }
 
-function Av(e) {
+function Uv(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function kv(e, t, r) {
-var n = Cv(e.name, r.roleName, t);
+function _v(e, t, r) {
+var n = xv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Uv(e, t, r, o, n) {
+function Nv(e, t, r, o, n) {
 if (n && ("larvaWorker" === r || "harvester" === r)) return my.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
@@ -37927,23 +37936,23 @@ return e >= 90 ? my.HIGH : e >= 60 ? my.NORMAL : my.LOW;
 }(o);
 }
 
-function _v(e, t) {
+function Pv(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
-var r, o, n, s, c, u, l, m;
-Av(e);
-var d = Ly(e.name), p = bv(e.name), f = [];
-if (Mv(e.name, e)) {
-var y = function(e, t, r) {
+var r, o, n, s, c, u, l, m, d;
+Uv(e);
+var p = Ly(e.name), f = Mv(e.name), y = [];
+if (kv(e.name, e)) {
+var v = function(e, t, r) {
 var o, n, i;
-if (0 === wv(Ly(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Ov(Ly(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Ly(e, !1), c = Ov(t);
+var s = Ly(e, !1), c = Av(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -37958,7 +37967,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = xv(e, m.role, r, !0);
+var p = bv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -37989,39 +37998,39 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return y && (R = vy[y]) && xv(e.name, y, t, !0) ? (f.push(kv(e, t, {
-roleName: y,
-def: R,
-current: null !== (n = d.get(y)) && void 0 !== n ? n : 0,
-priority: Uv(e, 0, y, R.priority, p),
+return v && (E = vy[v]) && bv(e.name, v, t, !0) ? (y.push(_v(e, t, {
+roleName: v,
+def: E,
+current: null !== (n = p.get(v)) && void 0 !== n ? n : 0,
+priority: Nv(e, 0, v, E.priority, f),
 bootstrap: !0
-})), f) : f;
+})), y) : y;
 }
 try {
-for (var v = a(Object.entries(vy)), g = v.next(); !g.done; g = v.next()) {
-var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (s = d.get(y)) && void 0 !== s ? s : 0, T = Rv(e.name, y);
-if (T) f.push({
-roleName: y,
-def: R,
-current: E,
-target: E + 1,
+for (var g = a(Object.entries(vy)), h = g.next(); !h.done; h = g.next()) {
+var R = i(h.value, 2), E = (v = R[0], R[1]), T = null !== (s = p.get(v)) && void 0 !== s ? s : 0, C = Tv(e.name, v);
+if (C) y.push({
+roleName: v,
+def: E,
+current: T,
+target: T + 1,
 missing: 1,
-priority: T.priority,
-targetRoom: T.targetRoom,
-task: T.task,
-assistTarget: T.targetRoom,
-defenseSquadId: T.defenseSquadId,
-defenseSquadSize: T.defenseSquadSize,
-defenseSquadCreatedAt: T.defenseSquadCreatedAt
-}); else if (xv(e.name, y, t, p)) {
-var C = Wy(y), S = C ? Sv(e.name, y, t) : null, x = "claimer" === y ? Jy(e.name, t) : null, w = "pioneer" === y ? tv(e.name, t) : null;
-C && !S || ("claimer" !== y || x) && ("pioneer" !== y || w) && f.push(kv(e, t, {
-roleName: y,
-def: R,
-current: E,
-priority: Uv(e, 0, y, R.priority, p),
-targetRoom: null !== (l = null !== (u = null !== (c = null == x ? void 0 : x.targetRoom) && void 0 !== c ? c : null == w ? void 0 : w.targetRoom) && void 0 !== u ? u : S) && void 0 !== l ? l : void 0,
-task: null !== (m = null == x ? void 0 : x.task) && void 0 !== m ? m : null == w ? void 0 : w.task
+priority: C.priority,
+targetRoom: C.targetRoom,
+task: C.task,
+assistTarget: C.targetRoom,
+defenseSquadId: C.defenseSquadId,
+defenseSquadSize: C.defenseSquadSize,
+defenseSquadCreatedAt: C.defenseSquadCreatedAt
+}); else if (bv(e.name, v, t, f)) {
+var S = Wy(v), x = S ? wv(e.name, v, t) : null, w = "claimer" === v ? Jy(e.name, t) : null, b = "pioneer" === v ? ov(e.name, t) : null;
+S && !x || ("claimer" !== v || w) && ("pioneer" !== v || b) && y.push(_v(e, t, {
+roleName: v,
+def: E,
+current: T,
+priority: null !== (c = null == b ? void 0 : b.priority) && void 0 !== c ? c : Nv(e, 0, v, E.priority, f),
+targetRoom: null !== (m = null !== (l = null !== (u = null == w ? void 0 : w.targetRoom) && void 0 !== u ? u : null == b ? void 0 : b.targetRoom) && void 0 !== l ? l : x) && void 0 !== m ? m : void 0,
+task: null !== (d = null == w ? void 0 : w.task) && void 0 !== d ? d : null == b ? void 0 : b.task
 }));
 }
 }
@@ -38031,16 +38040,16 @@ error: e
 };
 } finally {
 try {
-g && !g.done && (o = v.return) && o.call(v);
+h && !h.done && (o = g.return) && o.call(g);
 } finally {
 if (r) throw r.error;
 }
 }
-return f;
+return y;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Nv(e, l.value);
+var m = Iv(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38061,10 +38070,10 @@ requests: c
 };
 }
 
-function Nv(e, t) {
+function Iv(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = My.getMaxAffordableInTicks(e, l), d = av(e), p = t.priority >= my.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Dr(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= my.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Pr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Pr(f, d, g)) && void 0 !== r ? r : ov(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = My.getMaxAffordableInTicks(e, l), d = sv(e), p = t.priority >= my.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Dr(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= my.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Pr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Pr(f, d, g)) && void 0 !== r ? r : av(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38121,25 +38130,25 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Pv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Iv = new Set([ "guard", "ranger", "healer" ]);
+var Gv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Lv = new Set([ "guard", "ranger", "healer" ]);
 
-function Gv() {
+function Dv() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Lv(e) {
+function Fv(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Dv(e) {
+function Bv(e) {
 var t;
 return e.priority >= my.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Fv(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = av(e), m = r.urgency >= 2 || t.danger >= 3 ? my.EMERGENCY : my.HIGH, d = Or(j(e)), p = function(e) {
+function Wv(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = sv(e), m = r.urgency >= 2 || t.danger >= 3 ? my.EMERGENCY : my.HIGH, d = Or(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
 }(d) ? u : m === my.EMERGENCY ? l : u, f = function(e, t) {
@@ -38152,8 +38161,8 @@ try {
 for (var s = a(by.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
 Game.time - u.createdAt > 1500 || u.body.cost > t || ("guard" === u.role && (n.guards++,
-Wv(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Wv(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Wv(i, "healer", u.body.parts)));
+Hv(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Hv(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Hv(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38181,7 +38190,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Wv(n, u, l);
+0 !== l.length && Hv(n, u, l);
 }
 }
 }
@@ -38220,26 +38229,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Bv("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) Kv(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Bv("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) Kv(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, x = null !== (c = g.bodies.healer) && void 0 !== c ? c : Bv("healer", p, d);
-if (S > 0 && x && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Kv(e, "healer", "military", my.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), x);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Kv("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) Yv(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Kv("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) Yv(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, x = null !== (c = g.bodies.healer) && void 0 !== c ? c : Kv("healer", p, d);
+if (S > 0 && x && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Yv(e, "healer", "military", my.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), x);
 !function(e, t, r, o) {
 if (!(t < my.EMERGENCY || function(e, t) {
 var r, o, n, i = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Iv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Lv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
 for (var s = a(by.getPendingRequests(e.name)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.priority < my.EMERGENCY || Iv.has(u.role) && (u.targetRoom && u.targetRoom !== e.name || (null === (n = u.additionalMemory) || void 0 === n ? void 0 : n.assistTarget) || u.body.cost <= t && i++);
+u.priority < my.EMERGENCY || Lv.has(u.role) && (u.targetRoom && u.targetRoom !== e.name || (null === (n = u.additionalMemory) || void 0 === n ? void 0 : n.assistTarget) || u.body.cost <= t && i++);
 }
 } catch (e) {
 r = {
@@ -38256,7 +38265,7 @@ return i;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = rv(t, e);
+var r = nv(t, e);
 return r ? {
 role: t,
 body: r
@@ -38271,23 +38280,23 @@ var r = xr(t.body.parts).score - xr(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Kv(e, n.role, "military", my.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && Yv(e, n.role, "military", my.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Bv(e, t, r) {
+function Kv(e, t, r) {
 return r ? Pr(e, t, r) : null;
 }
 
-function Wv(e, t, r) {
+function Hv(e, t, r) {
 var o = xr(r);
 e[t] = e[t] ? wr(e[t], o) : o;
 }
 
-function Kv(e, t, r, o, n, a, i) {
+function Yv(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
 var s = null != i ? i : Cy({
@@ -38313,7 +38322,7 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Hv(e, t, r) {
+function Vv(e, t, r) {
 if (void 0 === r && (r = e.energyAvailable), t.priority >= my.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
@@ -38325,16 +38334,16 @@ if (o / e.energyCapacityAvailable < .5) return !0;
 return t.priority === my.NORMAL && o / e.energyCapacityAvailable < .3 && My.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function Yv(e, t) {
+function qv(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Av(e);
-var s = by.getQueueSize(e.name), c = Mv(e.name, e), u = bv(e.name) && !by.hasEmergencySpawns(e.name), l = fr(e), m = vr(e);
+Uv(e);
+var s = by.getQueueSize(e.name), c = kv(e.name, e), u = Mv(e.name) && !by.hasEmergencySpawns(e.name), l = fr(e), m = vr(e);
 if (c) {
-s > 0 && by.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Fv(e, t, l, m);
+s > 0 && by.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Wv(e, t, l, m);
 try {
-for (var d = a(_v(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Pv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 by.addRequest(f);
 }
@@ -38349,7 +38358,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Fv(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Wv(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38358,12 +38367,12 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(by.getPendingRequests(e.name).map(Lv));
+var c = new Set(by.getPendingRequests(e.name).map(Fv));
 try {
-for (var u = a(_v(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= my.HIGH, p = "claimer" === m.role && Gv(), f = Dv(m);
-if (Pv.has(m.role) || d || p || f) {
-var y = Lv(m);
+for (var u = a(Pv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= my.HIGH, p = "claimer" === m.role && Dv(), f = Bv(m);
+if (Gv.has(m.role) || d || p || f) {
+var y = Fv(m);
 c.has(y) || (by.addRequest(m), c.add(y));
 }
 }
@@ -38383,16 +38392,16 @@ if (r) throw r.error;
 !function(e) {
 var t = Ay.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = my.NORMAL, n = 0; n < t.powerHarvesters; n++) Kv(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) Kv(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) Kv(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = my.NORMAL, n = 0; n < t.powerHarvesters; n++) Yv(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) Yv(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) Yv(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a(_v(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+for (var y = a(Pv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
 by.addRequest(f);
 } catch (e) {
 n = {
@@ -38414,12 +38423,12 @@ subsystem: "SpawnPipeline"
 var r = function(e) {
 var t, r, o = by.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = av(e);
+var n = 0, i = sv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = by.getNextRequest(e.name, i);
 if (!l) break;
-if (Hv(e, l, i)) {
+if (Vv(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
@@ -38459,7 +38468,7 @@ stats: o
 }(e, t);
 }
 
-var Vv = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, qv = /^(\d{1,2})\|(.+)$/, jv = A("SS2TerminalComms"), zv = function() {
+var jv = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, zv = /^(\d{1,2})\|(.+)$/, Qv = A("SS2TerminalComms"), Xv = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38519,11 +38528,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(Vv);
+var t = e.match(jv);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(qv);
+var i = a.match(zv);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38558,7 +38567,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-jv.warn("Missing packet in multi-packet message", {
+Qv.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38574,7 +38583,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), jv.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), Qv.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38598,7 +38607,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && jv.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && Qv.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38610,7 +38619,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return jv.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return Qv.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38618,14 +38627,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), jv.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), Qv.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (jv.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (Qv.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38650,7 +38659,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-jv.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+Qv.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -38662,7 +38671,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-jv.info("Completed sending multi-packet message", {
+Qv.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -38670,25 +38679,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? jv.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? Qv.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (jv.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (Qv.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else jv.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else Qv.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else jv.warn("Terminal not found for queue item, removing from queue", {
+} else Qv.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -38722,7 +38731,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && jv.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && Qv.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -38732,7 +38741,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-jv.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+Qv.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -38823,7 +38832,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (jv.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (Qv.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -38845,7 +38854,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return jv.error("Error parsing JSON", {
+return Qv.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -38856,7 +38865,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), Qv = [ {
+}(), Zv = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -38876,7 +38885,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Xv = function() {
+} ], Jv = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -38923,9 +38932,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), Zv = new Xv;
+}(), $v = new Jv;
 
-function Jv(e) {
+function eg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -38933,19 +38942,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function $v(e, t) {
+function tg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function eg(e, t) {
+function rg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var tg = {
+var og = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -38956,9 +38965,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, rg = function() {
+}, ng = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, tg), e);
+void 0 === e && (e = {}), this.config = o(o({}, og), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -38979,7 +38988,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = Zv.getSwarmState(r.toRoom);
+var o = $v.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -38992,7 +39001,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = Zv.getSwarmState(c);
+var l = $v.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39062,9 +39071,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort($v), u = n.filter(function(e) {
+}).sort(tg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(eg), l = [], m = [], d = function(t) {
+}).sort(rg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39086,11 +39095,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return Jv({
+return eg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + Jv({
+}) + eg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39189,7 +39198,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), og = new rg, ng = {
+}(), ag = new ng, ig = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39210,14 +39219,14 @@ siegeUnits: 1
 }
 };
 
-function ag(e) {
+function sg(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function ig(e) {
+function cg(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39240,9 +39249,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function sg(e) {
+function ug(e) {
 var t, r, o;
-ig(e);
+cg(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39266,20 +39275,20 @@ if (t) throw t.error;
 return n;
 }
 
-function cg(e) {
+function lg(e) {
 var t;
-ig(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = sg(e);
+cg(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = ug(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function ug(e) {
-return !!cg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function mg(e) {
+return !!lg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-ig(e);
+cg(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39290,12 +39299,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = sg(e);
+var d = ug(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function lg(e, t) {
+function dg(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39316,20 +39325,20 @@ if (r) throw r.error;
 return n;
 }
 
-function mg(e, t) {
+function pg(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = ng[r]) && void 0 !== t ? t : ng[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = ig[r]) && void 0 !== t ? t : ig[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = lg(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = dg(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: ag(r),
+targetComposition: sg(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39341,7 +39350,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function dg(e) {
+function fg(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39361,9 +39370,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function pg(e) {
+function yg(e) {
 var t = e.members.length;
-ig(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+cg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39377,7 +39386,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && ug(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && mg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39406,7 +39415,7 @@ subsystem: "Squad"
 }
 }
 
-var fg = {
+var vg = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39493,7 +39502,7 @@ prioritizeDefenses: !0
 }
 };
 
-function yg(e, t) {
+function gg(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39508,8 +39517,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function vg(e, t) {
-var r, o, n, i = fg[t], s = 0;
+function hg(e, t) {
+var r, o, n, i = vg[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39535,7 +39544,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var gg, hg, Rg, Eg = {
+var Rg, Eg, Tg, Cg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39544,11 +39553,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Tg = new Map;
+}, Sg = new Map;
 
-function Cg(e, t) {
+function xg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Tg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Sg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39560,7 +39569,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = fg[p].composition;
+d = vg[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39575,19 +39584,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Tg.set(m, y), function(e, t, r, o) {
+v ? (Sg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = fg[s].useBoosts;
+i = vg[s].useBoosts;
 }
 var c = my.NORMAL;
 "siege" === t.type ? c = my.HIGH : "defense" === t.type && (c = my.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = Sg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Eg[t];
-}, 0), m = i ? wg(r) : [], d = {
+var u = wg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Cg[t];
+}, 0), m = i ? Og(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39630,42 +39639,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function Sg(e, t, r) {
+function wg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return xg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return bg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return xg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return bg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return xg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return bg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return xg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return bg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return xg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return bg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return xg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return bg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function xg(e, t, r) {
+function bg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Eg[t];
+return e + Cg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Eg[t];
+return e + Cg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function wg(e) {
+function Og(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -39696,45 +39705,45 @@ return [];
 }
 }
 
-function bg(e) {
-return Tg.has(e);
+function Mg(e) {
+return Sg.has(e);
 }
 
-function Og(e) {
-return cg(e) || ug(e);
+function Ag(e) {
+return lg(e) || mg(e);
 }
 
-(gg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, gg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-gg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (hg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-hg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, hg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-hg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Rg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Rg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Rg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Rg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Rg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(Rg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Rg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Rg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Eg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Eg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Eg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Eg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Tg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Tg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Tg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Tg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Tg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var Mg = {
+var kg = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Ag(e, t) {
-var r = Mg[t], o = Zv.getClusters();
+function Ug(e, t) {
+var r = kg[t], o = $v.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function kg(e, t, r) {
+function _g(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = Zv.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = $v.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Ag(e, i.danger),
+reservedEnergy: Ug(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -39824,7 +39833,7 @@ success: !1
 });
 }
 
-var Ug = {
+var Ng = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -39834,7 +39843,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function _g(e, t, r, o) {
+function Pg(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -39844,7 +39853,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function Ng(e, t) {
+function Ig(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -39865,19 +39874,19 @@ if (r) throw r.error;
 return n;
 }
 
-function Pg() {
-var e = Zv.getEmpire();
+function Gg() {
+var e = $v.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function Ig(e) {
-Pg()[e.id] = e;
+function Lg(e) {
+Gg()[e.id] = e;
 }
 
-function Gg(e) {
+function Dg(e) {
 e.lastUpdate = Game.time;
-var t = Zv.getCluster(e.clusterId);
-if (!t) return e.state = "failed", Ig(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = $v.getCluster(e.clusterId);
+if (!t) return e.state = "failed", Lg(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -39887,12 +39896,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (Og(r) || bg(e) || Cg(0, r), Og(r));
+return !!r && (Ag(r) || Mg(e) || xg(0, r), Ag(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), Ig(e);
+})), Lg(e);
 }(e, t);
 break;
 
@@ -39903,7 +39912,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (pg(o), dg(o)) {
+if (yg(o), fg(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -39932,7 +39941,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = Zv.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = $v.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -39959,14 +39968,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), Ig(e);
+})), Lg(e);
 }(e, t);
 }
 }
 
-var Lg = "defenseAssist";
+var Fg = "defenseAssist";
 
-function Dg(e, t, r) {
+function Bg(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -39985,11 +39994,11 @@ score: n.score + o.score
 }
 }
 
-function Fg(e, t, r) {
+function Wg(e, t, r) {
 return Pr(e, t, r);
 }
 
-function Bg(e, t) {
+function Kg(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40002,11 +40011,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function Wg(e) {
+function Hg(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function Kg(e, t, r) {
+function Yg(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40019,8 +40028,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function Hg(e, t, r) {
-var o = Fg(t, e.energyCapacityAvailable, r);
+function Vg(e, t, r) {
+var o = Wg(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40028,16 +40037,16 @@ var a = xr(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function Yg(e, t, r, o) {
+function qg(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = Hg(e, t, o);
-if (s !== Hg(n, t, o)) return s ? -1 : 1;
+var a, i, s = Vg(e, t, o);
+if (s !== Vg(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function Vg(e, t) {
+function jg(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40121,25 +40130,25 @@ if (r) throw r.error;
 return u;
 }
 
-function qg(e, t) {
+function zg(e, t) {
 return {
-guard: Math.max(0, Bg(e, "guard") - t.counts.guard),
-ranger: Math.max(0, Bg(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, Bg(e, "healer") - t.counts.healer)
+guard: Math.max(0, Kg(e, "guard") - t.counts.guard),
+ranger: Math.max(0, Kg(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, Kg(e, "healer") - t.counts.healer)
 };
 }
 
-function jg(e, t, r) {
+function Qg(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function zg(e) {
+function Xg(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function Qg(e, t) {
+function Zg(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return zg(e.role);
+return Xg(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40152,12 +40161,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function Xg(e) {
+function Jg(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Lg ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Fg ? e.targetRoom : void 0;
 }
 
-function Zg(e) {
+function $g(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40169,7 +40178,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-zg(m) && Xg(l) === e && !u.spawning && Dg(i, m, u.body.filter(function(e) {
+Xg(m) && Jg(l) === e && !u.spawning && Bg(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40187,7 +40196,7 @@ if (t) throw t.error;
 return i;
 }
 
-function Jg(e, t, r) {
+function eh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40217,16 +40226,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: Qg(e, r)
+pendingAssist: Zg(e, r)
 };
 }
 }
 
-function $g(e, t) {
+function th(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = Fg(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = Wg(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40247,7 +40256,7 @@ subsystem: "Cluster"
 }
 }
 
-function eh(e, t, r) {
+function rh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40289,20 +40298,20 @@ exitAccess: a
 };
 }
 
-function th(e, t) {
+function oh(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function rh(e, t, r) {
+function nh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function oh(e) {
+function ah(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function nh(e, t) {
+function ih(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40313,7 +40322,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function ah(e, t, r) {
+function sh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40324,8 +40333,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = oh(g);
-h && (g.assistTarget || nh(v, h) && (t.assignedCreeps.includes(v.name) || th(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = ah(g);
+h && (g.assistTarget || ih(v, h) && (t.assignedCreeps.includes(v.name) || oh(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40362,7 +40371,7 @@ return e.distance - t.distance;
 });
 }
 
-function ih(e, t) {
+function ch(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40387,21 +40396,21 @@ if (r) throw r.error;
 return i;
 }
 
-function sh(e) {
+function uh(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var ch = {
+var lh = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, uh = function() {
+}, mh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, ch), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, lh), e);
 }
 return e.prototype.run = function() {
-var e = Zv.getClusters();
+var e = $v.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40420,7 +40429,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: Qv.map(function(t) {
+steps: Zv.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40481,7 +40490,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-og.processCluster(t);
+ag.processCluster(t);
 break;
 
 case "squads":
@@ -40513,7 +40522,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = eh(e, new RoomPosition(s, c, e.name), "defense");
+var u = rh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40562,9 +40571,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = Zv.getSwarmState(i);
+var i = n.value, s = $v.getSwarmState(i);
 if (s) {
-var c = Ag(i, s.danger);
+var c = Ug(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40595,7 +40604,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = Zv.getSwarmState(m);
+var m = l.value, d = $v.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -40627,7 +40636,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += sh(l.controller.level));
+}).length, i += uh(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -40744,7 +40753,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-pg(i), "gathering" !== i.state || Og(i) || bg(i.id) || Cg(0, i), dg(i) && (i.state = "dissolving");
+yg(i), "gathering" !== i.state || Ag(i) || Mg(i.id) || xg(0, i), fg(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -40769,7 +40778,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = mg(e, s);
+var s = i.value, c = pg(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -40786,7 +40795,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(Pg()).filter(function(e) {
+var t = (a = e.id, Object.values(Gg()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -40797,7 +40806,7 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u, l;
 void 0 === n && (n = {});
-var m = o(o({}, Ug), n), d = [], p = Zv.getEmpire(), f = {
+var m = o(o({}, Ng), n), d = [], p = $v.getEmpire(), f = {
 empire: p
 }, y = p.knownRooms || {}, v = new Set((p.warTargets || []).filter(function(e) {
 return !Y(e, f);
@@ -40814,13 +40823,13 @@ if (R.owner !== E && !(R.owner && Y(R.owner, f) || R.reserver && Y(R.reserver, f
 var T = v.has(h) || Boolean(R.owner && v.has(R.owner));
 if (T || Boolean(R.owner && g.has(R.owner))) {
 if (!R.isHighway && !R.isSK) {
-var C = Ng(e, h);
+var C = Ig(e, h);
 if (!(C > 10)) {
 var S = null !== (l = null === (u = Memory.lastAttacked) || void 0 === u ? void 0 : u[h]) && void 0 !== l ? l : 0;
 if (!(Game.time - S < 5e3)) {
-var x = _g(R, C, T, m), w = "neutral";
+var x = Pg(R, C, T, m), w = "neutral";
 R.owner && (w = T ? "enemy" : "hostile");
-var b = yg(h, {
+var b = gg(h, {
 towerCount: R.towerCount,
 spawnCount: R.spawnCount,
 rcl: R.controllerLevel,
@@ -40855,9 +40864,9 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-vg(e, n.doctrine) ? function(e, t, r) {
+hg(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t = (Zv.getEmpire().knownRooms || {})[e];
+var t = ($v.getEmpire().knownRooms || {})[e];
 return t ? !(Game.time - t.lastSeen > 5e3 && (U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - t.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), 1)) : (U.warn("No intel for target ".concat(e), {
@@ -40866,13 +40875,13 @@ subsystem: "AttackTarget"
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (Zv.getEmpire().knownRooms || {})[t], n = null != r ? r : yg(t, {
+var o = ($v.getEmpire().knownRooms || {})[t], n = null != r ? r : gg(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!vg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!hg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -40885,7 +40894,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-Ig(i);
+Lg(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -40899,13 +40908,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = lg(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = dg(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: ag(n),
+targetComposition: sg(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -40920,8 +40929,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), Ig(i), Cg(0, c), i.state = "forming", i.lastUpdate = Game.time,
-Ig(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), Lg(i), xg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+Lg(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -40940,11 +40949,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Tg.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Sg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Tg.delete(c));
+}), Sg.delete(c));
 }
 } catch (t) {
 e = {
@@ -40958,10 +40967,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = Pg();
-for (var t in e) Gg(e[t]);
+var e = Gg();
+for (var t in e) Dg(e[t]);
 !function() {
-var e = Pg();
+var e = Gg();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41039,14 +41048,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = Zv.getCluster(t, e);
+var t = "cluster_".concat(e), r = $v.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = Zv.getCluster(e);
+var o = $v.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41075,7 +41084,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && kg(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && _g(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41092,7 +41101,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = Zv.getSwarmState(t);
+var n, a, i = $v.getSwarmState(t);
 if (!i) return "continue";
 if (gr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41133,7 +41142,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mr(g), f[g] = Zg(g);
+p[g] = Mr(g), f[g] = $g(g);
 }
 } catch (e) {
 r = {
@@ -41149,7 +41158,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = Jg(E, m, t);
+d[E] = eh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41168,13 +41177,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Kg(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = Yg(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = Vg(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = jg(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Lr(T, R, qg(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Lr(T, R, zg(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var x = (o = void 0, a([ "guard", "ranger", "healer" ])), w = x.next(); !w.done; w = x.next()) for (var b = w.value, O = C.counts[b], M = Yg(h, b, g.roomName, R), A = 0; A < O; A++) {
+for (var x = (o = void 0, a([ "guard", "ranger", "healer" ])), w = x.next(); !w.done; w = x.next()) for (var b = w.value, O = C.counts[b], M = qg(h, b, g.roomName, R), A = 0; A < O; A++) {
 var k = M.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41186,13 +41195,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(k.roomName, "_").con
 roomName: k.roomName,
 role: b,
 family: "military",
-priority: Wg(g.urgency),
+priority: Hg(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: Lg,
-defenseSquadId: jg(k.roomName, g.roomName, e.now),
+task: Fg,
+defenseSquadId: Qg(k.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41232,7 +41241,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), x = S.next(); !x.done; x = S.next()) $g(x.value, t) && C++;
+for (var S = a(T), x = S.next(); !x.done; x = S.next()) th(x.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41259,7 +41268,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = ih(f, ah(e, f, t)), v = y.reduce(function(e, t) {
+var y = ch(f, sh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41270,7 +41279,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-rh(f, R.role, th(f, R.role) - 1), l.push({
+nh(f, R.role, oh(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41337,19 +41346,19 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ka() ], e);
-}(), lh = new uh, mh = /^([WE])(\d+)([NS])(\d+)$/;
+}(), dh = new mh, ph = /^([WE])(\d+)([NS])(\d+)$/;
 
-function dh(e) {
-return mh.test(e);
+function fh(e) {
+return ph.test(e);
 }
 
-var ph = {
+var yh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, fh = function() {
+}, vh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, ph), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, yh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
@@ -41424,7 +41433,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), x = S.next(); !x.done; x = S.next()) {
 var w = x.value;
-if (e.isAlly(w)) f.add(w); else if (dh(w)) {
+if (e.isAlly(w)) f.add(w); else if (fh(w)) {
 var b = v.get(w);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41500,7 +41509,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Oi() ], e);
-}(), yh = new fh, vh = function() {
+}(), gh = new vh, hh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41577,9 +41586,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), gh = new vh;
+}(), Rh = new hh;
 
-function hh(e, t) {
+function Eh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41602,11 +41611,11 @@ if (r) throw r.error;
 return n;
 }
 
-function Rh(e, t, r) {
+function Th(e, t, r) {
 if (!function(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }(e)) return 0;
-var o = hh(e.name, t);
+var o = Eh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += Zs(e.mineralType),
@@ -41615,7 +41624,7 @@ n += tc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += oc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function Eh(e) {
+function Ch(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -41626,8 +41635,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function Th(e) {
-var t = Eh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function Sh(e) {
+var t = Ch(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -41646,14 +41655,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var Ch = {
+var xh = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, Sh = function() {
+}, wh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Ch), e);
+void 0 === e && (e = {}), this.config = o(o({}, xh), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -41744,7 +41753,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = Eh(e);
+var t = Ch(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -41756,14 +41765,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return Th(xh(e));
+return Sh(bh(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = Th(xh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = Sh(bh(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function xh(e) {
+function bh(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -41795,11 +41804,11 @@ swamps: d
 };
 }
 
-var wh = new Sh, bh = /^([WE])(\d+)([NS])(\d+)$/, Oh = {
+var Oh = new wh, Mh = /^([WE])(\d+)([NS])(\d+)$/, Ah = {
 allies: []
-}, Mh = function() {
+}, kh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Oh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Ah), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -41819,7 +41828,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!bh.test(e)) return !1;
+if (!Mh.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -41927,7 +41936,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return bh.test(e);
+return Mh.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -41954,7 +41963,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), Ah = new Mh, kh = {
+}(), Uh = new kh, _h = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -41967,9 +41976,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, Uh = function() {
+}, Nh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, kh), e);
+void 0 === e && (e = {}), this.config = o(o({}, _h), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -41982,7 +41991,7 @@ t.updateExpansionQueue(o);
 }), qi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), qi.measureSubsystem("empire:warTargets", function() {
-Ah.updateWarTargets(o);
+Uh.updateWarTargets(o);
 }), qi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), qi.measureSubsystem("empire:gclTracking", function() {
@@ -41990,13 +41999,13 @@ t.trackGCLProgress(o);
 }), s && qi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (qi.measureSubsystem("empire:intelRefresh", function() {
-wh.refreshRoomIntel(o);
+Oh.refreshRoomIntel(o);
 }), qi.measureSubsystem("empire:roomDiscovery", function() {
-wh.discoverNearbyRooms(o);
+Oh.discoverNearbyRooms(o);
 })), s && qi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (qi.measureSubsystem("empire:clusterHealth", function() {
-gh.monitorClusterHealth();
+Rh.monitorClusterHealth();
 }), qi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42055,11 +42064,11 @@ var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
 if (a) {
-var i = Rh(a, t, r);
+var i = Th(a, t, r);
 i < r.minExpansionScore || o.push({
 roomName: a.name,
 score: i,
-distance: hh(a.name, t),
+distance: Eh(a.name, t),
 claimed: !1,
 lastEvaluated: Game.time
 });
@@ -42352,13 +42361,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Oi() ], e);
-}(), _h = new Uh;
+}(), Ph = new Nh;
 
-function Nh(e) {
+function Ih(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var Ph = {
+var Gh = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42366,10 +42375,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, Ih = function() {
+}, Lh = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, Ph), e);
+this.config = o(o({}, Gh), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -42513,7 +42522,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, Nh(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, Ih(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -42688,7 +42697,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Oi() ], e);
-}(), Gh = new Ih, Lh = function() {
+}(), Dh = new Lh, Fh = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new zs(o(o({}, Ps), e), {
 getEmpire: function() {
@@ -42724,7 +42733,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Oi() ], e);
-}(), Dh = new Lh, Fh = function() {
+}(), Bh = new Fh, Wh = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -42742,9 +42751,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), Bh = new (function(e) {
+}(), Kh = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new Fh) || this;
+return void 0 === t && (t = {}), e.call(this, t, new Wh) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -42756,22 +42765,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Oi() ], t);
 }(Ni));
 
-function Wh() {
+function Hh() {
 return global;
 }
 
-function Kh(e) {
+function Yh(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function Hh(e) {
+function Vh(e) {
 return Number(null != e ? e : 0);
 }
 
-var Yh = function() {
+var qh = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = Wh();
+var e = Hh();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -42779,12 +42788,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return Wh()._pixelGenerationMemory;
+return Hh()._pixelGenerationMemory;
 }, e;
-}(), Vh = function(e) {
+}(), jh = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new Yh) || this;
+var r = e.call(this, t, new qh) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -42801,7 +42810,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(Kh).length : Object.values(null != t ? t : {}).filter(Kh).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(Yh).length : Object.values(null != t ? t : {}).filter(Yh).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -42812,9 +42821,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (Hh(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (Hh(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = Hh(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = Hh(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (Vh(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (Vh(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = Vh(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = Vh(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -42836,9 +42845,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Oi() ], t);
-}(Ii), qh = new Vh;
+}(Ii), zh = new jh;
 
-function jh(e, t) {
+function Qh(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -42860,7 +42869,7 @@ lost: !1
 };
 }
 
-function zh(e, t, r) {
+function Xh(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -42874,20 +42883,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var Qh = Ue().cpu.bucketThresholds.highMode + 1800, Xh = {
+var Zh = Ue().cpu.bucketThresholds.highMode + 1800, Jh = {
 updateInterval: 250,
-minBucket: Qh,
+minBucket: Zh,
 maxSitesPerRemotePerTick: 2
 };
 
-function Zh(e, t) {
+function $h(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var Jh = function() {
+var eR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, Xh), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, Jh), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -42904,8 +42913,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = jh(l);
-m.lost && m.reason && zh(e, u, m.reason);
+var m = Qh(l);
+m.lost && m.reason && Xh(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -42923,10 +42932,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = Zh("remoteInfrastructure.intent", function() {
+var i = $h("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-Zh("remoteInfrastructure.execute", function() {
+$h("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43092,13 +43101,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = Zh("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = $h("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = Zh("remoteInfrastructure.roomSnapshot", function() {
+u[t] = $h("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43131,7 +43140,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = Zh("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = $h("remoteInfrastructure.calculateRemoteRoads", function() {
 return Sn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43160,14 +43169,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = Zh("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = $h("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? Zh("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? $h("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43184,7 +43193,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? Zh("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? $h("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43202,7 +43211,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return Zh("remoteInfrastructure.findSources", function() {
+return $h("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43299,10 +43308,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ xi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: va.LOW,
 interval: 1e3,
-minBucket: Qh,
+minBucket: Zh,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Oi() ], e);
-}(), $h = new Jh, eR = new (function(e) {
+}(), tR = new eR, rR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43314,7 +43323,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ Oi() ], t);
-}(Cp)), tR = function() {
+}(Cp)), oR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43404,7 +43413,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ Oi() ], e);
-}(), rR = new tR, oR = new (function() {
+}(), nR = new oR, aR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43451,7 +43460,7 @@ if (e) throw e.error;
 Ei.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(rR, Os, _s, ns, _h, lc, Gh, $h, Cs, Bh, qh, Dh, Bc, Vc, eR, yh, Pc, lh, qa, _a),
+}(nR, Os, _s, ns, Ph, lc, Dh, tR, Cs, Kh, zh, Bh, Bc, Vc, rR, gh, Pc, dh, qa, _a),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -43518,9 +43527,9 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), nR = "_ownedRooms", aR = "_ownedRoomsTick";
+}), iR = "_ownedRooms", sR = "_ownedRoomsTick";
 
-function iR(e) {
+function cR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -43530,13 +43539,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var sR = hi("NativeCallsTracker");
+var uR = hi("NativeCallsTracker");
 
-function cR(e, t, r) {
+function lR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) sR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) uR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -43552,7 +43561,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-sR.warn("Failed to wrap method", {
+uR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -43562,30 +43571,30 @@ error: String(e)
 }
 }
 
-var uR, lR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], mR = "shard1", dR = {
+var mR, dR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], pR = "shard1", fR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, pR = {
+}, yR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, fR = {
+}, vR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function yR() {
+function gR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function vR() {
+function hR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: lR,
+targetShards: dR,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -43595,11 +43604,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = lR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = dR),
 Memory.interShardOperation;
 }
 
-function gR() {
+function RR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -43640,33 +43649,33 @@ checksum: 0
 }
 }
 
-function hR(e) {
+function ER(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
 InterShardMemory.setLocal(fp(e));
 } catch (e) {}
 }
 
-function RR() {
-var e, t, r, o, n, i, s, c = gR(), u = yR();
+function TR() {
+var e, t, r, o, n, i, s, c = RR(), u = gR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: lR,
+targetShards: dR,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : lR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : dR,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && ER() ? "established" : "unreached",
+status: p === u && CR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -43684,7 +43693,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === mR ? "core" : "frontier",
+role: u === pR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -43701,24 +43710,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), hR(c), c.footprintOperation;
+}), ER(c), c.footprintOperation;
 }
 
-function ER() {
+function CR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function TR() {
+function SR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function CR(e, t) {
+function xR(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -43737,7 +43746,7 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(TR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(SR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 s += by.getPendingRequests(p.name).filter(function(r) {
 var o;
@@ -43758,7 +43767,7 @@ if (n) throw n.error;
 return s;
 }
 
-function SR(e) {
+function wR(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -43802,7 +43811,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = gR().shards[yR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = RR().shards[gR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -43812,8 +43821,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function xR(e, t) {
-if (!(CR("scout", t) >= 1)) {
+function bR(e, t) {
+if (!(xR("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -43856,7 +43865,7 @@ id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: fR,
+body: vR,
 priority: my.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
@@ -43868,13 +43877,13 @@ task: "interShardPortalScout"
 }
 }
 
-function wR(e, t, r) {
-CR("interShardClaimer", t) >= 1 || by.addRequest({
+function OR(e, t, r) {
+xR("interShardClaimer", t) >= 1 || by.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: dR,
+body: fR,
 priority: my.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
@@ -43888,13 +43897,13 @@ workflowState: "movingToPortal"
 });
 }
 
-function bR(e, t, r) {
-CR("interShardScout", t) >= 1 || by.addRequest({
+function MR(e, t, r) {
+xR("interShardScout", t) >= 1 || by.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: fR,
+body: vR,
 priority: my.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
@@ -43908,14 +43917,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function OR(e, t, r) {
+function AR(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (CR("interShardPioneer", t.shard) >= 3 || by.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (xR("interShardPioneer", t.shard) >= 3 || by.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: pR,
+body: yR,
 priority: my.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
@@ -43929,16 +43938,16 @@ workflowState: "movingToPortal"
 }));
 }
 
-function MR(e) {
+function kR(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = yR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = gR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : lR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : dR), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
 var f = InterShardMemory.getRemote(p), y = f ? yp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
@@ -43973,7 +43982,7 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(TR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(SR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 n += by.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
@@ -43994,7 +44003,7 @@ return n;
 }() < o;
 }
 
-(uR = {
+(mR = {
 optimizeBody: Cy,
 spawnQueue: {
 addRequest: function(e) {
@@ -44006,10 +44015,10 @@ LOW: my.LOW,
 NORMAL: my.NORMAL,
 HIGH: my.HIGH
 }
-}).optimizeBody && (xp.optimizeBody = uR.optimizeBody), uR.spawnQueue && (xp.spawnQueue = uR.spawnQueue),
-uR.spawnPriorities && (xp.spawnPriorities = o(o({}, xp.spawnPriorities), uR.spawnPriorities));
+}).optimizeBody && (xp.optimizeBody = mR.optimizeBody), mR.spawnQueue && (xp.spawnQueue = mR.spawnQueue),
+mR.spawnPriorities && (xp.spawnPriorities = o(o({}, xp.spawnPriorities), mR.spawnPriorities));
 
-var AR, kR = function() {
+var UR, _R = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44053,7 +44062,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function UR(e) {
+function NR(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44074,7 +44083,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function _R(e, t, r) {
+function PR(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44140,16 +44149,16 @@ return u;
 });
 }
 
-function NR(e) {
+function IR(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(AR || (AR = {}));
+}(UR || (UR = {}));
 
-var PR = function() {
+var GR = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44187,8 +44196,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = _R(h.pos, T.pos, this.logger);
-if (NR(C)) {
+var T = E.value, C = PR(h.pos, T.pos, this.logger);
+if (IR(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44215,8 +44224,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(w)), O = b.next(); !O.done; O = b.next()) {
-var M = O.value, A = _R(M, u.pos, this.logger);
-NR(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(M, u.pos, S, "hauler"),
+var M = O.value, A = PR(M, u.pos, this.logger);
+IR(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(M, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44255,8 +44264,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = _R(e, t, this.logger);
-if (NR(n)) {
+var n = PR(e, t, this.logger);
+if (IR(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44266,7 +44275,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), IR = function() {
+}(), LR = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44276,7 +44285,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = UR(s);
+var c = NR(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44302,7 +44311,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), GR = function() {
+}(), DR = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44351,7 +44360,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), LR = {
+}(), FR = {
 debug: function(e, t) {
 return A("RemoteMining").debug(e, t);
 },
@@ -44364,7 +44373,7 @@ return A("RemoteMining").warn(e, t);
 error: function(e, t) {
 return A("RemoteMining").error(e, t);
 }
-}, DR = {
+}, BR = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44391,7 +44400,7 @@ direction: a
 }
 return t;
 }
-}, FR = {
+}, WR = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
 void 0 === o && (o = am.MEDIUM), vm.register({
@@ -44404,13 +44413,13 @@ skippable: o !== am.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, BR = new PR(DR, LR), WR = new IR(LR, FR, BR), KR = new GR(LR, DR, BR, ku.moveTo);
+}, KR = new GR(BR, FR), HR = new LR(FR, WR, KR), YR = new DR(FR, BR, KR, ku.moveTo);
 
-function HR(e, t, r, o) {
-return KR.moveToWithRemoteCache(e, t, r, o);
+function VR(e, t, r, o) {
+return YR.moveToWithRemoteCache(e, t, r, o);
 }
 
-var YR, VR = function() {
+var qR, jR = function() {
 function e() {
 this.logger = A("Pathfinding");
 }
@@ -44423,12 +44432,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), qR = function() {
+}(), zR = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), jR = function() {
+}(), QR = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44473,28 +44482,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), zR = function() {
+}(), XR = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return UR(e);
+return NR(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-BR.precacheRemoteRoutes(e, t);
+KR.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), QR = new kR(new VR, new qR, new jR, new zR), XR = {
+}(), ZR = new _R(new jR, new zR, new QR, new XR), JR = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, ZR = function() {
+}, $R = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, XR), e);
+this.config = o(o({}, JR), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -44588,123 +44597,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new ZR, (YR = {})[FIND_STRUCTURES] = {
+new $R, (qR = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, YR[FIND_MY_STRUCTURES] = {
+}, qR[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, YR[FIND_HOSTILE_STRUCTURES] = {
+}, qR[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, YR[FIND_SOURCES_ACTIVE] = {
+}, qR[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, YR[FIND_SOURCES] = {
+}, qR[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, YR[FIND_MINERALS] = {
+}, qR[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, YR[FIND_DEPOSITS] = {
+}, qR[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, YR[FIND_MY_CONSTRUCTION_SITES] = {
+}, qR[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, YR[FIND_CONSTRUCTION_SITES] = {
+}, qR[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, YR[FIND_CREEPS] = {
+}, qR[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, YR[FIND_MY_CREEPS] = {
+}, qR[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, YR[FIND_HOSTILE_CREEPS] = {
+}, qR[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, YR[FIND_DROPPED_RESOURCES] = {
+}, qR[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, YR[FIND_TOMBSTONES] = {
+}, qR[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, YR[FIND_RUINS] = {
+}, qR[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, YR[FIND_FLAGS] = {
+}, qR[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, YR[FIND_MY_SPAWNS] = {
+}, qR[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, YR[FIND_HOSTILE_SPAWNS] = {
+}, qR[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, YR[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, qR[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, YR[FIND_NUKES] = {
+}, qR[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, YR[FIND_POWER_CREEPS] = {
+}, qR[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, YR[FIND_MY_POWER_CREEPS] = {
+}, qR[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, YR[FIND_HOSTILE_POWER_CREEPS] = {
+}, qR[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, YR[FIND_EXIT_TOP] = {
+}, qR[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, YR[FIND_EXIT_RIGHT] = {
+}, qR[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, YR[FIND_EXIT_BOTTOM] = {
+}, qR[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, YR[FIND_EXIT_LEFT] = {
+}, qR[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, YR[FIND_EXIT] = {
+}, qR[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var JR = new le({}, mr), $R = new Ee({}, mr);
+var eE = new le({}, mr), tE = new Ee({}, mr);
 
-function eE(e) {
+function rE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -44712,11 +44721,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var tE = !1;
+var oE = !1;
 
-function rE() {
+function nE() {
 var e, t;
-tE || (ni({
+oE || (ni({
 level: (t = Ue()).debug ? za.DEBUG : za.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -44803,7 +44812,7 @@ return pu.getLabOverflow(e);
 }), qi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) sR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) uR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -44817,7 +44826,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-sR.warn("Failed to wrap PathFinder.search", {
+uR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -44825,11 +44834,11 @@ error: String(e)
 }
 }
 }
-}(), cR(e = Creep.prototype, "moveTo", "moveTo"), cR(e, "move", "move"), cR(e, "harvest", "harvest"),
-cR(e, "transfer", "transfer"), cR(e, "withdraw", "withdraw"), cR(e, "build", "build"),
-cR(e, "repair", "repair"), cR(e, "upgradeController", "upgradeController"), cR(e, "attack", "attack"),
-cR(e, "rangedAttack", "rangedAttack"), cR(e, "heal", "heal"), cR(e, "dismantle", "dismantle"),
-cR(e, "say", "say")), function(e, t, r) {
+}(), lR(e = Creep.prototype, "moveTo", "moveTo"), lR(e, "move", "move"), lR(e, "harvest", "harvest"),
+lR(e, "transfer", "transfer"), lR(e, "withdraw", "withdraw"), lR(e, "build", "build"),
+lR(e, "repair", "repair"), lR(e, "upgradeController", "upgradeController"), lR(e, "attack", "attack"),
+lR(e, "rangedAttack", "rangedAttack"), lR(e, "heal", "heal"), lR(e, "dismantle", "dismantle"),
+lR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -44845,15 +44854,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Xa, mr, df), QR.initializePathCacheEvents(), WR.initialize(am.MEDIUM), ml = HR,
-Ft.initialize(), eR.initialize(), tE = !0), mr.initialize();
-var r = oR.configureForCurrentTick();
+}(Xa, mr, df), ZR.initializePathCacheEvents(), HR.initialize(am.MEDIUM), ml = VR,
+Ft.initialize(), rR.initialize(), oE = !0), mr.initialize();
+var r = aR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ei.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = vR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, RR(), function() {
-var e, t, r, o, n = gR(), a = n.footprintOperation, i = yR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = hR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, TR(), function() {
+var e, t, r, o, n = RR(), a = n.footprintOperation, i = gR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44866,15 +44875,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, hR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, ER(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = vR();
+var e, t, r, n, i, s, c = hR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : lR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === mR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : dR), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === pR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -44892,7 +44901,7 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !ER())) try {
+}(), !CR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
 "interShardClaimer" !== c && "interShardScout" !== c || Wp(s), "interShardPioneer" === c && Bp(s);
@@ -44919,17 +44928,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ei.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: tE
+systemsInitialized: oE
 }
-}), oR.ensureProcessesRegistered(), qi.startTick(), Su.clear(), oR.startEventTick();
+}), aR.ensureProcessesRegistered(), qi.startTick(), Su.clear(), aR.startEventTick();
 var i = function(e) {
-var t = e.cache[nR], r = e.cache[aR];
+var t = e.cache[iR], r = e.cache[sR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[nR] = o, e.cache[aR] = e.tick, o;
+return e.cache[iR] = o, e.cache[sR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -44966,15 +44975,15 @@ if (e) throw e.error;
 }
 }), qi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = vR();
+var e, t, r, o = hR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = RR();
+var n = TR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : lR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : dR), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== yR()) try {
+if (d !== gR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
 var f = yp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
@@ -44995,20 +45004,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = TR().sort(function(e, t) {
+var i = SR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : lR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : dR), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== yR()) {
+if (u !== gR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = SR(u);
+var m = wR(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? OR(i, l, m) : MR() ? wR(i, u, m) : (bR(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (xR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? AR(i, l, m) : kR() ? OR(i, u, m) : (MR(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (bR(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45025,8 +45034,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = gR();
-d.footprintOperation = n, hR(d);
+var d = RR();
+d.footprintOperation = n, ER(d);
 }
 }
 })(), function() {
@@ -45034,8 +45043,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || eE(s))) {
-var c = Yv(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || rE(s))) {
+var c = qv(s, mr.getOrInitSwarmState(s.name));
 qi.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45054,11 +45063,11 @@ if (e) throw e.error;
 }), ku.preTick(), qi.measureSubsystem("processSync", function() {
 Jp.syncCreepProcesses(), $f.syncRoomProcesses();
 }), qi.measureSubsystem("kernel", function() {
-oR.runProcesses();
+aR.runProcesses();
 }), qi.measureSubsystem("eventQueue", function() {
-oR.processQueuedEvents();
+aR.processQueuedEvents();
 }), qi.measureSubsystem("ss2PacketQueue", function() {
-zv.processQueue();
+Xv.processQueue();
 }), Xa.hasCpuBudget() && qi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
@@ -45079,7 +45088,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), iR({
+}), cR({
 hasCpuBudget: Xa.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && qi.measureSubsystem("visualizations", function() {
@@ -45089,8 +45098,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = JR.getConfig(), s = $R.getConfig();
-JR.setConfig(n.roomVisualizerConfig), n.renderMap && $R.setConfig(n.mapVisualizerConfig);
+var i = eE.getConfig(), s = tE.getConfig();
+eE.setConfig(n.roomVisualizerConfig), n.renderMap && tE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45101,7 +45110,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-JR.draw(m);
+eE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ei.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45123,14 +45132,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-$R.draw();
+tE.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ei.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-JR.setConfig(i), $R.setConfig(s);
+eE.setConfig(i), tE.setConfig(s);
 }
 }
 }
@@ -45215,7 +45224,7 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), ku.reconcileTraffic(), iR({
+}), ku.reconcileTraffic(), cR({
 hasCpuBudget: Xa.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && qi.measureSubsystem("scheduledTasks", function() {
@@ -45227,7 +45236,7 @@ return e.set(t.id, t), e;
 qi.finalizeTick(), Ei.flush();
 }
 
-var oE = function() {
+var aE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45235,25 +45244,25 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = JR.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = eE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-JR.toggle(o);
-var n = JR.getConfig()[o];
+eE.toggle(o);
+var n = eE.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = $R.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = tE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-$R.toggle(o);
-var n = $R.getConfig()[o];
+tE.toggle(o);
+var n = tE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = $R.getConfig();
+var e = tE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45376,15 +45385,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), nE = function() {
+}(), iE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = eR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = rR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = eR.getAllShards();
+var e, t, r = rR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45406,9 +45415,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (eR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (rR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = eR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = rR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45433,16 +45442,16 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = eR.getOptimalPortalRoute(e, t);
+var r, o = rR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (eR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (rR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (eR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (rR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
 var e, t, r = bp.getActiveRequests();
@@ -45466,7 +45475,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = eR.getCurrentShardState();
+var e, t, r = rR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45487,7 +45496,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = eR.getActiveTransferTasks();
+var e, t, r, o = rR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -45508,16 +45517,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = eR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+var e = rR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
 return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(hp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = eR.getMemoryStats();
+var e = rR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return eR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return rR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = gR().footprintOperation;
+var e, t, r, o = RR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -45623,9 +45632,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), aE = new nE;
+}(), sE = new iE;
 
-function iE(e) {
+function cE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -45655,7 +45664,7 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? iE(e.metadata.usage) : void 0
+params: e.metadata.usage ? cE(e.metadata.usage) : void 0
 };
 });
 return wm({
@@ -45870,39 +45879,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var sE = new ty, cE = new oE, uE = new ry, lE = new Eu, mE = new ey, dE = new oy, pE = new ny, fE = "__screepsGlobalRuntimeDiagnostics";
+var uE = new ty, lE = new aE, mE = new ry, dE = new Eu, pE = new ey, fE = new oy, yE = new ny, vE = "__screepsGlobalRuntimeDiagnostics";
 
-function yE() {
+function gE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function vE(e, t) {
+function hE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function gE(e, t) {
+function RE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function hE(e) {
+function EE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function RE(e) {
+function TE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: vE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: vE(n.switchCount, 0),
-lastTick: gE(n.lastTick, Game.time),
-lastResetTick: gE(n.lastResetTick, Game.time),
-lastSwitchTick: hE(n.lastSwitchTick),
-lastSwitchPreviousTick: hE(n.lastSwitchPreviousTick),
-lastWarningTick: hE(n.lastWarningTick)
+resetCount: hE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: hE(n.switchCount, 0),
+lastTick: RE(n.lastTick, Game.time),
+lastResetTick: RE(n.lastResetTick, Game.time),
+lastSwitchTick: EE(n.lastSwitchTick),
+lastSwitchPreviousTick: EE(n.lastSwitchPreviousTick),
+lastWarningTick: EE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -45916,13 +45925,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var EE = hi("Main");
+var CE = hi("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(sE), Ct(cE), Ct(uE), Ct(lE), Ct(mE), Ct(dE), Ct(pE), Ct(gu),
-Ct(hu), Ct(Ru), Ct(aE), Ct(Mt), Ct(dc), Ct(Lc), global.tooangel = Ic;
+Et.initialize(), Ct(uE), Ct(lE), Ct(mE), Ct(dE), Ct(pE), Ct(fE), Ct(yE), Ct(gu),
+Ct(hu), Ct(Ru), Ct(sE), Ct(Mt), Ct(dc), Ct(Lc), global.tooangel = Ic;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -45937,12 +45946,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : yE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[fE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : gE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[vE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[fE] = s, function(e, t) {
-var r, o = RE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[vE] = s, function(e, t) {
+var r, o = TE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -45960,7 +45969,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = RE(e.heapId);
+var n, a = TE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -45981,14 +45990,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = RE(s.heapId);
+var u = TE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: EE
-}), rE();
+logger: CE
+}), nE();
 } catch (e) {
-throw EE.error("Critical error in main loop: ".concat(String(e)), {
+throw CE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-spawn/src/spawn-demand/pioneerDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/pioneerDemand.ts
@@ -7,7 +7,7 @@
  */
 import { memoryManager } from "@ralphschuler/screeps-memory";
 import type { SwarmCreepMemory, SwarmState } from "@ralphschuler/screeps-memory";
-import { spawnQueue } from "../spawnQueue";
+import { spawnQueue, SpawnPriority } from "../spawnQueue";
 import {
   getSafeRoomLinearDistance,
   getSpawnQueueRoomNames,
@@ -20,6 +20,7 @@ const MAX_PIONEERS_PER_SPAWN_SITE = 3;
 export interface PioneerSpawnAssignment {
   targetRoom: string;
   task: "bootstrapSpawn";
+  priority: SpawnPriority;
 }
 
 function countAssignedPioneers(targetRoom: string): number {
@@ -42,12 +43,18 @@ function countAssignedPioneers(targetRoom: string): number {
   return count;
 }
 
-function getPioneerTargetCount(targetRoom: Room): number {
-  const hasSpawnSite = targetRoom
+function hasSpawnConstructionSite(targetRoom: Room): boolean {
+  return targetRoom
     .find(FIND_MY_CONSTRUCTION_SITES)
     .some(site => site.structureType === STRUCTURE_SPAWN);
+}
 
-  return hasSpawnSite ? MAX_PIONEERS_PER_SPAWN_SITE : 1;
+function getPioneerTargetCount(targetRoom: Room): number {
+  return hasSpawnConstructionSite(targetRoom) ? MAX_PIONEERS_PER_SPAWN_SITE : 1;
+}
+
+function getPioneerPriority(targetRoom: Room): SpawnPriority {
+  return hasSpawnConstructionSite(targetRoom) ? SpawnPriority.EMERGENCY : SpawnPriority.HIGH;
 }
 
 function isEligiblePioneerParent(room: Room, activeHomeRoom: string, activeSwarm: SwarmState): boolean {
@@ -96,7 +103,7 @@ export function getPioneerSpawnAssignment(homeRoom: string, swarm: SwarmState): 
 
   for (const target of spawnlessTargets) {
     if (getPioneerParentForTarget(target.room, homeRoom, swarm) === homeRoom) {
-      return { targetRoom: target.room.name, task: "bootstrapSpawn" };
+      return { targetRoom: target.room.name, task: "bootstrapSpawn", priority: getPioneerPriority(target.room) };
     }
   }
 

--- a/packages/screeps-spawn/src/spawnIntentCompiler.ts
+++ b/packages/screeps-spawn/src/spawnIntentCompiler.ts
@@ -195,7 +195,7 @@ export function planSpawnDemand(room: Room, swarm: SwarmState): SpawnDemand[] {
       roleName,
       def,
       current,
-      priority: priorityForDemand(room, swarm, roleName, def.priority, isEmergency),
+      priority: pioneerAssignment?.priority ?? priorityForDemand(room, swarm, roleName, def.priority, isEmergency),
       targetRoom: claimerAssignment?.targetRoom ?? pioneerAssignment?.targetRoom ?? remoteTargetRoom ?? undefined,
       task: claimerAssignment?.task ?? pioneerAssignment?.task
     }));

--- a/packages/screeps-spawn/test/claimerPioneerDemand.test.ts
+++ b/packages/screeps-spawn/test/claimerPioneerDemand.test.ts
@@ -5,7 +5,8 @@ import {
   getPioneerSpawnAssignment,
   needsRole
 } from "../src/spawnNeedsAnalyzer";
-import { spawnQueue } from "../src/spawnQueue";
+import { createSpawnPlan } from "../src/spawnIntentCompiler";
+import { spawnQueue, SpawnPriority } from "../src/spawnQueue";
 
 type RoomOptions = {
   my?: boolean;
@@ -65,6 +66,20 @@ function createDangerousHostile(username = "Invader"): Creep {
     owner: { username },
     body: [{ type: ATTACK, hits: 100 }]
   } as Creep;
+}
+
+function addStableHomeCreep(name: string, role: string, homeRoom = "E1N1"): void {
+  Game.creeps[name] = {
+    name,
+    spawning: false,
+    memory: { role, homeRoom }
+  } as Creep;
+}
+
+function seedStableHomeEconomy(homeRoom = "E1N1"): void {
+  addStableHomeCreep(`${homeRoom}-harvester`, "harvester", homeRoom);
+  addStableHomeCreep(`${homeRoom}-hauler`, "hauler", homeRoom);
+  addStableHomeCreep(`${homeRoom}-upgrader`, "upgrader", homeRoom);
 }
 
 function createClaimerCreep(targetRoom: string, parts: BodyPartConstant[]): Creep {
@@ -245,8 +260,33 @@ describe("claimer and pioneer demand", () => {
     expect(getPioneerSpawnAssignment("E1N1", createSwarm())).to.equal(null);
     expect(getPioneerSpawnAssignment("E2N1", createSwarm())).to.deep.equal({
       targetRoom: "E3N1",
-      task: "bootstrapSpawn"
+      task: "bootstrapSpawn",
+      priority: SpawnPriority.EMERGENCY
     });
+  });
+
+  it("promotes spawnless-room pioneer recovery with a spawn site to emergency priority", () => {
+    Game.rooms.E2N1 = createRoom("E2N1", { my: true, spawnSite: true });
+    seedStableHomeEconomy();
+
+    const pioneerRequest = createSpawnPlan(Game.rooms.E1N1, createSwarm()).requests.find(request =>
+      request.role === "pioneer" && request.targetRoom === "E2N1"
+    );
+
+    expect(pioneerRequest?.priority).to.equal(SpawnPriority.EMERGENCY);
+    expect(pioneerRequest?.additionalMemory).to.deep.equal({ task: "bootstrapSpawn" });
+  });
+
+  it("keeps normal spawnless pioneer recovery high priority without a spawn site", () => {
+    Game.rooms.E2N1 = createRoom("E2N1", { my: true });
+    seedStableHomeEconomy();
+
+    const pioneerRequest = createSpawnPlan(Game.rooms.E1N1, createSwarm()).requests.find(request =>
+      request.role === "pioneer" && request.targetRoom === "E2N1"
+    );
+
+    expect(pioneerRequest?.priority).to.equal(SpawnPriority.HIGH);
+    expect(pioneerRequest?.additionalMemory).to.deep.equal({ task: "bootstrapSpawn" });
   });
 
   it("suppresses pioneer demand when a spawnless room already has enough bootstrap workers", () => {


### PR DESCRIPTION
## Summary

Promotes pioneer recovery for owned spawnless rooms with a spawn construction site to emergency spawn priority.

## Linked issue

Closes #3208

## Changes

- Adds priority metadata to pioneer spawn assignments in `@ralphschuler/screeps-spawn`.
- Uses `SpawnPriority.EMERGENCY` for spawnless owned targets with a spawn construction site; keeps normal spawnless targets at `HIGH`.
- Keeps dangerous-hostile gating unchanged.
- Updates spawn package tests for emergency and normal pioneer priority behavior.
- Rebuilds tracked bot bundle.

## Validation

- ✅ `npm test -w @ralphschuler/screeps-spawn -- --grep "pioneer"`
- ✅ `npm test -w @ralphschuler/screeps-spawn`
- ✅ `npm run typecheck`
- ✅ `npm run build:spawn`
- ✅ `npm run build:bot`
- ✅ `npm run lint:spawn`
- ⚠️ `npm run build` timed out locally after 300s during repeated workspace dependency builds; targeted framework spawn build and bot bundle build passed.

## Deployment impact

Runtime spawn priority change only. Deploy path remains `npm run push`; tracked bundle updated.

## Live bot evidence

Read-only live analysis for #3196/#3208 showed shard1 `W18S28` owned RCL5 with no completed spawn, no owned creeps, a spawn construction site, and hostiles clearing between samples. This PR makes the safe rebuild window preempt noncritical local work.

## Follow-up issues

- Parent live recovery tracking remains in #3196.
- Memory API rate-limit blocker remains in #3121.
