### PR TITLE
[codex] Honor defense refuel hauler priority

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
@@ -13,7 +13,7 @@ import { findDistributedTarget, registerAssignment } from "@ralphschuler/screeps
 import { findCachedClosest } from "../../cache";
 import { updateWorkingState, switchToCollectionMode } from "./common/stateManagement";
 import { createLogger } from "@ralphschuler/screeps-core";
-import { taskBoard } from "../../tasks";
+import { taskBoard, type TaskType } from "../../tasks";
 import { hasTaskBoardCriticalEnergyDelivery } from "./common/energyManagement";
 import { getTerminalEnergyExportRequest } from "../../tasks/energyExport";
 
@@ -24,6 +24,8 @@ const STORAGE_ENERGY_RESERVE = 50000;
 const MINERAL_STORAGE_BUFFER = 5000;
 const TERMINAL_MINERAL_TARGET = 10000;
 const HAULER_DISTRIBUTED_TARGET_CACHE_TTL = 5;
+const DEFENSE_REFUEL_TASK = "defenseRefuel";
+const DEFENSE_REFUEL_CORE_DELIVERY_TASKS: TaskType[] = ["refillSpawn", "refillExtension"];
 
 interface HaulerTargetCacheMemory {
   haulerTargetCache?: Record<string, { id: string; tick: number }>;
@@ -38,6 +40,7 @@ interface HaulerTargetCacheMemory {
  */
 export function hauler(ctx: CreepContext): CreepAction {
   const isWorking = updateWorkingState(ctx);
+  const isDefenseRefuel = ctx.memory.task === DEFENSE_REFUEL_TASK;
   logger.debug(`${ctx.creep.name} hauler state: working=${isWorking}, energy=${ctx.creep.store.getUsedCapacity(RESOURCE_ENERGY)}/${ctx.creep.store.getCapacity()}`);
 
   if (isWorking) {
@@ -50,6 +53,11 @@ export function hauler(ctx: CreepContext): CreepAction {
     if (energyCarried === 0 && resourceType && resourceType !== RESOURCE_ENERGY) {
       const target = ctx.terminal ?? ctx.storage;
       if (target) return { type: "transfer", target, resourceType };
+    }
+
+    if (isDefenseRefuel) {
+      const defenseRefuelDelivery = findDefenseRefuelDelivery(ctx);
+      if (defenseRefuelDelivery) return defenseRefuelDelivery;
     }
     
     const assignedDelivery = taskBoard.getAssignedDeliveryAction(ctx);
@@ -130,6 +138,11 @@ export function hauler(ctx: CreepContext): CreepAction {
 
   // Collect resources - priority order
   // BUGFIX: Use distributed targets for containers to prevent clustering with larvaWorkers
+  if (isDefenseRefuel) {
+    const defenseRefuelCollection = findDefenseRefuelCollection(ctx);
+    if (defenseRefuelCollection) return defenseRefuelCollection;
+  }
+
   // 1. Dropped resources (use cached - transient and rarely contested)
   // Collects all resource types, not just energy
   if (ctx.droppedResources.length > 0) {
@@ -223,6 +236,52 @@ export function hauler(ctx: CreepContext): CreepAction {
 
   logger.warn(`${ctx.creep.name} hauler idle (no energy sources found)`);
   return { type: "idle" };
+}
+
+function findDefenseRefuelDelivery(ctx: CreepContext): CreepAction | null {
+  const assignedCoreDelivery = taskBoard.getAssignedAction(ctx, DEFENSE_REFUEL_CORE_DELIVERY_TASKS);
+  if (assignedCoreDelivery?.type === "transfer") return assignedCoreDelivery;
+
+  if (taskBoard.hasActiveTask(ctx.room.name, DEFENSE_REFUEL_CORE_DELIVERY_TASKS)) return null;
+
+  const spawns = ctx.spawnStructures.filter(
+    (s): s is StructureSpawn =>
+      s.structureType === STRUCTURE_SPAWN &&
+      s.store.getFreeCapacity(RESOURCE_ENERGY) > 0
+  );
+  if (spawns.length > 0) {
+    const closest = findCachedClosest(ctx.creep, spawns, "defense_refuel_spawn", 3);
+    if (closest) return { type: "transfer", target: closest, resourceType: RESOURCE_ENERGY };
+  }
+
+  const extensions = ctx.spawnStructures.filter(
+    (s): s is StructureExtension =>
+      s.structureType === STRUCTURE_EXTENSION &&
+      s.store.getFreeCapacity(RESOURCE_ENERGY) > 0
+  );
+  if (extensions.length > 0) {
+    const closest = findCachedClosest(ctx.creep, extensions, "defense_refuel_ext", 3);
+    if (closest) return { type: "transfer", target: closest, resourceType: RESOURCE_ENERGY };
+  }
+
+  return null;
+}
+
+function findDefenseRefuelCollection(ctx: CreepContext): CreepAction | null {
+  // Spawn demand only creates defenseRefuel haulers when helper-room source containers
+  // hold useful energy; role behavior consumes the context's container contract here.
+  const containersWithEnergy = ctx.containers.filter(
+    c => c.store.getUsedCapacity(RESOURCE_ENERGY) > 100
+  );
+  if (containersWithEnergy.length === 0) return null;
+
+  const target = getCachedDistributedTarget(ctx.creep, containersWithEnergy, "energy_container");
+  if (target) return { type: "withdraw", target, resourceType: RESOURCE_ENERGY };
+
+  const fallback = ctx.creep.pos.findClosestByRange(containersWithEnergy);
+  if (fallback) return { type: "withdraw", target: fallback, resourceType: RESOURCE_ENERGY };
+
+  return null;
 }
 
 function getCachedDistributedTarget<T extends RoomObject & _HasId>(creep: Creep, targets: T[], typeKey: string): T | null {

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -24,6 +24,7 @@ import { createMockCreep, createMockRoom, resetMockGame } from "./setup";
 describe("Behavior Contracts", () => {
   beforeEach(() => {
     resetMockGame();
+    delete (Memory as Memory & { creepTaskBoard?: unknown }).creepTaskBoard;
     (Game as unknown as { getObjectById: (id: string) => unknown }).getObjectById = () => null;
     setLabManagerProvider(undefined);
     setRemoteMoveHandler(undefined);
@@ -77,6 +78,15 @@ describe("Behavior Contracts", () => {
       tombstones: [],
       mineralContainers: []
     };
+  }
+
+  function makeEnergyStore(used: number, capacity: number): Store<RESOURCE_ENERGY, false> {
+    return {
+      [RESOURCE_ENERGY]: used,
+      getUsedCapacity: (resource?: ResourceConstant) => resource === undefined || resource === RESOURCE_ENERGY ? used : 0,
+      getFreeCapacity: (resource?: ResourceConstant) => resource === undefined || resource === RESOURCE_ENERGY ? Math.max(0, capacity - used) : 0,
+      getCapacity: () => capacity
+    } as unknown as Store<RESOURCE_ENERGY, false>;
   }
 
   it("exports current economy behavior functions", () => {
@@ -195,6 +205,212 @@ describe("Behavior Contracts", () => {
     });
 
     expect(action.type).to.equal("idle");
+  });
+
+  it("prioritizes source-container energy for defenseRefuel haulers before dropped resources", () => {
+    const ctx = createContext("hauler");
+    ctx.memory.task = "defenseRefuel";
+
+    const dropped = {
+      id: "drop1",
+      resourceType: RESOURCE_ENERGY,
+      amount: 500,
+      pos: new RoomPosition(24, 25, ctx.room.name)
+    } as Resource<RESOURCE_ENERGY>;
+    const sourceContainer = {
+      id: "sourceContainer1" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      pos: new RoomPosition(20, 20, ctx.room.name),
+      store: makeEnergyStore(500, 2000)
+    } as unknown as StructureContainer;
+
+    const action = evaluateEconomyBehavior({
+      ...ctx,
+      droppedResources: [dropped],
+      containers: [sourceContainer]
+    });
+
+    expect(action.type).to.equal("withdraw");
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).target).to.equal(sourceContainer);
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).resourceType).to.equal(RESOURCE_ENERGY);
+  });
+
+  it("fills spawn and extension targets before task-board tower work for defenseRefuel haulers", () => {
+    const room = createMockRoom("W1N1");
+    const extension = {
+      id: "extension1",
+      structureType: STRUCTURE_EXTENSION,
+      pos: new RoomPosition(24, 25, room.name),
+      store: makeEnergyStore(0, 50)
+    } as unknown as StructureExtension;
+    const tower = {
+      id: "tower1",
+      structureType: STRUCTURE_TOWER,
+      pos: new RoomPosition(25, 25, room.name),
+      store: makeEnergyStore(200, 1000)
+    } as unknown as StructureTower;
+    const storage = {
+      id: "storage1",
+      store: makeEnergyStore(0, 100000)
+    } as unknown as StructureStorage;
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", homeRoom: room.name, task: "defenseRefuel", working: true },
+      store: makeEnergyStore(50, 50)
+    });
+
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    (Game as unknown as { getObjectById: (id: string) => unknown }).getObjectById = id => id === "tower1" ? tower : null;
+    (Memory as Memory & { creepTaskBoard?: unknown }).creepTaskBoard = {
+      enabled: true,
+      rooms: {
+        [room.name]: {
+          roomName: room.name,
+          lastGeneratedTick: Game.time,
+          lastCleanedTick: 0,
+          stats: { generated: 0, assigned: 0, completed: 0, invalidated: 0, staleReservations: 0, preemptions: 0 },
+          tasks: {
+            "W1N1:refillTower:tower1": {
+              id: "W1N1:refillTower:tower1",
+              roomName: room.name,
+              type: "refillTower",
+              priority: 100,
+              status: "open",
+              targetId: "tower1" as Id<StructureTower>,
+              targetPos: { x: 25, y: 25, roomName: room.name },
+              resourceType: RESOURCE_ENERGY,
+              amount: 800,
+              reservedAmount: 0,
+              maxAssignments: 1,
+              assignedCreeps: [],
+              reservations: {},
+              allowedRoles: ["hauler"],
+              createdTick: Game.time,
+              updatedTick: Game.time,
+              expiresTick: Game.time + 50
+            }
+          }
+        }
+      }
+    };
+
+    const action = evaluateEconomyBehavior({
+      ...createContext("hauler"),
+      creep,
+      room,
+      memory: creep.memory as CreepContext["memory"],
+      isEmpty: false,
+      isFull: true,
+      isWorking: true,
+      spawnStructures: [extension],
+      towers: [tower],
+      storage
+    });
+
+    expect(action.type).to.equal("transfer");
+    expect((action as Extract<CreepAction, { type: "transfer" }>).target).to.equal(extension);
+  });
+
+  it("does not duplicate a reserved spawn or extension refill task for defenseRefuel haulers", () => {
+    const room = createMockRoom("W1N1");
+    const extension = {
+      id: "extension1",
+      structureType: STRUCTURE_EXTENSION,
+      pos: new RoomPosition(24, 25, room.name),
+      store: makeEnergyStore(0, 50)
+    } as unknown as StructureExtension;
+    const storage = {
+      id: "storage1",
+      store: makeEnergyStore(0, 100000)
+    } as unknown as StructureStorage;
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", homeRoom: room.name, task: "defenseRefuel", working: true },
+      store: makeEnergyStore(50, 50)
+    });
+    const otherHauler = createMockCreep("otherHauler", {
+      room,
+      memory: { role: "hauler", homeRoom: room.name, working: true },
+      store: makeEnergyStore(50, 50)
+    });
+
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    Game.creeps[otherHauler.name] = otherHauler;
+    (Game as unknown as { getObjectById: (id: string) => unknown }).getObjectById = id => id === "extension1" ? extension : null;
+    (Memory as Memory & { creepTaskBoard?: unknown }).creepTaskBoard = {
+      enabled: true,
+      rooms: {
+        [room.name]: {
+          roomName: room.name,
+          lastGeneratedTick: Game.time,
+          lastCleanedTick: 0,
+          stats: { generated: 0, assigned: 0, completed: 0, invalidated: 0, staleReservations: 0, preemptions: 0 },
+          tasks: {
+            "W1N1:refillExtension:extension1": {
+              id: "W1N1:refillExtension:extension1",
+              roomName: room.name,
+              type: "refillExtension",
+              priority: 100,
+              status: "assigned",
+              targetId: "extension1" as Id<StructureExtension>,
+              targetPos: { x: 24, y: 25, roomName: room.name },
+              resourceType: RESOURCE_ENERGY,
+              amount: 50,
+              reservedAmount: 50,
+              maxAssignments: 1,
+              assignedCreeps: [otherHauler.name],
+              reservations: {
+                [otherHauler.name]: {
+                  creepName: otherHauler.name,
+                  amount: 50,
+                  assignedTick: Game.time,
+                  expiresTick: Game.time + 10
+                }
+              },
+              allowedRoles: ["hauler"],
+              createdTick: Game.time,
+              updatedTick: Game.time,
+              expiresTick: Game.time + 50
+            }
+          }
+        }
+      }
+    };
+
+    const action = evaluateEconomyBehavior({
+      ...createContext("hauler"),
+      creep,
+      room,
+      memory: creep.memory as CreepContext["memory"],
+      isEmpty: false,
+      isFull: true,
+      isWorking: true,
+      spawnStructures: [extension],
+      storage
+    });
+
+    expect(action.type).to.equal("transfer");
+    expect((action as Extract<CreepAction, { type: "transfer" }>).target).to.equal(storage);
+  });
+
+  it("falls back to normal hauler energy collection when defenseRefuel has no source container", () => {
+    const storage = {
+      id: "storage1",
+      store: makeEnergyStore(1000, 100000)
+    } as unknown as StructureStorage;
+    const ctx = createContext("hauler");
+    ctx.memory.task = "defenseRefuel";
+
+    const action = evaluateEconomyBehavior({
+      ...ctx,
+      storage
+    });
+
+    expect(action.type).to.equal("withdraw");
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).target).to.equal(storage);
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).resourceType).to.equal(RESOURCE_ENERGY);
   });
 
   it("keeps spawn delivery ahead of terminal energy buffering", () => {

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -27014,9 +27014,9 @@ return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null 
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var qm = A("HarvesterBehavior"), jm = A("HaulerBehavior");
+var qm = A("HarvesterBehavior"), jm = A("HaulerBehavior"), zm = [ "refillSpawn", "refillExtension" ];
 
-function zm(e, t, r) {
+function Qm(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
@@ -27031,7 +27031,7 @@ tick: Game.time
 } : delete i[r], u;
 }
 
-var Qm = {
+var Xm = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27041,11 +27041,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, Xm = Qm, Zm = function(e) {
-return Xm.getLabResourceNeeds(e);
+}, Zm = Xm, Jm = function(e) {
+return Zm.getLabResourceNeeds(e);
 };
 
-function Jm(e) {
+function $m(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27067,7 +27067,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = Zm(e.room.name);
+var n = Jm(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27095,7 +27095,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, Xm.getLabOverflow(r));
+var t, r, o = (r = e.room.name, Zm.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27110,7 +27110,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = Zm(e.room.name);
+var i = Jm(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27129,7 +27129,7 @@ type: "idle"
 }(e);
 }
 
-var $m = {
+var ed = {
 larvaWorker: Km,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
@@ -27335,48 +27335,72 @@ resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = Sl(e);
+var t, r = Sl(e), o = "defenseRefuel" === e.memory.task;
 if (jm.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
-var o = Object.keys(e.creep.store)[0];
-if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && o && o !== RESOURCE_ENERGY) {
-var n = null !== (t = e.terminal) && void 0 !== t ? t : e.storage;
-if (n) return {
+var n = Object.keys(e.creep.store)[0];
+if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
+var i = null !== (t = e.terminal) && void 0 !== t ? t : e.storage;
+if (i) return {
 type: "transfer",
-target: n,
-resourceType: o
+target: i,
+resourceType: n
 };
 }
-var i = ll.getAssignedDeliveryAction(e);
-if (i) return i;
-if (!Gm(e)) {
-var s = e.spawnStructures.filter(function(e) {
+if (o) {
+var s = function(e) {
+var t = ll.getAssignedAction(e, zm);
+if ("transfer" === (null == t ? void 0 : t.type)) return t;
+if (ll.hasActiveTask(e.room.name, zm)) return null;
+var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (s.length > 0 && (m = Je(e.creep, s, "hauler_spawn", 10))) return jm.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(m.id)),
-{
+if (r.length > 0 && (o = Je(e.creep, r, "defense_refuel_spawn", 3))) return {
 type: "transfer",
-target: m,
+target: o,
 resourceType: RESOURCE_ENERGY
 };
-var c = e.spawnStructures.filter(function(e) {
+var o, n = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_EXTENSION && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (c.length > 0 && (m = Je(e.creep, c, "hauler_ext", 10))) return {
+return n.length > 0 && (o = Je(e.creep, n, "defense_refuel_ext", 3)) ? {
 type: "transfer",
-target: m,
+target: o,
+resourceType: RESOURCE_ENERGY
+} : null;
+}(e);
+if (s) return s;
+}
+var c = ll.getAssignedDeliveryAction(e);
+if (c) return c;
+if (!Gm(e)) {
+var u = e.spawnStructures.filter(function(e) {
+return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
+});
+if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return jm.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+{
+type: "transfer",
+target: p,
 resourceType: RESOURCE_ENERGY
 };
-var u = e.towers.filter(function(e) {
+var l = e.spawnStructures.filter(function(e) {
+return e.structureType === STRUCTURE_EXTENSION && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
+});
+if (l.length > 0 && (p = Je(e.creep, l, "hauler_ext", 10))) return {
+type: "transfer",
+target: p,
+resourceType: RESOURCE_ENERGY
+};
+var m = e.towers.filter(function(e) {
 return e.store.getFreeCapacity(RESOURCE_ENERGY) >= 100;
 });
-if (u.length > 0 && (m = Je(e.creep, u, "hauler_tower", 15))) return {
+if (m.length > 0 && (p = Je(e.creep, m, "hauler_tower", 15))) return {
 type: "transfer",
-target: m,
+target: p,
 resourceType: RESOURCE_ENERGY
 };
 }
-var l = function(e, t) {
+var d = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
 var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Gu(e.room);
@@ -27391,19 +27415,19 @@ type: "transfer",
 target: e.terminal,
 resourceType: t
 } : null;
-}(e, o);
-if (l) return l;
+}(e, n);
+if (d) return d;
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
 type: "transfer",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
 };
-var m, d = e.depositContainers.filter(function(e) {
+var p, f = e.depositContainers.filter(function(e) {
 return e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (d.length > 0 && (m = Je(e.creep, d, "hauler_cont", 15))) return {
+if (f.length > 0 && (p = Je(e.creep, f, "hauler_cont", 15))) return {
 type: "transfer",
-target: m,
+target: p,
 resourceType: RESOURCE_ENERGY
 };
 if (e.isEmpty) return jm.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
@@ -27413,75 +27437,96 @@ type: "idle"
 jm.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
 xl(e);
 }
-if (e.droppedResources.length > 0 && (m = Je(e.creep, e.droppedResources, "hauler_drop", 5))) return {
-type: "pickup",
-target: m
-};
-var p = e.tombstones.filter(function(e) {
-return e.store.getUsedCapacity() > 0;
-});
-if (p.length > 0) {
-var f = Je(e.creep, p, "hauler_tomb", 10);
-if (f) {
-if (f.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return {
-type: "withdraw",
-target: f,
-resourceType: RESOURCE_ENERGY
-};
-var y = Object.keys(f.store).find(function(e) {
-return e !== RESOURCE_ENERGY && f.store.getUsedCapacity(e) > 0;
-});
-if (y) return {
-type: "withdraw",
-target: f,
-resourceType: y
-};
-}
-}
-var v = e.containers.filter(function(e) {
+if (o) {
+var y = function(e) {
+var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
+if (0 === t.length) return null;
+var r = Qm(e.creep, t, "energy_container");
+if (r) return {
+type: "withdraw",
+target: r,
+resourceType: RESOURCE_ENERGY
+};
+var o = e.creep.pos.findClosestByRange(t);
+return o ? {
+type: "withdraw",
+target: o,
+resourceType: RESOURCE_ENERGY
+} : null;
+}(e);
+if (y) return y;
+}
+if (e.droppedResources.length > 0 && (p = Je(e.creep, e.droppedResources, "hauler_drop", 5))) return {
+type: "pickup",
+target: p
+};
+var v = e.tombstones.filter(function(e) {
+return e.store.getUsedCapacity() > 0;
+});
 if (v.length > 0) {
-var g = zm(e.creep, v, "energy_container");
-if (g) return jm.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(g.id, " with ").concat(g.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-{
+var g = Je(e.creep, v, "hauler_tomb", 10);
+if (g) {
+if (g.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return {
 type: "withdraw",
 target: g,
 resourceType: RESOURCE_ENERGY
 };
-jm.warn("".concat(e.creep.name, " hauler found ").concat(v.length, " containers but distribution returned null, falling back to closest"));
-var h = e.creep.pos.findClosestByRange(v);
-if (h) return jm.debug("".concat(e.creep.name, " hauler using fallback container ").concat(h.id)),
+var h = Object.keys(g.store).find(function(e) {
+return e !== RESOURCE_ENERGY && g.store.getUsedCapacity(e) > 0;
+});
+if (h) return {
+type: "withdraw",
+target: g,
+resourceType: h
+};
+}
+}
+var R = e.containers.filter(function(e) {
+return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
+});
+if (R.length > 0) {
+var E = Qm(e.creep, R, "energy_container");
+if (E) return jm.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
-target: h,
+target: E,
+resourceType: RESOURCE_ENERGY
+};
+jm.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+var T = e.creep.pos.findClosestByRange(R);
+if (T) return jm.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+{
+type: "withdraw",
+target: T,
 resourceType: RESOURCE_ENERGY
 };
 }
 if (e.mineralContainers.length > 0) {
-var R = zm(e.creep, e.mineralContainers, "mineral_container");
-if (R) {
-if (E = Object.keys(R.store).find(function(e) {
-return e !== RESOURCE_ENERGY && R.store.getUsedCapacity(e) > 0;
+var C = Qm(e.creep, e.mineralContainers, "mineral_container");
+if (C) {
+if (S = Object.keys(C.store).find(function(e) {
+return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
 })) return {
 type: "withdraw",
-target: R,
-resourceType: E
+target: C,
+resourceType: S
 };
 } else {
 jm.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
-var E, T = e.creep.pos.findClosestByRange(e.mineralContainers);
-if (T && (E = Object.keys(T.store).find(function(e) {
-return e !== RESOURCE_ENERGY && T.store.getUsedCapacity(e) > 0;
-}))) return jm.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(T.id)),
+var S, x = e.creep.pos.findClosestByRange(e.mineralContainers);
+if (x && (S = Object.keys(x.store).find(function(e) {
+return e !== RESOURCE_ENERGY && x.store.getUsedCapacity(e) > 0;
+}))) return jm.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(x.id)),
 {
 type: "withdraw",
-target: T,
-resourceType: E
+target: x,
+resourceType: S
 };
 }
 }
-var C = function(e) {
+var w = function(e) {
 var t, r;
 if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
@@ -27518,7 +27563,7 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return C || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (jm.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+return w || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (jm.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
 {
 type: "withdraw",
 target: e.storage,
@@ -27798,9 +27843,9 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : Jm(e);
+} : $m(e);
 },
-labSupply: Jm,
+labSupply: $m,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
@@ -28110,12 +28155,12 @@ roomName: o
 }
 };
 
-function ed(e) {
+function td(e) {
 var t;
-return (null !== (t = $m[e.memory.role]) && void 0 !== t ? t : Km)(e);
+return (null !== (t = ed[e.memory.role]) && void 0 !== t ? t : Km)(e);
 }
 
-var td = "patrol", rd = [ {
+var rd = "patrol", od = [ {
 x: 10,
 y: 5
 }, {
@@ -28151,7 +28196,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], od = [ {
+} ], nd = [ {
 x: 10,
 y: 10
 }, {
@@ -28168,7 +28213,7 @@ x: 25,
 y: 25
 } ];
 
-function nd(e) {
+function ad(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28176,7 +28221,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function ad(e) {
+function id(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28186,9 +28231,9 @@ roomName: e.roomName
 });
 }
 
-function id(e) {
+function sd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Fe.get(e.name, {
-namespace: td
+namespace: rd
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28208,25 +28253,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(rd), !1), i(od), !1);
-}(t).map(nd).filter(function(e) {
+}(e)), !1), i(od), !1), i(nd), !1);
+}(t).map(ad).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Fe.set(e.name, {
-waypoints: ad(n),
+waypoints: id(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: td,
+namespace: rd,
 ttl: 1e3
 }), n;
 }
 
-function sd(e, t) {
+function cd(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28236,87 +28281,87 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var cd = A("MilitaryBehaviors"), ud = "defenseAssist";
-
-function ld(e) {
-var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ud ? e.targetRoom : void 0;
-}
+var ud = A("MilitaryBehaviors"), ld = "defenseAssist";
 
 function md(e) {
+var t;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ld ? e.targetRoom : void 0;
+}
+
+function dd(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === ud && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === ld && (delete e.task,
 delete e.targetRoom);
 }
 
-function dd(e, t) {
+function pd(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function pd(e) {
+function fd(e) {
 return Ir(kr(e));
 }
 
-function fd(e) {
+function yd(e) {
 return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
 }
 
-function yd(e) {
+function vd(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function vd(e, t) {
+function gd(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function gd(e) {
-return vd(e, "guard") + vd(e, "ranger") + vd(e, "healer");
+function hd(e) {
+return gd(e, "guard") + gd(e, "ranger") + gd(e, "healer");
 }
 
-function hd(e, t, r) {
+function Rd(e, t, r) {
 var o = e.memory;
-return ld(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
-}
-
-function Rd(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-return hd(r, e, t);
-});
+return md(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
 function Ed(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+return Rd(r, e, t);
+});
+}
+
+function Td(e, t) {
 return "defenseAssist:".concat(e, ":").concat(t, ":active");
 }
 
-function Td(e, t, r) {
-return vd(e, t) > function(e, t) {
+function Cd(e, t, r) {
+return gd(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
-return !r.spawning && o.role === t && ld(o) === e;
+return !r.spawning && o.role === t && md(o) === e;
 }).length;
-}(e.roomName, t) || gd(e) > 0 && pd(e.roomName) && function(e, t) {
-return Rd(e, t).length;
+}(e.roomName, t) || hd(e) > 0 && fd(e.roomName) && function(e, t) {
+return Ed(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Cd(e, t) {
+function Sd(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== ud) return null;
-if (fd(e)) return null;
+if (t.task && t.task !== ld) return null;
+if (yd(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(yd).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(vd).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== j(l).length && Td(u, t.role, e.homeRoom)) return t.task = ud, t.targetRoom = u.roomName,
-t.assistTarget = u.roomName, t.defenseSquadId = Ed(e.homeRoom, u.roomName), t.defenseSquadSize = pd(u.roomName) ? Math.max(5, gd(u)) : Math.max(1, gd(u)),
+if (l && 0 !== j(l).length && Cd(u, t.role, e.homeRoom)) return t.task = ld, t.targetRoom = u.roomName,
+t.assistTarget = u.roomName, t.defenseSquadId = Td(e.homeRoom, u.roomName), t.defenseSquadSize = fd(u.roomName) ? Math.max(5, hd(u)) : Math.max(1, hd(u)),
 t.defenseSquadCreatedAt = Game.time, u.roomName;
 }
 } catch (e) {
@@ -28333,7 +28378,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Sd(e) {
+function xd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28341,19 +28386,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function xd(e, t) {
+function wd(e, t) {
 if (!function(e) {
-return Boolean(ld(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(md(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = ld(t);
+var r = md(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = kr(r), n = Ir(o), a = n ? Rd(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = ld(e);
+var o = kr(r), n = Ir(o), a = n ? Ed(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = md(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && hd(e, r, o);
+return e.memory.defenseSquadId === t && Rd(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28367,7 +28412,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return Rd(e, t).reduce(function(e, t) {
+return Ed(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = br(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28389,16 +28434,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return dd(t, "parity-ready"), null;
-if (c >= u) return dd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return pd(t, "parity-ready"), null;
+if (c >= u) return pd(t, "squad-quorum"), null;
 if (l) {
-if (!n) return dd(t, "expired-staging"), null;
+if (!n) return pd(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Sd(e) - Sd(t);
+var r = xd(e) - xd(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28406,11 +28451,11 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return dd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return pd(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return dd(t, "squad-quorum"), null;
-if (l) return dd(t, "expired-staging"), null;
+if (c >= u) return pd(t, "squad-quorum"), null;
+if (l) return pd(t, "expired-staging"), null;
 }
 var m = Nu(e.room.name);
 return {
@@ -28419,7 +28464,7 @@ position: null != m ? m : e.creep.pos
 };
 }
 
-function wd(e) {
+function bd(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28451,21 +28496,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function bd(e, t) {
+function Od(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Od(e, t) {
+function Md(e, t) {
 if (!e.swarmState) return null;
 var r = Nu(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (cd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+return r && e.creep.pos.getRangeTo(r) > 2 ? (ud.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Md(e) {
+function Ad(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28489,7 +28534,7 @@ if (t) throw t.error;
 }
 }
 
-function Ad(e) {
+function kd(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28497,23 +28542,23 @@ return Boolean(e);
 });
 }
 
-function kd(e) {
+function Ud(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Ud(e) {
+function _d(e) {
 var t, r = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Md(e.memory.squadId);
-if (o) return _d(e, o);
+var o = Ad(e.memory.squadId);
+if (o) return Nd(e, o);
 }
-var n = null !== (t = Cd(e, r)) && void 0 !== t ? t : ld(r);
-if (n && !fd(e)) {
-var a = xd(e, r);
+var n = null !== (t = Sd(e, r)) && void 0 !== t ? t : md(r);
+if (n && !yd(e)) {
+var a = wd(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28526,9 +28571,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = wd(e);
+var s = bd(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = bd(e.creep, RANGED_ATTACK), l = bd(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Od(e.creep, RANGED_ATTACK), l = Od(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28540,7 +28585,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = bd(e.creep, RANGED_ATTACK), l = bd(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Od(e.creep, RANGED_ATTACK), l = Od(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28551,7 +28596,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (md(r), e.creep.room.name !== e.homeRoom) return {
+} else if (dd(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28560,8 +28605,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = wd(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = bd(e.creep, RANGED_ATTACK), l = bd(e.creep, ATTACK),
+var m = bd(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Od(e.creep, RANGED_ATTACK), l = Od(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28572,7 +28617,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = id(e.room), p = sd(e.creep, d);
+var d = sd(e.room), p = cd(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28586,7 +28631,7 @@ type: "idle"
 };
 }
 
-function _d(e, t) {
+function Nd(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28594,7 +28639,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = kd(t);
+var n = Ud(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28602,7 +28647,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Ad(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(kd(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -28625,7 +28670,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Ad(e).filter(function(t) {
+var t, r, o = kd(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -28654,7 +28699,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Ad(t).filter(function(t) {
+var r = kd(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -28670,7 +28715,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Ad(t).sort(function(e, t) {
+var a = kd(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -28707,7 +28752,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Ad(t).filter(function(e) {
+var l = kd(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -28724,7 +28769,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Ad(e).find(function(e) {
+return null !== (t = kd(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -28735,7 +28780,7 @@ target: m
 type: "idle"
 };
 }
-var d = wd(e);
+var d = bd(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -28747,10 +28792,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : bd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Od(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : bd(e.creep, ATTACK) && p <= 1 ? {
+} : Od(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -28766,10 +28811,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : bd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Od(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : bd(e.creep, ATTACK) && p <= 1 ? {
+} : Od(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -28785,7 +28830,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: kd(t)
+target: Ud(t)
 };
 
 case "dissolving":
@@ -28803,8 +28848,8 @@ type: "idle"
 }
 }
 
-var Nd = {
-guard: Ud,
+var Pd = {
+guard: _d,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -28813,8 +28858,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = id(e.room);
-return (o = sd(e.creep, r)) ? {
+var r = sd(e.room);
+return (o = cd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -28835,7 +28880,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = id(e.room), (o = sd(e.creep, r)) ? {
+} : (r = sd(e.room), (o = cd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -28849,11 +28894,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return bd(e, HEAL);
+return Od(e, HEAL);
 }), t.filter(function(e) {
-return bd(e, RANGED_ATTACK);
+return Od(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return bd(e, ATTACK);
+return Od(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -28874,7 +28919,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = bd(e.creep, RANGED_ATTACK), u = bd(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Od(e.creep, RANGED_ATTACK), u = Od(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28905,19 +28950,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Md(e.memory.squadId);
-if (o) return _d(e, o);
+var o = Ad(e.memory.squadId);
+if (o) return Nd(e, o);
 }
-var n = null !== (t = Cd(e, r)) && void 0 !== t ? t : ld(r);
-if (n && !fd(e)) {
-var a = xd(e, r);
+var n = null !== (t = Sd(e, r)) && void 0 !== t ? t : md(r);
+if (n && !yd(e)) {
+var a = wd(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === j(i).length) return md(r), {
+if (0 === j(i).length) return dd(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -28925,7 +28970,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== ud && !r.assistTarget) {
+if (r.targetRoom && r.task !== ld && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -28985,7 +29030,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || ld(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || md(r) === t);
 }(e, t);
 }
 });
@@ -29011,7 +29056,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = id(e.room), v = sd(e.creep, y);
+var y = sd(e.room), v = cd(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29022,8 +29067,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Md(e.memory.squadId);
-if (r) return _d(e, r);
+var r = Ad(e.memory.squadId);
+if (r) return Nd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29045,9 +29090,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = wd(e);
+var a = bd(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = bd(e.creep, RANGED_ATTACK), c = bd(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Od(e.creep, RANGED_ATTACK), c = Od(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29066,7 +29111,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = id(e.room), m = sd(e.creep, l);
+var l = sd(e.room), m = cd(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29088,8 +29133,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Md(e.memory.squadId);
-if (r) return _d(e, r);
+var r = Ad(e.memory.squadId);
+if (r) return Nd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29150,9 +29195,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Od(e, "siegeUnit");
+var p = Md(e, "siegeUnit");
 if (p) return p;
-var f = id(e.room), y = sd(e.creep, f);
+var f = sd(e.room), y = cd(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29163,8 +29208,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Md(e.memory.squadId);
-if (r) return _d(e, r);
+var r = Ad(e.memory.squadId);
+if (r) return Nd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29181,7 +29226,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Od(e, "harasser (no target)") || {
+if (!t) return Md(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29223,9 +29268,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Od(e, "harasser (no targets)");
+var c = Md(e, "harasser (no targets)");
 if (c) return c;
-var u = id(e.room), l = sd(e.creep, u);
+var u = sd(e.room), l = cd(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29238,9 +29283,9 @@ var t, r, o = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Md(e.memory.squadId))) return _d(e, a);
+if (e.memory.squadId && (a = Ad(e.memory.squadId))) return Nd(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (ld(o) && md(o), e.room.name !== e.homeRoom) return {
+if (md(o) && dd(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29254,9 +29299,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Cd(e, o)) && void 0 !== t ? t : ld(o);
-if (i && !fd(e)) {
-var s = xd(e, o);
+var a, i = null !== (t = Sd(e, o)) && void 0 !== t ? t : md(o);
+if (i && !yd(e)) {
+var s = wd(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29266,14 +29311,14 @@ roomName: i
 var u = j(c), l = z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return md(o), {
+if (0 === u.length && 0 === l.length) return dd(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = wd(e);
+var m = bd(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29293,8 +29338,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Md(e.memory.squadId))) return _d(e, a);
-var p, f = wd(e);
+if (e.memory.squadId && (a = Ad(e.memory.squadId))) return Nd(e, a);
+var p, f = bd(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29305,7 +29350,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = id(e.room), v = sd(e.creep, y);
+var y = sd(e.room), v = cd(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29326,21 +29371,21 @@ type: "idle"
 }
 };
 
-function Pd(e) {
+function Id(e) {
 var t;
-return ll.getAssignedAction(e) || (null !== (t = Nd[e.memory.role]) && void 0 !== t ? t : Ud)(e);
+return ll.getAssignedAction(e) || (null !== (t = Pd[e.memory.role]) && void 0 !== t ? t : _d)(e);
 }
 
-var Id = A("PowerExecutor");
+var Gd = A("PowerExecutor");
 
-function Gd(e, t) {
+function Ld(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Ld(e) {
+function Dd(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29382,8 +29427,8 @@ type: "idle"
 };
 }
 
-var Dd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Fd = {
-powerHarvester: Ld,
+var Fd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Bd = {
+powerHarvester: Dd,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29455,65 +29500,65 @@ roomName: e.homeRoom
 }
 };
 
-function Bd(e) {
+function Wd(e) {
 var t;
-return (null !== (t = Fd[e.memory.role]) && void 0 !== t ? t : Ld)(e);
+return (null !== (t = Bd[e.memory.role]) && void 0 !== t ? t : Dd)(e);
 }
 
-function Wd(e) {
+function Kd(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var Kd = {
+var Hd = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, Hd = {
+}, Yd = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, Yd = {
+}, Vd = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, Vd = {
+}, qd = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, qd = {
+}, jd = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, jd = {
+}, zd = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, zd = {
+}, Qd = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, Qd = {
+}, Xd = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function Xd(e) {
+function Zd(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function Zd(e) {
+function Jd(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29521,7 +29566,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function Jd(e) {
+function $d(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29529,12 +29574,12 @@ y: parseInt(n, 10)
 };
 }
 
-function $d(e) {
+function ep(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = ep(s);
+o[s.n] = tp(s);
 }
 } catch (e) {
 t = {
@@ -29550,23 +29595,23 @@ if (t) throw t.error;
 return o;
 }
 
-function ep(e) {
+function tp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = Hd[e.r]) && void 0 !== t ? t : "core",
-health: tp(e.h),
+role: null !== (t = Yd[e.r]) && void 0 !== t ? t : "core",
+health: rp(e.h),
 activeTasks: e.t,
-portals: e.p.map(rp),
+portals: e.p.map(op),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(op)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(np)
 };
 }
 
-function tp(e) {
+function rp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = Vd[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = qd[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29579,11 +29624,11 @@ lastUpdate: e.u
 };
 }
 
-function rp(e) {
+function op(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: Zd(e.sp),
+sourcePos: Jd(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29593,7 +29638,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function op(e) {
+function np(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29602,7 +29647,7 @@ bucketLevel: e.b
 };
 }
 
-function np(e) {
+function ap(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -29612,12 +29657,12 @@ isAlly: 1 === e.a
 };
 }
 
-function ap(e) {
+function ip(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = ip(u);
+i[u.n] = sp(u);
 }
 } catch (e) {
 t = {
@@ -29640,13 +29685,13 @@ updatedAt: e.u
 };
 }
 
-function ip(e) {
+function sp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: Jd(e.pp),
+portalPos: $d(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -29657,46 +29702,46 @@ lastUpdate: e.u
 };
 }
 
-function sp(e) {
+function cp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = jd[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = zd[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = Qd[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = Xd[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function cp(e, t) {
+function up(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
-}
-
-function up(e) {
-var t;
-return {
-c: null !== (t = Yd[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: cp(e.cpuUsage, 2),
-b: e.bucketLevel,
-e: Math.round(e.economyIndex),
-w: Math.round(e.warIndex),
-m: Math.round(e.commodityIndex),
-rc: e.roomCount,
-rl: cp(e.avgRCL, 1),
-cc: e.creepCount,
-u: e.lastUpdate
-};
 }
 
 function lp(e) {
 var t;
 return {
+c: null !== (t = Vd[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: up(e.cpuUsage, 2),
+b: e.bucketLevel,
+e: Math.round(e.economyIndex),
+w: Math.round(e.warIndex),
+m: Math.round(e.commodityIndex),
+rc: e.roomCount,
+rl: up(e.avgRCL, 1),
+cc: e.creepCount,
+u: e.lastUpdate
+};
+}
+
+function mp(e) {
+var t;
+return {
 sr: e.sourceRoom,
-sp: Xd(e.sourcePos),
+sp: Zd(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -29705,27 +29750,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function mp(e) {
+function dp(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: cp(e.cpuUsed, 2),
+u: up(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function dp(e) {
+function pp(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(pp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(fp)
 };
 }
 
-function pp(e) {
+function fp(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -29735,23 +29780,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function fp(e) {
+function yp(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = qd[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = jd[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = zd[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = Qd[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function yp(e) {
+function vp(e) {
 return {
 name: e,
 role: "core",
@@ -29774,7 +29819,7 @@ cpuLimit: 0
 };
 }
 
-function vp(e) {
+function gp(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -29784,16 +29829,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = Kd[t.role]) && void 0 !== r ? r : t.role[0],
-h: up(t.health),
+r: null !== (r = Hd[t.role]) && void 0 !== r ? r : t.role[0],
+h: lp(t.health),
 t: t.activeTasks,
-p: t.portals.map(lp),
+p: t.portals.map(mp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(mp)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(dp)
 };
 }(t[0], t[1]);
 }),
-g: dp(e.globalTargets),
+g: pp(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -29807,7 +29852,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? Xd(t.portalPos) : void 0,
+pp: t.portalPos ? Zd(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -29819,20 +29864,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(fp),
+k: e.tasks.map(yp),
 ls: e.lastSync
 };
 var t;
-}(e), r = Wd(JSON.stringify(t));
+}(e), r = Kd(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function gp(e) {
+function hp(e) {
 try {
-var t = JSON.parse(e), r = Wd(JSON.stringify(t.d));
+var t = JSON.parse(e), r = Kd(JSON.stringify(t.d));
 return t.c !== r ? (va.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -29841,13 +29886,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: $d(a.s),
+shards: ep(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(np)), n),
-footprintOperation: a.o ? ap(a.o) : void 0,
-tasks: a.k.map(sp),
+o.en && (n.enemies = o.en.map(ap)), n),
+footprintOperation: a.o ? ip(a.o) : void 0,
+tasks: a.k.map(cp),
 lastSync: a.ls,
 checksum: i
 });
@@ -29859,34 +29904,34 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var hp, Rp, Ep = 102400;
+var Rp, Ep, Tp = 102400;
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(hp || (hp = {})), function(e) {
+}(Rp || (Rp = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(Rp || (Rp = {}));
+}(Ep || (Ep = {}));
 
-var Tp = null != va ? va : {
+var Cp = null != va ? va : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Cp = {
+}, Sp = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Sp = {
+}, xp = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, xp = function() {
+}, wp = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Cp), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Sp), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -29903,19 +29948,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = gp(r);
-o && (this.interShardMemory = o, Tp.debug("Loaded InterShardMemory", {
+var o = hp(r);
+o && (this.interShardMemory = o, Cp.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Tp.error("Failed to load InterShardMemory: ".concat(n), {
+Cp.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = yp(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = vp(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30076,25 +30121,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Tp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Cp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Tp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Cp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Tp.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Cp.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Tp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Cp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30127,7 +30172,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Tp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Cp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30157,12 +30202,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Tp.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Cp.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Tp.info("War ended, transitioning to ".concat(i), {
+Cp.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Tp.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Cp.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30188,7 +30233,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Sp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = xp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30240,13 +30285,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Tp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Cp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Tp.debug("Could not set shard limits: ".concat(S), {
+Cp.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30254,27 +30299,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Tp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Cp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
 try {
-var t = InterShardMemory.getLocal(), r = t ? gp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
+var t = InterShardMemory.getLocal(), r = t ? hp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
 o && (!n || o.updatedAt >= n.updatedAt) && (this.interShardMemory.footprintOperation = o);
 } catch (e) {}
-var a = vp(this.interShardMemory);
-if (a.length > Ep) {
-Tp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Ep), {
+var a = gp(this.interShardMemory);
+if (a.length > Tp) {
+Cp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Tp), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var i = vp(this.interShardMemory);
-return i.length > Ep ? (Tp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Ep), {
+var i = gp(this.interShardMemory);
+return i.length > Tp ? (Cp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Tp), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(i);
 }
 InterShardMemory.setLocal(a), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var s = e instanceof Error ? e.message : String(e);
-Tp.error("Failed to sync InterShardMemory: ".concat(s), {
+Cp.error("Failed to sync InterShardMemory: ".concat(s), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30312,7 +30357,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = yp(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = vp(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30330,40 +30375,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Tp.info("Repaired InterShardMemory structure", {
+Cp.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Tp.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Cp.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = gp(r);
-if (!o) return void Tp.warn("InterShardMemory verification failed: deserialization failed", {
+var o = hp(r);
+if (!o) return void Cp.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Tp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Cp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Tp.warn("InterShardMemory verification failed: ".concat(a), {
+Cp.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Tp.info("Attempting InterShardMemory recovery", {
+Cp.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = gp(r);
-if (o) return this.interShardMemory = o, void Tp.info("Recovered InterShardMemory from storage", {
+var o = hp(r);
+if (o) return this.interShardMemory = o, void Cp.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30378,12 +30423,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = yp(n), Tp.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = vp(n), Cp.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Tp.error("InterShardMemory recovery failed: ".concat(a), {
+Cp.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30393,7 +30438,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Tp.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Cp.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30409,7 +30454,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Tp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Cp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30425,7 +30470,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Tp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Cp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30440,7 +30485,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Tp.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Cp.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30459,7 +30504,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Tp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Cp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30505,11 +30550,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Tp.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Cp.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = vp(this.interShardMemory).length, o = r / Ep * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = gp(this.interShardMemory).length, o = r / Tp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30536,11 +30581,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Tp.info("Forcing InterShardMemory sync with validation", {
+Cp.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = vp(this.interShardMemory).length, n = vp(o(o({}, this.interShardMemory), {
+var e, t, r = gp(this.interShardMemory).length, n = gp(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -30564,8 +30609,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: Ep,
-percent: Math.round(r / Ep * 1e4) / 100,
+limit: Tp,
+percent: Math.round(r / Tp * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -30573,10 +30618,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (hp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Rp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), wp = new xp, bp = {
+}(), bp = new wp, Op = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -30587,11 +30632,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: Rp.LOW,
-NORMAL: Rp.NORMAL,
-HIGH: Rp.HIGH
+LOW: Ep.LOW,
+NORMAL: Ep.NORMAL,
+HIGH: Ep.HIGH
 }
-}, Op = function() {
+}, Mp = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -30601,7 +30646,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = wp.getActiveTransferTasks();
+var n = bp.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -30628,7 +30673,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = wp.getOptimalPortalRoute(e.targetShard);
+var t = bp.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -30696,7 +30741,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-wp.updateTaskProgress(e.taskId, t);
+bp.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -30712,7 +30757,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = bp.optimizeBody({
+i = Op.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -30723,8 +30768,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = bp.spawnPriorities.LOW;
-e.priority >= 80 ? d = bp.spawnPriorities.HIGH : e.priority >= 50 && (d = bp.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Op.spawnPriorities.LOW;
+e.priority >= 80 ? d = Op.spawnPriorities.HIGH : e.priority >= 50 && (d = Op.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -30742,7 +30787,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-bp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Op.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -30769,7 +30814,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void wp.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void bp.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", va.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -30781,8 +30826,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, wp.updateTaskProgress(e.taskId, 100, "complete"),
-wp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, bp.updateTaskProgress(e.taskId, 100, "complete"),
+bp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -30812,12 +30857,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Mp = new Op;
+}(), Ap = new Mp;
 
-function Ap(e, t, r) {
+function kp(e, t, r) {
 var o, n, a, i;
 try {
-var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = gp(c)) && void 0 !== a ? a : {
+var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = hp(c)) && void 0 !== a ? a : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30832,11 +30877,11 @@ if (!(null == l ? void 0 : l.targets[s])) return;
 var m = l.targets[s];
 m.status = e, null !== (i = m.arrivedAt) && void 0 !== i || (m.arrivedAt = Game.time),
 m.claimTargetRoom = null != t ? t : m.claimTargetRoom, m.blockedReason = r, m.lastUpdate = Game.time,
-"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(vp(u));
+"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(gp(u));
 } catch (e) {}
 }
 
-function kp(e) {
+function Up(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -30864,15 +30909,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Ap("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (kp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || j(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Ap("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (kp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Ap((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (kp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -30889,24 +30934,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Ap("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, kp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Ap("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (kp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Up(e) {
+function _p(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function _p(e, t) {
+function Np(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -30940,14 +30985,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (M.mineralType = y.mineralType), u[e.name] = M;
 }
 
-function Np(e, t) {
+function Pp(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function Pp(e) {
+function Ip(e) {
 var t = Bm.getEmpire();
-if (_u.isExit(e.creep.pos)) return Up(e.room.name);
+if (_u.isExit(e.creep.pos)) return _p(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -30962,7 +31007,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Np(t.x, t.y - 1), Np(t.x + 1, t.y), Np(t.x, t.y + 1), Np(t.x - 1, t.y) ] : [];
+return t ? [ Pp(t.x, t.y - 1), Pp(t.x + 1, t.y), Pp(t.x, t.y + 1), Pp(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31025,13 +31070,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (_p(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Np(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (_p(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Np(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31041,19 +31086,19 @@ type: "idle"
 };
 }
 
-function Ip(e) {
+function Gp(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function Gp(e) {
-return e.hostiles.some(Ip);
-}
-
 function Lp(e) {
-return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+return e.hostiles.some(Gp);
 }
 
 function Dp(e) {
+return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+}
+
+function Fp(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31076,8 +31121,8 @@ type: "idle"
 };
 }
 
-var Fp = {
-scout: Pp,
+var Bp = {
+scout: Ip,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31111,7 +31156,7 @@ return {
 type: "idle"
 };
 }
-if (_u.isExit(e.creep.pos)) return Up(e.room.name);
+if (_u.isExit(e.creep.pos)) return _p(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31133,8 +31178,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: kp,
-interShardScout: kp,
+interShardClaimer: Up,
+interShardScout: Up,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31210,8 +31255,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return Dp(e);
-if (Gp(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return Fp(e);
+if (Lp(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31252,7 +31297,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return Lp(t) - Lp(e);
+return Dp(t) - Dp(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31272,7 +31317,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : Dp(e);
+} : Fp(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31361,9 +31406,9 @@ type: "idle"
 }
 };
 
-function Bp(e, t) {
+function Wp(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Gp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Lp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31371,24 +31416,24 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function Wp(e) {
-var t;
-return (null !== (t = Fp[e.memory.role]) && void 0 !== t ? t : Pp)(e);
-}
-
 function Kp(e) {
-var t = Au(e);
-vl(e, Cl(t, ed), t);
+var t;
+return (null !== (t = Bp[e.memory.role]) && void 0 !== t ? t : Ip)(e);
 }
 
 function Hp(e) {
 var t = Au(e);
-vl(e, Cl(t, Wp, {
-interrupt: Bp
-}), t);
+vl(e, Cl(t, td), t);
 }
 
 function Yp(e) {
+var t = Au(e);
+vl(e, Cl(t, Kp, {
+interrupt: Wp
+}), t);
+}
+
+function Vp(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31429,8 +31474,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Dd.has(i) && V(s))) {
-Id.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && Fd.has(i) && V(s))) {
+Gd.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31495,7 +31540,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Gd(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Ld(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31505,7 +31550,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Gd(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Ld(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31516,7 +31561,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Gd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Ld(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -31569,7 +31614,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Gd(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Ld(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -31611,7 +31656,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Gd(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Ld(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -31621,7 +31666,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Gd(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Ld(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -31629,7 +31674,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && j(e.room).length > 0) {
 var o = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Gd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Ld(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -31641,7 +31686,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Gd(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Ld(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -31649,12 +31694,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Gd(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Ld(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Gd(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Ld(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -31688,18 +31733,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function Vp(e) {
+function qp(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var qp = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), jp = -1, zp = Object.create(null);
+var jp = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), zp = -1, Qp = Object.create(null);
 
-function Qp(e) {
+function Xp(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var Xp = {
+var Zp = {
 harvester: ha.CRITICAL,
 queenCarrier: ha.CRITICAL,
 hauler: ha.HIGH,
@@ -31734,12 +31779,12 @@ labTech: ha.IDLE,
 factoryWorker: ha.IDLE
 };
 
-function Zp(e) {
+function Jp(e) {
 var t;
-return null !== (t = Xp[e]) && void 0 !== t ? t : ha.MEDIUM;
+return null !== (t = Zp[e]) && void 0 !== t ? t : ha.MEDIUM;
 }
 
-function Jp(e) {
+function $p(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -31755,20 +31800,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && Qp(o) === e && t++;
+o && Xp(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (jp !== Game.time && (jp = Game.time, zp = function() {
+}(e) : null !== (r = (zp !== Game.time && (zp = Game.time, Qp = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = Qp(o);
+var n = Xp(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), zp)[e]) && void 0 !== r ? r : 0;
+}()), Qp)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Ue().cpu.disableCreepBootstrapCountCache
@@ -31778,7 +31823,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!qp.has(t.role)) return !1;
+if (!jp.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -31788,7 +31833,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Vp(r)) return !1;
+if (!r || !qp(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -31802,7 +31847,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Vp(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !qp(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -31810,7 +31855,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Vp(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !qp(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -31818,7 +31863,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Vp(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !qp(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -31826,7 +31871,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && Vp(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && qp(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -31842,7 +31887,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Vp(r)) return !1;
+if (!r || !qp(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -31883,28 +31928,28 @@ case "economy":
 default:
 !function(e) {
 var t = Au(e);
-vl(e, Cl(t, ed), t);
+vl(e, Cl(t, td), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
 var t = Au(e);
-vl(e, Cl(t, Pd), t);
+vl(e, Cl(t, Id), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
 var t = Au(e);
-vl(e, Cl(t, Wp), t);
+vl(e, Cl(t, Kp), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
 var t = Au(e);
-vl(e, Cl(t, Bd), t);
+vl(e, Cl(t, Wd), t);
 }(e);
 }
 });
@@ -31925,7 +31970,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var $p = function() {
+var ef = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -31966,7 +32011,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Zp(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = Jp(r), n = "creep:".concat(e.name);
 Ja.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -31982,7 +32027,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Jp(t);
+t && !t.spawning && $p(t);
 }
 }), this.registeredCreeps.add(e.name), Ci.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32007,7 +32052,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Zp(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = Jp(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32032,20 +32077,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), ef = new $p;
-
-function tf(e) {
-var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, rf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
-}
+}(), tf = new ef;
 
 function rf(e) {
+var t, r, o;
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, of(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+}
+
+function of(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function of(e) {
+function nf(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32058,14 +32103,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function nf(e, t) {
+function af(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var af = {
+var sf = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32093,11 +32138,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function sf(e, t) {
+function cf(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function cf(e) {
+function uf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32107,9 +32152,9 @@ tick: Game.time
 }, a;
 }
 
-var uf = [ "defense", "war", "expand", "siege" ];
+var lf = [ "defense", "war", "expand", "siege" ];
 
-function lf(e) {
+function mf(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32122,11 +32167,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function mf(e, t, r) {
-t >= 2 && (e.pheromones.war = sf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = sf(e.pheromones.siege + 20, r));
+function df(e, t, r) {
+t >= 2 && (e.pheromones.war = cf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = cf(e.pheromones.siege + 20, r));
 }
 
-var df = function() {
+var pf = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32141,27 +32186,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), pf = function() {
+}(), ff = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, af), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, sf), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new df(10),
-energySpawning: new df(10),
-energyConstruction: new df(10),
-energyRepair: new df(10),
-energyTower: new df(10),
-controllerProgress: new df(10),
-hostileCount: new df(5),
-damageReceived: new df(5),
-idleWorkers: new df(10),
+energyHarvested: new pf(10),
+energySpawning: new pf(10),
+energyConstruction: new pf(10),
+energyRepair: new pf(10),
+energyTower: new pf(10),
+controllerProgress: new pf(10),
+hostileCount: new pf(5),
+damageReceived: new pf(5),
+idleWorkers: new pf(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = cf(e);
+var o = uf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32234,7 +32279,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = sf(e[s] * c, t);
+e[s] = cf(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32250,43 +32295,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = cf(t);
+var o = uf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = sf(e.harvest + n / 3e3 * 10, r);
+e.harvest = cf(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = sf(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = cf(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = sf(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = cf(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = sf(e.defense + 10 * o, r));
+o > 0 && (e.defense = cf(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = sf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = sf(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = cf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = cf(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = sf(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = cf(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = sf(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = cf(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = sf(e.pheromones.defense + 5 * t, o), mf(e, r, o),
+e.danger = r, e.pheromones.defense = cf(e.pheromones.defense + 5 * t, o), df(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32294,7 +32339,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = sf(t / 10, o), mf(e, r, o);
+e.danger = r, e.pheromones.defense = cf(t / 10, o), df(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32307,8 +32352,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = sf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = sf(f + y, o);
+var p = cf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = cf(f + y, o);
 }
 }
 }
@@ -32327,18 +32372,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = sf(e.pheromones.defense + 5, r), e.pheromones.build = sf(e.pheromones.build + 10, r),
+e.pheromones.defense = cf(e.pheromones.defense + 5, r), e.pheromones.build = cf(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = sf(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = cf(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = sf(e.pheromones.siege + 50, t), e.pheromones.defense = sf(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = cf(e.pheromones.siege + 50, t), e.pheromones.defense = cf(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = sf(e.pheromones.expand - 10, t), e.pheromones.defense = sf(e.pheromones.defense + 5, t);
+e.pheromones.expand = cf(e.pheromones.expand - 10, t), e.pheromones.defense = cf(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32348,10 +32393,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(lf(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(mf(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(uf)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(lf)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32405,7 +32450,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = sf(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = cf(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32440,7 +32485,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), ff = new pf, yf = {
+}(), yf = new ff, vf = {
 seedNest: {
 rcl: 1
 },
@@ -32481,7 +32526,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, vf = {
+}, gf = {
 eco: {
 economy: .75,
 military: .05,
@@ -32524,7 +32569,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, gf = {
+}, hf = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -32581,13 +32626,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, hf = function() {
+}, Rf = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = yf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = yf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= yf.fortifiedHive.rcl ? "fortifiedHive" : s >= yf.matureColony.rcl ? "matureColony" : s >= yf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = vf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = vf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= vf.fortifiedHive.rcl ? "fortifiedHive" : s >= vf.matureColony.rcl ? "matureColony" : s >= vf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Fe.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -32622,7 +32667,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = yf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, x = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = vf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, x = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -32635,7 +32680,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Rf = function() {
+}(), Ef = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -32657,9 +32702,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return vf[e];
-}, e.prototype.getResourcePriorities = function(e) {
 return gf[e];
+}, e.prototype.getResourcePriorities = function(e) {
+return hf[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -32669,15 +32714,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Ef = new hf, Tf = new Rf;
+}(), Tf = new Rf, Cf = new Ef;
 
-function Cf(e) {
+function Sf(e) {
 return !Y(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Sf(e, t, r) {
+function xf(e, t, r) {
 if (!e) return null;
 var o = mr.getEmpire();
 if (Y(e, {
@@ -32716,11 +32761,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function xf() {
+function wf() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var wf = new Map, bf = function() {
+var bf = new Map, Of = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = j(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -32864,7 +32909,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: wf.get(e.name),
+previousStructures: bf.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -32894,7 +32939,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && wf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && bf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -32903,7 +32948,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Cf(u) && o.add(u.owner.username);
+Sf(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -32917,7 +32962,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Sf(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) xf(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -32933,7 +32978,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? ff.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? ff.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && ff.onNukeDetected(t);
+"danger" === y.type ? yf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? yf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && yf.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -32993,10 +33038,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = xf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = wf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = xf()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = wf()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, x = [];
 try {
 for (var w = a(e.towers), b = w.next(); !b.done; b = w.next()) {
@@ -33039,7 +33084,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Tf.isCombatPosture(t.posture),
+isCombatPosture: Cf.isCombatPosture(t.posture),
 wallRepairTarget: so(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33063,27 +33108,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Of = new bf, Mf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Mf = new Of, Af = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Af() {
+function kf() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function kf(e, t, r, o) {
+function Uf(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Af()
+selectedAt: kf()
 });
 }
 
-function Uf(e) {
+function _f(e) {
 return e >= 2 && e <= 3;
 }
 
-function _f(e, t) {
+function Nf(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33096,10 +33141,10 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-var Nf = function() {
+var Pf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Uf(e) ? 5 : 10;
+return _f(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33800,7 +33845,7 @@ y: e.y - T.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-kf(t, v, C.name, f);
+Uf(t, v, C.name, f);
 var S = t.danger >= 1 && f >= 3 ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f, y, v, g;
 if (r <= 0) return 0;
@@ -33915,7 +33960,7 @@ var r, o, n, i = Vo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && _f(e, u) < l) return !0;
+if (!(l <= 0) && Nf(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -33931,8 +33976,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + g + h + S >= 10 && !x) t.metrics.constructionSites = p.length + g + h + S; else {
-if (!Tf.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Af());
+if (!Cf.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== kf());
 }(t, v)) {
 var w = function(e, t, r, o, n) {
 var i, s;
@@ -34090,7 +34135,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Mf.has(e.structureType);
+return Af.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34099,7 +34144,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var A = Uf(f) ? 2 : 3;
+var A = _f(f) ? 2 : 3;
 (M = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -34775,13 +34820,13 @@ anchor: l
 }
 return null;
 }(e, f);
-G && (kf(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
+G && (Uf(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), Pf = new Nf;
+}(), If = new Pf;
 
-function If(e) {
+function Gf(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -34803,7 +34848,7 @@ siege: e.pheromones.siege
 };
 }
 
-var Gf = {
+var Lf = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -34816,10 +34861,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Lf = new (function() {
+}, Df = new (function() {
 function e() {
 this.manager = new $c({
-logger: Gf
+logger: Lf
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -34829,23 +34874,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = If(t);
+var r = Gf(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = If(t);
+var r = Gf(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), Df = {
+}()), Ff = {
 labManager: yu,
 boostManager: lu,
-chemistryPlanner: Lf,
+chemistryPlanner: Df,
 labConfigManager: pu,
 logger: Ci
-}, Ff = function() {
+}, Bf = function() {
 function e(e) {
-void 0 === e && (e = Df), this.deps = e;
+void 0 === e && (e = Ff), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -34884,9 +34929,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), Bf = new Ff, Wf = function() {
+}(), Wf = new Bf, Kf = function() {
 function e(e) {
-void 0 === e && (e = Bf), this.labWorkflow = e;
+void 0 === e && (e = Wf), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -34931,27 +34976,27 @@ if (r) throw r.error;
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), Kf = new Wf, Hf = {
+}(), Hf = new Kf, Yf = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, Yf = new Map;
+}, Vf = new Map;
 
-function Vf(e) {
+function qf(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function qf(e) {
+function jf(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var jf = function() {
+var zf = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Hf), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Yf), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = zi.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -34993,7 +35038,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = Yf.get(e.name);
+var t = Vf.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35015,28 +35060,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return Yf.set(e.name, o), o;
+return Vf.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && ff.updateMetrics(i, c),
-Of.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && yf.updateMetrics(i, c),
+Mf.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Ef.updateEvolutionStage(c, i, e),
-s || Ef.updateMissingStructures(c, i)), Tf.updatePosture(c), this.config.enablePheromones && !s && ff.updatePheromones(c, i),
-this.config.enableTowers && Of.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Pf.getConstructionInterval(l), d = Tf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Tf.updateEvolutionStage(c, i, e),
+s || Tf.updateMissingStructures(c, i)), Cf.updatePosture(c), this.config.enablePheromones && !s && yf.updatePheromones(c, i),
+this.config.enableTowers && Mf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = If.getConstructionInterval(l), d = Cf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = Vf(r), n = qf(e);
+var o = qf(r), n = jf(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Pf.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (If.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = Vf(r), n = qf(e);
+var o = qf(r), n = jf(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && Kf.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && Hf.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35046,7 +35091,7 @@ var f = Game.cpu.getUsed() - n;
 zi.recordRoom(i, f), zi.endRoom(this.roomName, n);
 } else zi.endRoom(this.roomName, n);
 }, e;
-}(), zf = function() {
+}(), Qf = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35060,7 +35105,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new jf(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new zf(v.name));
 }
 } catch (t) {
 e = {
@@ -35123,7 +35168,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new jf(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new zf(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35144,9 +35189,9 @@ stack: c
 }
 }
 }, e;
-}(), Qf = new zf;
+}(), Xf = new Qf;
 
-function Xf(e) {
+function Zf(e) {
 var t, r, o;
 if (j(e).length > 0) return ha.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
@@ -35157,14 +35202,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
 }
 
-function Zf(e) {
+function Jf(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function Jf(e, t, r) {
+function $f(e, t, r) {
 var o;
 return t === ha.CRITICAL ? {
 tickModulo: void 0,
@@ -35184,7 +35229,7 @@ tickOffset: void 0
 };
 }
 
-var $f, ey = function() {
+var ey, ty = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35200,7 +35245,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = Xf(n), u = Zf(n);
+var i = "room:".concat(o), s = Ja.getProcess(i), c = Zf(n), u = Jf(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35219,7 +35264,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = Xf(e), o = Zf(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Jf(e, r, a);
+var t, r = Zf(e), o = Jf(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = $f(e, r, a);
 Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35236,7 +35281,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Qf.runRoom(t);
+t && Xf.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35244,7 +35289,7 @@ Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Jf(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = $f(e, t, a);
 Ja.unregisterProcess(n), Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35261,7 +35306,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Qf.runRoom(t);
+t && Xf.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35283,7 +35328,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = Xf(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = Zf(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35310,7 +35355,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), ty = new ey, ry = function() {
+}(), ry = new ty, oy = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Ja.getStatsSummary(), t = Ja.getConfig();
@@ -35387,11 +35432,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(of(e.summary.byLayer)), "Groups: ".concat(of(e.summary.byGroup)), "States: ".concat(of(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(nf(e.summary.byLayer)), "Groups: ".concat(nf(e.summary.byGroup)), "States: ".concat(nf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(nf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(af)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(tf(m));
+c.push(rf(m));
 }
 } catch (e) {
 t = {
@@ -35490,7 +35535,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = ef.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = tf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35509,7 +35554,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = ty.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = ry.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35656,7 +35701,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), oy = function() {
+}(), ny = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -35689,7 +35734,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), ny = function() {
+}(), ay = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36214,7 +36259,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), ay = function() {
+}(), iy = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36233,7 +36278,7 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), iy = function() {
+}(), sy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
@@ -36268,21 +36313,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), sy = (($f = {})[MOVE] = 50, $f[WORK] = 100, $f[CARRY] = 50, $f[ATTACK] = 80,
-$f[RANGED_ATTACK] = 150, $f[HEAL] = 250, $f[CLAIM] = 600, $f[TOUGH] = 10, $f);
+}(), cy = ((ey = {})[MOVE] = 50, ey[WORK] = 100, ey[CARRY] = 50, ey[ATTACK] = 80,
+ey[RANGED_ATTACK] = 150, ey[HEAL] = 250, ey[CLAIM] = 600, ey[TOUGH] = 10, ey);
 
-function cy(e, t) {
+function uy(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, sy), t);
+var r = o(o({}, cy), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : sy[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : cy[t]);
 }, 0);
 }
 
-function uy(e, t) {
+function ly(e, t) {
 void 0 === t && (t = 0);
-var r = cy(e);
+var r = uy(e);
 return {
 parts: e,
 cost: r,
@@ -36290,7 +36335,7 @@ minCapacity: t || r
 };
 }
 
-function ly() {
+function my() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36298,11 +36343,11 @@ return Array(o).fill(r);
 });
 }
 
-var my, dy, py, fy = {
+var dy, py, fy, yy = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ uy([ WORK, CARRY ], 150), uy([ WORK, CARRY, MOVE ], 200), uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), uy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), uy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ly([ WORK, CARRY ], 150), ly([ WORK, CARRY, MOVE ], 200), ly([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), ly([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), ly([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36310,7 +36355,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ uy([ WORK, CARRY, MOVE ], 200), uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), uy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), uy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ly([ WORK, CARRY, MOVE ], 200), ly([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), ly([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), ly([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36318,7 +36363,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ uy([ WORK, CARRY, MOVE, MOVE ], 250), uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ ly([ WORK, CARRY, MOVE, MOVE ], 250), ly([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36326,7 +36371,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ uy([ WORK, CARRY, MOVE ], 200), uy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), uy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), uy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ ly([ WORK, CARRY, MOVE ], 200), ly([ WORK, WORK, CARRY, MOVE, MOVE ], 350), ly([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), ly([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), ly([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36334,7 +36379,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ uy([ CARRY, CARRY, MOVE, MOVE ], 200), uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), uy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ly([ CARRY, CARRY, MOVE, MOVE ], 200), ly([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), ly(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36342,7 +36387,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ uy([ WORK, CARRY, MOVE ], 200), uy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ ly([ WORK, CARRY, MOVE ], 200), ly([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), ly([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), ly([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36350,7 +36395,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ uy([ WORK, CARRY, MOVE, MOVE ], 250), uy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), uy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ ly([ WORK, CARRY, MOVE, MOVE ], 250), ly([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), ly([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36358,7 +36403,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ ly([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36366,7 +36411,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ uy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), uy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ ly([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), ly([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36374,7 +36419,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ ly([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36382,7 +36427,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ ly([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36390,7 +36435,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ uy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), uy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ ly([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), ly([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), ly([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), ly([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36398,7 +36443,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), uy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ly([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), ly(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36406,7 +36451,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ly([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), ly([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36414,16 +36459,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ uy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), uy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), uy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), uy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ly(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), ly(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), ly(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), ly(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, yy = {
+}, vy = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ uy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), uy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), uy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), uy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ ly([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), ly([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), ly([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), ly([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36431,7 +36476,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ uy([ TOUGH, ATTACK, MOVE, MOVE ], 190), uy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), uy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ ly([ TOUGH, ATTACK, MOVE, MOVE ], 190), ly([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), ly([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36439,7 +36484,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ uy([ HEAL, MOVE, MOVE ], 350), uy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), uy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), uy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ ly([ HEAL, MOVE, MOVE ], 350), ly([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), ly([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), ly([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36447,7 +36492,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ uy([ ATTACK, ATTACK, MOVE, MOVE ], 260), uy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), uy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ ly([ ATTACK, ATTACK, MOVE, MOVE ], 260), ly([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), ly([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36455,7 +36500,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ uy([ WORK, WORK, MOVE, MOVE ], 300), uy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), uy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ ly([ WORK, WORK, MOVE, MOVE ], 300), ly([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), ly([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36463,7 +36508,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ uy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), uy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), uy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), uy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ ly([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), ly([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), ly([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), ly([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36471,16 +36516,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ uy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), uy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), uy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ ly([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), ly([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), ly([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, vy = {
+}, gy = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ uy(ly([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), uy(ly([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ ly(my([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), ly(my([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36488,16 +36533,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ uy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), uy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ ly(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), ly(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, gy = {
+}, hy = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ uy([ MOVE ], 50) ],
+bodies: [ ly([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36505,7 +36550,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ uy([ MOVE ], 50) ],
+bodies: [ ly([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36513,7 +36558,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ uy([ CLAIM, MOVE ], 650) ],
+bodies: [ ly([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36521,7 +36566,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ uy([ CLAIM, MOVE ], 650), uy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ ly([ CLAIM, MOVE ], 650), ly([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36529,7 +36574,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ uy([ WORK, CARRY, MOVE, MOVE ], 250), uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ ly([ WORK, CARRY, MOVE, MOVE ], 250), ly([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36537,30 +36582,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), uy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ ly([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), ly([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, hy = o(o(o(o({}, fy), yy), gy), vy);
+}, Ry = o(o(o(o({}, yy), vy), hy), gy);
 
 try {
-for (var Ry = a(Object.values(hy)), Ey = Ry.next(); !Ey.done; Ey = Ry.next()) Ey.value.bodies.sort(function(e, t) {
+for (var Ey = a(Object.values(Ry)), Ty = Ey.next(); !Ty.done; Ty = Ey.next()) Ty.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-my = {
+dy = {
 error: e
 };
 } finally {
 try {
-Ey && !Ey.done && (dy = Ry.return) && dy.call(Ry);
+Ty && !Ty.done && (py = Ey.return) && py.call(Ey);
 } finally {
-if (my) throw my.error;
+if (dy) throw dy.error;
 }
 }
 
-function Ty(e) {
+function Cy(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36575,11 +36620,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Cy(o);
+return Sy(o);
 }
 
-function Cy(e) {
-var t = cy(e);
+function Sy(e) {
+var t = uy(e);
 return {
 parts: e,
 cost: t,
@@ -36587,16 +36632,16 @@ minCapacity: t
 };
 }
 
-function Sy(e, t) {
+function xy(e, t) {
 var r;
-return null !== (r = e.map(Cy).filter(function(e) {
+return null !== (r = e.map(Sy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function xy(e) {
+function wy(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36610,7 +36655,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = cy(a);
+var s = uy(a);
 return {
 parts: a,
 cost: s,
@@ -36635,8 +36680,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: cy(p),
-minCapacity: cy(p)
+cost: uy(p),
+minCapacity: uy(p)
 };
 }(e);
 
@@ -36647,7 +36692,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return Ty([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Cy([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -36668,7 +36713,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return Ty([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Cy([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -36677,13 +36722,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Cy).filter(function(e) {
+var u = n.map(Sy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Sy(n, t);
+var l = xy(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -36693,7 +36738,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Sy(n, t);
+var u = xy(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -36702,14 +36747,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Sy(r, t);
+var a = xy(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function wy(e) {
+function by(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -36720,9 +36765,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function by(e, t) {
+function Oy(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: wy(t)
+memory: by(t)
 });
 var r;
 }
@@ -36730,9 +36775,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(py || (py = {}));
+}(fy || (fy = {}));
 
-var Oy = function() {
+var My = function() {
 function e() {
 this.queues = new Map;
 }
@@ -36827,7 +36872,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = by(m, d);
+var p = Oy(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -36847,7 +36892,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= py.EMERGENCY;
+return e.priority >= fy.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -36865,7 +36910,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= py.EMERGENCY ? n.emergency++ : c.priority >= py.HIGH ? n.high++ : c.priority >= py.NORMAL ? n.normal++ : n.low++;
+c.priority >= fy.EMERGENCY ? n.emergency++ : c.priority >= fy.HIGH ? n.high++ : c.priority >= fy.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -36880,14 +36925,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), My = new Oy, Ay = {
+}(), Ay = new My, ky = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, ky = {
+}, Uy = {
 predictConsumption: function() {
 return 0;
 },
@@ -36906,7 +36951,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Uy = {
+}, _y = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -36923,44 +36968,44 @@ healers: 0,
 powerCarriers: 0
 };
 }
-}, _y = {
+}, Ny = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Ny(e, t, r, o, n) {
+function Py(e, t, r, o, n) {
 return Js(e, t, r, o, n);
 }
 
-var Py = new Map, Iy = -1, Gy = null;
+var Iy = new Map, Gy = -1, Ly = null;
 
-function Ly() {
-Iy === Game.time && Gy === Game.creeps || (Py.clear(), Iy = Game.time, Gy = Game.creeps);
+function Dy() {
+Gy === Game.time && Ly === Game.creeps || (Iy.clear(), Gy = Game.time, Ly = Game.creeps);
 }
 
-function Dy(e) {
+function Fy(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Fy(e, t) {
+function By(e, t) {
 var r;
-void 0 === t && (t = !1), Ly();
-var o = t ? "".concat(e, "_active") : e, n = Py.get(o);
+void 0 === t && (t = !1), Dy();
+var o = t ? "".concat(e, "_active") : e, n = Iy.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Dy(c);
+var u = Fy(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Py.set(o, a), a;
+return Iy.set(o, a), a;
 }
 
-function By(e, t, r) {
+function Wy(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -36981,22 +37026,22 @@ if (o) throw o.error;
 return i;
 }
 
-function Wy(e) {
+function Ky(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var Ky = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
-
-function Hy(e) {
-return Ky.includes(e);
-}
+var Hy = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
 function Yy(e) {
+return Hy.includes(e);
+}
+
+function Vy(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Vy(e, t, r, o) {
+function qy(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37009,10 +37054,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Ny(e, t, ze(r).length, o, {
-reserved: Yy(r)
+if (r) return Py(e, t, ze(r).length, o, {
+reserved: Vy(r)
 }).recommendedHaulers;
-var n = Ny(e, t, 2, o, {
+var n = Py(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37023,7 +37068,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: Wy
+filter: Ky
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37034,7 +37079,7 @@ return 2;
 }
 }
 
-function qy(e, t) {
+function jy(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37044,13 +37089,13 @@ return null;
 }
 }
 
-function jy() {
+function zy() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function zy(e) {
-var t = jy(), r = function(e) {
+function Qy(e) {
+var t = zy(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37062,14 +37107,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function Qy(e) {
+function Xy(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = jy();
+var r = zy();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function Xy(e) {
+function Zy(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37077,11 +37122,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function Zy(e) {
+function Jy(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function Jy() {
+function $y() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37091,7 +37136,7 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-function $y(e, t) {
+function ev(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37103,8 +37148,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(Jy()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = My.getPendingRequests(c).some(function(r) {
+for (var i = a($y()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Ay.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37124,7 +37169,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function ev(e, t) {
+function tv(e, t) {
 var r, o, n, c = mr.getEmpire(), u = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37134,15 +37179,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !$y(e.roomName, "claim");
+return !ev(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || Xy(t));
+return !(!r || r.my || r.owner || r.reservation || Zy(t));
 }
-return !Qy(e);
+return !Xy(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37161,7 +37206,7 @@ return e.roomName;
 })), !1)) : new Set;
 if (l) {
 var p = c.claimQueue.find(function(e) {
-return !e.claimed && !$y(e.roomName, "claim");
+return !e.claimed && !ev(e.roomName, "claim");
 });
 if (p) return {
 targetRoom: p.roomName,
@@ -37173,20 +37218,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = jy();
+var l = zy();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !$y(p, "claim")) {
+if (!t.has(p) && !ev(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || zy(y)) continue;
-if (Xy(f)) continue;
+if (y.owner || Qy(y)) continue;
+if (Zy(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !$y(p, "reserve")) return p;
-} else if (!Qy(p) && !$y(p, "reserve")) return p;
+if ((!v || g < 3e3) && !ev(p, "reserve")) return p;
+} else if (!Xy(p) && !ev(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37208,34 +37253,34 @@ task: "reserve"
 } : null;
 }
 
-function tv(e) {
+function rv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function rv(e) {
-return tv(e) ? py.EMERGENCY : py.HIGH;
+function ov(e) {
+return rv(e) ? fy.EMERGENCY : fy.HIGH;
 }
 
-function ov(e, t, r) {
+function nv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!Zy(e)) return !1;
+if (!Jy(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function nv(e, t, r) {
+function av(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return ov(e, t, r);
+return nv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = qy(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = jy(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37243,18 +37288,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function av(e, t) {
+function iv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !ov(n, e, t)) return null;
+if (!n || !nv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !Zy(e);
+return !Jy(e);
 }).filter(function(e) {
-return !Xy(e);
+return !Zy(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37275,9 +37320,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(Jy()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a($y()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += My.getPendingRequests(d).filter(function(t) {
+i += Ay.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37294,12 +37339,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (tv(e) ? 3 : 1);
+}(e.name) < (rv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = qy(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = jy(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37307,10 +37352,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (nv(u.room, e, t) === e) return {
+if (av(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: rv(u.room)
+priority: ov(u.room)
 };
 }
 } catch (e) {
@@ -37327,10 +37372,10 @@ if (r) throw r.error;
 return null;
 }
 
-function iv(e, t) {
+function sv(e, t) {
 if (t <= 0) return null;
 try {
-var r = xy({
+var r = wy({
 maxEnergy: t,
 role: e
 });
@@ -37340,18 +37385,18 @@ return null;
 }
 }
 
-function sv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : iv(e, t);
+function cv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : sv(e, t);
 }
 
-function cv(e) {
+function uv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function uv(e) {
+function lv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37365,7 +37410,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += cv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += uv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37386,7 +37431,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += cv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += uv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37402,23 +37447,23 @@ return i;
 }(e)) : r;
 }
 
-var lv = "defenseAssist", mv = [ "guard", "ranger", "healer" ];
+var mv = "defenseAssist", dv = [ "guard", "ranger", "healer" ];
 
-function dv(e, t) {
+function pv(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function pv(e, t, r, o) {
+function fv(e, t, r, o) {
 void 0 === o && (o = kr(e.roomName));
-var n = dv(e, t);
+var n = pv(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = gv(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, dv(e, "guard") - i.guard),
-ranger: Math.max(0, dv(e, "ranger") - i.ranger),
-healer: Math.max(0, dv(e, "healer") - i.healer)
-}, Rv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = hv(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, pv(e, "guard") - i.guard),
+ranger: Math.max(0, pv(e, "ranger") - i.ranger),
+healer: Math.max(0, pv(e, "healer") - i.healer)
+}, Ev(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37433,7 +37478,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && Ev(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Tv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37451,30 +37496,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function fv(e) {
+function yv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function yv(e) {
+function vv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === lv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === mv ? e.targetRoom : void 0;
 }
 
-function vv(e, t) {
-var r = kr(e.roomName), o = gv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, dv(e, "guard") - o.guard),
-ranger: Math.max(0, dv(e, "ranger") - o.ranger),
-healer: Math.max(0, dv(e, "healer") - o.healer)
-}, Rv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function gv(e, t) {
+var r = kr(e.roomName), o = hv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, pv(e, "guard") - o.guard),
+ranger: Math.max(0, pv(e, "ranger") - o.ranger),
+healer: Math.max(0, pv(e, "healer") - o.healer)
+}, Ev(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = mv.filter(function(o) {
-return !(pv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = dv.filter(function(o) {
+return !(fv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function gv(e) {
+function hv(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37483,7 +37528,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && yv(d) === e && u[p]++;
+Br(p) && vv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37497,9 +37542,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(My.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Ay.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === lv && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === mv && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37515,21 +37560,21 @@ if (o) throw o.error;
 return u;
 }
 
-function hv(e, t, r) {
+function Rv(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function Rv(e) {
+function Ev(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && yv(f) === e) {
+if (Br(y) && vv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && hv(l, y, v);
+v.length > 0 && Rv(l, y, v);
 }
 }
 } catch (e) {
@@ -37544,9 +37589,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(My.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Ay.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === lv && E.targetRoom === e) && hv(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === mv && E.targetRoom === e) && Rv(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37562,27 +37607,27 @@ if (o) throw o.error;
 return l;
 }
 
-function Ev(e) {
+function Tv(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function Tv(e, t, r) {
+function Cv(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function Cv(e, t, r, o) {
+function Sv(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && sv("guard", uv(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && cv("guard", lv(r), o) ? 1 : 0;
 }
 
-function Sv(e, t) {
+function xv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !Ev(o)) return null;
+if (!o || !Tv(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -37607,7 +37652,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(fv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(yv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -37615,15 +37660,15 @@ return t.roomName !== e;
 var r = kr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(pv(e, t, n, r), Cv(e, t, o, r))
+helperNeed: Math.max(fv(e, t, n, r), Sv(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return fv(e.request);
+return yv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? gv(e)[t] : 0;
+return Br(t) ? hv(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37648,28 +37693,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: lv,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? py.EMERGENCY : py.HIGH,
-defenseSquadId: Tv(e, r, n.createdAt),
-defenseSquadSize: vv(r, t),
+task: mv,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? fy.EMERGENCY : fy.HIGH,
+defenseSquadId: Cv(e, r, n.createdAt),
+defenseSquadSize: gv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var xv = "defenseRefuel", wv = {
+var wv = "defenseRefuel", bv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function bv(e, t) {
+function Ov(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < wv.cost);
-}(n) ? uv(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < bv.cost);
+}(n) ? lv(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -37706,9 +37751,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(My.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Ay.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === xv && s++;
+"hauler" === p.role && f === wv && s++;
 }
 } catch (e) {
 o = {
@@ -37723,24 +37768,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: xv,
-priority: py.EMERGENCY,
-body: wv
+task: wv,
+priority: fy.EMERGENCY,
+body: bv
 } : null : null;
-}
-
-function Ov(e) {
-var t = Game.rooms[e];
-return t ? !!t.controller && !zy(t.controller) && !Xy(t) : !Qy(e);
 }
 
 function Mv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !zy(t.controller) : !Qy(e);
+return t ? !!t.controller && !Qy(t.controller) && !Zy(t) : !Xy(e);
 }
 
-function Av(e, t, r) {
-var o = hy[t];
+function Av(e) {
+var t = Game.rooms[e];
+return (null == t ? void 0 : t.controller) ? !Qy(t.controller) : !Xy(e);
+}
+
+function kv(e, t, r) {
+var o = Ry[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -37752,13 +37797,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function kv(e, t, r) {
+function Uv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Ov(l) && By(e, t, l) < Vy(e, l, t, Game.rooms[l])) return l;
+if (Mv(l) && Wy(e, t, l) < qy(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37774,10 +37819,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Uv(e, t, r, o) {
+function _v(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = hy[t];
+var p = Ry[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -37791,32 +37836,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = hy[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = hy[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Ry[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Ry[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Fy(e), y)) return !1;
+}(t, By(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (Hy(t)) return !("remoteWorker" === t && function(e, t) {
-Ly();
-var r = "".concat(e, ":").concat(t), o = Py.get(r);
+if (Yy(t)) return !("remoteWorker" === t && function(e, t) {
+Dy();
+var r = "".concat(e, ":").concat(t), o = Iy.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Py.set(r, n), n;
-}(e, t) >= Av(e, t, r)) && null !== kv(e, t, r);
+return Iy.set(r, n), n;
+}(e, t) >= kv(e, t, r)) && null !== Uv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Mv(R)) {
+if (Av(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -37824,7 +37869,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && By(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && Wy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -37841,9 +37886,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Fy(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== av(e, r);
-if (C >= Av(e, t, r)) return !1;
+var C = null !== (u = By(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== iv(e, r);
+if (C >= kv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -37855,14 +37900,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = qy(e, o);
+var a = jy(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== ev(0, r);
+if ("claimer" === t) return null !== tv(0, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var x = f.find(FIND_MINERALS)[0];
@@ -37898,7 +37943,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Ay.getActiveRequests) || void 0 === m ? void 0 : m.call(Ay)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = ky.getActiveRequests) || void 0 === m ? void 0 : m.call(ky)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -37926,16 +37971,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function _v(e) {
+function Nv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Nv(e) {
-return 0 === _v(Fy(e, !0));
+function Pv(e) {
+return 0 === Nv(By(e, !0));
 }
 
-function Pv(e) {
+function Iv(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -37958,14 +38003,14 @@ minCount: 1
 } ];
 }
 
-function Iv(e, t) {
-var r, o, n, i, s = Fy(e, !0);
-if (0 === _v(s)) return !0;
+function Gv(e, t) {
+var r, o, n, i, s = By(e, !0);
+if (0 === Nv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Fy(e, !1), u = Pv(t);
+var c = By(e, !1), u = Iv(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -37985,57 +38030,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function Gv(e) {
+function Lv(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Lv(e, t, r) {
-var n = Av(e.name, r.roleName, t);
+function Dv(e, t, r) {
+var n = kv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Dv(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return py.EMERGENCY;
+function Fv(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return fy.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return py.HIGH;
-if (_y.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return fy.HIGH;
+if (Ny.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return py.EMERGENCY;
-if (a > 0) return py.HIGH;
+if (a >= 100) return fy.EMERGENCY;
+if (a > 0) return fy.HIGH;
 }
 return function(e) {
-return e >= 90 ? py.HIGH : e >= 60 ? py.NORMAL : py.LOW;
+return e >= 90 ? fy.HIGH : e >= 60 ? fy.NORMAL : fy.LOW;
 }(o);
 }
 
-function Fv(e, t) {
+function Bv(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-Gv(e);
-var l = Fy(e.name), m = Nv(e.name), d = [];
-if (Iv(e.name, e)) {
+Lv(e);
+var l = By(e.name), m = Pv(e.name), d = [];
+if (Gv(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === _v(Fy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Nv(By(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Fy(e, !1), c = Pv(t);
+var s = By(e, !1), c = Iv(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38050,7 +38095,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Uv(e, m.role, r, !0);
+var p = _v(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38081,17 +38126,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = hy[p]) && Uv(e.name, p, t, !0) ? (d.push(Lv(e, t, {
+return p && (g = Ry[p]) && _v(e.name, p, t, !0) ? (d.push(Dv(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: Dv(e, 0, p, g.priority, m),
+priority: Fv(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(hy)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = bv(e.name, p);
+for (var f = a(Object.entries(Ry)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Ov(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38102,7 +38147,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Sv(e.name, p);
+var E = xv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38116,8 +38161,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Uv(e.name, p, t, m)) {
-var T = Hy(p), C = T ? kv(e.name, p, t) : null, S = "claimer" === p ? ev(e.name, t) : null, x = "pioneer" === p ? av(e.name, t) : null;
+}); else if (_v(e.name, p, t, m)) {
+var T = Yy(p), C = T ? Uv(e.name, p, t) : null, S = "claimer" === p ? tv(e.name, t) : null, x = "pioneer" === p ? iv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || x) && (x ? d.push({
 roleName: p,
 def: g,
@@ -38127,11 +38172,11 @@ missing: 1,
 priority: x.priority,
 targetRoom: x.targetRoom,
 task: x.task
-}) : d.push(Lv(e, t, {
+}) : d.push(Dv(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: Dv(e, 0, p, g.priority, m),
+priority: Fv(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38153,7 +38198,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Bv(e, l.value);
+var m = Wv(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38174,10 +38219,10 @@ requests: c
 };
 }
 
-function Bv(e, t) {
+function Wv(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = ky.getMaxAffordableInTicks(e, l), d = uv(e), p = t.priority >= py.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= py.EMERGENCY, g = t.assistTarget ? kr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : sv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Uy.getMaxAffordableInTicks(e, l), d = lv(e), p = t.priority >= fy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= fy.EMERGENCY, g = t.assistTarget ? kr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : cv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38198,7 +38243,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : xy({
+}(t.def, p)) && void 0 !== c ? c : wy({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38234,44 +38279,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Wv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Kv = new Set([ "guard", "ranger", "healer" ]);
+var Kv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Hv = new Set([ "guard", "ranger", "healer" ]);
 
-function Hv() {
+function Yv() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Yv(e) {
+function Vv(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Vv(e) {
-var t;
-return e.priority >= py.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
-}
-
 function qv(e) {
 var t;
-return e.priority >= py.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= fy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function jv(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = uv(e), m = r.urgency >= 2 || t.danger >= 3 ? py.EMERGENCY : py.HIGH, d = Ar(j(e)), p = function(e) {
+function jv(e) {
+var t;
+return e.priority >= fy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+}
+
+function zv(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = lv(e), m = r.urgency >= 2 || t.danger >= 3 ? fy.EMERGENCY : fy.HIGH, d = Ar(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === py.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === fy.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(My.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Ay.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || zv(u, e) && ("guard" === u.role && (n.guards++,
-Xv(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Xv(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Xv(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Qv(u, e) && ("guard" === u.role && (n.guards++,
+Zv(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Zv(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Zv(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38299,7 +38344,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Xv(n, u, l);
+0 !== l.length && Zv(n, u, l);
 }
 }
 }
@@ -38338,26 +38383,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Qv("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) Zv(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Qv("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) Zv(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, x = null !== (c = g.bodies.healer) && void 0 !== c ? c : Qv("healer", p, d);
-if (S > 0 && x && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Zv(e, "healer", "military", py.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), x);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Xv("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) Jv(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Xv("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) Jv(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, x = null !== (c = g.bodies.healer) && void 0 !== c ? c : Xv("healer", p, d);
+if (S > 0 && x && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Jv(e, "healer", "military", fy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), x);
 !function(e, t, r, o) {
-if (!(t < py.EMERGENCY || function(e, t) {
+if (!(t < fy.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Kv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Hv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(My.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Ay.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < py.EMERGENCY || Kv.has(c.role) && zv(c, e.name) && c.body.cost <= t && n++;
+c.priority < fy.EMERGENCY || Hv.has(c.role) && Qv(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38374,7 +38419,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = iv(t, e);
+var r = sv(t, e);
 return r ? {
 role: t,
 body: r
@@ -38389,38 +38434,38 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Zv(e, n.role, "military", py.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && Jv(e, n.role, "military", fy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function zv(e, t) {
+function Qv(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Qv(e, t, r) {
+function Xv(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function Xv(e, t, r) {
+function Zv(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function Zv(e, t, r, o, n, a, i) {
+function Jv(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
-var s = null != i ? i : xy({
+var s = null != i ? i : wy({
 maxEnergy: n,
 role: t
 });
 if (s.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(s.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-My.addRequest({
+Ay.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38436,34 +38481,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Jv(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= py.HIGH) return !1;
+function $v(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= fy.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < py.NORMAL) {
-if (ky.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < fy.NORMAL) {
+if (Uy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === py.NORMAL && o / e.energyCapacityAvailable < .3 && ky.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === fy.NORMAL && o / e.energyCapacityAvailable < .3 && Uy.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function $v(e, t) {
+function eg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Gv(e);
-var s = My.getQueueSize(e.name);
+Lv(e);
+var s = Ay.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Iv(e.name, e), u = Nv(e.name) && !My.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = Gv(e.name, e), u = Pv(e.name) && !Ay.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && My.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && jv(e, t, l, m);
+s > 0 && Ay.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && zv(e, t, l, m);
 try {
-for (var d = a(Fv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Bv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-My.addRequest(f);
+Ay.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38476,7 +38521,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && jv(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && zv(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38485,13 +38530,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(My.getPendingRequests(e.name).map(Yv));
+var c = new Set(Ay.getPendingRequests(e.name).map(Vv));
 try {
-for (var u = a(Fv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= py.HIGH, p = "claimer" === m.role && Hv(), f = Vv(m), y = qv(m);
-if (Wv.has(m.role) || d || p || f || y) {
-var v = Yv(m);
-c.has(v) || (My.addRequest(m), c.add(v));
+for (var u = a(Bv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= fy.HIGH, p = "claimer" === m.role && Yv(), f = qv(m), y = jv(m);
+if (Kv.has(m.role) || d || p || f || y) {
+var v = Vv(m);
+c.has(v) || (Ay.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38508,19 +38553,19 @@ if (r) throw r.error;
 }
 }(e, t); else {
 !function(e) {
-var t = Uy.requestSpawns(e.name);
+var t = _y.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = py.NORMAL, n = 0; n < t.powerHarvesters; n++) Zv(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) Zv(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) Zv(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = fy.NORMAL, n = 0; n < t.powerHarvesters; n++) Jv(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) Jv(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) Jv(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a(Fv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-My.addRequest(f);
+for (var y = a(Bv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Ay.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38532,32 +38577,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = My.getQueueStats(e.name);
+var g = Ay.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && My.clearQueue(e.name);
+} else s > 0 && Ay.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = My.getAvailableSpawns(e.name);
+var t, r, o = Ay.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = uv(e);
+var n = 0, i = lv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = My.getNextRequest(e.name, i);
+var u = c.value, l = Ay.getNextRequest(e.name, i);
 if (!l) break;
-if (Jv(e, l, i)) {
+if ($v(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = by(u, l);
-m === OK ? (n++, i -= l.body.cost, My.markInProgress(e.name, l.id, u.id), My.removeRequest(e.name, l.id),
+var m = Oy(u, l);
+m === OK ? (n++, i -= l.body.cost, Ay.markInProgress(e.name, l.id, u.id), Ay.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (My.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Ay.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -38573,7 +38618,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = My.getQueueStats(e.name);
+}(e), o = Ay.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -38587,7 +38632,7 @@ stats: o
 }(e, t);
 }
 
-var eg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, tg = /^(\d{1,2})\|(.+)$/, rg = A("SS2TerminalComms"), og = function() {
+var tg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, rg = /^(\d{1,2})\|(.+)$/, og = A("SS2TerminalComms"), ng = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38647,11 +38692,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(eg);
+var t = e.match(tg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(tg);
+var i = a.match(rg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38686,7 +38731,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-rg.warn("Missing packet in multi-packet message", {
+og.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38702,7 +38747,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), rg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), og.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38726,7 +38771,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && rg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && og.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38738,7 +38783,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return rg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return og.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38746,14 +38791,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), rg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), og.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (rg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (og.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38778,7 +38823,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-rg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+og.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -38790,7 +38835,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-rg.info("Completed sending multi-packet message", {
+og.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -38798,25 +38843,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? rg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? og.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (rg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (og.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else rg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else og.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else rg.warn("Terminal not found for queue item, removing from queue", {
+} else og.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -38850,7 +38895,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && rg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && og.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -38860,7 +38905,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-rg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+og.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -38951,7 +38996,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (rg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (og.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -38973,7 +39018,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return rg.error("Error parsing JSON", {
+return og.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -38984,7 +39029,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), ng = [ {
+}(), ag = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39004,7 +39049,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], ag = function() {
+} ], ig = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39051,9 +39096,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), ig = new ag;
+}(), sg = new ig;
 
-function sg(e) {
+function cg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39061,19 +39106,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function cg(e, t) {
+function ug(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function ug(e, t) {
+function lg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var lg = {
+var mg = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39084,9 +39129,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, mg = function() {
+}, dg = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, lg), e);
+void 0 === e && (e = {}), this.config = o(o({}, mg), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39107,7 +39152,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = ig.getSwarmState(r.toRoom);
+var o = sg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39120,7 +39165,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = ig.getSwarmState(c);
+var l = sg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39190,9 +39235,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(cg), u = n.filter(function(e) {
+}).sort(ug), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(ug), l = [], m = [], d = function(t) {
+}).sort(lg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39214,11 +39259,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return sg({
+return cg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + sg({
+}) + cg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39317,7 +39362,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), dg = new mg, pg = {
+}(), pg = new dg, fg = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39338,14 +39383,14 @@ siegeUnits: 1
 }
 };
 
-function fg(e) {
+function yg(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function yg(e) {
+function vg(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39368,9 +39413,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function vg(e) {
+function gg(e) {
 var t, r, o;
-yg(e);
+vg(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39394,20 +39439,20 @@ if (t) throw t.error;
 return n;
 }
 
-function gg(e) {
+function hg(e) {
 var t;
-yg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = vg(e);
+vg(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = gg(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function hg(e) {
-return !!gg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function Rg(e) {
+return !!hg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-yg(e);
+vg(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39418,12 +39463,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = vg(e);
+var d = gg(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function Rg(e, t) {
+function Eg(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39444,20 +39489,20 @@ if (r) throw r.error;
 return n;
 }
 
-function Eg(e, t) {
+function Tg(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = pg[r]) && void 0 !== t ? t : pg[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = fg[r]) && void 0 !== t ? t : fg[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Rg(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Eg(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: fg(r),
+targetComposition: yg(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39469,7 +39514,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function Tg(e) {
+function Cg(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39489,9 +39534,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function Cg(e) {
+function Sg(e) {
 var t = e.members.length;
-yg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+vg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39505,7 +39550,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && hg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && Rg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39534,7 +39579,7 @@ subsystem: "Squad"
 }
 }
 
-var Sg = {
+var xg = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39621,7 +39666,7 @@ prioritizeDefenses: !0
 }
 };
 
-function xg(e, t) {
+function wg(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39636,8 +39681,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function wg(e, t) {
-var r, o, n, i = Sg[t], s = 0;
+function bg(e, t) {
+var r, o, n, i = xg[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39663,7 +39708,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var bg, Og, Mg, Ag = {
+var Og, Mg, Ag, kg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39672,11 +39717,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, kg = new Map;
+}, Ug = new Map;
 
-function Ug(e, t) {
+function _g(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (kg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Ug.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39688,7 +39733,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Sg[p].composition;
+d = xg[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39703,19 +39748,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (kg.set(m, y), function(e, t, r, o) {
+v ? (Ug.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Sg[s].useBoosts;
+i = xg[s].useBoosts;
 }
-var c = py.NORMAL;
-"siege" === t.type ? c = py.HIGH : "defense" === t.type && (c = py.EMERGENCY);
+var c = fy.NORMAL;
+"siege" === t.type ? c = fy.HIGH : "defense" === t.type && (c = fy.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = _g(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Ag[t];
-}, 0), m = i ? Pg(r) : [], d = {
+var u = Ng(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + kg[t];
+}, 0), m = i ? Ig(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39744,7 +39789,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-My.addRequest(d), o.spawnRequests.add(d.id);
+Ay.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -39758,42 +39803,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function _g(e, t, r) {
+function Ng(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Ng([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return Pg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Ng([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Pg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Ng([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Pg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Ng([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return Pg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Ng([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return Pg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Ng([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return Pg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Ng(e, t, r) {
+function Pg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Ag[t];
+return e + kg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Ag[t];
+return e + kg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Pg(e) {
+function Ig(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -39824,45 +39869,45 @@ return [];
 }
 }
 
-function Ig(e) {
-return kg.has(e);
-}
-
 function Gg(e) {
-return gg(e) || hg(e);
+return Ug.has(e);
 }
 
-(bg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, bg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-bg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Og = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Og[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Og[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Og[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Mg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Mg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Mg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Mg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Mg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+function Lg(e) {
+return hg(e) || Rg(e);
+}
 
-var Lg = {
+(Og = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Og[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Og[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Mg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Mg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Mg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Mg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Ag = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Ag[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Ag[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Ag[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Ag[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+
+var Dg = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Dg(e, t) {
-var r = Lg[t], o = ig.getClusters();
+function Fg(e, t) {
+var r = Dg[t], o = sg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function Fg(e, t, r) {
+function Bg(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = ig.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = sg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Dg(e, i.danger),
+reservedEnergy: Fg(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -39952,7 +39997,7 @@ success: !1
 });
 }
 
-var Bg = {
+var Wg = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -39962,7 +40007,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Wg(e, t, r, o) {
+function Kg(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -39972,7 +40017,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function Kg(e, t) {
+function Hg(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -39993,19 +40038,19 @@ if (r) throw r.error;
 return n;
 }
 
-function Hg() {
-var e = ig.getEmpire();
+function Yg() {
+var e = sg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function Yg(e) {
-Hg()[e.id] = e;
+function Vg(e) {
+Yg()[e.id] = e;
 }
 
-function Vg(e) {
+function qg(e) {
 e.lastUpdate = Game.time;
-var t = ig.getCluster(e.clusterId);
-if (!t) return e.state = "failed", Yg(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = sg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", Vg(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40015,12 +40060,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (Gg(r) || Ig(e) || Ug(0, r), Gg(r));
+return !!r && (Lg(r) || Gg(e) || _g(0, r), Lg(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), Yg(e);
+})), Vg(e);
 }(e, t);
 break;
 
@@ -40031,7 +40076,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (Cg(o), Tg(o)) {
+if (Sg(o), Cg(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40060,7 +40105,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = ig.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = sg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40087,14 +40132,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), Yg(e);
+})), Vg(e);
 }(e, t);
 }
 }
 
-var qg = "defenseAssist";
+var jg = "defenseAssist";
 
-function jg(e, t, r) {
+function zg(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40113,11 +40158,11 @@ score: n.score + o.score
 }
 }
 
-function zg(e, t, r) {
+function Qg(e, t, r) {
 return Gr(e, t, r);
 }
 
-function Qg(e, t) {
+function Xg(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40130,11 +40175,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function Xg(e) {
+function Zg(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function Zg(e, t, r) {
+function Jg(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40147,8 +40192,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function Jg(e, t, r) {
-var o = zg(t, e.energyCapacityAvailable, r);
+function $g(e, t, r) {
+var o = Qg(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40156,16 +40201,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function $g(e, t, r, o) {
+function eh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = Jg(e, t, o);
-if (s !== Jg(n, t, o)) return s ? -1 : 1;
+var a, i, s = $g(e, t, o);
+if (s !== $g(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function eh(e, t) {
+function th(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40249,25 +40294,25 @@ if (r) throw r.error;
 return u;
 }
 
-function th(e, t) {
+function rh(e, t) {
 return {
-guard: Math.max(0, Qg(e, "guard") - t.counts.guard),
-ranger: Math.max(0, Qg(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, Qg(e, "healer") - t.counts.healer)
+guard: Math.max(0, Xg(e, "guard") - t.counts.guard),
+ranger: Math.max(0, Xg(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, Xg(e, "healer") - t.counts.healer)
 };
 }
 
-function rh(e, t, r) {
+function oh(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function oh(e) {
+function nh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function nh(e, t) {
+function ah(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return oh(e.role);
+return nh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40280,12 +40325,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function ah(e) {
+function ih(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === qg ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === jg ? e.targetRoom : void 0;
 }
 
-function ih(e) {
+function sh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40297,7 +40342,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-oh(m) && ah(l) === e && !u.spawning && jg(i, m, u.body.filter(function(e) {
+nh(m) && ih(l) === e && !u.spawning && zg(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40315,7 +40360,7 @@ if (t) throw t.error;
 return i;
 }
 
-function sh(e, t, r) {
+function ch(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40345,16 +40390,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: nh(e, r)
+pendingAssist: ah(e, r)
 };
 }
 }
 
-function ch(e, t) {
+function uh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = zg(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = Qg(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40375,7 +40420,7 @@ subsystem: "Cluster"
 }
 }
 
-function uh(e, t, r) {
+function lh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40417,20 +40462,20 @@ exitAccess: a
 };
 }
 
-function lh(e, t) {
+function mh(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function mh(e, t, r) {
+function dh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function dh(e) {
+function ph(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function ph(e, t) {
+function fh(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40441,7 +40486,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function fh(e, t, r) {
+function yh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40452,8 +40497,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = dh(g);
-h && (g.assistTarget || ph(v, h) && (t.assignedCreeps.includes(v.name) || lh(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = ph(g);
+h && (g.assistTarget || fh(v, h) && (t.assignedCreeps.includes(v.name) || mh(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40490,7 +40535,7 @@ return e.distance - t.distance;
 });
 }
 
-function yh(e, t) {
+function vh(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40515,21 +40560,21 @@ if (r) throw r.error;
 return i;
 }
 
-function vh(e) {
+function gh(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var gh = {
+var hh = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, hh = function() {
+}, Rh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, gh), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, hh), e);
 }
 return e.prototype.run = function() {
-var e = ig.getClusters();
+var e = sg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40548,7 +40593,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: ng.map(function(t) {
+steps: ag.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40609,7 +40654,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-dg.processCluster(t);
+pg.processCluster(t);
 break;
 
 case "squads":
@@ -40641,7 +40686,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = uh(e, new RoomPosition(s, c, e.name), "defense");
+var u = lh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40690,9 +40735,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = ig.getSwarmState(i);
+var i = n.value, s = sg.getSwarmState(i);
 if (s) {
-var c = Dg(i, s.danger);
+var c = Fg(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40723,7 +40768,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = ig.getSwarmState(m);
+var m = l.value, d = sg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -40755,7 +40800,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += vh(l.controller.level));
+}).length, i += gh(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -40872,7 +40917,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Cg(i), "gathering" !== i.state || Gg(i) || Ig(i.id) || Ug(0, i), Tg(i) && (i.state = "dissolving");
+Sg(i), "gathering" !== i.state || Lg(i) || Gg(i.id) || _g(0, i), Cg(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -40897,7 +40942,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Eg(e, s);
+var s = i.value, c = Tg(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -40914,7 +40959,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(Hg()).filter(function(e) {
+var t = (a = e.id, Object.values(Yg()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -40925,7 +40970,7 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u, l;
 void 0 === n && (n = {});
-var m = o(o({}, Bg), n), d = [], p = ig.getEmpire(), f = {
+var m = o(o({}, Wg), n), d = [], p = sg.getEmpire(), f = {
 empire: p
 }, y = p.knownRooms || {}, v = new Set((p.warTargets || []).filter(function(e) {
 return !Y(e, f);
@@ -40942,13 +40987,13 @@ if (R.owner !== E && !(R.owner && Y(R.owner, f) || R.reserver && Y(R.reserver, f
 var T = v.has(h) || Boolean(R.owner && v.has(R.owner));
 if (T || Boolean(R.owner && g.has(R.owner))) {
 if (!R.isHighway && !R.isSK) {
-var C = Kg(e, h);
+var C = Hg(e, h);
 if (!(C > 10)) {
 var S = null !== (l = null === (u = Memory.lastAttacked) || void 0 === u ? void 0 : u[h]) && void 0 !== l ? l : 0;
 if (!(Game.time - S < 5e3)) {
-var x = Wg(R, C, T, m), w = "neutral";
+var x = Kg(R, C, T, m), w = "neutral";
 R.owner && (w = T ? "enemy" : "hostile");
-var b = xg(h, {
+var b = wg(h, {
 towerCount: R.towerCount,
 spawnCount: R.spawnCount,
 rcl: R.controllerLevel,
@@ -40983,9 +41028,9 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-wg(e, n.doctrine) ? function(e, t, r) {
+bg(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t = (ig.getEmpire().knownRooms || {})[e];
+var t = (sg.getEmpire().knownRooms || {})[e];
 return t ? !(Game.time - t.lastSeen > 5e3 && (U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - t.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), 1)) : (U.warn("No intel for target ".concat(e), {
@@ -40994,13 +41039,13 @@ subsystem: "AttackTarget"
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (ig.getEmpire().knownRooms || {})[t], n = null != r ? r : xg(t, {
+var o = (sg.getEmpire().knownRooms || {})[t], n = null != r ? r : wg(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!wg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!bg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41013,7 +41058,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-Yg(i);
+Vg(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41027,13 +41072,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Rg(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Eg(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: fg(n),
+targetComposition: yg(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41048,8 +41093,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), Yg(i), Ug(0, c), i.state = "forming", i.lastUpdate = Game.time,
-Yg(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), Vg(i), _g(0, c), i.state = "forming", i.lastUpdate = Game.time,
+Vg(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41068,11 +41113,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(kg.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Ug.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), kg.delete(c));
+}), Ug.delete(c));
 }
 } catch (t) {
 e = {
@@ -41086,10 +41131,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = Hg();
-for (var t in e) Vg(e[t]);
+var e = Yg();
+for (var t in e) qg(e[t]);
 !function() {
-var e = Hg();
+var e = Yg();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41167,14 +41212,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = ig.getCluster(t, e);
+var t = "cluster_".concat(e), r = sg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = ig.getCluster(e);
+var o = sg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41203,7 +41248,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Fg(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Bg(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41220,7 +41265,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = ig.getSwarmState(t);
+var n, a, i = sg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41261,7 +41306,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = kr(g), f[g] = ih(g);
+p[g] = kr(g), f[g] = sh(g);
 }
 } catch (e) {
 r = {
@@ -41277,7 +41322,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = sh(E, m, t);
+d[E] = ch(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41296,13 +41341,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Zg(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = Jg(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = eh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = th(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, th(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, rh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var x = (o = void 0, a([ "guard", "ranger", "healer" ])), w = x.next(); !w.done; w = x.next()) for (var b = w.value, O = C.counts[b], M = $g(h, b, g.roomName, R), A = 0; A < O; A++) {
+for (var x = (o = void 0, a([ "guard", "ranger", "healer" ])), w = x.next(); !w.done; w = x.next()) for (var b = w.value, O = C.counts[b], M = eh(h, b, g.roomName, R), A = 0; A < O; A++) {
 var k = M.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41314,13 +41359,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(k.roomName, "_").con
 roomName: k.roomName,
 role: b,
 family: "military",
-priority: Xg(g.urgency),
+priority: Zg(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: qg,
-defenseSquadId: rh(k.roomName, g.roomName, e.now),
+task: jg,
+defenseSquadId: oh(k.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41360,7 +41405,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), x = S.next(); !x.done; x = S.next()) ch(x.value, t) && C++;
+for (var S = a(T), x = S.next(); !x.done; x = S.next()) uh(x.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41375,7 +41420,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, My);
+}(e, Ay);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41387,7 +41432,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = yh(f, fh(e, f, t)), v = y.reduce(function(e, t) {
+var y = vh(f, yh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41398,7 +41443,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-mh(f, R.role, lh(f, R.role) - 1), l.push({
+dh(f, R.role, mh(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41465,28 +41510,28 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Rh = new hh, Eh = /^([WE])(\d+)([NS])(\d+)$/;
+}(), Eh = new Rh, Th = /^([WE])(\d+)([NS])(\d+)$/;
 
-function Th(e) {
-return Eh.test(e);
+function Ch(e) {
+return Th.test(e);
 }
 
-var Ch = {
+var Sh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Sh = function() {
+}, xh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ch), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Sh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
 var e = InterShardMemory.getLocal();
 if (e) {
-var t = gp(e);
+var t = hp(e);
 if (t) {
 this.updateEnemyIntelligence(t);
-var r = vp(t);
+var r = gp(t);
 InterShardMemory.setLocal(r);
 }
 }
@@ -41552,7 +41597,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), x = S.next(); !x.done; x = S.next()) {
 var w = x.value;
-if (e.isAlly(w)) f.add(w); else if (Th(w)) {
+if (e.isAlly(w)) f.add(w); else if (Ch(w)) {
 var b = v.get(w);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41620,7 +41665,7 @@ subsystem: "CrossShardIntel"
 }, e.prototype.getGlobalEnemies = function() {
 var e = InterShardMemory.getLocal();
 if (!e) return [];
-var t = gp(e);
+var t = hp(e);
 return t && t.globalTargets.enemies || [];
 }, n([ Oi("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: ha.LOW,
@@ -41628,7 +41673,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Ai() ], e);
-}(), xh = new Sh, wh = function() {
+}(), wh = new xh, bh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41705,9 +41750,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), bh = new wh;
+}(), Oh = new bh;
 
-function Oh(e, t) {
+function Mh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41730,11 +41775,11 @@ if (r) throw r.error;
 return n;
 }
 
-function Mh(e, t, r) {
+function Ah(e, t, r) {
 if (!function(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }(e)) return 0;
-var o = Oh(e.name, t);
+var o = Mh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += $s(e.mineralType),
@@ -41743,7 +41788,7 @@ n += oc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += ac(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function Ah(e) {
+function kh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -41754,8 +41799,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function kh(e) {
-var t = Ah(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function Uh(e) {
+var t = kh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -41774,14 +41819,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var Uh = {
+var _h = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, _h = function() {
+}, Nh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Uh), e);
+void 0 === e && (e = {}), this.config = o(o({}, _h), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -41872,7 +41917,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = Ah(e);
+var t = kh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -41884,14 +41929,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return kh(Nh(e));
+return Uh(Ph(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = kh(Nh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = Uh(Ph(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function Nh(e) {
+function Ph(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -41923,11 +41968,11 @@ swamps: d
 };
 }
 
-var Ph = new _h, Ih = /^([WE])(\d+)([NS])(\d+)$/, Gh = {
+var Ih = new Nh, Gh = /^([WE])(\d+)([NS])(\d+)$/, Lh = {
 allies: []
-}, Lh = function() {
+}, Dh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Gh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Lh), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -41947,7 +41992,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!Ih.test(e)) return !1;
+if (!Gh.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42055,7 +42100,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return Ih.test(e);
+return Gh.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42082,7 +42127,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), Dh = new Lh, Fh = {
+}(), Fh = new Dh, Bh = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42095,9 +42140,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, Bh = function() {
+}, Wh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Fh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Bh), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42110,7 +42155,7 @@ t.updateExpansionQueue(o);
 }), zi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), zi.measureSubsystem("empire:warTargets", function() {
-Dh.updateWarTargets(o);
+Fh.updateWarTargets(o);
 }), zi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), zi.measureSubsystem("empire:gclTracking", function() {
@@ -42118,13 +42163,13 @@ t.trackGCLProgress(o);
 }), s && zi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (zi.measureSubsystem("empire:intelRefresh", function() {
-Ph.refreshRoomIntel(o);
+Ih.refreshRoomIntel(o);
 }), zi.measureSubsystem("empire:roomDiscovery", function() {
-Ph.discoverNearbyRooms(o);
+Ih.discoverNearbyRooms(o);
 })), s && zi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (zi.measureSubsystem("empire:clusterHealth", function() {
-bh.monitorClusterHealth();
+Oh.monitorClusterHealth();
 }), zi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42183,11 +42228,11 @@ var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
 if (a) {
-var i = Mh(a, t, r);
+var i = Ah(a, t, r);
 i < r.minExpansionScore || o.push({
 roomName: a.name,
 score: i,
-distance: Oh(a.name, t),
+distance: Mh(a.name, t),
 claimed: !1,
 lastEvaluated: Game.time
 });
@@ -42480,13 +42525,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Ai() ], e);
-}(), Wh = new Bh;
+}(), Kh = new Wh;
 
-function Kh(e) {
+function Hh(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var Hh = {
+var Yh = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42494,10 +42539,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, Yh = function() {
+}, Vh = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, Hh), e);
+this.config = o(o({}, Yh), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -42641,7 +42686,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, Kh(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, Hh(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -42816,7 +42861,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Ai() ], e);
-}(), Vh = new Yh, qh = function() {
+}(), qh = new Vh, jh = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Xs(o(o({}, Gs), e), {
 getEmpire: function() {
@@ -42852,7 +42897,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Ai() ], e);
-}(), jh = new qh, zh = function() {
+}(), zh = new jh, Qh = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -42870,9 +42915,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), Qh = new (function(e) {
+}(), Xh = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new zh) || this;
+return void 0 === t && (t = {}), e.call(this, t, new Qh) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -42884,22 +42929,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Ai() ], t);
 }(Ii));
 
-function Xh() {
+function Zh() {
 return global;
 }
 
-function Zh(e) {
+function Jh(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function Jh(e) {
+function $h(e) {
 return Number(null != e ? e : 0);
 }
 
-var $h = function() {
+var eR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = Xh();
+var e = Zh();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -42907,12 +42952,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return Xh()._pixelGenerationMemory;
+return Zh()._pixelGenerationMemory;
 }, e;
-}(), eR = function(e) {
+}(), tR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new $h) || this;
+var r = e.call(this, t, new eR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -42929,7 +42974,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(Zh).length : Object.values(null != t ? t : {}).filter(Zh).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(Jh).length : Object.values(null != t ? t : {}).filter(Jh).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -42940,9 +42985,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (Jh(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (Jh(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = Jh(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = Jh(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if ($h(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if ($h(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = $h(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = $h(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -42964,9 +43009,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Ai() ], t);
-}(Li), tR = new eR;
+}(Li), rR = new tR;
 
-function rR(e, t) {
+function oR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -42988,7 +43033,7 @@ lost: !1
 };
 }
 
-function oR(e, t, r) {
+function nR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43002,20 +43047,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var nR = Ue().cpu.bucketThresholds.highMode + 1800, aR = {
+var aR = Ue().cpu.bucketThresholds.highMode + 1800, iR = {
 updateInterval: 250,
-minBucket: nR,
+minBucket: aR,
 maxSitesPerRemotePerTick: 2
 };
 
-function iR(e, t) {
+function sR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var sR = function() {
+var cR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, aR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, iR), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43032,8 +43077,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = rR(l);
-m.lost && m.reason && oR(e, u, m.reason);
+var m = oR(l);
+m.lost && m.reason && nR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43051,10 +43096,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = iR("remoteInfrastructure.intent", function() {
+var i = sR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-iR("remoteInfrastructure.execute", function() {
+sR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43220,13 +43265,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = iR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = sR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = iR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = sR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43259,7 +43304,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = iR("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = sR("remoteInfrastructure.calculateRemoteRoads", function() {
 return wn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43288,14 +43333,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = iR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = sR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? iR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? sR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43312,7 +43357,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? iR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? sR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43330,7 +43375,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return iR("remoteInfrastructure.findSources", function() {
+return sR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43427,10 +43472,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: ha.LOW,
 interval: 1e3,
-minBucket: nR,
+minBucket: aR,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Ai() ], e);
-}(), cR = new sR, uR = new (function(e) {
+}(), uR = new cR, lR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43442,7 +43487,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ Ai() ], t);
-}(xp)), lR = function() {
+}(wp)), mR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43486,7 +43531,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-ff.applyDiffusion(o);
+yf.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -43532,7 +43577,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ Ai() ], e);
-}(), mR = new lR, dR = new (function() {
+}(), dR = new mR, pR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43579,7 +43624,7 @@ if (e) throw e.error;
 Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(mR, As, Ps, is, Wh, dc, Vh, cR, xs, Qh, tR, jh, Kc, jc, uR, xh, Gc, Rh, za, Pa),
+}(dR, As, Ps, is, Kh, dc, qh, uR, xs, Xh, rR, zh, Kc, jc, lR, wh, Gc, Eh, za, Pa),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -43646,9 +43691,9 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), pR = "_ownedRooms", fR = "_ownedRoomsTick";
+}), fR = "_ownedRooms", yR = "_ownedRoomsTick";
 
-function yR(e) {
+function vR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -43658,13 +43703,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var vR = Ei("NativeCallsTracker");
+var gR = Ei("NativeCallsTracker");
 
-function gR(e, t, r) {
+function hR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) vR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) gR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -43680,7 +43725,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-vR.warn("Failed to wrap method", {
+gR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -43690,30 +43735,30 @@ error: String(e)
 }
 }
 
-var hR, RR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], ER = "shard1", TR = {
+var RR, ER = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], TR = "shard1", CR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, CR = {
+}, SR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, SR = {
+}, xR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function xR() {
+function wR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function wR() {
+function bR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: RR,
+targetShards: ER,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -43723,11 +43768,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = RR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = ER),
 Memory.interShardOperation;
 }
 
-function bR() {
+function OR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -43742,7 +43787,7 @@ lastSync: 0,
 checksum: 0
 };
 var t = InterShardMemory.getLocal();
-return t && null !== (e = gp(t)) && void 0 !== e ? e : {
+return t && null !== (e = hp(t)) && void 0 !== e ? e : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -43768,33 +43813,33 @@ checksum: 0
 }
 }
 
-function OR(e) {
+function MR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
-InterShardMemory.setLocal(vp(e));
+InterShardMemory.setLocal(gp(e));
 } catch (e) {}
 }
 
-function MR() {
-var e, t, r, o, n, i, s, c = bR(), u = xR();
+function AR() {
+var e, t, r, o, n, i, s, c = OR(), u = wR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: RR,
+targetShards: ER,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : RR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : ER,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && AR() ? "established" : "unreached",
+status: p === u && kR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -43812,7 +43857,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === ER ? "core" : "frontier",
+role: u === TR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -43829,24 +43874,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), OR(c), c.footprintOperation;
+}), MR(c), c.footprintOperation;
 }
 
-function AR() {
+function kR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function kR() {
+function UR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function UR(e, t) {
+function _R(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -43865,9 +43910,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(kR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(UR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += My.getPendingRequests(p.name).filter(function(r) {
+s += Ay.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -43886,7 +43931,7 @@ if (n) throw n.error;
 return s;
 }
 
-function _R(e) {
+function NR(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -43930,7 +43975,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = bR().shards[xR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = OR().shards[wR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -43940,8 +43985,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function NR(e, t) {
-if (!(UR("scout", t) >= 1)) {
+function PR(e, t) {
+if (!(_R("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -43979,13 +44024,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && My.addRequest({
+r && Ay.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: SR,
-priority: py.LOW + 5,
+body: xR,
+priority: fy.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -43996,14 +44041,14 @@ task: "interShardPortalScout"
 }
 }
 
-function PR(e, t, r) {
-UR("interShardClaimer", t) >= 1 || My.addRequest({
+function IR(e, t, r) {
+_R("interShardClaimer", t) >= 1 || Ay.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: TR,
-priority: py.NORMAL + 50,
+body: CR,
+priority: fy.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44016,14 +44061,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function IR(e, t, r) {
-UR("interShardScout", t) >= 1 || My.addRequest({
+function GR(e, t, r) {
+_R("interShardScout", t) >= 1 || Ay.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: SR,
-priority: py.NORMAL,
+body: xR,
+priority: fy.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44036,15 +44081,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function GR(e, t, r) {
+function LR(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (UR("interShardPioneer", t.shard) >= 3 || My.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (_R("interShardPioneer", t.shard) >= 3 || Ay.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: CR,
-priority: py.NORMAL + 25,
+body: SR,
+priority: fy.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44057,19 +44102,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function LR(e) {
+function DR(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = xR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = wR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : RR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : ER), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? gp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? hp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44101,9 +44146,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(kR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(UR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += My.getPendingRequests(l.name).filter(function(e) {
+n += Ay.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44122,22 +44167,22 @@ return n;
 }() < o;
 }
 
-(hR = {
-optimizeBody: xy,
+(RR = {
+optimizeBody: wy,
 spawnQueue: {
 addRequest: function(e) {
-return My.addRequest(e);
+return Ay.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: py.LOW,
-NORMAL: py.NORMAL,
-HIGH: py.HIGH
+LOW: fy.LOW,
+NORMAL: fy.NORMAL,
+HIGH: fy.HIGH
 }
-}).optimizeBody && (bp.optimizeBody = hR.optimizeBody), hR.spawnQueue && (bp.spawnQueue = hR.spawnQueue),
-hR.spawnPriorities && (bp.spawnPriorities = o(o({}, bp.spawnPriorities), hR.spawnPriorities));
+}).optimizeBody && (Op.optimizeBody = RR.optimizeBody), RR.spawnQueue && (Op.spawnQueue = RR.spawnQueue),
+RR.spawnPriorities && (Op.spawnPriorities = o(o({}, Op.spawnPriorities), RR.spawnPriorities));
 
-var DR, FR = function() {
+var FR, BR = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44181,7 +44226,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function BR(e) {
+function WR(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44202,7 +44247,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function WR(e, t, r) {
+function KR(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44268,16 +44313,16 @@ return u;
 });
 }
 
-function KR(e) {
+function HR(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(DR || (DR = {}));
+}(FR || (FR = {}));
 
-var HR = function() {
+var YR = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44315,8 +44360,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = WR(h.pos, T.pos, this.logger);
-if (KR(C)) {
+var T = E.value, C = KR(h.pos, T.pos, this.logger);
+if (HR(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44343,8 +44388,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(w)), O = b.next(); !O.done; O = b.next()) {
-var M = O.value, A = WR(M, u.pos, this.logger);
-KR(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(M, u.pos, S, "hauler"),
+var M = O.value, A = KR(M, u.pos, this.logger);
+HR(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(M, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44383,8 +44428,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = WR(e, t, this.logger);
-if (KR(n)) {
+var n = KR(e, t, this.logger);
+if (HR(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44394,7 +44439,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), YR = function() {
+}(), VR = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44404,7 +44449,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = BR(s);
+var c = WR(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44430,7 +44475,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), VR = function() {
+}(), qR = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44479,7 +44524,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), qR = {
+}(), jR = {
 debug: function(e, t) {
 return A("RemoteMining").debug(e, t);
 },
@@ -44492,7 +44537,7 @@ return A("RemoteMining").warn(e, t);
 error: function(e, t) {
 return A("RemoteMining").error(e, t);
 }
-}, jR = {
+}, zR = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44519,7 +44564,7 @@ direction: a
 }
 return t;
 }
-}, zR = {
+}, QR = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
 void 0 === o && (o = sm.MEDIUM), hm.register({
@@ -44532,13 +44577,13 @@ skippable: o !== sm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, QR = new HR(jR, qR), XR = new YR(qR, zR, QR), ZR = new VR(qR, jR, QR, _u.moveTo);
+}, XR = new YR(zR, jR), ZR = new VR(jR, QR, XR), JR = new qR(jR, zR, XR, _u.moveTo);
 
-function JR(e, t, r, o) {
-return ZR.moveToWithRemoteCache(e, t, r, o);
+function $R(e, t, r, o) {
+return JR.moveToWithRemoteCache(e, t, r, o);
 }
 
-var $R, eE = function() {
+var eE, tE = function() {
 function e() {
 this.logger = A("Pathfinding");
 }
@@ -44551,12 +44596,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), tE = function() {
+}(), rE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), rE = function() {
+}(), oE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44601,28 +44646,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), oE = function() {
+}(), nE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return BR(e);
+return WR(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-QR.precacheRemoteRoutes(e, t);
+XR.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), nE = new FR(new eE, new tE, new rE, new oE), aE = {
+}(), aE = new BR(new tE, new rE, new oE, new nE), iE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, iE = function() {
+}, sE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, aE), e);
+this.config = o(o({}, iE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -44716,123 +44761,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new iE, ($R = {})[FIND_STRUCTURES] = {
+new sE, (eE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, $R[FIND_MY_STRUCTURES] = {
+}, eE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, $R[FIND_HOSTILE_STRUCTURES] = {
+}, eE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, $R[FIND_SOURCES_ACTIVE] = {
+}, eE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, $R[FIND_SOURCES] = {
+}, eE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, $R[FIND_MINERALS] = {
+}, eE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, $R[FIND_DEPOSITS] = {
+}, eE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, $R[FIND_MY_CONSTRUCTION_SITES] = {
+}, eE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, $R[FIND_CONSTRUCTION_SITES] = {
+}, eE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, $R[FIND_CREEPS] = {
+}, eE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, $R[FIND_MY_CREEPS] = {
+}, eE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, $R[FIND_HOSTILE_CREEPS] = {
+}, eE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, $R[FIND_DROPPED_RESOURCES] = {
+}, eE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, $R[FIND_TOMBSTONES] = {
+}, eE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, $R[FIND_RUINS] = {
+}, eE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, $R[FIND_FLAGS] = {
+}, eE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, $R[FIND_MY_SPAWNS] = {
+}, eE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, $R[FIND_HOSTILE_SPAWNS] = {
+}, eE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, $R[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, eE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, $R[FIND_NUKES] = {
+}, eE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, $R[FIND_POWER_CREEPS] = {
+}, eE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, $R[FIND_MY_POWER_CREEPS] = {
+}, eE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, $R[FIND_HOSTILE_POWER_CREEPS] = {
+}, eE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, $R[FIND_EXIT_TOP] = {
+}, eE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, $R[FIND_EXIT_RIGHT] = {
+}, eE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, $R[FIND_EXIT_BOTTOM] = {
+}, eE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, $R[FIND_EXIT_LEFT] = {
+}, eE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, $R[FIND_EXIT] = {
+}, eE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var sE = new le({}, mr), cE = new Ee({}, mr);
+var cE = new le({}, mr), uE = new Ee({}, mr);
 
-function uE(e) {
+function lE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -44840,11 +44885,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var lE = !1;
+var mE = !1;
 
-function mE() {
+function dE() {
 var e, t;
-lE || (ii({
+mE || (ii({
 level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -44859,11 +44904,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Ay.getPendingTransfers = function(e) {
+r.getPendingTransfers && (ky.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Ay.needsCarrier = function(e) {
+}), r.needsCarrier && (ky.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Ay.getActiveRequests = function() {
+}), r.getActiveRequests && (ky.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -44877,47 +44922,47 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (ky.predictConsumption = function(e) {
+a.predictConsumption && (Uy.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (ky.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Uy.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (ky.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Uy.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (ky.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Uy.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Uy.getActivePowerBanks = function() {
+i.getActivePowerBanks && (_y.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Uy.needsHarvesters = function(e) {
+}), i.needsHarvesters && (_y.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Uy.needsCarriers = function(e) {
+}), i.needsCarriers && (_y.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Uy.requestSpawns = function(e) {
+}), i.requestSpawns && (_y.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-_y.getEmergencyState = function(e) {
+Ny.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: bt,
 powerBankHarvestingManager: Kc,
-resourceTransferCoordinator: Mp,
+resourceTransferCoordinator: Ap,
 emergencyResponseManager: Ba,
 kernel: Ja
 }), function(e) {
 var t, r, o, n;
-Xm = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : Qm.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : Qm.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : Qm.getLabOverflow
-} : Qm;
+Zm = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : Xm.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : Xm.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : Xm.getLabOverflow
+} : Xm;
 }({
 getLabResourceNeeds: function(e) {
 return yu.getLabResourceNeeds(e);
@@ -44931,7 +44976,7 @@ return yu.getLabOverflow(e);
 }), zi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) vR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) gR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -44945,7 +44990,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-vR.warn("Failed to wrap PathFinder.search", {
+gR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -44953,11 +44998,11 @@ error: String(e)
 }
 }
 }
-}(), gR(e = Creep.prototype, "moveTo", "moveTo"), gR(e, "move", "move"), gR(e, "harvest", "harvest"),
-gR(e, "transfer", "transfer"), gR(e, "withdraw", "withdraw"), gR(e, "build", "build"),
-gR(e, "repair", "repair"), gR(e, "upgradeController", "upgradeController"), gR(e, "attack", "attack"),
-gR(e, "rangedAttack", "rangedAttack"), gR(e, "heal", "heal"), gR(e, "dismantle", "dismantle"),
-gR(e, "say", "say")), function(e, t, r) {
+}(), hR(e = Creep.prototype, "moveTo", "moveTo"), hR(e, "move", "move"), hR(e, "harvest", "harvest"),
+hR(e, "transfer", "transfer"), hR(e, "withdraw", "withdraw"), hR(e, "build", "build"),
+hR(e, "repair", "repair"), hR(e, "upgradeController", "upgradeController"), hR(e, "attack", "attack"),
+hR(e, "rangedAttack", "rangedAttack"), hR(e, "heal", "heal"), hR(e, "dismantle", "dismantle"),
+hR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -44973,15 +45018,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, ff), nE.initializePathCacheEvents(), XR.initialize(sm.MEDIUM), pl = JR,
-Ft.initialize(), uR.initialize(), lE = !0), mr.initialize();
-var r = dR.configureForCurrentTick();
+}(Ja, mr, yf), aE.initializePathCacheEvents(), ZR.initialize(sm.MEDIUM), pl = $R,
+Ft.initialize(), lR.initialize(), mE = !0), mr.initialize();
+var r = pR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = wR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, MR(), function() {
-var e, t, r, o, n = bR(), a = n.footprintOperation, i = xR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = bR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, AR(), function() {
+var e, t, r, o, n = OR(), a = n.footprintOperation, i = wR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44994,15 +45039,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, OR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, MR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = wR();
+var e, t, r, n, i, s, c = bR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : RR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === ER ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : ER), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === TR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45020,10 +45065,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !AR())) try {
+}(), !kR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || Hp(s), "interShardPioneer" === c && Kp(s);
+"interShardClaimer" !== c && "interShardScout" !== c || Yp(s), "interShardPioneer" === c && Hp(s);
 }
 } catch (t) {
 e = {
@@ -45047,17 +45092,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: lE
+systemsInitialized: mE
 }
-}), dR.ensureProcessesRegistered(), zi.startTick(), wu.clear(), dR.startEventTick();
+}), pR.ensureProcessesRegistered(), zi.startTick(), wu.clear(), pR.startEventTick();
 var i = function(e) {
-var t = e.cache[pR], r = e.cache[fR];
+var t = e.cache[fR], r = e.cache[yR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[pR] = o, e.cache[fR] = e.tick, o;
+return e.cache[fR] = o, e.cache[yR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45094,18 +45139,18 @@ if (e) throw e.error;
 }
 }), zi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = wR();
+var e, t, r, o = bR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = MR();
+var n = AR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : RR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : ER), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== xR()) try {
+if (d !== wR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = gp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = hp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45123,20 +45168,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = kR().sort(function(e, t) {
+var i = UR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : RR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : ER), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== xR()) {
+if (u !== wR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = _R(u);
+var m = NR(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? GR(i, l, m) : LR() ? PR(i, u, m) : (IR(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (NR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? LR(i, l, m) : DR() ? IR(i, u, m) : (GR(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (PR(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45153,8 +45198,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = bR();
-d.footprintOperation = n, OR(d);
+var d = OR();
+d.footprintOperation = n, MR(d);
 }
 }
 })(), function() {
@@ -45162,8 +45207,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || uE(s))) {
-var c = $v(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || lE(s))) {
+var c = eg(s, mr.getOrInitSwarmState(s.name));
 zi.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45180,20 +45225,20 @@ if (e) throw e.error;
 }
 }();
 }), _u.preTick(), zi.measureSubsystem("processSync", function() {
-ef.syncCreepProcesses(), ty.syncRoomProcesses();
+tf.syncCreepProcesses(), ry.syncRoomProcesses();
 }), zi.measureSubsystem("kernel", function() {
-dR.runProcesses();
+pR.runProcesses();
 }), zi.measureSubsystem("eventQueue", function() {
-dR.processQueuedEvents();
+pR.processQueuedEvents();
 }), zi.measureSubsystem("ss2PacketQueue", function() {
-og.processQueue();
+ng.processQueue();
 }), Ja.hasCpuBudget() && zi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && Yp(n);
+void 0 !== n.ticksToLive && Vp(n);
 }
 } catch (t) {
 e = {
@@ -45207,7 +45252,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), yR({
+}), vR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && zi.measureSubsystem("visualizations", function() {
@@ -45217,8 +45262,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = sE.getConfig(), s = cE.getConfig();
-sE.setConfig(n.roomVisualizerConfig), n.renderMap && cE.setConfig(n.mapVisualizerConfig);
+var i = cE.getConfig(), s = uE.getConfig();
+cE.setConfig(n.roomVisualizerConfig), n.renderMap && uE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45229,7 +45274,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-sE.draw(m);
+cE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45251,14 +45296,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-cE.draw();
+uE.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-sE.setConfig(i), cE.setConfig(s);
+cE.setConfig(i), uE.setConfig(s);
 }
 }
 }
@@ -45343,7 +45388,7 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), _u.reconcileTraffic(), yR({
+}), _u.reconcileTraffic(), vR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && zi.measureSubsystem("scheduledTasks", function() {
@@ -45355,7 +45400,7 @@ return e.set(t.id, t), e;
 zi.finalizeTick(), Ci.flush();
 }
 
-var dE = function() {
+var pE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45363,15 +45408,6 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = sE.getConfig(), r = Object.keys(t).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof t[e];
-});
-if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
-var o = e;
-sE.toggle(o);
-var n = sE.getConfig()[o];
-return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t = cE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
@@ -45379,9 +45415,18 @@ if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.
 var o = e;
 cE.toggle(o);
 var n = cE.getConfig()[o];
+return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t = uE.getConfig(), r = Object.keys(t).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof t[e];
+});
+if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
+var o = e;
+uE.toggle(o);
+var n = uE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = cE.getConfig();
+var e = uE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45504,15 +45549,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), pE = function() {
+}(), fE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = uR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = lR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = uR.getAllShards();
+var e, t, r = lR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45534,9 +45579,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (uR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (lR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = uR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = lR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45561,19 +45606,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = uR.getOptimalPortalRoute(e, t);
+var r, o = lR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (uR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (lR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (uR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (lR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Mp.getActiveRequests();
+var e, t, r = Ap.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -45594,7 +45639,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = uR.getCurrentShardState();
+var e, t, r = lR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45615,7 +45660,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = uR.getActiveTransferTasks();
+var e, t, r, o = lR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -45636,16 +45681,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = uR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Ep, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = lR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Tp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = uR.getMemoryStats();
+var e = lR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return uR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return lR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = bR().footprintOperation;
+var e, t, r, o = OR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -45751,9 +45796,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), fE = new pE;
+}(), yE = new fE;
 
-function yE(e) {
+function vE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -45783,7 +45828,7 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? yE(e.metadata.usage) : void 0
+params: e.metadata.usage ? vE(e.metadata.usage) : void 0
 };
 });
 return Om({
@@ -45998,39 +46043,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var vE = new oy, gE = new dE, hE = new ny, RE = new Cu, EE = new ry, TE = new ay, CE = new iy, SE = "__screepsGlobalRuntimeDiagnostics";
+var gE = new ny, hE = new pE, RE = new ay, EE = new Cu, TE = new oy, CE = new iy, SE = new sy, xE = "__screepsGlobalRuntimeDiagnostics";
 
-function xE() {
+function wE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function wE(e, t) {
+function bE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function bE(e, t) {
+function OE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function OE(e) {
+function ME(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function ME(e) {
+function AE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: wE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: wE(n.switchCount, 0),
-lastTick: bE(n.lastTick, Game.time),
-lastResetTick: bE(n.lastResetTick, Game.time),
-lastSwitchTick: OE(n.lastSwitchTick),
-lastSwitchPreviousTick: OE(n.lastSwitchPreviousTick),
-lastWarningTick: OE(n.lastWarningTick)
+resetCount: bE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: bE(n.switchCount, 0),
+lastTick: OE(n.lastTick, Game.time),
+lastResetTick: OE(n.lastResetTick, Game.time),
+lastSwitchTick: ME(n.lastSwitchTick),
+lastSwitchPreviousTick: ME(n.lastSwitchPreviousTick),
+lastWarningTick: ME(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46044,13 +46089,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var AE = Ei("Main");
+var kE = Ei("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(vE), Ct(gE), Ct(hE), Ct(RE), Ct(EE), Ct(TE), Ct(CE), Ct(Ru),
-Ct(Eu), Ct(Tu), Ct(fE), Ct(Mt), Ct(fc), Ct(Fc), global.tooangel = Lc;
+Et.initialize(), Ct(gE), Ct(hE), Ct(RE), Ct(EE), Ct(TE), Ct(CE), Ct(SE), Ct(Ru),
+Ct(Eu), Ct(Tu), Ct(yE), Ct(Mt), Ct(fc), Ct(Fc), global.tooangel = Lc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -46065,12 +46110,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : xE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[SE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : wE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[xE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[SE] = s, function(e, t) {
-var r, o = ME(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[xE] = s, function(e, t) {
+var r, o = AE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46088,7 +46133,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = ME(e.heapId);
+var n, a = AE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46109,14 +46154,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = ME(s.heapId);
+var u = AE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: AE
-}), mE();
+logger: kE
+}), dE();
 } catch (e) {
-throw AE.error("Critical error in main loop: ".concat(String(e)), {
+throw kE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time


### PR DESCRIPTION
## Summary

Adds an explicit `defenseRefuel` hauler behavior contract so emergency refuel haulers prioritize source-container energy and refill spawn/extension energy before generic tower/storage work.

## Linked issue

Closes #3223

## Changes

- Code changes
  - `@ralphschuler/screeps-roles` hauler now detects `memory.task === "defenseRefuel"`.
  - Empty defense-refuel haulers withdraw from local energy containers before dropped/tombstone resources.
  - Loaded defense-refuel haulers fill spawns/extensions before generic tower/storage paths, while respecting task-board spawn/extension reservations.
  - Normal hauler fallback remains when no defense-refuel source or spawn/extension target exists.
- Test changes
  - Added behavior contract tests for source-container-first collection, spawn/extension delivery precedence, reservation de-dupe, and safe fallback.
- Docs changes
  - None; behavior is covered by issue and tests.

## Validation

- ✅ RED observed first: `npm run test:roles -- --grep defenseRefuel` failed on the two new behavior-contract assertions before implementation.
- ✅ RED observed for reviewer follow-up: `npm run test:roles` failed on reserved extension de-dupe before the task-board reservation guard.
- ✅ `npm run test:roles`
- ✅ `npm run test:spawn`
- ✅ `npm run lint:roles`
- ✅ `npm run build:roles`
- ✅ `npm run build`

## Deployment impact

Runtime behavior change in the roles framework plus rebuilt `packages/screeps-bot/dist/main.js`. Deploy path remains `npm run push` after merge.

## Live bot evidence

This addresses the follow-up from live recovery work where helper rooms need defense-refuel haulers to convert source-container energy into spawn/extension energy during W18S27/W18S28 no-spawn recovery.

## Follow-up issues

- #3226 tracks non-blocking task-board accounting cleanup for old non-core reservations when defense-refuel preempts to core refill.
