### PR TITLE
[codex] Export task-board amount telemetry

### DIFF
--- a/packages/@ralphschuler/screeps-stats/src/statsTypes.ts
+++ b/packages/@ralphschuler/screeps-stats/src/statsTypes.ts
@@ -199,7 +199,7 @@ export interface RoomStatsEntry {
     constructionSites: number;
   };
   
-  // Creep task board reservations
+  // Creep task board reservations and amount-aware pressure.
   taskBoard?: {
     tasks: number;
     openTasks: number;
@@ -207,6 +207,22 @@ export interface RoomStatsEntry {
     reservations: number;
     staleReservations: number;
     blockedReservations: number;
+    amount: number;
+    reservedAmount: number;
+    remainingAmount: number;
+    deliveryAmount: number;
+    deliveryReservedAmount: number;
+    deliveryRemainingAmount: number;
+    criticalDeliveryRemainingAmount: number;
+    byType: Record<string, {
+      tasks: number;
+      openTasks: number;
+      assignedTasks: number;
+      reservations: number;
+      amount: number;
+      reservedAmount: number;
+      remainingAmount: number;
+    }>;
   };
 
   // Spawn queue health for this room

--- a/packages/@ralphschuler/screeps-stats/src/unifiedStats.ts
+++ b/packages/@ralphschuler/screeps-stats/src/unifiedStats.ts
@@ -86,6 +86,59 @@ type CpuProfilerGlobal = {
   status: () => CpuDetailsConfig;
 };
 
+type TaskBoardStatsEntry = NonNullable<RoomStatsEntry["taskBoard"]>;
+type TaskBoardTypeStatsEntry = TaskBoardStatsEntry["byType"][string];
+
+type RawTaskBoardTask = {
+  type?: string;
+  status?: string;
+  priority?: number;
+  amount?: number;
+  reservations?: Record<string, { amount?: number }>;
+};
+
+const TASK_BOARD_DELIVERY_TYPES = new Set(["refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy"]);
+const TASK_BOARD_HIGH_PRIORITY_DELIVERY = 100;
+
+function emptyTaskBoardTypeStats(): TaskBoardTypeStatsEntry {
+  return {
+    tasks: 0,
+    openTasks: 0,
+    assignedTasks: 0,
+    reservations: 0,
+    amount: 0,
+    reservedAmount: 0,
+    remainingAmount: 0
+  };
+}
+
+function emptyTaskBoardStats(): TaskBoardStatsEntry {
+  return {
+    tasks: 0,
+    openTasks: 0,
+    assignedTasks: 0,
+    reservations: 0,
+    staleReservations: 0,
+    blockedReservations: 0,
+    amount: 0,
+    reservedAmount: 0,
+    remainingAmount: 0,
+    deliveryAmount: 0,
+    deliveryReservedAmount: 0,
+    deliveryRemainingAmount: 0,
+    criticalDeliveryRemainingAmount: 0,
+    byType: {}
+  };
+}
+
+function taskAmount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function taskReservationAmount(task: RawTaskBoardTask): number {
+  return Object.values(task.reservations ?? {}).reduce((total, reservation) => total + taskAmount(reservation?.amount), 0);
+}
+
 // ============================================================================
 // Unified Stats Manager
 // ============================================================================
@@ -428,25 +481,60 @@ export class UnifiedStatsManager {
     const memory = Memory as unknown as {
       creepTaskBoard?: {
         rooms?: Record<string, {
-          tasks?: Record<string, { status?: string; reservations?: Record<string, unknown> }>;
+          tasks?: Record<string, RawTaskBoardTask>;
           stats?: { staleReservations?: number; blockedReservations?: number };
         }>;
       };
     };
     const board = memory.creepTaskBoard?.rooms?.[roomName];
-    if (!board) {
-      return { tasks: 0, openTasks: 0, assignedTasks: 0, reservations: 0, staleReservations: 0, blockedReservations: 0 };
+    const summary = emptyTaskBoardStats();
+    if (!board) return summary;
+
+    summary.staleReservations = board.stats?.staleReservations ?? 0;
+    summary.blockedReservations = board.stats?.blockedReservations ?? 0;
+
+    for (const task of Object.values(board.tasks ?? {})) {
+      const type = task.type ?? "unknown";
+      const byType = summary.byType[type] ?? emptyTaskBoardTypeStats();
+      const reservations = Object.keys(task.reservations ?? {}).length;
+      const amount = taskAmount(task.amount);
+      const reservedAmount = taskReservationAmount(task);
+      const remainingAmount = Math.max(0, amount - reservedAmount);
+      const deliveryTask = TASK_BOARD_DELIVERY_TYPES.has(type);
+
+      summary.tasks++;
+      summary.reservations += reservations;
+      summary.amount += amount;
+      summary.reservedAmount += reservedAmount;
+      summary.remainingAmount += remainingAmount;
+
+      byType.tasks++;
+      byType.reservations += reservations;
+      byType.amount += amount;
+      byType.reservedAmount += reservedAmount;
+      byType.remainingAmount += remainingAmount;
+
+      if (task.status === "open") {
+        summary.openTasks++;
+        byType.openTasks++;
+      } else if (task.status === "assigned") {
+        summary.assignedTasks++;
+        byType.assignedTasks++;
+      }
+
+      if (deliveryTask) {
+        summary.deliveryAmount += amount;
+        summary.deliveryReservedAmount += reservedAmount;
+        summary.deliveryRemainingAmount += remainingAmount;
+        if ((task.priority ?? 0) >= TASK_BOARD_HIGH_PRIORITY_DELIVERY) {
+          summary.criticalDeliveryRemainingAmount += remainingAmount;
+        }
+      }
+
+      summary.byType[type] = byType;
     }
 
-    const tasks = Object.values(board.tasks ?? {});
-    return {
-      tasks: tasks.length,
-      openTasks: tasks.filter(task => task.status === "open").length,
-      assignedTasks: tasks.filter(task => task.status === "assigned").length,
-      reservations: tasks.reduce((total, task) => total + Object.keys(task.reservations ?? {}).length, 0),
-      staleReservations: board.stats?.staleReservations ?? 0,
-      blockedReservations: board.stats?.blockedReservations ?? 0
-    };
+    return summary;
   }
 
   private getMyUsername(): string {
@@ -1711,7 +1799,23 @@ export class UnifiedStatsManager {
           assigned_tasks: room.taskBoard.assignedTasks,
           reservations: room.taskBoard.reservations,
           stale_reservations: room.taskBoard.staleReservations,
-          blocked_reservations: room.taskBoard.blockedReservations
+          blocked_reservations: room.taskBoard.blockedReservations,
+          amount: room.taskBoard.amount,
+          reserved_amount: room.taskBoard.reservedAmount,
+          remaining_amount: room.taskBoard.remainingAmount,
+          delivery_amount: room.taskBoard.deliveryAmount,
+          delivery_reserved_amount: room.taskBoard.deliveryReservedAmount,
+          delivery_remaining_amount: room.taskBoard.deliveryRemainingAmount,
+          critical_delivery_remaining_amount: room.taskBoard.criticalDeliveryRemainingAmount,
+          by_type: Object.fromEntries(Object.entries(room.taskBoard.byType).map(([type, stats]) => [type, {
+            tasks: stats.tasks,
+            open_tasks: stats.openTasks,
+            assigned_tasks: stats.assignedTasks,
+            reservations: stats.reservations,
+            amount: stats.amount,
+            reserved_amount: stats.reservedAmount,
+            remaining_amount: stats.remainingAmount
+          }]))
         } : undefined,
         spawn_queue: room.spawnQueue ? {
           total: room.spawnQueue.total,

--- a/packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts
+++ b/packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts
@@ -1,5 +1,71 @@
 import { expect } from "chai";
 import { UnifiedStatsManager } from "../src/unifiedStats.ts";
+import type { RoomStatsEntry } from "../src/statsTypes.ts";
+
+type RoomStatsOverrides = Omit<Partial<RoomStatsEntry>, "energy" | "controller" | "brain" | "metrics" | "profiler"> & {
+  energy?: Partial<RoomStatsEntry["energy"]>;
+  controller?: Partial<RoomStatsEntry["controller"]>;
+  brain?: Partial<RoomStatsEntry["brain"]>;
+  metrics?: Partial<RoomStatsEntry["metrics"]>;
+  profiler?: Partial<RoomStatsEntry["profiler"]>;
+};
+
+function makeRoomStats(overrides: RoomStatsOverrides = {}): RoomStatsEntry {
+  const base: RoomStatsEntry = {
+    name: "W1N1",
+    rcl: 1,
+    energy: {
+      available: 0,
+      capacity: 0,
+      storage: 0,
+      terminal: 0
+    },
+    controller: {
+      progress: 0,
+      progressTotal: 1,
+      progressPercent: 0,
+      ticksToDowngrade: 1000,
+      downgradeRisk: false
+    },
+    creeps: 0,
+    hostiles: 0,
+    brain: {
+      danger: 0,
+      postureCode: 0,
+      colonyLevelCode: 0
+    },
+    pheromones: {},
+    metrics: {
+      energyHarvested: 0,
+      energySpawning: 0,
+      energyConstruction: 0,
+      energyRepair: 0,
+      energyTower: 0,
+      energyAvailableForSharing: 0,
+      energyCapacityTotal: 0,
+      energyNeed: 0,
+      controllerProgress: 0,
+      hostileCount: 0,
+      damageReceived: 0,
+      constructionSites: 0
+    },
+    profiler: {
+      avgCpu: 0,
+      peakCpu: 0,
+      samples: 1
+    }
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    energy: { ...base.energy, ...overrides.energy },
+    controller: { ...base.controller, ...overrides.controller },
+    brain: { ...base.brain, ...overrides.brain },
+    metrics: { ...base.metrics, ...overrides.metrics },
+    profiler: { ...base.profiler, ...overrides.profiler }
+  };
+}
 
 describe("UnifiedStatsManager", () => {
   beforeEach(() => {
@@ -104,7 +170,7 @@ describe("UnifiedStatsManager", () => {
     const state = manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } };
 
     state.currentSnapshot.rooms = {
-      W1N1: {
+      W1N1: makeRoomStats({
         name: "W1N1",
         rcl: 1,
         energy: {
@@ -121,33 +187,10 @@ describe("UnifiedStatsManager", () => {
           downgradeRisk: false
         },
         creeps: 2,
-        hostiles: 0,
-        brain: {
-          danger: 0,
-          postureCode: 0,
-          colonyLevelCode: 0
-        },
-        pheromones: {},
         metrics: {
-          energyHarvested: 0,
-          energySpawning: 0,
-          energyConstruction: 0,
-          energyRepair: 0,
-          energyTower: 0,
-          energyAvailableForSharing: 0,
-          energyCapacityTotal: 300,
-          energyNeed: 0,
-          controllerProgress: 0,
-          hostileCount: 0,
-          damageReceived: 0,
-          constructionSites: 0
-        },
-        profiler: {
-          avgCpu: 0,
-          peakCpu: 0,
-          samples: 1
+          energyCapacityTotal: 300
         }
-      } as Record<string, unknown>
+      }) as Record<string, unknown>
     };
 
     (Game as unknown as { rooms: Record<string, unknown> }).rooms = {
@@ -162,6 +205,104 @@ describe("UnifiedStatsManager", () => {
     manager.startTick();
 
     expect((manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } }).currentSnapshot.rooms.W1N1).to.exist;
+  });
+
+  it("summarizes task-board amounts by type for live backlog diagnosis", () => {
+    const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
+    (Memory as Memory & { creepTaskBoard?: unknown }).creepTaskBoard = {
+      rooms: {
+        W1N1: {
+          stats: { staleReservations: 1, blockedReservations: 2 },
+          tasks: {
+            spawn: { type: "refillSpawn", status: "open", priority: 200, amount: 300, reservations: {} },
+            extension: { type: "refillExtension", status: "assigned", priority: 100, amount: 200, reservations: { hauler1: { amount: 50 } } },
+            storage: { type: "storeEnergy", status: "open", priority: 10, amount: 1000, reservations: { hauler2: { amount: 100 } } },
+            defend: { type: "defend", status: "open", priority: 200, amount: 5000, reservations: {} }
+          }
+        }
+      }
+    };
+
+    const stats = (manager as unknown as {
+      getRoomTaskBoardStats(roomName: string): NonNullable<RoomStatsEntry["taskBoard"]>;
+    }).getRoomTaskBoardStats("W1N1");
+
+    expect(stats).to.include({
+      tasks: 4,
+      openTasks: 3,
+      assignedTasks: 1,
+      reservations: 2,
+      staleReservations: 1,
+      blockedReservations: 2,
+      amount: 6500,
+      reservedAmount: 150,
+      remainingAmount: 6350,
+      deliveryAmount: 1500,
+      deliveryReservedAmount: 150,
+      deliveryRemainingAmount: 1350,
+      criticalDeliveryRemainingAmount: 450
+    });
+    expect(stats.byType.refillExtension).to.deep.equal({
+      tasks: 1,
+      openTasks: 0,
+      assignedTasks: 1,
+      reservations: 1,
+      amount: 200,
+      reservedAmount: 50,
+      remainingAmount: 150
+    });
+  });
+
+  it("publishes compact task-board amount stats to Memory.stats", () => {
+    const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
+    const taskBoard = {
+      tasks: 1,
+      openTasks: 1,
+      assignedTasks: 0,
+      reservations: 1,
+      staleReservations: 0,
+      blockedReservations: 0,
+      amount: 200,
+      reservedAmount: 50,
+      remainingAmount: 150,
+      deliveryAmount: 200,
+      deliveryReservedAmount: 50,
+      deliveryRemainingAmount: 150,
+      criticalDeliveryRemainingAmount: 150,
+      byType: {
+        refillExtension: {
+          tasks: 1,
+          openTasks: 1,
+          assignedTasks: 0,
+          reservations: 1,
+          amount: 200,
+          reservedAmount: 50,
+          remainingAmount: 150
+        }
+      }
+    };
+    const state = manager as unknown as { currentSnapshot: { rooms: Record<string, RoomStatsEntry> } };
+    state.currentSnapshot.rooms = { W1N1: makeRoomStats({ name: "W1N1", taskBoard }) };
+
+    (manager as unknown as { publishToMemory(): void }).publishToMemory();
+
+    const published = (Memory as unknown as {
+      stats: { rooms: Record<string, { taskBoard: Record<string, unknown> }> };
+    }).stats.rooms.W1N1.taskBoard;
+    expect(published).to.include({
+      tasks: 1,
+      open_tasks: 1,
+      assigned_tasks: 0,
+      amount: 200,
+      reserved_amount: 50,
+      remaining_amount: 150,
+      delivery_remaining_amount: 150,
+      critical_delivery_remaining_amount: 150
+    });
+    expect((published.by_type as Record<string, Record<string, number>>).refillExtension).to.include({
+      remaining_amount: 150,
+      reserved_amount: 50
+    });
   });
 
   it("captures gated CPU detail samples and auto-disables after TTL", () => {

--- a/packages/screeps-bot/test/unit/unifiedStats.test.ts
+++ b/packages/screeps-bot/test/unit/unifiedStats.test.ts
@@ -436,8 +436,8 @@ describe("UnifiedStatsManager", function () {
         rooms: {
           W1N1: {
             tasks: {
-              openTask: { status: "open", reservations: {} },
-              assignedTask: { status: "assigned", reservations: { hauler1: {} } }
+              openTask: { type: "refillSpawn", status: "open", priority: 200, amount: 300, reservations: {} },
+              assignedTask: { type: "refillExtension", status: "assigned", priority: 100, amount: 200, reservations: { hauler1: { amount: 50 } } }
             },
             stats: { staleReservations: 2, blockedReservations: 1 }
           }
@@ -455,7 +455,34 @@ describe("UnifiedStatsManager", function () {
         assigned_tasks: 1,
         reservations: 1,
         stale_reservations: 2,
-        blocked_reservations: 1
+        blocked_reservations: 1,
+        amount: 500,
+        reserved_amount: 50,
+        remaining_amount: 450,
+        delivery_amount: 500,
+        delivery_reserved_amount: 50,
+        delivery_remaining_amount: 450,
+        critical_delivery_remaining_amount: 450,
+        by_type: {
+          refillSpawn: {
+            tasks: 1,
+            open_tasks: 1,
+            assigned_tasks: 0,
+            reservations: 0,
+            amount: 300,
+            reserved_amount: 0,
+            remaining_amount: 300
+          },
+          refillExtension: {
+            tasks: 1,
+            open_tasks: 0,
+            assigned_tasks: 1,
+            reservations: 1,
+            amount: 200,
+            reserved_amount: 50,
+            remaining_amount: 150
+          }
+        }
       });
     });
 


### PR DESCRIPTION
## Summary

Adds amount-aware task-board telemetry to `Memory.stats.rooms.*.taskBoard` so live diagnosis can distinguish task counts from remaining energy demand.

## Linked issue

Closes #3186

## Changes

- Extends `RoomStatsEntry.taskBoard` with total/reserved/remaining amount fields.
- Adds by-type task-board summaries with count, reservation, amount, reserved, and remaining totals.
- Exports compact snake_case telemetry through `Memory.stats` (`by_type`, `remaining_amount`, `delivery_remaining_amount`, etc.).
- Keeps legacy count fields (`tasks`, `open_tasks`, `assigned_tasks`, `reservations`, stale/blocked reservations).
- Adds stats tests for mixed open/assigned delivery tasks and published Memory output.

## Validation

- `npm run test:stats` ✅
- `npm run build:stats` ✅
- `npm run lint -w @ralphschuler/screeps-stats` ✅
- `npm run check:alliance-safety` ✅
- `npm run build:bot` ✅
- `npm run build && git checkout -- packages/screeps-bot/dist/main.js` ✅
- `git diff --check` ✅

## Deployment impact

Stats-only runtime telemetry change. Deploy path still builds the bot bundle; no Screeps Memory migration required.

## Live bot evidence

Current read-only live analysis (`artifacts/live-analysis-20260703T222608Z-autonomous/`) showed shard1 task-board pressure where custom raw Memory analysis was required to separate refill/store tasks from diagnostic over-counting. This PR moves that amount/reservation detail into standard `Memory.stats`.

## Follow-up issues

Existing live task-board backlog issue remains: #3119.
