### PR TITLE
[codex] Health-gate empty live diagnostics

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -47,6 +47,18 @@ SCREEPS_TOKEN=<token> npm run profile:live:cpu -- --samples 5 --interval 1000 --
 
 Supported environment variables: `SCREEPS_TOKEN` (required), `SCREEPS_HOSTNAME`, `SCREEPS_PROTOCOL`, `SCREEPS_PORT`, and `SCREEPS_PATH`. The profiler only reads `Memory.stats`; do not paste token-bearing Screeps URLs into issues or logs.
 
+By default, the profiler fails closed when every requested shard returns zero samples, which usually means the Memory API is rate-limited or unavailable. Use `--allow-empty` only when you intentionally want degraded artifacts for investigation:
+
+```bash
+SCREEPS_TOKEN=<token> node scripts/live-cpu-profile.mjs --samples 1 --interval 0 --shards shard1 --allow-empty
+```
+
+For structural live snapshots, deployment gates can fail when Memory reads are unavailable while still writing redacted artifacts:
+
+```bash
+SCREEPS_TOKEN=<token> node packages/screeps-server/scripts/export-live-structural-snapshot.js --shard shard1 --rooms W18S28,W18S27 --fail-on-memory-errors
+```
+
 ## Runtime triage
 
 1. Check recent console errors and global reset frequency.

--- a/packages/screeps-server/scripts/export-live-structural-snapshot.js
+++ b/packages/screeps-server/scripts/export-live-structural-snapshot.js
@@ -14,7 +14,7 @@ const require = createRequire(import.meta.url);
 const { ScreepsAPI } = require("screeps-api");
 
 function printHelp() {
-  console.log(`Usage: node packages/screeps-server/scripts/export-live-structural-snapshot.js [options]\n\nOptions:\n  --shard <name>       Screeps shard (default shard1)\n  --rooms <list>       Comma-separated extra/source rooms to include\n  --maxRooms <n>       Maximum derived rooms to export (default 30)\n  --out <path>         Output JSON path (default packages/screeps-server/artifacts/cpu-benchmark/live-snapshot.json)\n  --hostname <host>    Screeps hostname (default screeps.com)\n  --protocol <proto>   Protocol (default https)\n  --port <n>           Port (default 443)\n\nRequires SCREEPS_TOKEN. Read-only endpoints only.`);
+  console.log(`Usage: node packages/screeps-server/scripts/export-live-structural-snapshot.js [options]\n\nOptions:\n  --shard <name>              Screeps shard (default shard1)\n  --rooms <list>              Comma-separated extra/source rooms to include\n  --maxRooms <n>              Maximum derived rooms to export (default 30)\n  --out <path>                Output JSON path (default packages/screeps-server/artifacts/cpu-benchmark/live-snapshot.json)\n  --hostname <host>           Screeps hostname (default screeps.com)\n  --protocol <proto>          Protocol (default https)\n  --port <n>                  Port (default 443)\n  --fail-on-memory-errors     Exit nonzero when read-only Memory paths fail\n\nRequires SCREEPS_TOKEN. Read-only endpoints only.`);
 }
 
 function parseOptions(argv = process.argv.slice(2), env = process.env) {
@@ -34,6 +34,7 @@ function parseOptions(argv = process.argv.slice(2), env = process.env) {
     hostname: args.get("hostname") ?? env.SCREEPS_HOSTNAME ?? "screeps.com",
     protocol: args.get("protocol") ?? env.SCREEPS_PROTOCOL ?? "https",
     port: Number(args.get("port") ?? env.SCREEPS_PORT ?? 443),
+    failOnMemoryErrors: args.has("fail-on-memory-errors") && args.get("fail-on-memory-errors") !== "false",
   };
 }
 
