### PR TITLE
[codex] Allow target-scoped pioneer recovery

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -37759,6 +37759,7 @@ if (n) throw n.error;
 return !1;
 }
 var C = null !== (u = Ly(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== ov(e, r);
 if (C >= xv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
@@ -37779,7 +37780,6 @@ return !1;
 }(e));
 }
 if ("claimer" === t) return null !== Jy(0, r);
-if ("pioneer" === t) return null !== ov(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var x = f.find(FIND_MINERALS)[0];
@@ -37942,11 +37942,11 @@ return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
-var r, o, n, s, c, u, l, m, d;
+var r, o, n, s, c, u;
 Uv(e);
-var p = Ly(e.name), f = Mv(e.name), y = [];
+var l = Ly(e.name), m = Mv(e.name), d = [];
 if (kv(e.name, e)) {
-var v = function(e, t, r) {
+var p = function(e, t, r) {
 var o, n, i;
 if (0 === Ov(Ly(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
@@ -37998,40 +37998,49 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return v && (E = vy[v]) && bv(e.name, v, t, !0) ? (y.push(_v(e, t, {
-roleName: v,
-def: E,
-current: null !== (n = p.get(v)) && void 0 !== n ? n : 0,
-priority: Nv(e, 0, v, E.priority, f),
+return p && (g = vy[p]) && bv(e.name, p, t, !0) ? (d.push(_v(e, t, {
+roleName: p,
+def: g,
+current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
+priority: Nv(e, 0, p, g.priority, m),
 bootstrap: !0
-})), y) : y;
+})), d) : d;
 }
 try {
-for (var g = a(Object.entries(vy)), h = g.next(); !h.done; h = g.next()) {
-var R = i(h.value, 2), E = (v = R[0], R[1]), T = null !== (s = p.get(v)) && void 0 !== s ? s : 0, C = Tv(e.name, v);
-if (C) y.push({
-roleName: v,
-def: E,
-current: T,
-target: T + 1,
+for (var f = a(Object.entries(vy)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Tv(e.name, p);
+if (R) d.push({
+roleName: p,
+def: g,
+current: h,
+target: h + 1,
 missing: 1,
-priority: C.priority,
-targetRoom: C.targetRoom,
-task: C.task,
-assistTarget: C.targetRoom,
-defenseSquadId: C.defenseSquadId,
-defenseSquadSize: C.defenseSquadSize,
-defenseSquadCreatedAt: C.defenseSquadCreatedAt
-}); else if (bv(e.name, v, t, f)) {
-var S = Wy(v), x = S ? wv(e.name, v, t) : null, w = "claimer" === v ? Jy(e.name, t) : null, b = "pioneer" === v ? ov(e.name, t) : null;
-S && !x || ("claimer" !== v || w) && ("pioneer" !== v || b) && y.push(_v(e, t, {
-roleName: v,
-def: E,
-current: T,
-priority: null !== (c = null == b ? void 0 : b.priority) && void 0 !== c ? c : Nv(e, 0, v, E.priority, f),
-targetRoom: null !== (m = null !== (l = null !== (u = null == w ? void 0 : w.targetRoom) && void 0 !== u ? u : null == b ? void 0 : b.targetRoom) && void 0 !== l ? l : x) && void 0 !== m ? m : void 0,
-task: null !== (d = null == w ? void 0 : w.task) && void 0 !== d ? d : null == b ? void 0 : b.task
-}));
+priority: R.priority,
+targetRoom: R.targetRoom,
+task: R.task,
+assistTarget: R.targetRoom,
+defenseSquadId: R.defenseSquadId,
+defenseSquadSize: R.defenseSquadSize,
+defenseSquadCreatedAt: R.defenseSquadCreatedAt
+}); else if (bv(e.name, p, t, m)) {
+var E = Wy(p), T = E ? wv(e.name, p, t) : null, C = "claimer" === p ? Jy(e.name, t) : null, S = "pioneer" === p ? ov(e.name, t) : null;
+E && !T || ("claimer" !== p || C) && ("pioneer" !== p || S) && (S ? d.push({
+roleName: p,
+def: g,
+current: h,
+target: h + 1,
+missing: 1,
+priority: S.priority,
+targetRoom: S.targetRoom,
+task: S.task
+}) : d.push(_v(e, t, {
+roleName: p,
+def: g,
+current: h,
+priority: Nv(e, 0, p, g.priority, m),
+targetRoom: null !== (u = null !== (c = null == C ? void 0 : C.targetRoom) && void 0 !== c ? c : T) && void 0 !== u ? u : void 0,
+task: null == C ? void 0 : C.task
+})));
 }
 }
 } catch (e) {
@@ -38040,12 +38049,12 @@ error: e
 };
 } finally {
 try {
-h && !h.done && (o = g.return) && o.call(g);
+y && !y.done && (o = f.return) && o.call(f);
 } finally {
 if (r) throw r.error;
 }
 }
-return y;
+return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {

--- a/packages/screeps-spawn/src/spawnIntentCompiler.ts
+++ b/packages/screeps-spawn/src/spawnIntentCompiler.ts
@@ -191,13 +191,27 @@ export function planSpawnDemand(room: Room, swarm: SwarmState): SpawnDemand[] {
       continue;
     }
 
+    if (pioneerAssignment) {
+      demands.push({
+        roleName,
+        def,
+        current,
+        target: current + 1,
+        missing: 1,
+        priority: pioneerAssignment.priority,
+        targetRoom: pioneerAssignment.targetRoom,
+        task: pioneerAssignment.task
+      });
+      continue;
+    }
+
     demands.push(createDemand(room, swarm, {
       roleName,
       def,
       current,
-      priority: pioneerAssignment?.priority ?? priorityForDemand(room, swarm, roleName, def.priority, isEmergency),
-      targetRoom: claimerAssignment?.targetRoom ?? pioneerAssignment?.targetRoom ?? remoteTargetRoom ?? undefined,
-      task: claimerAssignment?.task ?? pioneerAssignment?.task
+      priority: priorityForDemand(room, swarm, roleName, def.priority, isEmergency),
+      targetRoom: claimerAssignment?.targetRoom ?? remoteTargetRoom ?? undefined,
+      task: claimerAssignment?.task
     }));
   }
 

--- a/packages/screeps-spawn/src/spawnNeedsAnalyzer.ts
+++ b/packages/screeps-spawn/src/spawnNeedsAnalyzer.ts
@@ -267,6 +267,13 @@ export function needsRole(roomName: string, role: string, swarm: SwarmState, isB
   const counts = countCreepsByRole(roomName);
   const current = counts.get(role) ?? 0;
 
+  // Pioneer waves are capped per target spawnless room in pioneerDemand.ts.
+  // Do not let the home-room role cap for one recovery target block another
+  // spawnless owned room that still needs bootstrap workers.
+  if (role === "pioneer") {
+    return getPioneerSpawnAssignment(roomName, swarm) !== null;
+  }
+
   if (current >= getRoleTargetCount(roomName, role, swarm)) return false;
 
   // Special conditions
@@ -298,11 +305,6 @@ export function needsRole(roomName: string, role: string, swarm: SwarmState, isB
   // Claimer: Only spawn if the creep can be born with a concrete claim/reserve target.
   if (role === "claimer") {
     return getClaimerSpawnAssignment(roomName, swarm) !== null;
-  }
-
-  // Pioneer: parent-spawned bootstrap worker for newly claimed spawnless rooms.
-  if (role === "pioneer") {
-    return getPioneerSpawnAssignment(roomName, swarm) !== null;
   }
 
   // Intershard footprint roles are requested explicitly by the bot footprint manager.

--- a/packages/screeps-spawn/test/claimerPioneerDemand.test.ts
+++ b/packages/screeps-spawn/test/claimerPioneerDemand.test.ts
@@ -289,6 +289,39 @@ describe("claimer and pioneer demand", () => {
     expect(pioneerRequest?.additionalMemory).to.deep.equal({ task: "bootstrapSpawn" });
   });
 
+  it("continues pioneer recovery for a second spawnless room when another target has a full bootstrap wave", () => {
+    Game.rooms.E2N1 = createRoom("E2N1", { my: true, spawnSite: true });
+    Game.rooms.E3N1 = createRoom("E3N1", { my: true, spawnSite: true });
+    seedStableHomeEconomy();
+
+    for (let i = 1; i <= 3; i++) {
+      Game.creeps[`pioneer${i}`] = {
+        spawning: false,
+        memory: {
+          role: "pioneer",
+          homeRoom: "E1N1",
+          targetRoom: "E2N1",
+          task: "bootstrapSpawn"
+        }
+      } as Creep;
+    }
+
+    expect(getPioneerSpawnAssignment("E1N1", createSwarm())).to.deep.equal({
+      targetRoom: "E3N1",
+      task: "bootstrapSpawn",
+      priority: SpawnPriority.EMERGENCY
+    });
+    expect(needsRole("E1N1", "pioneer", createSwarm())).to.equal(true);
+
+    const plan = createSpawnPlan(Game.rooms.E1N1, createSwarm());
+    const pioneerDemand = plan.demands.find(demand => demand.roleName === "pioneer" && demand.targetRoom === "E3N1");
+    const pioneerRequest = plan.requests.find(request => request.role === "pioneer" && request.targetRoom === "E3N1");
+
+    expect(pioneerDemand?.missing).to.equal(1);
+    expect(pioneerRequest?.priority).to.equal(SpawnPriority.EMERGENCY);
+    expect(pioneerRequest?.additionalMemory).to.deep.equal({ task: "bootstrapSpawn" });
+  });
+
   it("suppresses pioneer demand when a spawnless room already has enough bootstrap workers", () => {
     Game.rooms.E2N1 = createRoom("E2N1", { my: true });
     Game.creeps.pioneer1 = {


### PR DESCRIPTION
## Summary

Keeps spawnless-room pioneer recovery target-scoped so one full bootstrap wave does not block another owned spawnless room that still needs a spawn-site recovery worker.

## Linked issue

Refs #3196
Refs #3210

## Changes

- Bypass the home-room generic role cap for `pioneer`; `getPioneerSpawnAssignment()` already enforces per-target caps and closest-parent ownership.
- Emit pioneer demands as a concrete one-creep target-scoped demand (`missing: 1`) instead of reporting `missing: 0` when another target already has a full wave.
- Add regression coverage for two spawnless owned rooms where the first target already has 3 bootstrap pioneers and the second still needs a pioneer.
- Rebuild `packages/screeps-bot/dist/main.js`.

## Validation

- `npm test -w @ralphschuler/screeps-spawn -- --grep "second spawnless room"` ✅
- `npm test -w @ralphschuler/screeps-spawn` ✅
- `npm run lint:spawn` ✅
- `npm run build` ✅
- `npm run test:server:smoke` ✅ (`packages/screeps-server/artifacts/smoke/summary.md`, 49/49 runtime assertions passing)

## Deployment impact

Runtime spawn behavior change. Deploy should upload the rebuilt bot bundle to `screeps.com/main` after merge.

## Live bot evidence

Live shard1 analysis at tick `72083954` showed multiple owned spawnless recovery rooms:

- `W18S28`: RCL5, 0 owned creeps, 0 built spawn capacity, spawn site present.
- `W18S27`: RCL2, no built spawn, spawn site present, 3 hostile Tigga creeps, 2 owned rangers.
- Helper rooms `W18S29`/`W17S29` remained energy-depleted, so recovery spawn time must not be wasted by a home-level pioneer cap once one target already has its full wave.

## Follow-up issues

- #3210 tracks the active W18S27 hostile/no-spawn defense case.
- #3121 tracks Memory API rate-limit blocking richer live CPU/task-board diagnostics.
- #3196 remains open for the broader cross-room defense/recovery/abandon handling.