@@ -45,6 +46,24 @@ function unwrapMemory(response) {
 
 export function redactedSnapshotError(fields, error) {
   return { ...fields, message: formatScreepsApiError(error) };
+}
+
+export function evaluateStructuralSnapshotHealth(snapshot, { failOnMemoryErrors = false } = {}) {
+  const errors = snapshot.errors || [];
+  const memoryErrors = errors.filter((error) => error.type === "memory");
+  const status = memoryErrors.length > 0 ? (failOnMemoryErrors ? "failed" : "degraded") : errors.length > 0 ? "partial" : "healthy";
+  return {
+    ok: !failOnMemoryErrors || memoryErrors.length === 0,
+    status,
+    fail_on_memory_errors: failOnMemoryErrors,
+    total_errors: errors.length,
+    memory_errors: memoryErrors.length,
+    message: memoryErrors.length > 0
+      ? `Structural snapshot recorded ${memoryErrors.length} Memory API errors${failOnMemoryErrors ? " and strict mode is enabled" : ""}.`
+      : errors.length > 0
+        ? `Structural snapshot recorded ${errors.length} non-Memory endpoint errors.`
+        : "Structural snapshot completed without endpoint errors."
+  };
 }
 
 async function fetchMemory(api, shard) {
@@ -120,9 +139,15 @@ async function main() {
     return;
   }
   const snapshot = await exportSnapshot(options);
+  const health = evaluateStructuralSnapshotHealth(snapshot, options);
   console.log(`wrote ${options.out}`);
   console.log(`rooms=${snapshot.roomCount} shard=${snapshot.source.shard} tick=${snapshot.source.tick} user=${snapshot.source.user}`);
   console.log(`read-only methods=${snapshot.source.apiPolicy.methodsUsed.join(",")}`);
+  console.log(`errors=${health.total_errors} memoryErrors=${health.memory_errors} health=${health.status}`);
+  if (!health.ok) {
+    console.error(health.message);
+    process.exitCode = 2;
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/live-cpu-profile.mjs
+++ b/scripts/live-cpu-profile.mjs
@@ -21,6 +21,7 @@ Options:
   --hostname <host>          Screeps hostname (default SCREEPS_HOSTNAME or screeps.com)
   --protocol <http|https>    Screeps API protocol (default SCREEPS_PROTOCOL or https)
   --port <n>                 Screeps API port (default SCREEPS_PORT or 443)
+  --allow-empty              Allow zero-sample degraded artifact collection (default fail closed)
   --help, -h                 Show this help
 
 Environment:
@@ -41,7 +42,8 @@ export function parseArgs(argv) {
     outDir: "artifacts/cpu-profile",
     hostname: process.env.SCREEPS_HOSTNAME || "screeps.com",
     protocol: process.env.SCREEPS_PROTOCOL || "https",
-    port: Number(process.env.SCREEPS_PORT || 443)
+    port: Number(process.env.SCREEPS_PORT || 443),
+    allowEmpty: false
   };
 
   for (let i = 2; i < argv.length; i++) {
@@ -54,6 +56,7 @@ export function parseArgs(argv) {
     else if (arg === "--hostname" && next) args.hostname = next, i++;
     else if (arg === "--protocol" && next) args.protocol = next, i++;
     else if (arg === "--port" && next) args.port = Number(next), i++;
+    else if (arg === "--allow-empty") args.allowEmpty = true;
     else if (arg === "--help" || arg === "-h") {
       console.log(formatHelp());
       process.exit(0);
@@ -93,7 +96,7 @@ function top(bucket, limit) {
     .slice(0, limit);
 }
 
-export function summarizeShard(samples) {
+export function summarizeShard(samples, errors = []) {
   const cpu = [];
   const bucket = [];
   const skipped = [];
@@ -162,7 +165,31 @@ export function summarizeShard(samples) {
     top_processes: top(processes, 15),
     top_rooms: top(rooms, 10),
     top_roles: top(roles, 10),
-    top_cpu_details: top(cpuDetails, 20)
+    top_cpu_details: top(cpuDetails, 20),
+    read_errors: errors.length,
+    errors
+  };
+}
+
+export function evaluateTelemetryHealth(summary, { allowEmpty = false } = {}) {
+  const shards = Object.entries(summary.shards || {});
+  const emptyShards = shards.filter(([, data]) => (data.samples || 0) === 0).map(([shard]) => shard);
+  const totalSamples = shards.reduce((sum, [, data]) => sum + (data.samples || 0), 0);
+  const readErrors = shards.reduce((sum, [, data]) => sum + (data.read_errors ?? data.errors?.length ?? 0), 0);
+  const allEmpty = shards.length > 0 && totalSamples === 0;
+  const status = allEmpty ? (allowEmpty ? "degraded" : "failed") : emptyShards.length > 0 ? "partial" : "healthy";
+  return {
+    ok: allowEmpty || !allEmpty,
+    status,
+    allow_empty: allowEmpty,
+    total_samples: totalSamples,
+    empty_shards: emptyShards,
+    read_errors: readErrors,
+    message: allEmpty
+      ? `Collected zero live CPU samples across ${shards.length} shard(s); Memory.stats telemetry is unavailable${allowEmpty ? " (allowed)" : ""}.`
+      : emptyShards.length > 0
+        ? `Collected partial live CPU samples; empty shard(s): ${emptyShards.join(", ")}.`
+        : "Live CPU telemetry collected."
   };
 }
 
@@ -176,7 +203,7 @@ async function fetchStats(api, shard) {
 function printSummary(summary) {
   for (const [shard, data] of Object.entries(summary.shards)) {
     console.log(`\n=== ${shard} ===`);
-    console.log(`samples=${data.samples} ticks=${data.tick_first ?? "n/a"}->${data.tick_last ?? "n/a"} cpu_avg=${data.cpu_avg.toFixed(2)} cpu_max=${data.cpu_max.toFixed(2)} bucket_avg=${data.bucket_avg.toFixed(0)} bucket_min=${data.bucket_min.toFixed(0)} skipped_avg=${data.skipped_avg.toFixed(1)}`);
+    console.log(`samples=${data.samples} ticks=${data.tick_first ?? "n/a"}->${data.tick_last ?? "n/a"} cpu_avg=${data.cpu_avg.toFixed(2)} cpu_max=${data.cpu_max.toFixed(2)} bucket_avg=${data.bucket_avg.toFixed(0)} bucket_min=${data.bucket_min.toFixed(0)} skipped_avg=${data.skipped_avg.toFixed(1)} read_errors=${data.read_errors || 0}`);
     for (const [label, rows] of [["subsystems", data.top_subsystems], ["processes", data.top_processes], ["rooms", data.top_rooms], ["roles", data.top_roles], ["cpu_details", data.top_cpu_details]]) {
       if (!rows.length) continue;
       console.log(`Top ${label}:`);
@@ -202,14 +229,16 @@ async function main() {
   });
 
   const byShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
+  const errorsByShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
   for (let sample = 1; sample <= args.samples; sample++) {
     await Promise.all(args.shards.map(async shard => {
       try {
         const stats = await fetchStats(api, shard);
         if (stats) byShard[shard].push(stats);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.warn(`WARN ${shard}: ${redactScreepsApiMessage(message)}`);
+        const message = redactScreepsApiMessage(error instanceof Error ? error.message : String(error));
+        errorsByShard[shard].push({ sample, message });
+        console.warn(`WARN ${shard}: ${message}`);
       }
     }));
     if (sample < args.samples && args.interval > 0) await sleep(args.interval);
@@ -220,14 +249,21 @@ async function main() {
     hostname: args.hostname,
     samples_requested: args.samples,
     interval_ms: args.interval,
-    shards: Object.fromEntries(Object.entries(byShard).map(([shard, samples]) => [shard, summarizeShard(samples)]))
+    allow_empty: args.allowEmpty,
+    shards: Object.fromEntries(Object.entries(byShard).map(([shard, samples]) => [shard, summarizeShard(samples, errorsByShard[shard] || [])]))
   };
+  summary.health = evaluateTelemetryHealth(summary, { allowEmpty: args.allowEmpty });
 
   fs.mkdirSync(args.outDir, { recursive: true });
   const outPath = path.join(args.outDir, `live-cpu-profile-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
   fs.writeFileSync(outPath, JSON.stringify(summary, null, 2));
   printSummary(summary);
-  console.log(`\nWrote ${outPath}`);
+  console.log(`\nHealth: ${summary.health.status} (${summary.health.message})`);
+  console.log(`Wrote ${outPath}`);
+  if (!summary.health.ok) {
+    console.error(summary.health.message);
+    process.exitCode = 2;
+  }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/scripts/test/export-live-structural-snapshot-redaction.test.mjs
+++ b/scripts/test/export-live-structural-snapshot-redaction.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { redactedSnapshotError } from "../../packages/screeps-server/scripts/export-live-structural-snapshot.js";
+import {
+  evaluateStructuralSnapshotHealth,
+  parseOptions,
+  redactedSnapshotError
+} from "../../packages/screeps-server/scripts/export-live-structural-snapshot.js";
 
 const RATE_LIMIT_MESSAGE = [
   "Rate limit exceeded, retry after 123ms or disable rate limiting using this link:",
@@ -31,4 +35,37 @@ test("structural snapshot room endpoint errors redact token fragments", () => {
     assert.equal(entry.message.includes("6ea62d57"), false);
     assert.equal(entry.message.includes("token=<redacted>"), true);
   }
+});
+
+test("structural snapshot parser supports deploy-gate memory error failure flag", () => {
+  const options = parseOptions(["--shard", "shard3", "--rooms", "W1N1,W2N2", "--fail-on-memory-errors"], {
+    SCREEPS_HOSTNAME: "screeps.com",
+    SCREEPS_PROTOCOL: "https",
+    SCREEPS_PORT: "443"
+  });
+
+  assert.equal(options.shard, "shard3");
+  assert.deepEqual(options.rooms, ["W1N1", "W2N2"]);
+  assert.equal(options.failOnMemoryErrors, true);
+});
+
+test("structural snapshot health fails only when requested memory errors are present", () => {
+  const snapshot = {
+    errors: [
+      { type: "memory", path: "stats", message: "Rate limit exceeded token=<redacted>" },
+      { type: "roomObjects", room: "W1N1", message: "timeout" }
+    ]
+  };
+
+  const strict = evaluateStructuralSnapshotHealth(snapshot, { failOnMemoryErrors: true });
+  assert.equal(strict.ok, false);
+  assert.equal(strict.status, "failed");
+  assert.equal(strict.memory_errors, 1);
+  assert.equal(strict.total_errors, 2);
+  assert.match(strict.message, /Memory API errors/);
+
+  const degraded = evaluateStructuralSnapshotHealth(snapshot, { failOnMemoryErrors: false });
+  assert.equal(degraded.ok, true);
+  assert.equal(degraded.status, "degraded");
+  assert.equal(degraded.memory_errors, 1);
 });

--- a/scripts/test/live-cpu-profile-cli.test.mjs
+++ b/scripts/test/live-cpu-profile-cli.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-import { formatHelp, parseArgs, summarizeShard } from "../live-cpu-profile.mjs";
+import { evaluateTelemetryHealth, formatHelp, parseArgs, summarizeShard } from "../live-cpu-profile.mjs";
 
 const rootPackage = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
 
@@ -17,7 +17,8 @@ test("parseArgs honors documented CLI flags", () => {
     "--out-dir", "artifacts/test-cpu",
     "--hostname", "localhost",
     "--protocol", "http",
-    "--port", "21025"
+    "--port", "21025",
+    "--allow-empty"
   ]);
 
   assert.deepEqual(args, {
@@ -27,7 +28,8 @@ test("parseArgs honors documented CLI flags", () => {
     outDir: "artifacts/test-cpu",
     hostname: "localhost",
     protocol: "http",
-    port: 21025
+    port: 21025,
+    allowEmpty: true
   });
 });
 
@@ -42,6 +44,7 @@ test("help documents all flags and Screeps env vars", () => {
     "--hostname <host>",
     "--protocol <http|https>",
     "--port <n>",
+    "--allow-empty",
     "SCREEPS_TOKEN",
     "SCREEPS_HOSTNAME",
     "SCREEPS_PROTOCOL",
@@ -119,6 +122,58 @@ test("summarizeShard aggregates CPU stats and sorted top rows", () => {
   assert.equal(summary.top_rooms[0].rcl, 8);
   assert.equal(summary.top_roles[0].active, 3);
   assert.equal(summary.top_cpu_details[0].key, "pathfinder");
+  assert.equal(summary.read_errors, 0);
+  assert.deepEqual(summary.errors, []);
+});
+
+test("summarizeShard records redacted read errors", () => {
+  const summary = summarizeShard([], [{ sample: 1, message: "Rate limit exceeded token=<redacted>" }]);
+
+  assert.equal(summary.samples, 0);
+  assert.equal(summary.read_errors, 1);
+  assert.deepEqual(summary.errors, [{ sample: 1, message: "Rate limit exceeded token=<redacted>" }]);
+});
+
+test("telemetry health fails closed when every requested shard has zero samples", () => {
+  const summary = {
+    shards: {
+      shard1: { samples: 0, read_errors: 2 },
+      shard3: { samples: 0, read_errors: 1 }
+    }
+  };
+
+  const health = evaluateTelemetryHealth(summary, { allowEmpty: false });
+
+  assert.equal(health.ok, false);
+  assert.equal(health.status, "failed");
+  assert.deepEqual(health.empty_shards, ["shard1", "shard3"]);
+  assert.equal(health.read_errors, 3);
+  assert.match(health.message, /zero live CPU samples/);
+});
+
+test("telemetry health allows explicit degraded zero-sample artifact collection", () => {
+  const summary = { shards: { shard1: { samples: 0, read_errors: 1 } } };
+
+  const health = evaluateTelemetryHealth(summary, { allowEmpty: true });
+
+  assert.equal(health.ok, true);
+  assert.equal(health.status, "degraded");
+  assert.equal(health.allow_empty, true);
+});
+
+test("telemetry health reports partial samples without failing", () => {
+  const summary = {
+    shards: {
+      shard1: { samples: 2, read_errors: 0 },
+      shard3: { samples: 0, read_errors: 1 }
+    }
+  };
+
+  const health = evaluateTelemetryHealth(summary, { allowEmpty: false });
+
+  assert.equal(health.ok, true);
+  assert.equal(health.status, "partial");
+  assert.deepEqual(health.empty_shards, ["shard3"]);
 });
 
 test("root package exposes a bounded read-only live CPU profile script", () => {


### PR DESCRIPTION
## Summary

Adds strict health gating for live diagnostics so post-deploy evidence does not look healthy when Screeps Memory telemetry is empty/rate-limited.

## Linked issue

Closes #3161

## Changes

- `scripts/live-cpu-profile.mjs` now records per-shard read errors, emits health status, and exits nonzero when every requested shard has zero samples.
- Adds `--allow-empty` for intentional degraded artifact collection.
- `export-live-structural-snapshot.js` now reports total/Memory error counts and supports `--fail-on-memory-errors` for deploy gates.
- Adds unit coverage for health gating, degraded mode, structural strict mode, and token redaction.
- Updates operations docs with strict/degraded mode examples.

## Validation

- ✅ RED observed first: `node --test scripts/test/live-cpu-profile-cli.test.mjs scripts/test/export-live-structural-snapshot-redaction.test.mjs` failed on missing exports.
- ✅ `node --test scripts/test/live-cpu-profile-cli.test.mjs scripts/test/export-live-structural-snapshot-redaction.test.mjs`
- ✅ `npm run test:scripts` (Node 24.18.0)
- ✅ `npm run check-versions` (Node 24.18.0)
- ✅ `npm run sync:deps:check` (Node 24.18.0)
- ✅ `npm run build` (Node 24.18.0; generated dist diff intentionally reverted because source bundle was not part of this scripts/docs change)
- ✅ `npm run lint:all` (Node 24.18.0; existing MODULE_TYPELESS_PACKAGE_JSON warnings only)
- ✅ Live degraded-mode smoke: `node scripts/live-cpu-profile.mjs --samples 1 --interval 0 --shards shard1 --allow-empty` wrote artifact with `health=degraded` and redacted rate-limit warning.
- ✅ Live structural strict smoke: `export-live-structural-snapshot.js --shard shard1 --rooms W18S27 --fail-on-memory-errors` wrote artifact and exited `2` due 7 redacted Memory errors.

## Deployment impact

No bot runtime logic changes. Deploy bundle behavior unchanged; this only affects repository live-diagnostic tooling and operations docs.

## Live bot evidence

Current live analysis still shows Screeps Memory API rate limits (#3121), with roomObjects/status endpoints usable. This PR makes those empty telemetry runs fail/degrade explicitly instead of silently passing.

## Follow-up issues

Existing live runtime follow-ups were updated during this run: #3121, #3105, #3210, #3190, #3181.