### PR TITLE
[codex] Prune legacy task-board work tasks

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
+++ b/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
@@ -29,6 +29,7 @@ const ENERGY_DELIVERY_TASK_TYPES: TaskType[] = [
   "fillTerminalEnergy",
   "storeEnergy"
 ];
+const LEGACY_UNCONSUMED_TASK_TYPES = new Set<TaskType>(["build", "repair", "upgrade"]);
 
 const MILITARY_ROLES = ["guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger"];
 
@@ -105,6 +106,10 @@ function remainingAmount(task: CreepTask): number {
 
 function isEnergyDeliveryTaskType(type: TaskType): boolean {
   return ENERGY_DELIVERY_TASK_TYPES.includes(type);
+}
+
+function isLegacyUnconsumedTaskType(type: TaskType): boolean {
+  return LEGACY_UNCONSUMED_TASK_TYPES.has(type);
 }
 
 function getCreepEnergy(creep: Creep): number {
@@ -319,12 +324,34 @@ function isTargetStillValid(task: CreepTask): boolean {
   }
 }
 
+function clearTaskAssignmentMemory(task: CreepTask): void {
+  for (const creepName of new Set([...task.assignedCreeps, ...Object.keys(task.reservations)])) {
+    const creep = Game.creeps[creepName];
+    const memory = creep?.memory as unknown as Record<string, unknown> | undefined;
+    if (memory?.assignedTaskId === task.id) {
+      delete memory.assignedTaskId;
+    }
+  }
+}
+
+function invalidateTask(board: RoomTaskBoardMemory, task: CreepTask): void {
+  task.status = "invalid";
+  clearTaskAssignmentMemory(task);
+  board.stats.invalidated++;
+  delete board.tasks[task.id];
+}
+
 function cleanupBoard(board: RoomTaskBoardMemory, force = false): void {
   if (!force && board.lastCleanedTick === Game.time) return;
   board.lastCleanedTick = Game.time;
   let staleReservations = 0;
 
   for (const task of Object.values(board.tasks)) {
+    if (isLegacyUnconsumedTaskType(task.type)) {
+      invalidateTask(board, task);
+      continue;
+    }
+
     for (const [creepName, reservation] of Object.entries(task.reservations)) {
       if (!Game.creeps[creepName] || Game.time > reservation.expiresTick) {
         delete task.reservations[creepName];
@@ -335,9 +362,7 @@ function cleanupBoard(board: RoomTaskBoardMemory, force = false): void {
     recomputeReservationTotals(task);
 
     if (Game.time > task.expiresTick || !isTargetStillValid(task)) {
-      task.status = "invalid";
-      board.stats.invalidated++;
-      delete board.tasks[task.id];
+      invalidateTask(board, task);
       continue;
     }
 

--- a/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
@@ -581,6 +581,118 @@ describe("TaskBoard", () => {
     expect(taskBoard.getStats(room.name)).to.include({ open: 0, assigned: 0, reservations: 0 });
   });
 
+  it("prunes legacy build repair and upgrade tasks from memory while keeping delivery tasks", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const controller = makeController("controller1" as Id<StructureController>);
+    const site = {
+      id: "site1" as Id<ConstructionSite>,
+      structureType: STRUCTURE_EXTENSION,
+      progress: 0,
+      progressTotal: 100,
+      pos: { x: 14, y: 10, roomName: "W1N1" }
+    } as ConstructionSite;
+    const road = {
+      id: "road1" as Id<StructureRoad>,
+      structureType: STRUCTURE_ROAD,
+      hits: 100,
+      hitsMax: 5000,
+      pos: { x: 15, y: 10, roomName: "W1N1" }
+    } as StructureRoad;
+    const room = createMockRoom("W1N1", { controller });
+    (room as any).find = (type: number) => {
+      if (type === FIND_MY_STRUCTURES) return [extension];
+      if (type === FIND_MY_CREEPS) return [];
+      return [];
+    };
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => {
+      if (id === extension.id) return extension;
+      if (id === site.id) return site;
+      if (id === road.id) return road;
+      if (id === controller.id) return controller;
+      return null;
+    };
+
+    const builder = createMockCreep("builder1", {
+      room,
+      memory: { role: "builder", family: "economy", homeRoom: room.name, version: 1, assignedTaskId: `${room.name}:build:${site.id}` } as any,
+      store: makeStore(50, 50),
+      body: [{ type: WORK, hits: 100 }, { type: CARRY, hits: 100 }, { type: MOVE, hits: 100 }]
+    });
+    MockGame.creeps[builder.name] = builder;
+
+    const baseTask = {
+      roomName: room.name,
+      priority: TaskPriority.NORMAL,
+      amount: 50,
+      maxAssignments: 1,
+      allowedRoles: ["builder"],
+      createdTick: Game.time - 10,
+      updatedTick: Game.time - 10,
+      expiresTick: Game.time + 50,
+      reservedAmount: 0,
+      assignedCreeps: [],
+      reservations: {},
+      status: "open"
+    };
+
+    (Memory as any).creepTaskBoard = {
+      enabled: true,
+      rooms: {
+        [room.name]: {
+          roomName: room.name,
+          tasks: {
+            [`${room.name}:build:${site.id}`]: {
+              ...baseTask,
+              id: `${room.name}:build:${site.id}`,
+              type: "build",
+              targetId: site.id,
+              targetPos: { x: 14, y: 10, roomName: room.name },
+              reservedAmount: 50,
+              assignedCreeps: [builder.name],
+              reservations: { [builder.name]: { creepName: builder.name, amount: 50, assignedTick: Game.time - 1, expiresTick: Game.time + 10 } },
+              status: "assigned"
+            },
+            [`${room.name}:repair:${road.id}`]: {
+              ...baseTask,
+              id: `${room.name}:repair:${road.id}`,
+              type: "repair",
+              targetId: road.id,
+              targetPos: { x: 15, y: 10, roomName: room.name }
+            },
+            [`${room.name}:upgrade:${controller.id}`]: {
+              ...baseTask,
+              id: `${room.name}:upgrade:${controller.id}`,
+              type: "upgrade",
+              targetId: controller.id,
+              targetPos: { x: 40, y: 40, roomName: room.name }
+            },
+            [`${room.name}:refillExtension:${extension.id}`]: {
+              ...baseTask,
+              id: `${room.name}:refillExtension:${extension.id}`,
+              type: "refillExtension",
+              priority: TaskPriority.HIGH,
+              targetId: extension.id,
+              targetPos: { x: 12, y: 10, roomName: room.name },
+              resourceType: RESOURCE_ENERGY,
+              allowedRoles: ["hauler"]
+            }
+          },
+          lastGeneratedTick: Game.time,
+          lastCleanedTick: Game.time - 1,
+          stats: { generated: 0, assigned: 0, completed: 0, invalidated: 0, staleReservations: 0, preemptions: 0 }
+        }
+      }
+    };
+
+    taskBoard.refreshRoom(room);
+
+    const board = (Memory as any).creepTaskBoard.rooms[room.name];
+    expect(Object.values(board.tasks).map((task: any) => task.type)).to.deep.equal(["refillExtension"]);
+    expect(board.stats.invalidated).to.equal(3);
+    expect((builder.memory as any).assignedTaskId).to.equal(undefined);
+  });
+
   it("assigns builder critical extension refill through the task board before direct build fallback", () => {
     const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
     const controller = makeController("controller1" as Id<StructureController>);

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -24276,19 +24276,19 @@ amount: u
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
 }(Du || (Du = {}));
 
-var Wu = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Ku = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Hu = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Wu = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Ku = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Hu = new Set([ "build", "repair", "upgrade" ]), Yu = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function Yu(e, t) {
+function Vu(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function Vu() {
+function qu() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function qu() {
+function ju() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24303,8 +24303,8 @@ rooms: {}
 };
 }
 
-function ju(e) {
-var t = qu();
+function zu(e) {
+var t = ju();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24323,23 +24323,27 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function zu(e, t, r) {
+function Qu(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Qu(e) {
+function Xu(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function Xu(e) {
+function Zu(e) {
 return Ku.includes(e);
 }
 
-function Zu(e) {
+function Ju(e) {
+return Hu.has(e);
+}
+
+function $u(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY);
 }
 
-function Ju(e, t) {
+function el(e, t) {
 if (!t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -24347,12 +24351,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return Zu(e.creep) > 0;
+return $u(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return Zu(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return $u(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -24371,7 +24375,7 @@ return !1;
 }
 }
 
-function $u(e, t) {
+function tl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24388,7 +24392,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function el(e) {
+function rl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24396,14 +24400,14 @@ roomName: e.roomName
 };
 }
 
-function tl(e, t, r, o, n) {
+function ol(e, t, r, o, n) {
 return {
-id: zu(e, t, r.id),
+id: Qu(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: el(r.pos),
+targetPos: rl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
@@ -24412,20 +24416,20 @@ expiresTick: Game.time + 50
 };
 }
 
-function rl(e, t) {
+function nl(e, t) {
 var r, o, n, i, s, c, u = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = Vu()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = qu()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < u)) {
 t.lastGeneratedTick = Game.time;
-var l = Yu("taskBoard.findMyStructures", function() {
+var l = Vu("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p, f = d.value;
-f.structureType !== STRUCTURE_SPAWN ? f.structureType !== STRUCTURE_EXTENSION ? f.structureType === STRUCTURE_TOWER && (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && $u(t, tl(e.name, "refillTower", f, p, Du.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && $u(t, tl(e.name, "refillExtension", f, p, Du.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && $u(t, tl(e.name, "refillSpawn", f, p, Du.CRITICAL));
+f.structureType !== STRUCTURE_SPAWN ? f.structureType !== STRUCTURE_EXTENSION ? f.structureType === STRUCTURE_TOWER && (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && tl(t, ol(e.name, "refillTower", f, p, Du.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && tl(t, ol(e.name, "refillExtension", f, p, Du.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && tl(t, ol(e.name, "refillSpawn", f, p, Du.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24439,23 +24443,23 @@ if (r) throw r.error;
 }
 }
 var y = Bu(e);
-y && $u(t, tl(e.name, "fillTerminalEnergy", y.terminal, y.amount, Du.NORMAL)), e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0 && $u(t, tl(e.name, "storeEnergy", e.storage, e.storage.store.getFreeCapacity(RESOURCE_ENERGY), Du.LOW));
-var v = Yu("taskBoard.findHostiles", function() {
+y && tl(t, ol(e.name, "fillTerminalEnergy", y.terminal, y.amount, Du.NORMAL)), e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0 && tl(t, ol(e.name, "storeEnergy", e.storage, e.storage.store.getFreeCapacity(RESOURCE_ENERGY), Du.LOW));
+var v = Vu("taskBoard.findHostiles", function() {
 return j(e);
 });
 try {
 for (var g = a(v.slice(0, 5)), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-$u(t, {
-id: zu(e.name, "defend", R.id),
+tl(t, {
+id: Qu(e.name, "defend", R.id),
 roomName: e.name,
 type: "defend",
 priority: Du.CRITICAL,
 targetId: R.id,
-targetPos: el(R.pos),
+targetPos: rl(R.pos),
 amount: R.hits,
 maxAssignments: 3,
-allowedRoles: Hu,
+allowedRoles: Yu,
 expiresTick: Game.time + 50
 });
 }
@@ -24470,7 +24474,7 @@ h && !h.done && (i = g.return) && i.call(g);
 if (n) throw n.error;
 }
 }
-var E = Yu("taskBoard.findInjuredAllies", function() {
+var E = Vu("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -24480,13 +24484,13 @@ return e.hits < e.hitsMax;
 try {
 for (var T = a(E.slice(0, 5)), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-$u(t, {
-id: zu(e.name, "heal", S.id),
+tl(t, {
+id: Qu(e.name, "heal", S.id),
 roomName: e.name,
 type: "heal",
 priority: Du.HIGH,
 targetId: S.id,
-targetPos: el(S.pos),
+targetPos: rl(S.pos),
 amount: S.hitsMax - S.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -24507,17 +24511,17 @@ if (s) throw s.error;
 }
 }
 
-function ol(e) {
+function al(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function nl(e) {
+function il(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && V(e));
 }
 
-function al(e) {
+function sl(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -24542,11 +24546,33 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !nl(t);
+return !il(t);
 }
 }
 
-function il(e, t) {
+function cl(e, t) {
+t.status = "invalid", function(e) {
+var t, r;
+try {
+for (var o = a(new Set(s(s([], i(e.assignedCreeps), !1), i(Object.keys(e.reservations)), !1))), n = o.next(); !n.done; n = o.next()) {
+var c = n.value, u = Game.creeps[c], l = null == u ? void 0 : u.memory;
+(null == l ? void 0 : l.assignedTaskId) === e.id && delete l.assignedTaskId;
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+n && !n.done && (r = o.return) && r.call(o);
+} finally {
+if (t) throw t.error;
+}
+}
+}(t), e.stats.invalidated++, delete e.tasks[t.id];
+}
+
+function ul(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -24554,6 +24580,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
+if (Ju(m.type)) cl(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -24570,8 +24597,8 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-ol(m), Game.time > m.expiresTick || !al(m) ? (m.status = "invalid", e.stats.invalidated++,
-delete e.tasks[m.id]) : (Qu(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Xu(m.type)) && (m.status = "assigned");
+al(m), Game.time > m.expiresTick || !sl(m) ? cl(e, m) : (Xu(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Zu(m.type)) && (m.status = "assigned");
+}
 }
 } catch (e) {
 r = {
@@ -24588,7 +24615,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function sl(e, t, r) {
+function ll(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -24596,15 +24623,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-ol(t);
+al(t);
 }
 }
 
-function cl(e, t) {
+function ml(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function ul(e, t, r) {
+function dl(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -24616,39 +24643,39 @@ return Object.values(e.tasks).find(function(e) {
 return e.reservations[t];
 });
 }(e, t.creep.name, t.memory.assignedTaskId);
-if (s && cl(s, r) && al(s) && Ju(t, s)) {
+if (s && ml(s, r) && sl(s) && el(t, s)) {
 if (!function(e, t) {
 var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Du.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var c = ll(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Du.CRITICAL);
+var c = pl(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Du.CRITICAL);
 if (!c || u < l || !m) return s;
-sl(0, s, t.creep.name), e.stats.preemptions++;
+ll(0, s, t.creep.name), e.stats.preemptions++;
 }
-var d = ll(e, t, r);
+var d = pl(e, t, r);
 if (!d) return null;
-var p = Math.min(Math.max(1, Qu(d)), function(e, t) {
+var p = Math.min(Math.max(1, Xu(d)), function(e, t) {
 return "harvest" === t.type ? function(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
-}(e) : Math.max(1, Zu(e));
+}(e) : Math.max(1, $u(e));
 }(t.creep, d));
 return t.memory.assignedTaskId = d.id, d.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: p,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, d.updatedTick = Game.time, ol(d), e.stats.assigned++, d;
+}, d.updatedTick = Game.time, al(d), e.stats.assigned++, d;
 }
 
-function ll(e, t, r) {
+function pl(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (cl(l, r) && Ju(t, l) && al(l) && !(Qu(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Xu(l.type))) {
-var m = ml(t.creep, l), d = 1e3 * l.priority - m;
+if (ml(l, r) && el(t, l) && sl(l) && !(Xu(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Zu(l.type))) {
+var m = fl(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -24666,7 +24693,7 @@ if (o) throw o.error;
 return i;
 }
 
-function ml(e, t) {
+function fl(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -24674,7 +24701,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function dl(e, t) {
+function yl(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -24716,7 +24743,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (nl(t)) return null;
+if (il(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -24735,57 +24762,57 @@ return null;
 }
 }
 
-var pl = function() {
+var vl = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== qu().enabled;
+return !1 !== ju().enabled;
 }, e.prototype.setEnabled = function(e) {
-qu().enabled = e;
+ju().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !Vu()) return null;
-var r = ju(e.room.name);
-Yu("taskBoard.cleanup", function() {
-return il(r);
-}), Yu("taskBoard.generate", function() {
-return rl(e.room, r);
+if (!this.isEnabled() || !qu()) return null;
+var r = zu(e.room.name);
+Vu("taskBoard.cleanup", function() {
+return ul(r);
+}), Vu("taskBoard.generate", function() {
+return nl(e.room, r);
 });
-var o = ul(r, e, {
+var o = dl(r, e, {
 allowedTypes: t
 });
-return o ? dl(o, e) : null;
+return o ? yl(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !Vu()) return null;
-var t = ju(e.room.name);
-Yu("taskBoard.cleanup", function() {
-return il(t);
-}), Yu("taskBoard.generate", function() {
-return rl(e.room, t);
+if (!this.isEnabled() || !qu()) return null;
+var t = zu(e.room.name);
+Vu("taskBoard.cleanup", function() {
+return ul(t);
+}), Vu("taskBoard.generate", function() {
+return nl(e.room, t);
 });
-var r = ul(t, e, {
+var r = dl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
 preemptPriority: Du.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = dl(r, e);
+var o = yl(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = Vu();
+var r, o = qu();
 if (!this.isEnabled() || !o) return !1;
-var n = ju(e);
-Yu("taskBoard.cleanup", function() {
-return il(n);
+var n = zu(e);
+Vu("taskBoard.cleanup", function() {
+return ul(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && Yu("taskBoard.generate", function() {
-return rl(a, n);
+return a && Vu("taskBoard.generate", function() {
+return nl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && al(e);
+return t.includes(e.type) && sl(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && Vu()) {
+if (this.isEnabled() && qu()) {
 !function(e) {
-var t, r, o, n, s = qu();
+var t, r, o, n, s = ju();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -24806,20 +24833,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = ju(e.name);
-Yu("taskBoard.cleanup", function() {
-return il(t);
-}), Yu("taskBoard.generate", function() {
-return rl(e, t);
+var t = zu(e.name);
+Vu("taskBoard.cleanup", function() {
+return ul(t);
+}), Vu("taskBoard.generate", function() {
+return nl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = qu(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = ju(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) sl(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) ll(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -24844,18 +24871,18 @@ if (r) throw r.error;
 }
 }
 }, e.prototype.clear = function(e) {
-var t = qu();
+var t = ju();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = Vu();
+var t, r = qu();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = ju(e);
-Yu("taskBoard.cleanup", function() {
-return il(n, !0);
-}), Yu("taskBoard.generate", function() {
-return rl(o, n);
+var n = zu(e);
+Vu("taskBoard.cleanup", function() {
+return ul(n, !0);
+}), Vu("taskBoard.generate", function() {
+return nl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -24880,10 +24907,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = Vu(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = qu(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = ju(e);
-il(i, !0), rl(n, i);
+var i = zu(e);
+ul(i, !0), nl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -24905,8 +24932,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = ju(e);
-il(s, !0);
+var t, r, o, n, i, s = zu(e);
+ul(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -24941,15 +24968,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), fl = new pl;
+}(), gl = new vl;
 
-function yl(e) {
+function hl(e) {
 return e === ERR_NO_PATH;
 }
 
-function vl(e) {
+function Rl(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && yl(e.moveResult),
+clearState: void 0 !== e.moveResult && hl(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -24960,11 +24987,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var gl, hl = M("ActionExecutor");
+var El, Tl = M("ActionExecutor");
 
-function Rl(e, t, r) {
+function Cl(e, t, r) {
 var o;
-return !!V(r) && (hl.warn("Refusing harmful action against known ally target", {
+return !!V(r) && (Tl.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -24973,42 +25000,42 @@ target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
 }), delete e.memory.state, e.creep.id && (Gu.clearCachedPath(e.creep), $e(e.creep)),
-fl.releaseCreep(e.creep.name, e.creep.room.name), !0);
+gl.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function El(e, t, r) {
+function Sl(e, t, r) {
 var o, n;
-if (!t || !t.type) return hl.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return Tl.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && hl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-"idle" === a.type ? hl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : hl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && Tl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+"idle" === a.type ? Tl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Tl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
 
 case "transfer":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.transfer(a.target, a.resourceType);
 }, a.target, 0, a.type, {
 resourceType: a.resourceType
@@ -25020,92 +25047,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (Rl(r, a.type, a.target)) {
+if (Cl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (Rl(r, a.type, a.target)) {
+if (Cl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Cl(e, function() {
+xl(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (Rl(r, a.type, a.target)) {
+if (Cl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Cl(e, function() {
+xl(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-Cl(e, function() {
+xl(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), yl(Gu.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), hl(Gu.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (Rl(r, a.type, a.target)) {
+if (Cl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Cl(e, function() {
+i = xl(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-yl(Gu.moveTo(e, a.target)) && (i = !0);
+hl(Gu.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var s = new RoomPosition(25, 25, a.roomName);
-yl(Gu.moveTo(e, {
+hl(Gu.moveTo(e, {
 pos: s,
 range: 20
 }, {
@@ -25114,11 +25141,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-yl(Tl(e, a.target, a.routeType)) && (i = !0);
+hl(wl(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-s = new RoomPosition(25, 25, a.roomName), yl(Tl(e, {
+s = new RoomPosition(25, 25, a.roomName), hl(wl(e, {
 pos: s,
 range: 20
 }, a.routeType, {
@@ -25133,7 +25160,7 @@ pos: e,
 range: 10
 };
 });
-yl(Gu.moveTo(e, c, {
+hl(Gu.moveTo(e, c, {
 flee: !0
 })) && (i = !0);
 break;
@@ -25146,11 +25173,11 @@ priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || yl(Gu.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || hl(Gu.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-yl(Gu.moveTo(e, a.target, {
+hl(Gu.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
@@ -25166,7 +25193,7 @@ var l = Game.rooms[e.pos.roomName];
 if (l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my)) {
 var m = Lu(l.name);
 if (m && !e.pos.isEqualTo(m)) {
-yl(Gu.moveTo(e, m, {
+hl(Gu.moveTo(e, m, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25183,8 +25210,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, Gu.clearCachedPath(e), $e(e), fl.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || fl.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, Gu.clearCachedPath(e), $e(e), gl.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || gl.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25192,12 +25219,12 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function Tl(e, t, r, o) {
-if (!gl) return Gu.moveTo(e, t, o);
+function wl(e, t, r, o) {
+if (!El) return Gu.moveTo(e, t, o);
 try {
-return gl(e, t, r, o);
+return El(e, t, r, o);
 } catch (n) {
-return hl.warn("Remote movement handler failed; falling back to default movement", {
+return Tl.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25208,11 +25235,11 @@ error: n instanceof Error ? n.message : String(n)
 }
 }
 
-function Cl(e, t, r, o, n, a) {
+function xl(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
 var s = Gu.moveTo(e, r);
-return s !== OK && hl.info("Movement attempt returned non-OK result", {
+return s !== OK && Tl.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25220,12 +25247,12 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), vl({
+}), Rl({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = vl({
+var c = Rl({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
@@ -25291,7 +25318,7 @@ os(e).upgradeProgress += t;
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (hl.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (Tl.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25302,9 +25329,9 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Sl, wl = M("StateMachine");
+var bl, Ol = M("StateMachine");
 
-function xl(e, t, r) {
+function Al(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25327,7 +25354,7 @@ resourceType: e.resourceType
 }), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), wl.info(r, {
+}(t), Ol.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25335,13 +25362,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : wl.info("Behavior returned idle action", {
+})) : Ol.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (wl.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (Ol.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25352,11 +25379,11 @@ type: "idle"
 });
 }
 
-function bl(e, t, r) {
+function Ml(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, xl(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, Al(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -25436,7 +25463,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) wl.info("State completed, evaluating new action", {
+}(a, e)) Ol.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25553,7 +25580,7 @@ return null;
 }
 }(a);
 if (c) return c;
-wl.info("State reconstruction failed, re-evaluating behavior", {
+Ol.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25561,7 +25588,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (wl.info("State invalid, re-evaluating behavior", {
+} else a && (Ol.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -25570,10 +25597,10 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return xl(e, t(e), "Committed new state action");
+return Al(e, t(e), "Committed new state action");
 }
 
-function Ol(e) {
+function kl(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -25582,34 +25609,34 @@ var n = e.memory.working;
 return o !== n && et(e.creep), n;
 }
 
-function Al(e) {
+function Ul(e) {
 e.memory.working = !1, et(e.creep);
 }
 
-(Sl = {})[FIND_SOURCES] = 5e3, Sl[FIND_MINERALS] = 5e3, Sl[FIND_DEPOSITS] = 100,
-Sl[FIND_STRUCTURES] = 50, Sl[FIND_MY_STRUCTURES] = 50, Sl[FIND_HOSTILE_STRUCTURES] = 20,
-Sl[FIND_MY_SPAWNS] = 100, Sl[FIND_MY_CONSTRUCTION_SITES] = 20, Sl[FIND_CONSTRUCTION_SITES] = 20,
-Sl[FIND_CREEPS] = 5, Sl[FIND_MY_CREEPS] = 5, Sl[FIND_HOSTILE_CREEPS] = 3, Sl[FIND_DROPPED_RESOURCES] = 5,
-Sl[FIND_TOMBSTONES] = 10, Sl[FIND_RUINS] = 10, Sl[FIND_FLAGS] = 50, Sl[FIND_NUKES] = 20,
-Sl[FIND_POWER_CREEPS] = 10, Sl[FIND_MY_POWER_CREEPS] = 10;
+(bl = {})[FIND_SOURCES] = 5e3, bl[FIND_MINERALS] = 5e3, bl[FIND_DEPOSITS] = 100,
+bl[FIND_STRUCTURES] = 50, bl[FIND_MY_STRUCTURES] = 50, bl[FIND_HOSTILE_STRUCTURES] = 20,
+bl[FIND_MY_SPAWNS] = 100, bl[FIND_MY_CONSTRUCTION_SITES] = 20, bl[FIND_CONSTRUCTION_SITES] = 20,
+bl[FIND_CREEPS] = 5, bl[FIND_MY_CREEPS] = 5, bl[FIND_HOSTILE_CREEPS] = 3, bl[FIND_DROPPED_RESOURCES] = 5,
+bl[FIND_TOMBSTONES] = 10, bl[FIND_RUINS] = 10, bl[FIND_FLAGS] = 50, bl[FIND_NUKES] = 20,
+bl[FIND_POWER_CREEPS] = 10, bl[FIND_MY_POWER_CREEPS] = 10;
 
-var Ml, kl, Ul = {}, _l = {}, Nl = {}, Pl = {};
+var _l, Nl, Pl = {}, Il = {}, Gl = {}, Ll = {};
 
-function Il() {
-if (Ml) return Pl;
-Ml = 1;
+function Dl() {
+if (_l) return Ll;
+_l = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Pl.encode = function(t) {
+return Ll.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, Pl;
+}, Ll;
 }
 
-function Gl() {
-if (kl) return Nl;
-kl = 1;
-const e = Il();
-return Nl.encode = function(t) {
+function Fl() {
+if (Nl) return Gl;
+Nl = 1;
+const e = Dl();
+return Gl.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25617,23 +25644,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Nl;
+}, Gl;
 }
 
-var Ll, Dl, Fl, Bl = {}, Wl = jt(Object.freeze({
+var Bl, Wl, Kl, Hl = {}, Yl = jt(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Kl() {
-return Dl ? Ll : (Dl = 1, Ll = "function" == typeof URL ? URL : Wl.URL);
+function Vl() {
+return Wl ? Bl : (Wl = 1, Bl = "function" == typeof URL ? URL : Yl.URL);
 }
 
-function Hl() {
-if (Fl) return Bl;
-Fl = 1;
-const e = Kl();
-Bl.getArg = function(e, t, r) {
+function ql() {
+if (Kl) return Hl;
+Kl = 1;
+const e = Vl();
+Hl.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25653,16 +25680,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Bl.toSetString = t ? r : function(e) {
+Hl.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Bl.fromSetString = t ? r : function(e) {
+}, Hl.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Bl.compareByGeneratedPositionsInflated = function(e, t) {
+}, Hl.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Bl.parseSourceMapInput = function(e) {
+}, Hl.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25716,7 +25743,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Bl.normalize = f, Bl.join = y, Bl.relative = function(t, r) {
+return Hl.normalize = f, Hl.join = y, Hl.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25728,18 +25755,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Bl.computeSourceURL = function(e, t, r) {
+}, Hl.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Bl;
+}, Hl;
 }
 
-var Yl, Vl = {};
+var jl, zl = {};
 
-function ql() {
-if (Yl) return Vl;
-Yl = 1;
+function Ql() {
+if (jl) return zl;
+jl = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -25772,19 +25799,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Vl.ArraySet = e, Vl;
+return zl.ArraySet = e, zl;
 }
 
-var jl, zl, Ql = {};
+var Xl, Zl, Jl = {};
 
-function Xl() {
-if (zl) return _l;
-zl = 1;
-const e = Gl(), t = Hl(), r = ql().ArraySet, o = function() {
-if (jl) return Ql;
-jl = 1;
-const e = Hl();
-return Ql.MappingList = class {
+function $l() {
+if (Zl) return Il;
+Zl = 1;
+const e = Fl(), t = ql(), r = Ql().ArraySet, o = function() {
+if (Xl) return Jl;
+Xl = 1;
+const e = ql();
+return Jl.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -25804,7 +25831,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, Ql;
+}, Jl;
 }().MappingList;
 class n {
 constructor(e) {
@@ -25933,13 +25960,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, _l.SourceMapGenerator = n, _l;
+return n.prototype._version = 3, Il.SourceMapGenerator = n, Il;
 }
 
-var Zl, Jl = {}, $l = {};
+var em, tm = {}, rm = {};
 
-function em() {
-return Zl || (Zl = 1, function(e) {
+function om() {
+return em || (em = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -25951,36 +25978,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}($l)), $l;
+}(rm)), rm;
 }
 
-var tm, rm, om, nm, am = {
+var nm, am, im, sm, cm = {
 exports: {}
 };
 
-function im() {
-if (tm) return am.exports;
-tm = 1;
+function um() {
+if (nm) return cm.exports;
+nm = 1;
 let e = null;
-return am.exports = function() {
+return cm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, am.exports.initialize = t => {
+}, cm.exports.initialize = t => {
 e = t;
-}, am.exports;
+}, cm.exports;
 }
 
-function sm() {
-if (om) return rm;
-om = 1;
-const e = im();
+function lm() {
+if (im) return am;
+im = 1;
+const e = um();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return rm = function() {
+return am = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26047,28 +26074,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, rm;
+}, am;
 }
 
-var cm, um, lm, mm, dm = {};
+var mm, dm, pm, fm, ym = {};
 
-function pm(e, t, r) {
+function vm(e, t, r) {
 return e - t >= r;
 }
 
-function fm(e, t) {
+function gm(e, t) {
 return e.priority - t.priority;
 }
 
-function ym(e, t, r, o) {
+function hm(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function vm(e, t, r, o) {
+function Rm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function gm(e) {
+function Em(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26086,12 +26113,12 @@ if (t) throw t.error;
 return o;
 }
 
-um || (um = 1, Ul.SourceMapGenerator = Xl().SourceMapGenerator, Ul.SourceMapConsumer = function() {
-if (nm) return Jl;
-nm = 1;
-const e = Hl(), t = em(), r = ql().ArraySet;
-Gl();
-const o = im(), n = sm(), a = Symbol("smcInternal");
+dm || (dm = 1, Pl.SourceMapGenerator = $l().SourceMapGenerator, Pl.SourceMapConsumer = function() {
+if (sm) return tm;
+sm = 1;
+const e = ql(), t = om(), r = Ql().ArraySet;
+Fl();
+const o = um(), n = lm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26128,7 +26155,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, Jl.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, tm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26318,7 +26345,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, Jl.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, tm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26427,11 +26454,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return Jl.IndexedSourceMapConsumer = c, Jl;
-}().SourceMapConsumer, Ul.SourceNode = function() {
-if (cm) return dm;
-cm = 1;
-const e = Xl().SourceMapGenerator, t = Hl(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return tm.IndexedSourceMapConsumer = c, tm;
+}().SourceMapConsumer, Pl.SourceNode = function() {
+if (mm) return ym;
+mm = 1;
+const e = $l().SourceMapGenerator, t = ql(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26570,27 +26597,27 @@ map: o
 };
 }
 }
-return dm.SourceNode = n, dm;
+return ym.SourceNode = n, ym;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(mm || (mm = {}));
+}(fm || (fm = {}));
 
-var hm, Rm = [ mm.CRITICAL, mm.HIGH, mm.MEDIUM, mm.LOW ], Em = {
-bucketThresholds: (lm = {}, lm[mm.CRITICAL] = 0, lm[mm.HIGH] = 2e3, lm[mm.MEDIUM] = 5e3,
-lm[mm.LOW] = 8e3, lm),
+var Tm, Cm = [ fm.CRITICAL, fm.HIGH, fm.MEDIUM, fm.LOW ], Sm = {
+bucketThresholds: (pm = {}, pm[fm.CRITICAL] = 0, pm[fm.HIGH] = 2e3, pm[fm.MEDIUM] = 5e3,
+pm[fm.LOW] = 8e3, pm),
 defaultMaxCpu: 5,
 logExecution: !1
-}, Tm = function() {
+}, wm = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: gm(Rm),
+tasksByPriority: Em(Cm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, Em), e);
+}, this.config = o(o({}, Sm), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26604,13 +26631,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(fm), l = 0;
+var u = Array.from(this.tasks.values()).sort(gm), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (pm(Game.time, p.lastRun, p.interval)) if (ym(p.priority, s, this.config.bucketThresholds, mm.CRITICAL)) this.stats.skippedThisTick++; else {
+if (vm(Game.time, p.lastRun, p.interval)) if (hm(p.priority, s, this.config.bucketThresholds, fm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (vm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Rm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26658,7 +26685,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = gm(Rm);
+var t, r, o = Em(Cm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26675,22 +26702,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), Cm = ((hm = global)._computationScheduler || (hm._computationScheduler = new Tm),
-hm._computationScheduler), Sm = new Map;
+}(), xm = ((Tm = global)._computationScheduler || (Tm._computationScheduler = new wm),
+Tm._computationScheduler), bm = new Map;
 
-function wm(e) {
-var t = Sm.get(e);
+function Om(e) {
+var t = bm.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Sm.set(e, t)), t;
+}, bm.set(e, t)), t;
 }
 
-function xm(e, t, r) {
+function Am(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return bm(e, t[0], r), t[0];
-var i = wm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Mm(e, t[0], r), t[0];
+var i = Om(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26707,32 +26734,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && bm(e, s, r), s;
+return s && Mm(e, s, r), s;
 }
 
-function bm(e, t, r) {
-var o = wm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Mm(e, t, r) {
+var o = Om(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var Om = {
+var km = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function Am(e, t, r) {
+function Um(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(Om[t], ";") : "";
+var o = t ? "color: ".concat(km[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function Mm(e) {
+function _m(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var km = {
+var Nm = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26746,7 +26773,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(Mm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(_m((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -26763,44 +26790,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(Mm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(_m(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Um() {
+function Pm() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Pm() + Im() + '<div class="module-help">'.concat(e.map(_m).join(""), "</div>");
+return Lm() + Dm() + '<div class="module-help">'.concat(e.map(Im).join(""), "</div>");
 }
 
-var _m = function(e) {
-var t = e.api.map(Nm).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Am(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Am(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Nm = function(e) {
+var Im = function(e) {
+var t = e.api.map(Gm).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Um(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Um(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Gm = function(e) {
 var t = [];
-e.describe && t.push(Am(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(Am(e.name, "blue"), ": ").concat(Am(e.desc, "green"));
+e.describe && t.push(Um(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Um(e.name, "blue"), ": ").concat(Um(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return Am(e.name, "blue");
-}).join(", ") : "", o = Am(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Um(e.name, "blue");
+}).join(", ") : "", o = Um(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Am(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Pm = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Um(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, Lm = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, Im = function() {
+}, Dm = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Gm = M("EnergyCollection"), Lm = [ "refillSpawn", "refillExtension", "refillTower" ];
+}, Fm = M("EnergyCollection"), Bm = [ "refillSpawn", "refillExtension", "refillTower" ];
 
-function Dm(e) {
+function Wm(e) {
 if (e.droppedResources.length > 0) {
 var t = Je(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Gm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -26810,22 +26837,22 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = xm(e.creep, r, "energy_container");
-if (o) return Gm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Am(e.creep, r, "energy_container");
+if (o) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Gm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(r)) return Gm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
+if (Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(r)) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "withdraw",
 target: a,
 resourceType: RESOURCE_ENERGY
 };
 }
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Gm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -26835,35 +26862,35 @@ var n = ze(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (n.length > 0) {
-var a, i = xm(e.creep, n, "energy_source");
-if (i) return Gm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
+var a, i = Am(e.creep, n, "energy_source");
+if (i) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
-if (Gm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(n)) return Gm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
+if (Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(n)) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "harvest",
 target: a
 };
 }
-return Gm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Fm(e) {
-var t = fl.getAssignedAction(e, Lm);
+function Km(e) {
+var t = gl.getAssignedAction(e, Bm);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Bm(e) {
-return fl.hasActiveTask(e.room.name, Lm);
+function Hm(e) {
+return gl.hasActiveTask(e.room.name, Bm);
 }
 
-function Wm(e, t) {
+function Ym(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -26890,11 +26917,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Km(e) {
-var t = fl.getAssignedDeliveryAction(e);
+function Vm(e) {
+var t = gl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Bm(e)) {
-var r = Wm(e, "deliver");
+if (!Hm(e)) {
+var r = Ym(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -26916,7 +26943,7 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Hm = function() {
+var qm = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27011,16 +27038,16 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), Ym = new Hm, Vm = M("LarvaWorkerBehavior");
+}(), jm = new qm, zm = M("LarvaWorkerBehavior");
 
-function qm(e) {
-if (Ol(e)) {
-Vm.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var t = Km(e);
-if (t) return Vm.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
+function Qm(e) {
+if (kl(e)) {
+zm.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var t = Vm(e);
+if (t) return zm.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
 t;
 var r = function(e) {
-var t, r = Ym.getSwarmState(e.room.name);
+var t, r = jm.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (r) {
@@ -27037,7 +27064,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Vm.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return zm.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27046,52 +27073,52 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Vm.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return zm.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Vm.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-Al(e);
+zm.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+Ul(e);
 }
-return Dm(e);
+return Wm(e);
 }
 
-function jm(e) {
+function Xm(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function zm(e) {
+function Zm(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Qm(e) {
+function Jm(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var Xm = M("HarvesterBehavior"), Zm = M("HaulerBehavior"), Jm = [ "refillSpawn", "refillExtension" ];
+var $m = M("HarvesterBehavior"), ed = M("HaulerBehavior"), td = [ "refillSpawn", "refillExtension" ];
 
-function $m(e, t, r) {
+function rd(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return bm(e, c, r), c;
+if (c) return Mm(e, c, r), c;
 }
-var u = xm(e, t, r);
+var u = Am(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-var ed = {
+var od = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27101,11 +27128,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, td = ed, rd = function(e) {
-return td.getLabResourceNeeds(e);
+}, nd = od, ad = function(e) {
+return nd.getLabResourceNeeds(e);
 };
 
-function od(e) {
+function id(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27127,7 +27154,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = rd(e.room.name);
+var n = ad(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27155,7 +27182,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, td.getLabOverflow(r));
+var t, r, o = (r = e.room.name, nd.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27170,7 +27197,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = rd(e.room.name);
+var i = ad(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27189,8 +27216,8 @@ type: "idle"
 }(e);
 }
 
-var nd = {
-larvaWorker: qm,
+var sd = {
+larvaWorker: Qm,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27201,12 +27228,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(jm).length > 0) return {
+if (e.hostiles.filter(Xm).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (Ol(e)) {
+if (kl(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27225,7 +27252,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Dm(e);
+return Wm(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27259,10 +27286,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(zm)) return {
+if (e.hostiles.some(Zm)) return {
 type: "idle"
 };
-if (Ol(e)) {
+if (kl(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27281,10 +27308,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Dm(e);
+return Wm(e);
 },
 harvester: function(e) {
-var t, r = (t = Qm(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = Jm(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27333,8 +27360,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), Xm.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return Xm.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), $m.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return $m.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -27362,7 +27389,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return Xm.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return $m.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -27383,20 +27410,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (Xm.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? ($m.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (Xm.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : ($m.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = Ol(e), o = "defenseRefuel" === e.memory.task;
-if (Zm.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = kl(e), o = "defenseRefuel" === e.memory.task;
+if (ed.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -27409,9 +27436,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = fl.getAssignedAction(e, Jm);
+var t = gl.getAssignedAction(e, td);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (fl.hasActiveTask(e.room.name, Jm)) return null;
+if (gl.hasActiveTask(e.room.name, td)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27431,13 +27458,13 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = fl.getAssignedDeliveryAction(e);
+var c = gl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Bm(e)) {
+if (!Hm(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return Zm.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return ed.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
 {
 type: "transfer",
 target: p,
@@ -27490,12 +27517,12 @@ type: "transfer",
 target: p,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return Zm.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return ed.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-Zm.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-Al(e);
+ed.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+Ul(e);
 }
 if (o) {
 var y = function(e) {
@@ -27503,7 +27530,7 @@ var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = $m(e.creep, t, "energy_container");
+var r = rd(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -27547,16 +27574,16 @@ var R = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (R.length > 0) {
-var E = $m(e.creep, R, "energy_container");
-if (E) return Zm.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var E = rd(e.creep, R, "energy_container");
+if (E) return ed.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: E,
 resourceType: RESOURCE_ENERGY
 };
-Zm.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+ed.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
 var T = e.creep.pos.findClosestByRange(R);
-if (T) return Zm.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+if (T) return ed.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
 {
 type: "withdraw",
 target: T,
@@ -27564,7 +27591,7 @@ resourceType: RESOURCE_ENERGY
 };
 }
 if (e.mineralContainers.length > 0) {
-var C = $m(e.creep, e.mineralContainers, "mineral_container");
+var C = rd(e.creep, e.mineralContainers, "mineral_container");
 if (C) {
 if (S = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
@@ -27574,11 +27601,11 @@ target: C,
 resourceType: S
 };
 } else {
-Zm.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+ed.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var S, w = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (w && (S = Object.keys(w.store).find(function(e) {
 return e !== RESOURCE_ENERGY && w.store.getUsedCapacity(e) > 0;
-}))) return Zm.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
+}))) return ed.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
 {
 type: "withdraw",
 target: w,
@@ -27623,27 +27650,27 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (Zm.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (ed.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
 {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : (Zm.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+}) : (ed.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 }));
 },
 builder: function(e) {
-if (Ol(e)) {
-var t = Fm(e);
+if (kl(e)) {
+var t = Km(e);
 if (t) return t;
-if (!Bm(e)) {
-var r = Wm(e, "builder");
+if (!Hm(e)) {
+var r = Ym(e, "builder");
 if (r) return r;
 }
 var o = function(e) {
 if (!e.room) return null;
-var t = Qm(e);
+var t = Jm(e);
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r) return r;
@@ -27666,10 +27693,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Dm(e);
+return Wm(e);
 },
 upgrader: function(e) {
-if (Ol(e)) {
+if (kl(e)) {
 if (function(e) {
 return !function(e) {
 var t = globalThis.Game;
@@ -27683,10 +27710,10 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 });
 }(e);
 }(e)) {
-var t = Fm(e);
+var t = Km(e);
 if (t) return t;
-if (!Bm(e)) {
-var r = Wm(e, "upgrader");
+if (!Hm(e)) {
+var r = Ym(e, "upgrader");
 if (r) return r;
 }
 }
@@ -27759,7 +27786,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (Ol(e)) {
+if (kl(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -27783,7 +27810,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Km(e) || (e.storage ? {
+} : Vm(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -27903,15 +27930,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : od(e);
+} : id(e);
 },
-labSupply: od,
+labSupply: id,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (Ol(e)) {
+if (kl(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28091,7 +28118,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = Ol(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = kl(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28114,9 +28141,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : Km(e) || (e.isEmpty || e.room.name !== o ? {
+} : Vm(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (Al(e), {
+} : (Ul(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28215,12 +28242,12 @@ roomName: o
 }
 };
 
-function ad(e) {
+function cd(e) {
 var t;
-return (null !== (t = nd[e.memory.role]) && void 0 !== t ? t : qm)(e);
+return (null !== (t = sd[e.memory.role]) && void 0 !== t ? t : Qm)(e);
 }
 
-var id = "patrol", sd = [ {
+var ud = "patrol", ld = [ {
 x: 10,
 y: 5
 }, {
@@ -28256,7 +28283,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], cd = [ {
+} ], md = [ {
 x: 10,
 y: 10
 }, {
@@ -28273,7 +28300,7 @@ x: 25,
 y: 25
 } ];
 
-function ud(e) {
+function dd(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28281,7 +28308,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function ld(e) {
+function pd(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28291,9 +28318,9 @@ roomName: e.roomName
 });
 }
 
-function md(e) {
+function fd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Fe.get(e.name, {
-namespace: id
+namespace: ud
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28313,25 +28340,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(sd), !1), i(cd), !1);
-}(t).map(ud).filter(function(e) {
+}(e)), !1), i(ld), !1), i(md), !1);
+}(t).map(dd).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Fe.set(e.name, {
-waypoints: ld(n),
+waypoints: pd(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: id,
+namespace: ud,
 ttl: 1e3
 }), n;
 }
 
-function dd(e, t) {
+function yd(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28341,87 +28368,87 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var pd = M("MilitaryBehaviors"), fd = "defenseAssist";
+var vd = M("MilitaryBehaviors"), gd = "defenseAssist";
 
-function yd(e) {
+function hd(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === fd ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === gd ? e.targetRoom : void 0;
 }
 
-function vd(e) {
+function Rd(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === fd && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === gd && (delete e.task,
 delete e.targetRoom);
 }
 
-function gd(e, t) {
+function Ed(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function hd(e) {
+function Td(e) {
 return Ir(kr(e));
 }
 
-function Rd(e) {
+function Cd(e) {
 return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
 }
 
-function Ed(e) {
+function Sd(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Td(e, t) {
+function wd(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Cd(e) {
-return Td(e, "guard") + Td(e, "ranger") + Td(e, "healer");
-}
-
-function Sd(e, t, r) {
-var o = e.memory;
-return yd(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
-}
-
-function wd(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-return Sd(r, e, t);
-});
-}
-
-function xd(e, t) {
-return "defenseAssist:".concat(e, ":").concat(t, ":active");
+function xd(e) {
+return wd(e, "guard") + wd(e, "ranger") + wd(e, "healer");
 }
 
 function bd(e, t, r) {
-return Td(e, t) > function(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-var o = r.memory;
-return !r.spawning && o.role === t && yd(o) === e;
-}).length;
-}(e.roomName, t) || Cd(e) > 0 && hd(e.roomName) && function(e, t) {
-return wd(e, t).length;
-}(e.roomName, r) < 5;
+var o = e.memory;
+return hd(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
 function Od(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+return bd(r, e, t);
+});
+}
+
+function Ad(e, t) {
+return "defenseAssist:".concat(e, ":").concat(t, ":active");
+}
+
+function Md(e, t, r) {
+return wd(e, t) > function(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+var o = r.memory;
+return !r.spawning && o.role === t && hd(o) === e;
+}).length;
+}(e.roomName, t) || xd(e) > 0 && Td(e.roomName) && function(e, t) {
+return Od(e, t).length;
+}(e.roomName, r) < 5;
+}
+
+function kd(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== fd) return null;
-if (Rd(e)) return null;
+if (t.task && t.task !== gd) return null;
+if (Cd(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ed).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Sd).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== j(l).length && bd(u, t.role, e.homeRoom)) return t.task = fd, t.targetRoom = u.roomName,
-t.assistTarget = u.roomName, t.defenseSquadId = xd(e.homeRoom, u.roomName), t.defenseSquadSize = hd(u.roomName) ? Math.max(5, Cd(u)) : Math.max(1, Cd(u)),
+if (l && 0 !== j(l).length && Md(u, t.role, e.homeRoom)) return t.task = gd, t.targetRoom = u.roomName,
+t.assistTarget = u.roomName, t.defenseSquadId = Ad(e.homeRoom, u.roomName), t.defenseSquadSize = Td(u.roomName) ? Math.max(5, xd(u)) : Math.max(1, xd(u)),
 t.defenseSquadCreatedAt = Game.time, u.roomName;
 }
 } catch (e) {
@@ -28438,7 +28465,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Ad(e) {
+function Ud(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28446,19 +28473,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Md(e, t) {
+function _d(e, t) {
 if (!function(e) {
-return Boolean(yd(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(hd(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = yd(t);
+var r = hd(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = kr(r), n = Ir(o), a = n ? wd(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = yd(e);
+var o = kr(r), n = Ir(o), a = n ? Od(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = hd(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Sd(e, r, o);
+return e.memory.defenseSquadId === t && bd(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28472,7 +28499,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return wd(e, t).reduce(function(e, t) {
+return Od(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = br(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28494,16 +28521,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return gd(t, "parity-ready"), null;
-if (c >= u) return gd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Ed(t, "parity-ready"), null;
+if (c >= u) return Ed(t, "squad-quorum"), null;
 if (l) {
-if (!n) return gd(t, "expired-staging"), null;
+if (!n) return Ed(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Ad(e) - Ad(t);
+var r = Ud(e) - Ud(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28511,11 +28538,11 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return gd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Ed(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return gd(t, "squad-quorum"), null;
-if (l) return gd(t, "expired-staging"), null;
+if (c >= u) return Ed(t, "squad-quorum"), null;
+if (l) return Ed(t, "expired-staging"), null;
 }
 var m = Lu(e.room.name);
 return {
@@ -28524,7 +28551,7 @@ position: null != m ? m : e.creep.pos
 };
 }
 
-function kd(e) {
+function Nd(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28556,21 +28583,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Ud(e, t) {
+function Pd(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function _d(e, t) {
+function Id(e, t) {
 if (!e.swarmState) return null;
 var r = Lu(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (pd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+return r && e.creep.pos.getRangeTo(r) > 2 ? (vd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Nd(e) {
+function Gd(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28594,7 +28621,7 @@ if (t) throw t.error;
 }
 }
 
-function Pd(e) {
+function Ld(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28602,23 +28629,23 @@ return Boolean(e);
 });
 }
 
-function Id(e) {
+function Dd(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Gd(e) {
+function Fd(e) {
 var t, r = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Nd(e.memory.squadId);
-if (o) return Ld(e, o);
+var o = Gd(e.memory.squadId);
+if (o) return Bd(e, o);
 }
-var n = null !== (t = Od(e, r)) && void 0 !== t ? t : yd(r);
-if (n && !Rd(e)) {
-var a = Md(e, r);
+var n = null !== (t = kd(e, r)) && void 0 !== t ? t : hd(r);
+if (n && !Cd(e)) {
+var a = _d(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28631,9 +28658,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = kd(e);
+var s = Nd(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Ud(e.creep, RANGED_ATTACK), l = Ud(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Pd(e.creep, RANGED_ATTACK), l = Pd(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28645,7 +28672,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Ud(e.creep, RANGED_ATTACK), l = Ud(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Pd(e.creep, RANGED_ATTACK), l = Pd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28656,7 +28683,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (vd(r), e.creep.room.name !== e.homeRoom) return {
+} else if (Rd(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28665,8 +28692,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = kd(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Ud(e.creep, RANGED_ATTACK), l = Ud(e.creep, ATTACK),
+var m = Nd(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Pd(e.creep, RANGED_ATTACK), l = Pd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28677,7 +28704,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = md(e.room), p = dd(e.creep, d);
+var d = fd(e.room), p = yd(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28691,7 +28718,7 @@ type: "idle"
 };
 }
 
-function Ld(e, t) {
+function Bd(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28699,7 +28726,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Id(t);
+var n = Dd(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28707,7 +28734,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Pd(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Ld(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -28730,7 +28757,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Pd(e).filter(function(t) {
+var t, r, o = Ld(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -28759,7 +28786,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Pd(t).filter(function(t) {
+var r = Ld(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -28775,7 +28802,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Pd(t).sort(function(e, t) {
+var a = Ld(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -28812,7 +28839,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Pd(t).filter(function(e) {
+var l = Ld(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -28829,7 +28856,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Pd(e).find(function(e) {
+return null !== (t = Ld(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -28840,7 +28867,7 @@ target: m
 type: "idle"
 };
 }
-var d = kd(e);
+var d = Nd(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -28852,10 +28879,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Ud(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Pd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Ud(e.creep, ATTACK) && p <= 1 ? {
+} : Pd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -28871,10 +28898,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Ud(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Pd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Ud(e.creep, ATTACK) && p <= 1 ? {
+} : Pd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -28890,7 +28917,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Id(t)
+target: Dd(t)
 };
 
 case "dissolving":
@@ -28908,8 +28935,8 @@ type: "idle"
 }
 }
 
-var Dd = {
-guard: Gd,
+var Wd = {
+guard: Fd,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -28918,8 +28945,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = md(e.room);
-return (o = dd(e.creep, r)) ? {
+var r = fd(e.room);
+return (o = yd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -28940,7 +28967,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = md(e.room), (o = dd(e.creep, r)) ? {
+} : (r = fd(e.room), (o = yd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -28954,11 +28981,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Ud(e, HEAL);
+return Pd(e, HEAL);
 }), t.filter(function(e) {
-return Ud(e, RANGED_ATTACK);
+return Pd(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Ud(e, ATTACK);
+return Pd(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -28979,7 +29006,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Ud(e.creep, RANGED_ATTACK), u = Ud(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Pd(e.creep, RANGED_ATTACK), u = Pd(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29010,19 +29037,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Nd(e.memory.squadId);
-if (o) return Ld(e, o);
+var o = Gd(e.memory.squadId);
+if (o) return Bd(e, o);
 }
-var n = null !== (t = Od(e, r)) && void 0 !== t ? t : yd(r);
-if (n && !Rd(e)) {
-var a = Md(e, r);
+var n = null !== (t = kd(e, r)) && void 0 !== t ? t : hd(r);
+if (n && !Cd(e)) {
+var a = _d(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === j(i).length) return vd(r), {
+if (0 === j(i).length) return Rd(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29030,7 +29057,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== fd && !r.assistTarget) {
+if (r.targetRoom && r.task !== gd && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -29090,7 +29117,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || yd(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || hd(r) === t);
 }(e, t);
 }
 });
@@ -29116,7 +29143,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = md(e.room), v = dd(e.creep, y);
+var y = fd(e.room), v = yd(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29127,8 +29154,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Nd(e.memory.squadId);
-if (r) return Ld(e, r);
+var r = Gd(e.memory.squadId);
+if (r) return Bd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29150,9 +29177,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = kd(e);
+var a = Nd(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Ud(e.creep, RANGED_ATTACK), c = Ud(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Pd(e.creep, RANGED_ATTACK), c = Pd(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29171,7 +29198,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = md(e.room), m = dd(e.creep, l);
+var l = fd(e.room), m = yd(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29193,8 +29220,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Nd(e.memory.squadId);
-if (r) return Ld(e, r);
+var r = Gd(e.memory.squadId);
+if (r) return Bd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29255,9 +29282,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = _d(e, "siegeUnit");
+var p = Id(e, "siegeUnit");
 if (p) return p;
-var f = md(e.room), y = dd(e.creep, f);
+var f = fd(e.room), y = yd(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29268,8 +29295,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Nd(e.memory.squadId);
-if (r) return Ld(e, r);
+var r = Gd(e.memory.squadId);
+if (r) return Bd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29286,7 +29313,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return _d(e, "harasser (no target)") || {
+if (!t) return Id(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29328,9 +29355,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = _d(e, "harasser (no targets)");
+var c = Id(e, "harasser (no targets)");
 if (c) return c;
-var u = md(e.room), l = dd(e.creep, u);
+var u = fd(e.room), l = yd(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29343,9 +29370,9 @@ var t, r, o = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Nd(e.memory.squadId))) return Ld(e, a);
+if (e.memory.squadId && (a = Gd(e.memory.squadId))) return Bd(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (yd(o) && vd(o), e.room.name !== e.homeRoom) return {
+if (hd(o) && Rd(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29359,9 +29386,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Od(e, o)) && void 0 !== t ? t : yd(o);
-if (i && !Rd(e)) {
-var s = Md(e, o);
+var a, i = null !== (t = kd(e, o)) && void 0 !== t ? t : hd(o);
+if (i && !Cd(e)) {
+var s = _d(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29371,14 +29398,14 @@ roomName: i
 var u = j(c), l = z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return vd(o), {
+if (0 === u.length && 0 === l.length) return Rd(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = kd(e);
+var m = Nd(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29398,8 +29425,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Nd(e.memory.squadId))) return Ld(e, a);
-var p, f = kd(e);
+if (e.memory.squadId && (a = Gd(e.memory.squadId))) return Bd(e, a);
+var p, f = Nd(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29410,7 +29437,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = md(e.room), v = dd(e.creep, y);
+var y = fd(e.room), v = yd(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29431,21 +29458,21 @@ type: "idle"
 }
 };
 
-function Fd(e) {
+function Kd(e) {
 var t;
-return fl.getAssignedAction(e) || (null !== (t = Dd[e.memory.role]) && void 0 !== t ? t : Gd)(e);
+return gl.getAssignedAction(e) || (null !== (t = Wd[e.memory.role]) && void 0 !== t ? t : Fd)(e);
 }
 
-var Bd = M("PowerExecutor");
+var Hd = M("PowerExecutor");
 
-function Wd(e, t) {
+function Yd(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Kd(e) {
+function Vd(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29487,8 +29514,8 @@ type: "idle"
 };
 }
 
-var Hd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Yd = {
-powerHarvester: Kd,
+var qd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), jd = {
+powerHarvester: Vd,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29560,65 +29587,65 @@ roomName: e.homeRoom
 }
 };
 
-function Vd(e) {
+function zd(e) {
 var t;
-return (null !== (t = Yd[e.memory.role]) && void 0 !== t ? t : Kd)(e);
+return (null !== (t = jd[e.memory.role]) && void 0 !== t ? t : Vd)(e);
 }
 
-function qd(e) {
+function Qd(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var jd = {
+var Xd = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, zd = {
+}, Zd = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, Qd = {
+}, Jd = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, Xd = {
+}, $d = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, Zd = {
+}, ep = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, Jd = {
+}, tp = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, $d = {
+}, rp = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, ep = {
+}, op = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function tp(e) {
+function np(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function rp(e) {
+function ap(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29626,7 +29653,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function op(e) {
+function ip(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29634,12 +29661,12 @@ y: parseInt(n, 10)
 };
 }
 
-function np(e) {
+function sp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = ap(s);
+o[s.n] = cp(s);
 }
 } catch (e) {
 t = {
@@ -29655,23 +29682,23 @@ if (t) throw t.error;
 return o;
 }
 
-function ap(e) {
+function cp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = zd[e.r]) && void 0 !== t ? t : "core",
-health: ip(e.h),
+role: null !== (t = Zd[e.r]) && void 0 !== t ? t : "core",
+health: up(e.h),
 activeTasks: e.t,
-portals: e.p.map(sp),
+portals: e.p.map(lp),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(cp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(mp)
 };
 }
 
-function ip(e) {
+function up(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = Xd[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = $d[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29684,11 +29711,11 @@ lastUpdate: e.u
 };
 }
 
-function sp(e) {
+function lp(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: rp(e.sp),
+sourcePos: ap(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29698,7 +29725,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function cp(e) {
+function mp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29707,7 +29734,7 @@ bucketLevel: e.b
 };
 }
 
-function up(e) {
+function dp(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -29717,12 +29744,12 @@ isAlly: 1 === e.a
 };
 }
 
-function lp(e) {
+function pp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = mp(u);
+i[u.n] = fp(u);
 }
 } catch (e) {
 t = {
@@ -29745,13 +29772,13 @@ updatedAt: e.u
 };
 }
 
-function mp(e) {
+function fp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: op(e.pp),
+portalPos: ip(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -29762,46 +29789,46 @@ lastUpdate: e.u
 };
 }
 
-function dp(e) {
+function yp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = Jd[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = tp[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = ep[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = op[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function pp(e, t) {
+function vp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function fp(e) {
+function gp(e) {
 var t;
 return {
-c: null !== (t = Qd[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: pp(e.cpuUsage, 2),
+c: null !== (t = Jd[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: vp(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: pp(e.avgRCL, 1),
+rl: vp(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function yp(e) {
+function hp(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: tp(e.sourcePos),
+sp: np(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -29810,27 +29837,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function vp(e) {
+function Rp(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: pp(e.cpuUsed, 2),
+u: vp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function gp(e) {
+function Ep(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(hp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Tp)
 };
 }
 
-function hp(e) {
+function Tp(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -29840,23 +29867,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Rp(e) {
+function Cp(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = Zd[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = ep[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = $d[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = rp[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Ep(e) {
+function Sp(e) {
 return {
 name: e,
 role: "core",
@@ -29879,7 +29906,7 @@ cpuLimit: 0
 };
 }
 
-function Tp(e) {
+function wp(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -29889,16 +29916,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = jd[t.role]) && void 0 !== r ? r : t.role[0],
-h: fp(t.health),
+r: null !== (r = Xd[t.role]) && void 0 !== r ? r : t.role[0],
+h: gp(t.health),
 t: t.activeTasks,
-p: t.portals.map(yp),
+p: t.portals.map(hp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(vp)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Rp)
 };
 }(t[0], t[1]);
 }),
-g: gp(e.globalTargets),
+g: Ep(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -29912,7 +29939,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? tp(t.portalPos) : void 0,
+pp: t.portalPos ? np(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -29924,20 +29951,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Rp),
+k: e.tasks.map(Cp),
 ls: e.lastSync
 };
 var t;
-}(e), r = qd(JSON.stringify(t));
+}(e), r = Qd(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Cp(e) {
+function xp(e) {
 try {
-var t = JSON.parse(e), r = qd(JSON.stringify(t.d));
+var t = JSON.parse(e), r = Qd(JSON.stringify(t.d));
 return t.c !== r ? (va.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -29946,13 +29973,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: np(a.s),
+shards: sp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(up)), n),
-footprintOperation: a.o ? lp(a.o) : void 0,
-tasks: a.k.map(dp),
+o.en && (n.enemies = o.en.map(dp)), n),
+footprintOperation: a.o ? pp(a.o) : void 0,
+tasks: a.k.map(yp),
 lastSync: a.ls,
 checksum: i
 });
@@ -29964,34 +29991,34 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Sp, wp, xp = 102400;
+var bp, Op, Ap = 102400;
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Sp || (Sp = {})), function(e) {
+}(bp || (bp = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(wp || (wp = {}));
+}(Op || (Op = {}));
 
-var bp = null != va ? va : {
+var Mp = null != va ? va : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Op = {
+}, kp = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Ap = {
+}, Up = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Mp = function() {
+}, _p = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Op), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, kp), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30008,19 +30035,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Cp(r);
-o && (this.interShardMemory = o, bp.debug("Loaded InterShardMemory", {
+var o = xp(r);
+o && (this.interShardMemory = o, Mp.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-bp.error("Failed to load InterShardMemory: ".concat(n), {
+Mp.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Ep(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Sp(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30181,25 +30208,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-bp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Mp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-bp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Mp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", bp.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Mp.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-bp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Mp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30232,7 +30259,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-bp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Mp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30262,12 +30289,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", bp.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Mp.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-bp.info("War ended, transitioning to ".concat(i), {
+Mp.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, bp.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Mp.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30293,7 +30320,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Ap[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Up[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30345,13 +30372,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && bp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Mp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-bp.debug("Could not set shard limits: ".concat(S), {
+Mp.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30359,27 +30386,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (bp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Mp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
 try {
-var t = InterShardMemory.getLocal(), r = t ? Cp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
+var t = InterShardMemory.getLocal(), r = t ? xp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
 o && (!n || o.updatedAt >= n.updatedAt) && (this.interShardMemory.footprintOperation = o);
 } catch (e) {}
-var a = Tp(this.interShardMemory);
-if (a.length > xp) {
-bp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(xp), {
+var a = wp(this.interShardMemory);
+if (a.length > Ap) {
+Mp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Ap), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var i = Tp(this.interShardMemory);
-return i.length > xp ? (bp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(xp), {
+var i = wp(this.interShardMemory);
+return i.length > Ap ? (Mp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Ap), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(i);
 }
 InterShardMemory.setLocal(a), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var s = e instanceof Error ? e.message : String(e);
-bp.error("Failed to sync InterShardMemory: ".concat(s), {
+Mp.error("Failed to sync InterShardMemory: ".concat(s), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30417,7 +30444,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Ep(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Sp(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30435,40 +30462,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-bp.info("Repaired InterShardMemory structure", {
+Mp.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void bp.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Mp.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Cp(r);
-if (!o) return void bp.warn("InterShardMemory verification failed: deserialization failed", {
+var o = xp(r);
+if (!o) return void Mp.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || bp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Mp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-bp.warn("InterShardMemory verification failed: ".concat(a), {
+Mp.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-bp.info("Attempting InterShardMemory recovery", {
+Mp.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Cp(r);
-if (o) return this.interShardMemory = o, void bp.info("Recovered InterShardMemory from storage", {
+var o = xp(r);
+if (o) return this.interShardMemory = o, void Mp.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30483,12 +30510,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Ep(n), bp.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Sp(n), Mp.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-bp.error("InterShardMemory recovery failed: ".concat(a), {
+Mp.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30498,7 +30525,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), bp.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Mp.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30514,7 +30541,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-bp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Mp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30530,7 +30557,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), bp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Mp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30545,7 +30572,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, bp.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Mp.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30564,7 +30591,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), bp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Mp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30610,11 +30637,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, bp.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Mp.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = Tp(this.interShardMemory).length, o = r / xp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = wp(this.interShardMemory).length, o = r / Ap * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30641,11 +30668,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-bp.info("Forcing InterShardMemory sync with validation", {
+Mp.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = Tp(this.interShardMemory).length, n = Tp(o(o({}, this.interShardMemory), {
+var e, t, r = wp(this.interShardMemory).length, n = wp(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -30669,8 +30696,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: xp,
-percent: Math.round(r / xp * 1e4) / 100,
+limit: Ap,
+percent: Math.round(r / Ap * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -30678,10 +30705,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Sp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (bp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), kp = new Mp, Up = {
+}(), Np = new _p, Pp = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -30692,11 +30719,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: wp.LOW,
-NORMAL: wp.NORMAL,
-HIGH: wp.HIGH
+LOW: Op.LOW,
+NORMAL: Op.NORMAL,
+HIGH: Op.HIGH
 }
-}, _p = function() {
+}, Ip = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -30706,7 +30733,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = kp.getActiveTransferTasks();
+var n = Np.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -30733,7 +30760,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = kp.getOptimalPortalRoute(e.targetShard);
+var t = Np.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -30801,7 +30828,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-kp.updateTaskProgress(e.taskId, t);
+Np.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -30817,7 +30844,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = Up.optimizeBody({
+i = Pp.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -30828,8 +30855,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Up.spawnPriorities.LOW;
-e.priority >= 80 ? d = Up.spawnPriorities.HIGH : e.priority >= 50 && (d = Up.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Pp.spawnPriorities.LOW;
+e.priority >= 80 ? d = Pp.spawnPriorities.HIGH : e.priority >= 50 && (d = Pp.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -30847,7 +30874,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-Up.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Pp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -30874,7 +30901,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void kp.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Np.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", va.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -30886,8 +30913,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, kp.updateTaskProgress(e.taskId, 100, "complete"),
-kp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Np.updateTaskProgress(e.taskId, 100, "complete"),
+Np.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -30917,12 +30944,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Np = new _p;
+}(), Gp = new Ip;
 
-function Pp(e, t, r) {
+function Lp(e, t, r) {
 var o, n, a, i;
 try {
-var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Cp(c)) && void 0 !== a ? a : {
+var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = xp(c)) && void 0 !== a ? a : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30937,11 +30964,11 @@ if (!(null == l ? void 0 : l.targets[s])) return;
 var m = l.targets[s];
 m.status = e, null !== (i = m.arrivedAt) && void 0 !== i || (m.arrivedAt = Game.time),
 m.claimTargetRoom = null != t ? t : m.claimTargetRoom, m.blockedReason = r, m.lastUpdate = Game.time,
-"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(Tp(u));
+"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(wp(u));
 } catch (e) {}
 }
 
-function Ip(e) {
+function Dp(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -30969,15 +30996,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Pp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Lp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || j(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Pp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Lp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Pp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Lp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -30994,24 +31021,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Pp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Lp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Pp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Lp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Gp(e) {
+function Fp(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Lp(e, t) {
+function Bp(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31045,14 +31072,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (A.mineralType = y.mineralType), u[e.name] = A;
 }
 
-function Dp(e, t) {
+function Wp(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function Fp(e) {
-var t = Ym.getEmpire();
-if (Gu.isExit(e.creep.pos)) return Gp(e.room.name);
+function Kp(e) {
+var t = jm.getEmpire();
+if (Gu.isExit(e.creep.pos)) return Fp(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31067,7 +31094,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Dp(t.x, t.y - 1), Dp(t.x + 1, t.y), Dp(t.x, t.y + 1), Dp(t.x - 1, t.y) ] : [];
+return t ? [ Wp(t.x, t.y - 1), Wp(t.x + 1, t.y), Wp(t.x, t.y + 1), Wp(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31130,13 +31157,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Lp(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Bp(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Lp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Bp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31146,19 +31173,19 @@ type: "idle"
 };
 }
 
-function Bp(e) {
+function Hp(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function Wp(e) {
-return e.hostiles.some(Bp);
+function Yp(e) {
+return e.hostiles.some(Hp);
 }
 
-function Kp(e) {
+function Vp(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function Hp(e) {
+function qp(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31181,8 +31208,8 @@ type: "idle"
 };
 }
 
-var Yp = {
-scout: Fp,
+var jp = {
+scout: Kp,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31216,7 +31243,7 @@ return {
 type: "idle"
 };
 }
-if (Gu.isExit(e.creep.pos)) return Gp(e.room.name);
+if (Gu.isExit(e.creep.pos)) return Fp(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31238,8 +31265,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Ip,
-interShardScout: Ip,
+interShardClaimer: Dp,
+interShardScout: Dp,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31315,8 +31342,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return Hp(e);
-if (Wp(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return qp(e);
+if (Yp(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31357,7 +31384,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return Kp(t) - Kp(e);
+return Vp(t) - Vp(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31377,7 +31404,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : Hp(e);
+} : qp(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31466,9 +31493,9 @@ type: "idle"
 }
 };
 
-function Vp(e, t) {
+function zp(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Wp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Yp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31476,24 +31503,24 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function qp(e) {
+function Qp(e) {
 var t;
-return (null !== (t = Yp[e.memory.role]) && void 0 !== t ? t : Fp)(e);
+return (null !== (t = jp[e.memory.role]) && void 0 !== t ? t : Kp)(e);
 }
 
-function jp(e) {
+function Xp(e) {
 var t = Nu(e);
-El(e, bl(t, ad), t);
+Sl(e, Ml(t, cd), t);
 }
 
-function zp(e) {
+function Zp(e) {
 var t = Nu(e);
-El(e, bl(t, qp, {
-interrupt: Vp
+Sl(e, Ml(t, Qp, {
+interrupt: zp
 }), t);
 }
 
-function Qp(e) {
+function Jp(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31534,8 +31561,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Hd.has(i) && V(s))) {
-Bd.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && qd.has(i) && V(s))) {
+Hd.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31600,7 +31627,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Wd(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Yd(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31610,7 +31637,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Wd(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Yd(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31621,7 +31648,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Wd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Yd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -31674,7 +31701,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Wd(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Yd(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -31716,7 +31743,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Wd(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Yd(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -31726,7 +31753,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Wd(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Yd(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -31734,7 +31761,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && j(e.room).length > 0) {
 var o = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Wd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Yd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -31746,7 +31773,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Wd(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Yd(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -31754,12 +31781,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Wd(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Yd(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Wd(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Yd(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -31793,18 +31820,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function Xp(e) {
+function $p(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var Zp = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), Jp = -1, $p = Object.create(null);
+var ef = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), tf = -1, rf = Object.create(null);
 
-function ef(e) {
+function of(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var tf = {
+var nf = {
 harvester: ha.CRITICAL,
 queenCarrier: ha.CRITICAL,
 hauler: ha.HIGH,
@@ -31839,12 +31866,12 @@ labTech: ha.IDLE,
 factoryWorker: ha.IDLE
 };
 
-function rf(e) {
+function af(e) {
 var t;
-return null !== (t = tf[e]) && void 0 !== t ? t : ha.MEDIUM;
+return null !== (t = nf[e]) && void 0 !== t ? t : ha.MEDIUM;
 }
 
-function of(e) {
+function sf(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -31860,20 +31887,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && ef(o) === e && t++;
+o && of(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (Jp !== Game.time && (Jp = Game.time, $p = function() {
+}(e) : null !== (r = (tf !== Game.time && (tf = Game.time, rf = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = ef(o);
+var n = of(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), $p)[e]) && void 0 !== r ? r : 0;
+}()), rf)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Ue().cpu.disableCreepBootstrapCountCache
@@ -31883,7 +31910,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!Zp.has(t.role)) return !1;
+if (!ef.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -31893,7 +31920,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Xp(r)) return !1;
+if (!r || !$p(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -31907,7 +31934,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Xp(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !$p(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -31915,7 +31942,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Xp(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !$p(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -31923,7 +31950,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Xp(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !$p(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -31931,7 +31958,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && Xp(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && $p(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -31947,7 +31974,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Xp(r)) return !1;
+if (!r || !$p(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -31988,28 +32015,28 @@ case "economy":
 default:
 !function(e) {
 var t = Nu(e);
-El(e, bl(t, ad), t);
+Sl(e, Ml(t, cd), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
 var t = Nu(e);
-El(e, bl(t, Fd), t);
+Sl(e, Ml(t, Kd), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
 var t = Nu(e);
-El(e, bl(t, qp), t);
+Sl(e, Ml(t, Qp), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
 var t = Nu(e);
-El(e, bl(t, Vd), t);
+Sl(e, Ml(t, zd), t);
 }(e);
 }
 });
@@ -32030,7 +32057,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var nf = function() {
+var cf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32071,7 +32098,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = rf(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = af(r), n = "creep:".concat(e.name);
 Ja.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -32087,7 +32114,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && of(t);
+t && !t.spawning && sf(t);
 }
 }), this.registeredCreeps.add(e.name), Ci.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32112,7 +32139,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = rf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = af(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32137,20 +32164,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), af = new nf;
+}(), uf = new cf;
 
-function sf(e) {
+function lf(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, cf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, mf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function cf(e) {
+function mf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function uf(e) {
+function df(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32163,14 +32190,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function lf(e, t) {
+function pf(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var mf = {
+var ff = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32198,11 +32225,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function df(e, t) {
+function yf(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function pf(e) {
+function vf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32212,9 +32239,9 @@ tick: Game.time
 }, a;
 }
 
-var ff = [ "defense", "war", "expand", "siege" ];
+var gf = [ "defense", "war", "expand", "siege" ];
 
-function yf(e) {
+function hf(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32227,11 +32254,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function vf(e, t, r) {
-t >= 2 && (e.pheromones.war = df(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = df(e.pheromones.siege + 20, r));
+function Rf(e, t, r) {
+t >= 2 && (e.pheromones.war = yf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = yf(e.pheromones.siege + 20, r));
 }
 
-var gf = function() {
+var Ef = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32246,27 +32273,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), hf = function() {
+}(), Tf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, mf), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, ff), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new gf(10),
-energySpawning: new gf(10),
-energyConstruction: new gf(10),
-energyRepair: new gf(10),
-energyTower: new gf(10),
-controllerProgress: new gf(10),
-hostileCount: new gf(5),
-damageReceived: new gf(5),
-idleWorkers: new gf(10),
+energyHarvested: new Ef(10),
+energySpawning: new Ef(10),
+energyConstruction: new Ef(10),
+energyRepair: new Ef(10),
+energyTower: new Ef(10),
+controllerProgress: new Ef(10),
+hostileCount: new Ef(5),
+damageReceived: new Ef(5),
+idleWorkers: new Ef(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = pf(e);
+var o = vf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32339,7 +32366,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = df(e[s] * c, t);
+e[s] = yf(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32355,43 +32382,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = pf(t);
+var o = vf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = df(e.harvest + n / 3e3 * 10, r);
+e.harvest = yf(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = df(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = yf(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = df(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = yf(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = df(e.defense + 10 * o, r));
+o > 0 && (e.defense = yf(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = df(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = df(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = yf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = yf(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = df(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = yf(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = df(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = yf(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = df(e.pheromones.defense + 5 * t, o), vf(e, r, o),
+e.danger = r, e.pheromones.defense = yf(e.pheromones.defense + 5 * t, o), Rf(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32399,7 +32426,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = df(t / 10, o), vf(e, r, o);
+e.danger = r, e.pheromones.defense = yf(t / 10, o), Rf(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32412,8 +32439,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = df(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = df(f + y, o);
+var p = yf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = yf(f + y, o);
 }
 }
 }
@@ -32432,18 +32459,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = df(e.pheromones.defense + 5, r), e.pheromones.build = df(e.pheromones.build + 10, r),
+e.pheromones.defense = yf(e.pheromones.defense + 5, r), e.pheromones.build = yf(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = df(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = yf(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = df(e.pheromones.siege + 50, t), e.pheromones.defense = df(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = yf(e.pheromones.siege + 50, t), e.pheromones.defense = yf(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = df(e.pheromones.expand - 10, t), e.pheromones.defense = df(e.pheromones.defense + 5, t);
+e.pheromones.expand = yf(e.pheromones.expand - 10, t), e.pheromones.defense = yf(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32453,10 +32480,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(yf(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(hf(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(ff)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(gf)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32510,7 +32537,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = df(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = yf(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32545,7 +32572,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), Rf = new hf, Ef = {
+}(), Cf = new Tf, Sf = {
 seedNest: {
 rcl: 1
 },
@@ -32586,7 +32613,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, Tf = {
+}, wf = {
 eco: {
 economy: .75,
 military: .05,
@@ -32629,7 +32656,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Cf = {
+}, xf = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -32686,13 +32713,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Sf = function() {
+}, bf = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Ef.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Ef.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Ef.fortifiedHive.rcl ? "fortifiedHive" : s >= Ef.matureColony.rcl ? "matureColony" : s >= Ef.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Sf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Sf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Sf.fortifiedHive.rcl ? "fortifiedHive" : s >= Sf.matureColony.rcl ? "matureColony" : s >= Sf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Fe.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -32727,7 +32754,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Ef[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Sf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -32740,7 +32767,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), wf = function() {
+}(), Of = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -32762,9 +32789,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return Tf[e];
+return wf[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return Cf[e];
+return xf[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -32774,15 +32801,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), xf = new Sf, bf = new wf;
+}(), Af = new bf, Mf = new Of;
 
-function Of(e) {
+function kf(e) {
 return !Y(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Af(e, t, r) {
+function Uf(e, t, r) {
 if (!e) return null;
 var o = mr.getEmpire();
 if (Y(e, {
@@ -32821,11 +32848,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Mf() {
+function _f() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var kf = new Map, Uf = function() {
+var Nf = new Map, Pf = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = j(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -32969,7 +32996,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: kf.get(e.name),
+previousStructures: Nf.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -32999,7 +33026,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && kf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Nf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33008,7 +33035,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Of(u) && o.add(u.owner.username);
+kf(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33022,7 +33049,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Af(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Uf(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33038,7 +33065,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? Rf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Rf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Rf.onNukeDetected(t);
+"danger" === y.type ? Cf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Cf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Cf.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33098,10 +33125,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Mf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = _f()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Mf()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = _f()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33144,7 +33171,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: bf.isCombatPosture(t.posture),
+isCombatPosture: Mf.isCombatPosture(t.posture),
 wallRepairTarget: so(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33168,27 +33195,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), _f = new Uf, Nf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), If = new Pf, Gf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Pf() {
+function Lf() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function If(e, t, r, o) {
+function Df(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Pf()
+selectedAt: Lf()
 });
 }
 
-function Gf(e) {
+function Ff(e) {
 return e >= 2 && e <= 3;
 }
 
-function Lf(e, t) {
+function Bf(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33201,10 +33228,10 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-var Df = function() {
+var Wf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Gf(e) ? 5 : 10;
+return Ff(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33905,7 +33932,7 @@ y: e.y - T.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-If(t, v, C.name, f);
+Df(t, v, C.name, f);
 var S = t.danger >= 1 && f >= 3 ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f, y, v, g;
 if (r <= 0) return 0;
@@ -34020,7 +34047,7 @@ var r, o, n, i = Vo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && Lf(e, u) < l) return !0;
+if (!(l <= 0) && Bf(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34036,8 +34063,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + g + h + S >= 10 && !w) t.metrics.constructionSites = p.length + g + h + S; else {
-if (!bf.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Pf());
+if (!Mf.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Lf());
 }(t, v)) {
 var x = function(e, t, r, o, n) {
 var i, s;
@@ -34195,7 +34222,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Nf.has(e.structureType);
+return Gf.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34204,7 +34231,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = Gf(f) ? 2 : 3;
+var M = Ff(f) ? 2 : 3;
 (A = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -34880,13 +34907,13 @@ anchor: l
 }
 return null;
 }(e, f);
-G && (If(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
+G && (Df(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), Ff = new Df;
+}(), Kf = new Wf;
 
-function Bf(e) {
+function Hf(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -34908,7 +34935,7 @@ siege: e.pheromones.siege
 };
 }
 
-var Wf = {
+var Yf = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -34921,10 +34948,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Kf = new (function() {
+}, Vf = new (function() {
 function e() {
 this.manager = new ou({
-logger: Wf
+logger: Yf
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -34934,23 +34961,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = Bf(t);
+var r = Hf(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = Bf(t);
+var r = Hf(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), Hf = {
+}()), qf = {
 labManager: Ru,
 boostManager: fu,
-chemistryPlanner: Kf,
+chemistryPlanner: Vf,
 labConfigManager: gu,
 logger: Ci
-}, Yf = function() {
+}, jf = function() {
 function e(e) {
-void 0 === e && (e = Hf), this.deps = e;
+void 0 === e && (e = qf), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -34989,9 +35016,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), Vf = new Yf, qf = function() {
+}(), zf = new jf, Qf = function() {
 function e(e) {
-void 0 === e && (e = Vf), this.labWorkflow = e;
+void 0 === e && (e = zf), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35036,27 +35063,27 @@ if (r) throw r.error;
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), jf = new qf, zf = {
+}(), Xf = new Qf, Zf = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, Qf = new Map;
+}, Jf = new Map;
 
-function Xf(e) {
+function $f(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function Zf(e) {
+function ey(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var Jf = function() {
+var ty = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, zf), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Zf), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35098,7 +35125,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = Qf.get(e.name);
+var t = Jf.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35120,28 +35147,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return Qf.set(e.name, o), o;
+return Jf.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Rf.updateMetrics(i, c),
-_f.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Cf.updateMetrics(i, c),
+If.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (xf.updateEvolutionStage(c, i, e),
-s || xf.updateMissingStructures(c, i)), bf.updatePosture(c), this.config.enablePheromones && !s && Rf.updatePheromones(c, i),
-this.config.enableTowers && _f.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Ff.getConstructionInterval(l), d = bf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Af.updateEvolutionStage(c, i, e),
+s || Af.updateMissingStructures(c, i)), Mf.updatePosture(c), this.config.enablePheromones && !s && Cf.updatePheromones(c, i),
+this.config.enableTowers && If.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Kf.getConstructionInterval(l), d = Mf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = Xf(r), n = Zf(e);
+var o = $f(r), n = ey(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Ff.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (Kf.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = Xf(r), n = Zf(e);
+var o = $f(r), n = ey(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && jf.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && Xf.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35151,7 +35178,7 @@ var f = Game.cpu.getUsed() - n;
 Ji.recordRoom(i, f), Ji.endRoom(this.roomName, n);
 } else Ji.endRoom(this.roomName, n);
 }, e;
-}(), $f = function() {
+}(), ry = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35165,7 +35192,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new Jf(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new ty(v.name));
 }
 } catch (t) {
 e = {
@@ -35228,7 +35255,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new Jf(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new ty(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35249,9 +35276,9 @@ stack: c
 }
 }
 }, e;
-}(), ey = new $f;
+}(), oy = new ry;
 
-function ty(e) {
+function ny(e) {
 var t, r, o;
 if (j(e).length > 0) return ha.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
@@ -35262,14 +35289,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
 }
 
-function ry(e) {
+function ay(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function oy(e, t, r) {
+function iy(e, t, r) {
 var o;
 return t === ha.CRITICAL ? {
 tickModulo: void 0,
@@ -35289,7 +35316,7 @@ tickOffset: void 0
 };
 }
 
-var ny, ay = function() {
+var sy, cy = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35305,7 +35332,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = ty(n), u = ry(n);
+var i = "room:".concat(o), s = Ja.getProcess(i), c = ny(n), u = ay(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35324,7 +35351,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = ty(e), o = ry(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = oy(e, r, a);
+var t, r = ny(e), o = ay(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = iy(e, r, a);
 Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35341,7 +35368,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ey.runRoom(t);
+t && oy.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35349,7 +35376,7 @@ Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = oy(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = iy(e, t, a);
 Ja.unregisterProcess(n), Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35366,7 +35393,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ey.runRoom(t);
+t && oy.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35388,7 +35415,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = ty(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = ny(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35415,7 +35442,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), iy = new ay, sy = function() {
+}(), uy = new cy, ly = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Ja.getStatsSummary(), t = Ja.getConfig();
@@ -35492,11 +35519,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(uf(e.summary.byLayer)), "Groups: ".concat(uf(e.summary.byGroup)), "States: ".concat(uf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(df(e.summary.byLayer)), "Groups: ".concat(df(e.summary.byGroup)), "States: ".concat(df(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(lf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(pf)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(sf(m));
+c.push(lf(m));
 }
 } catch (e) {
 t = {
@@ -35595,7 +35622,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = af.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = uf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35614,7 +35641,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = iy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = uy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35761,7 +35788,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), cy = function() {
+}(), my = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -35794,7 +35821,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), uy = function() {
+}(), dy = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36319,7 +36346,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), ly = function() {
+}(), py = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36338,22 +36365,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), my = function() {
+}(), fy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? fl.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? gl.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? fl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? gl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return fl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return gl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ Tt({
 name: "tasks",
 description: "Show room creep task queue",
@@ -36373,21 +36400,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), dy = ((ny = {})[MOVE] = 50, ny[WORK] = 100, ny[CARRY] = 50, ny[ATTACK] = 80,
-ny[RANGED_ATTACK] = 150, ny[HEAL] = 250, ny[CLAIM] = 600, ny[TOUGH] = 10, ny);
+}(), yy = ((sy = {})[MOVE] = 50, sy[WORK] = 100, sy[CARRY] = 50, sy[ATTACK] = 80,
+sy[RANGED_ATTACK] = 150, sy[HEAL] = 250, sy[CLAIM] = 600, sy[TOUGH] = 10, sy);
 
-function py(e, t) {
+function vy(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, dy), t);
+var r = o(o({}, yy), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : dy[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : yy[t]);
 }, 0);
 }
 
-function fy(e, t) {
+function gy(e, t) {
 void 0 === t && (t = 0);
-var r = py(e);
+var r = vy(e);
 return {
 parts: e,
 cost: r,
@@ -36395,7 +36422,7 @@ minCapacity: t || r
 };
 }
 
-function yy() {
+function hy() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36403,11 +36430,11 @@ return Array(o).fill(r);
 });
 }
 
-var vy, gy, hy, Ry = {
+var Ry, Ey, Ty, Cy = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ fy([ WORK, CARRY ], 150), fy([ WORK, CARRY, MOVE ], 200), fy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), fy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), fy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ gy([ WORK, CARRY ], 150), gy([ WORK, CARRY, MOVE ], 200), gy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), gy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), gy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36415,7 +36442,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ fy([ WORK, CARRY, MOVE ], 200), fy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), fy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), fy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ gy([ WORK, CARRY, MOVE ], 200), gy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), gy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), gy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36423,7 +36450,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ fy([ WORK, CARRY, MOVE, MOVE ], 250), fy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ gy([ WORK, CARRY, MOVE, MOVE ], 250), gy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36431,7 +36458,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ fy([ WORK, CARRY, MOVE ], 200), fy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), fy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), fy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), fy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ gy([ WORK, CARRY, MOVE ], 200), gy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), gy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), gy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), gy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36439,7 +36466,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ fy([ CARRY, CARRY, MOVE, MOVE ], 200), fy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), fy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ gy([ CARRY, CARRY, MOVE, MOVE ], 200), gy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), gy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36447,7 +36474,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ fy([ WORK, CARRY, MOVE ], 200), fy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), fy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), fy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ gy([ WORK, CARRY, MOVE ], 200), gy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), gy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), gy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36455,7 +36482,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ fy([ WORK, CARRY, MOVE, MOVE ], 250), fy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), fy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ gy([ WORK, CARRY, MOVE, MOVE ], 250), gy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), gy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36463,7 +36490,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ fy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ gy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36471,7 +36498,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ fy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), fy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ gy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), gy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36479,7 +36506,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ fy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ gy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36487,7 +36514,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ fy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ gy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36495,7 +36522,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ fy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), fy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), fy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), fy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ gy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), gy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), gy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), gy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36503,7 +36530,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ fy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), fy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ gy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), gy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36511,7 +36538,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ fy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), fy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ gy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), gy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36519,16 +36546,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ fy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), fy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), fy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), fy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ gy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), gy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), gy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), gy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Ey = {
+}, Sy = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ fy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), fy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), fy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), fy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ gy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), gy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), gy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), gy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36536,7 +36563,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ fy([ TOUGH, ATTACK, MOVE, MOVE ], 190), fy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), fy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ gy([ TOUGH, ATTACK, MOVE, MOVE ], 190), gy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), gy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36544,7 +36571,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ fy([ HEAL, MOVE, MOVE ], 350), fy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), fy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), fy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ gy([ HEAL, MOVE, MOVE ], 350), gy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), gy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), gy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36552,7 +36579,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ fy([ ATTACK, ATTACK, MOVE, MOVE ], 260), fy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), fy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ gy([ ATTACK, ATTACK, MOVE, MOVE ], 260), gy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), gy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36560,7 +36587,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ fy([ WORK, WORK, MOVE, MOVE ], 300), fy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), fy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ gy([ WORK, WORK, MOVE, MOVE ], 300), gy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), gy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36568,7 +36595,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ fy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), fy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), fy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), fy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ gy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), gy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), gy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), gy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36576,16 +36603,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ fy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), fy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), fy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ gy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), gy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), gy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Ty = {
+}, wy = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ fy(yy([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), fy(yy([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ gy(hy([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), gy(hy([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36593,16 +36620,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ fy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), fy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ gy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), gy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Cy = {
+}, xy = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ fy([ MOVE ], 50) ],
+bodies: [ gy([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36610,7 +36637,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ fy([ MOVE ], 50) ],
+bodies: [ gy([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36618,7 +36645,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ fy([ CLAIM, MOVE ], 650) ],
+bodies: [ gy([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36626,7 +36653,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ fy([ CLAIM, MOVE ], 650), fy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ gy([ CLAIM, MOVE ], 650), gy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36634,7 +36661,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ fy([ WORK, CARRY, MOVE, MOVE ], 250), fy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ gy([ WORK, CARRY, MOVE, MOVE ], 250), gy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36642,30 +36669,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ fy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), fy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ gy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), gy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Sy = o(o(o(o({}, Ry), Ey), Cy), Ty);
+}, by = o(o(o(o({}, Cy), Sy), xy), wy);
 
 try {
-for (var wy = a(Object.values(Sy)), xy = wy.next(); !xy.done; xy = wy.next()) xy.value.bodies.sort(function(e, t) {
+for (var Oy = a(Object.values(by)), Ay = Oy.next(); !Ay.done; Ay = Oy.next()) Ay.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-vy = {
+Ry = {
 error: e
 };
 } finally {
 try {
-xy && !xy.done && (gy = wy.return) && gy.call(wy);
+Ay && !Ay.done && (Ey = Oy.return) && Ey.call(Oy);
 } finally {
-if (vy) throw vy.error;
+if (Ry) throw Ry.error;
 }
 }
 
-function by(e) {
+function My(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36680,11 +36707,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Oy(o);
+return ky(o);
 }
 
-function Oy(e) {
-var t = py(e);
+function ky(e) {
+var t = vy(e);
 return {
 parts: e,
 cost: t,
@@ -36692,16 +36719,16 @@ minCapacity: t
 };
 }
 
-function Ay(e, t) {
+function Uy(e, t) {
 var r;
-return null !== (r = e.map(Oy).filter(function(e) {
+return null !== (r = e.map(ky).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function My(e) {
+function _y(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36715,7 +36742,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = py(a);
+var s = vy(a);
 return {
 parts: a,
 cost: s,
@@ -36740,8 +36767,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: py(p),
-minCapacity: py(p)
+cost: vy(p),
+minCapacity: vy(p)
 };
 }(e);
 
@@ -36752,7 +36779,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return by([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return My([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -36773,7 +36800,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return by([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return My([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -36782,13 +36809,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Oy).filter(function(e) {
+var u = n.map(ky).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Ay(n, t);
+var l = Uy(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -36798,7 +36825,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Ay(n, t);
+var u = Uy(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -36807,14 +36834,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Ay(r, t);
+var a = Uy(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function ky(e) {
+function Ny(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -36825,9 +36852,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Uy(e, t) {
+function Py(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: ky(t)
+memory: Ny(t)
 });
 var r;
 }
@@ -36835,9 +36862,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(hy || (hy = {}));
+}(Ty || (Ty = {}));
 
-var _y = function() {
+var Iy = function() {
 function e() {
 this.queues = new Map;
 }
@@ -36932,7 +36959,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Uy(m, d);
+var p = Py(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -36952,7 +36979,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= hy.EMERGENCY;
+return e.priority >= Ty.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -36970,7 +36997,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= hy.EMERGENCY ? n.emergency++ : c.priority >= hy.HIGH ? n.high++ : c.priority >= hy.NORMAL ? n.normal++ : n.low++;
+c.priority >= Ty.EMERGENCY ? n.emergency++ : c.priority >= Ty.HIGH ? n.high++ : c.priority >= Ty.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -36985,14 +37012,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Ny = new _y, Py = {
+}(), Gy = new Iy, Ly = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Iy = {
+}, Dy = {
 predictConsumption: function() {
 return 0;
 },
@@ -37011,7 +37038,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Gy = {
+}, Fy = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37028,44 +37055,44 @@ healers: 0,
 powerCarriers: 0
 };
 }
-}, Ly = {
+}, By = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Dy(e, t, r, o, n) {
+function Wy(e, t, r, o, n) {
 return rc(e, t, r, o, n);
 }
 
-var Fy = new Map, By = -1, Wy = null;
+var Ky = new Map, Hy = -1, Yy = null;
 
-function Ky() {
-By === Game.time && Wy === Game.creeps || (Fy.clear(), By = Game.time, Wy = Game.creeps);
+function Vy() {
+Hy === Game.time && Yy === Game.creeps || (Ky.clear(), Hy = Game.time, Yy = Game.creeps);
 }
 
-function Hy(e) {
+function qy(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Yy(e, t) {
+function jy(e, t) {
 var r;
-void 0 === t && (t = !1), Ky();
-var o = t ? "".concat(e, "_active") : e, n = Fy.get(o);
+void 0 === t && (t = !1), Vy();
+var o = t ? "".concat(e, "_active") : e, n = Ky.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Hy(c);
+var u = qy(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Fy.set(o, a), a;
+return Ky.set(o, a), a;
 }
 
-function Vy(e, t, r) {
+function zy(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37086,22 +37113,22 @@ if (o) throw o.error;
 return i;
 }
 
-function qy(e) {
+function Qy(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var jy = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var Xy = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function zy(e) {
-return jy.includes(e);
+function Zy(e) {
+return Xy.includes(e);
 }
 
-function Qy(e) {
+function Jy(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Xy(e, t, r, o) {
+function $y(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37114,10 +37141,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Dy(e, t, ze(r).length, o, {
-reserved: Qy(r)
+if (r) return Wy(e, t, ze(r).length, o, {
+reserved: Jy(r)
 }).recommendedHaulers;
-var n = Dy(e, t, 2, o, {
+var n = Wy(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37128,7 +37155,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: qy
+filter: Qy
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37139,7 +37166,7 @@ return 2;
 }
 }
 
-function Zy(e, t) {
+function ev(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37149,13 +37176,13 @@ return null;
 }
 }
 
-function Jy() {
+function tv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function $y(e) {
-var t = Jy(), r = function(e) {
+function rv(e) {
+var t = tv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37167,14 +37194,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function ev(e) {
+function ov(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Jy();
+var r = tv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function tv(e) {
+function nv(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37182,11 +37209,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function rv(e) {
+function av(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function ov() {
+function iv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37196,7 +37223,7 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-function nv(e, t) {
+function sv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37208,8 +37235,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(ov()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Ny.getPendingRequests(c).some(function(r) {
+for (var i = a(iv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Gy.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37229,7 +37256,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function av(e, t) {
+function cv(e, t) {
 var r, o, n, c = mr.getEmpire(), u = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37239,15 +37266,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !nv(e.roomName, "claim");
+return !sv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || tv(t));
+return !(!r || r.my || r.owner || r.reservation || nv(t));
 }
-return !ev(e);
+return !ov(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37266,7 +37293,7 @@ return e.roomName;
 })), !1)) : new Set;
 if (l) {
 var p = c.claimQueue.find(function(e) {
-return !e.claimed && !nv(e.roomName, "claim");
+return !e.claimed && !sv(e.roomName, "claim");
 });
 if (p) return {
 targetRoom: p.roomName,
@@ -37278,20 +37305,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Jy();
+var l = tv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !nv(p, "claim")) {
+if (!t.has(p) && !sv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || $y(y)) continue;
-if (tv(f)) continue;
+if (y.owner || rv(y)) continue;
+if (nv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !nv(p, "reserve")) return p;
-} else if (!ev(p) && !nv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !sv(p, "reserve")) return p;
+} else if (!ov(p) && !sv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37313,34 +37340,34 @@ task: "reserve"
 } : null;
 }
 
-function iv(e) {
+function uv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function sv(e) {
-return iv(e) ? hy.EMERGENCY : hy.HIGH;
+function lv(e) {
+return uv(e) ? Ty.EMERGENCY : Ty.HIGH;
 }
 
-function cv(e, t, r) {
+function mv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!rv(e)) return !1;
+if (!av(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function uv(e, t, r) {
+function dv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return cv(e, t, r);
+return mv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Zy(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = ev(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37348,18 +37375,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function lv(e, t) {
+function pv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !cv(n, e, t)) return null;
+if (!n || !mv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !rv(e);
+return !av(e);
 }).filter(function(e) {
-return !tv(e);
+return !nv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37380,9 +37407,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(ov()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(iv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Ny.getPendingRequests(d).filter(function(t) {
+i += Gy.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37399,12 +37426,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (iv(e) ? 3 : 1);
+}(e.name) < (uv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Zy(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = ev(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37412,10 +37439,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (uv(u.room, e, t) === e) return {
+if (dv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: sv(u.room)
+priority: lv(u.room)
 };
 }
 } catch (e) {
@@ -37432,10 +37459,10 @@ if (r) throw r.error;
 return null;
 }
 
-function mv(e, t) {
+function fv(e, t) {
 if (t <= 0) return null;
 try {
-var r = My({
+var r = _y({
 maxEnergy: t,
 role: e
 });
@@ -37445,18 +37472,18 @@ return null;
 }
 }
 
-function dv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : mv(e, t);
+function yv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : fv(e, t);
 }
 
-function pv(e) {
+function vv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function fv(e) {
+function gv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37470,7 +37497,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += pv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += vv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37491,7 +37518,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += pv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += vv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37507,23 +37534,23 @@ return i;
 }(e)) : r;
 }
 
-var yv = "defenseAssist", vv = [ "guard", "ranger", "healer" ];
+var hv = "defenseAssist", Rv = [ "guard", "ranger", "healer" ];
 
-function gv(e, t) {
+function Ev(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function hv(e, t, r, o) {
+function Tv(e, t, r, o) {
 void 0 === o && (o = kr(e.roomName));
-var n = gv(e, t);
+var n = Ev(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = Cv(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, gv(e, "guard") - i.guard),
-ranger: Math.max(0, gv(e, "ranger") - i.ranger),
-healer: Math.max(0, gv(e, "healer") - i.healer)
-}, wv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = xv(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, Ev(e, "guard") - i.guard),
+ranger: Math.max(0, Ev(e, "ranger") - i.ranger),
+healer: Math.max(0, Ev(e, "healer") - i.healer)
+}, Ov(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37538,7 +37565,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && xv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Av(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37556,30 +37583,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function Rv(e) {
+function Cv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function Ev(e) {
+function Sv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === yv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === hv ? e.targetRoom : void 0;
 }
 
-function Tv(e, t) {
-var r = kr(e.roomName), o = Cv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, gv(e, "guard") - o.guard),
-ranger: Math.max(0, gv(e, "ranger") - o.ranger),
-healer: Math.max(0, gv(e, "healer") - o.healer)
-}, wv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function wv(e, t) {
+var r = kr(e.roomName), o = xv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, Ev(e, "guard") - o.guard),
+ranger: Math.max(0, Ev(e, "ranger") - o.ranger),
+healer: Math.max(0, Ev(e, "healer") - o.healer)
+}, Ov(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = vv.filter(function(o) {
-return !(hv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = Rv.filter(function(o) {
+return !(Tv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function Cv(e) {
+function xv(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37588,7 +37615,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && Ev(d) === e && u[p]++;
+Br(p) && Sv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37602,9 +37629,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Ny.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Gy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === yv && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === hv && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37620,21 +37647,21 @@ if (o) throw o.error;
 return u;
 }
 
-function Sv(e, t, r) {
+function bv(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function wv(e) {
+function Ov(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && Ev(f) === e) {
+if (Br(y) && Sv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && Sv(l, y, v);
+v.length > 0 && bv(l, y, v);
 }
 }
 } catch (e) {
@@ -37649,9 +37676,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Ny.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Gy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === yv && E.targetRoom === e) && Sv(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === hv && E.targetRoom === e) && bv(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37667,27 +37694,27 @@ if (o) throw o.error;
 return l;
 }
 
-function xv(e) {
+function Av(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function bv(e, t, r) {
+function Mv(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function Ov(e, t, r, o) {
+function kv(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && dv("guard", fv(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && yv("guard", gv(r), o) ? 1 : 0;
 }
 
-function Av(e, t) {
+function Uv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !xv(o)) return null;
+if (!o || !Av(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -37712,7 +37739,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Rv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Cv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -37720,15 +37747,15 @@ return t.roomName !== e;
 var r = kr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(hv(e, t, n, r), Ov(e, t, o, r))
+helperNeed: Math.max(Tv(e, t, n, r), kv(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return Rv(e.request);
+return Cv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? Cv(e)[t] : 0;
+return Br(t) ? xv(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37753,28 +37780,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: yv,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? hy.EMERGENCY : hy.HIGH,
-defenseSquadId: bv(e, r, n.createdAt),
-defenseSquadSize: Tv(r, t),
+task: hv,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Ty.EMERGENCY : Ty.HIGH,
+defenseSquadId: Mv(e, r, n.createdAt),
+defenseSquadSize: wv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var Mv = "defenseRefuel", kv = {
+var _v = "defenseRefuel", Nv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Uv(e, t) {
+function Pv(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < kv.cost);
-}(n) ? fv(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Nv.cost);
+}(n) ? gv(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -37811,9 +37838,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Ny.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Gy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Mv && s++;
+"hauler" === p.role && f === _v && s++;
 }
 } catch (e) {
 o = {
@@ -37828,24 +37855,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Mv,
-priority: hy.EMERGENCY,
-body: kv
+task: _v,
+priority: Ty.EMERGENCY,
+body: Nv
 } : null : null;
 }
 
-function _v(e) {
+function Iv(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !$y(t.controller) && !tv(t) : !ev(e);
+return t ? !!t.controller && !rv(t.controller) && !nv(t) : !ov(e);
 }
 
-function Nv(e) {
+function Gv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !$y(t.controller) : !ev(e);
+return (null == t ? void 0 : t.controller) ? !rv(t.controller) : !ov(e);
 }
 
-function Pv(e, t, r) {
-var o = Sy[t];
+function Lv(e, t, r) {
+var o = by[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -37857,13 +37884,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Iv(e, t, r) {
+function Dv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (_v(l) && Vy(e, t, l) < Xy(e, l, t, Game.rooms[l])) return l;
+if (Iv(l) && zy(e, t, l) < $y(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37879,10 +37906,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Gv(e, t, r, o) {
+function Fv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Sy[t];
+var p = by[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -37896,32 +37923,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Sy[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Sy[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = by[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = by[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Yy(e), y)) return !1;
+}(t, jy(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (zy(t)) return !("remoteWorker" === t && function(e, t) {
-Ky();
-var r = "".concat(e, ":").concat(t), o = Fy.get(r);
+if (Zy(t)) return !("remoteWorker" === t && function(e, t) {
+Vy();
+var r = "".concat(e, ":").concat(t), o = Ky.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Fy.set(r, n), n;
-}(e, t) >= Pv(e, t, r)) && null !== Iv(e, t, r);
+return Ky.set(r, n), n;
+}(e, t) >= Lv(e, t, r)) && null !== Dv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Nv(R)) {
+if (Gv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -37929,7 +37956,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && Vy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && zy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -37946,9 +37973,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Yy(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== lv(e, r);
-if (C >= Pv(e, t, r)) return !1;
+var C = null !== (u = jy(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== pv(e, r);
+if (C >= Lv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -37960,14 +37987,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = Zy(e, o);
+var a = ev(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== av(0, r);
+if ("claimer" === t) return null !== cv(0, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38003,7 +38030,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Py.getActiveRequests) || void 0 === m ? void 0 : m.call(Py)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = Ly.getActiveRequests) || void 0 === m ? void 0 : m.call(Ly)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38031,16 +38058,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Lv(e) {
+function Bv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Dv(e) {
-return 0 === Lv(Yy(e, !0));
+function Wv(e) {
+return 0 === Bv(jy(e, !0));
 }
 
-function Fv(e) {
+function Kv(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -38063,14 +38090,14 @@ minCount: 1
 } ];
 }
 
-function Bv(e, t) {
-var r, o, n, i, s = Yy(e, !0);
-if (0 === Lv(s)) return !0;
+function Hv(e, t) {
+var r, o, n, i, s = jy(e, !0);
+if (0 === Bv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Yy(e, !1), u = Fv(t);
+var c = jy(e, !1), u = Kv(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38090,57 +38117,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function Wv(e) {
+function Yv(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Kv(e, t, r) {
-var n = Pv(e.name, r.roleName, t);
+function Vv(e, t, r) {
+var n = Lv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Hv(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return hy.EMERGENCY;
+function qv(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Ty.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return hy.HIGH;
-if (Ly.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Ty.HIGH;
+if (By.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return hy.EMERGENCY;
-if (a > 0) return hy.HIGH;
+if (a >= 100) return Ty.EMERGENCY;
+if (a > 0) return Ty.HIGH;
 }
 return function(e) {
-return e >= 90 ? hy.HIGH : e >= 60 ? hy.NORMAL : hy.LOW;
+return e >= 90 ? Ty.HIGH : e >= 60 ? Ty.NORMAL : Ty.LOW;
 }(o);
 }
 
-function Yv(e, t) {
+function jv(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-Wv(e);
-var l = Yy(e.name), m = Dv(e.name), d = [];
-if (Bv(e.name, e)) {
+Yv(e);
+var l = jy(e.name), m = Wv(e.name), d = [];
+if (Hv(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Lv(Yy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Bv(jy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Yy(e, !1), c = Fv(t);
+var s = jy(e, !1), c = Kv(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38155,7 +38182,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Gv(e, m.role, r, !0);
+var p = Fv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38186,17 +38213,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = Sy[p]) && Gv(e.name, p, t, !0) ? (d.push(Kv(e, t, {
+return p && (g = by[p]) && Fv(e.name, p, t, !0) ? (d.push(Vv(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: Hv(e, 0, p, g.priority, m),
+priority: qv(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(Sy)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Uv(e.name, p);
+for (var f = a(Object.entries(by)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Pv(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38207,7 +38234,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Av(e.name, p);
+var E = Uv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38221,8 +38248,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Gv(e.name, p, t, m)) {
-var T = zy(p), C = T ? Iv(e.name, p, t) : null, S = "claimer" === p ? av(e.name, t) : null, w = "pioneer" === p ? lv(e.name, t) : null;
+}); else if (Fv(e.name, p, t, m)) {
+var T = Zy(p), C = T ? Dv(e.name, p, t) : null, S = "claimer" === p ? cv(e.name, t) : null, w = "pioneer" === p ? pv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38232,11 +38259,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(Kv(e, t, {
+}) : d.push(Vv(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: Hv(e, 0, p, g.priority, m),
+priority: qv(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38258,7 +38285,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Vv(e, l.value);
+var m = zv(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38279,10 +38306,10 @@ requests: c
 };
 }
 
-function Vv(e, t) {
+function zv(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Iy.getMaxAffordableInTicks(e, l), d = fv(e), p = t.priority >= hy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= hy.EMERGENCY, g = t.assistTarget ? kr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : dv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Dy.getMaxAffordableInTicks(e, l), d = gv(e), p = t.priority >= Ty.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Ty.EMERGENCY, g = t.assistTarget ? kr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : yv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38303,7 +38330,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : My({
+}(t.def, p)) && void 0 !== c ? c : _y({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38339,44 +38366,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var qv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), jv = new Set([ "guard", "ranger", "healer" ]);
+var Qv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Xv = new Set([ "guard", "ranger", "healer" ]);
 
-function zv() {
+function Zv() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Qv(e) {
+function Jv(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Xv(e) {
+function $v(e) {
 var t;
-return e.priority >= hy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Ty.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Zv(e) {
+function eg(e) {
 var t;
-return e.priority >= hy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Ty.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Jv(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = fv(e), m = r.urgency >= 2 || t.danger >= 3 ? hy.EMERGENCY : hy.HIGH, d = Mr(j(e)), p = function(e) {
+function tg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = gv(e), m = r.urgency >= 2 || t.danger >= 3 ? Ty.EMERGENCY : Ty.HIGH, d = Mr(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === hy.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === Ty.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Ny.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Gy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || $v(u, e) && ("guard" === u.role && (n.guards++,
-tg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, tg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, tg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || rg(u, e) && ("guard" === u.role && (n.guards++,
+ng(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, ng(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, ng(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38404,7 +38431,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && tg(n, u, l);
+0 !== l.length && ng(n, u, l);
 }
 }
 }
@@ -38443,26 +38470,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : eg("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) rg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : eg("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) rg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : eg("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) rg(e, "healer", "military", hy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : og("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) ag(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : og("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) ag(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : og("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) ag(e, "healer", "military", Ty.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < hy.EMERGENCY || function(e, t) {
+if (!(t < Ty.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !jv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Xv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Ny.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Gy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < hy.EMERGENCY || jv.has(c.role) && $v(c, e.name) && c.body.cost <= t && n++;
+c.priority < Ty.EMERGENCY || Xv.has(c.role) && rg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38479,7 +38506,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = mv(t, e);
+var r = fv(t, e);
 return r ? {
 role: t,
 body: r
@@ -38494,38 +38521,38 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && rg(e, n.role, "military", hy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && ag(e, n.role, "military", Ty.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function $v(e, t) {
+function rg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function eg(e, t, r) {
+function og(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function tg(e, t, r) {
+function ng(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function rg(e, t, r, o, n, a, i) {
+function ag(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
-var s = null != i ? i : My({
+var s = null != i ? i : _y({
 maxEnergy: n,
 role: t
 });
 if (s.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(s.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Ny.addRequest({
+Gy.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38541,34 +38568,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function og(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= hy.HIGH) return !1;
+function ig(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Ty.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < hy.NORMAL) {
-if (Iy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Ty.NORMAL) {
+if (Dy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === hy.NORMAL && o / e.energyCapacityAvailable < .3 && Iy.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Ty.NORMAL && o / e.energyCapacityAvailable < .3 && Dy.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function ng(e, t) {
+function sg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Wv(e);
-var s = Ny.getQueueSize(e.name);
+Yv(e);
+var s = Gy.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Bv(e.name, e), u = Dv(e.name) && !Ny.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = Hv(e.name, e), u = Wv(e.name) && !Gy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && Ny.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Jv(e, t, l, m);
+s > 0 && Gy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && tg(e, t, l, m);
 try {
-for (var d = a(Yv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(jv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Ny.addRequest(f);
+Gy.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38581,7 +38608,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Jv(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && tg(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38590,13 +38617,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Ny.getPendingRequests(e.name).map(Qv));
+var c = new Set(Gy.getPendingRequests(e.name).map(Jv));
 try {
-for (var u = a(Yv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= hy.HIGH, p = "claimer" === m.role && zv(), f = Xv(m), y = Zv(m);
-if (qv.has(m.role) || d || p || f || y) {
-var v = Qv(m);
-c.has(v) || (Ny.addRequest(m), c.add(v));
+for (var u = a(jv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Ty.HIGH, p = "claimer" === m.role && Zv(), f = $v(m), y = eg(m);
+if (Qv.has(m.role) || d || p || f || y) {
+var v = Jv(m);
+c.has(v) || (Gy.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38613,19 +38640,19 @@ if (r) throw r.error;
 }
 }(e, t); else {
 !function(e) {
-var t = Gy.requestSpawns(e.name);
+var t = Fy.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = hy.NORMAL, n = 0; n < t.powerHarvesters; n++) rg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) rg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) rg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = Ty.NORMAL, n = 0; n < t.powerHarvesters; n++) ag(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) ag(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) ag(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a(Yv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Ny.addRequest(f);
+for (var y = a(jv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Gy.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38637,32 +38664,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Ny.getQueueStats(e.name);
+var g = Gy.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Ny.clearQueue(e.name);
+} else s > 0 && Gy.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Ny.getAvailableSpawns(e.name);
+var t, r, o = Gy.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = fv(e);
+var n = 0, i = gv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Ny.getNextRequest(e.name, i);
+var u = c.value, l = Gy.getNextRequest(e.name, i);
 if (!l) break;
-if (og(e, l, i)) {
+if (ig(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Uy(u, l);
-m === OK ? (n++, i -= l.body.cost, Ny.markInProgress(e.name, l.id, u.id), Ny.removeRequest(e.name, l.id),
+var m = Py(u, l);
+m === OK ? (n++, i -= l.body.cost, Gy.markInProgress(e.name, l.id, u.id), Gy.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Ny.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Gy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -38678,7 +38705,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Ny.getQueueStats(e.name);
+}(e), o = Gy.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -38692,7 +38719,7 @@ stats: o
 }(e, t);
 }
 
-var ag = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, ig = /^(\d{1,2})\|(.+)$/, sg = M("SS2TerminalComms"), cg = function() {
+var cg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, ug = /^(\d{1,2})\|(.+)$/, lg = M("SS2TerminalComms"), mg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38752,11 +38779,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(ag);
+var t = e.match(cg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(ig);
+var i = a.match(ug);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38791,7 +38818,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-sg.warn("Missing packet in multi-packet message", {
+lg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38807,7 +38834,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), sg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), lg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38831,7 +38858,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && sg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && lg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38843,7 +38870,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return sg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return lg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38851,14 +38878,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), sg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), lg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (sg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (lg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38883,7 +38910,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-sg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+lg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -38895,7 +38922,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-sg.info("Completed sending multi-packet message", {
+lg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -38903,25 +38930,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? sg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? lg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (sg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (lg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else sg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else lg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else sg.warn("Terminal not found for queue item, removing from queue", {
+} else lg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -38955,7 +38982,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && sg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && lg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -38965,7 +38992,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-sg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+lg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39056,7 +39083,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (sg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (lg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39078,7 +39105,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return sg.error("Error parsing JSON", {
+return lg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39089,7 +39116,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), ug = [ {
+}(), dg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39109,7 +39136,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], lg = function() {
+} ], pg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39156,9 +39183,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), mg = new lg;
+}(), fg = new pg;
 
-function dg(e) {
+function yg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39166,19 +39193,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function pg(e, t) {
+function vg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function fg(e, t) {
+function gg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var yg = {
+var hg = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39189,9 +39216,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, vg = function() {
+}, Rg = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, yg), e);
+void 0 === e && (e = {}), this.config = o(o({}, hg), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39212,7 +39239,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = mg.getSwarmState(r.toRoom);
+var o = fg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39225,7 +39252,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = mg.getSwarmState(c);
+var l = fg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39295,9 +39322,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(pg), u = n.filter(function(e) {
+}).sort(vg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(fg), l = [], m = [], d = function(t) {
+}).sort(gg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39319,11 +39346,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return dg({
+return yg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + dg({
+}) + yg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39422,7 +39449,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), gg = new vg, hg = {
+}(), Eg = new Rg, Tg = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39443,14 +39470,14 @@ siegeUnits: 1
 }
 };
 
-function Rg(e) {
+function Cg(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function Eg(e) {
+function Sg(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39473,9 +39500,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function Tg(e) {
+function wg(e) {
 var t, r, o;
-Eg(e);
+Sg(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39499,20 +39526,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Cg(e) {
+function xg(e) {
 var t;
-Eg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Tg(e);
+Sg(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = wg(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function Sg(e) {
-return !!Cg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function bg(e) {
+return !!xg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-Eg(e);
+Sg(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39523,12 +39550,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = Tg(e);
+var d = wg(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function wg(e, t) {
+function Og(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39549,20 +39576,20 @@ if (r) throw r.error;
 return n;
 }
 
-function xg(e, t) {
+function Ag(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = hg[r]) && void 0 !== t ? t : hg[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Tg[r]) && void 0 !== t ? t : Tg[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = wg(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Og(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: Rg(r),
+targetComposition: Cg(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39574,7 +39601,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function bg(e) {
+function Mg(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39594,9 +39621,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function Og(e) {
+function kg(e) {
 var t = e.members.length;
-Eg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+Sg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39610,7 +39637,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && Sg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && bg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39639,7 +39666,7 @@ subsystem: "Squad"
 }
 }
 
-var Ag = {
+var Ug = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39726,7 +39753,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Mg(e, t) {
+function _g(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39741,8 +39768,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function kg(e, t) {
-var r, o, n, i = Ag[t], s = 0;
+function Ng(e, t) {
+var r, o, n, i = Ug[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39768,7 +39795,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Ug, _g, Ng, Pg = {
+var Pg, Ig, Gg, Lg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39777,11 +39804,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Ig = new Map;
+}, Dg = new Map;
 
-function Gg(e, t) {
+function Fg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Ig.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Dg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39793,7 +39820,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Ag[p].composition;
+d = Ug[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39808,19 +39835,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Ig.set(m, y), function(e, t, r, o) {
+v ? (Dg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Ag[s].useBoosts;
+i = Ug[s].useBoosts;
 }
-var c = hy.NORMAL;
-"siege" === t.type ? c = hy.HIGH : "defense" === t.type && (c = hy.EMERGENCY);
+var c = Ty.NORMAL;
+"siege" === t.type ? c = Ty.HIGH : "defense" === t.type && (c = Ty.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = Lg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Pg[t];
-}, 0), m = i ? Fg(r) : [], d = {
+var u = Bg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Lg[t];
+}, 0), m = i ? Kg(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39849,7 +39876,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Ny.addRequest(d), o.spawnRequests.add(d.id);
+Gy.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -39863,42 +39890,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function Lg(e, t, r) {
+function Bg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Dg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return Wg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Dg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Wg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Dg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Wg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Dg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return Wg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Dg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return Wg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Dg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return Wg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Dg(e, t, r) {
+function Wg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Pg[t];
+return e + Lg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Pg[t];
+return e + Lg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Fg(e) {
+function Kg(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -39929,45 +39956,45 @@ return [];
 }
 }
 
-function Bg(e) {
-return Ig.has(e);
+function Hg(e) {
+return Dg.has(e);
 }
 
-function Wg(e) {
-return Cg(e) || Sg(e);
+function Yg(e) {
+return xg(e) || bg(e);
 }
 
-(Ug = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Ug[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Ug[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (_g = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-_g[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, _g[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-_g[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Ng = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Ng[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Ng[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Ng[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Ng[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(Pg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Pg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Pg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Ig = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Ig[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Ig[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Ig[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Gg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Gg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Gg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Gg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Gg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var Kg = {
+var Vg = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Hg(e, t) {
-var r = Kg[t], o = mg.getClusters();
+function qg(e, t) {
+var r = Vg[t], o = fg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function Yg(e, t, r) {
+function jg(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = mg.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = fg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Hg(e, i.danger),
+reservedEnergy: qg(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40057,7 +40084,7 @@ success: !1
 });
 }
 
-var Vg = {
+var zg = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40067,7 +40094,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function qg(e, t, r) {
+function Qg(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40098,7 +40125,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function jg(e, t, r, o) {
+function Xg(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40108,7 +40135,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function zg(e, t) {
+function Zg(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40129,19 +40156,19 @@ if (r) throw r.error;
 return n;
 }
 
-function Qg() {
-var e = mg.getEmpire();
+function Jg() {
+var e = fg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function Xg(e) {
-Qg()[e.id] = e;
+function $g(e) {
+Jg()[e.id] = e;
 }
 
-function Zg(e) {
+function eh(e) {
 e.lastUpdate = Game.time;
-var t = mg.getCluster(e.clusterId);
-if (!t) return e.state = "failed", Xg(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = fg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", $g(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40151,12 +40178,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (Wg(r) || Bg(e) || Gg(0, r), Wg(r));
+return !!r && (Yg(r) || Hg(e) || Fg(0, r), Yg(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), Xg(e);
+})), $g(e);
 }(e, t);
 break;
 
@@ -40167,7 +40194,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (Og(o), bg(o)) {
+if (kg(o), Mg(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40196,7 +40223,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = mg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = fg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40223,14 +40250,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), Xg(e);
+})), $g(e);
 }(e, t);
 }
 }
 
-var Jg = "defenseAssist";
+var th = "defenseAssist";
 
-function $g(e, t, r) {
+function rh(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40249,11 +40276,11 @@ score: n.score + o.score
 }
 }
 
-function eh(e, t, r) {
+function oh(e, t, r) {
 return Gr(e, t, r);
 }
 
-function th(e, t) {
+function nh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40266,11 +40293,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function rh(e) {
+function ah(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function oh(e, t, r) {
+function ih(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40283,8 +40310,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function nh(e, t, r) {
-var o = eh(t, e.energyCapacityAvailable, r);
+function sh(e, t, r) {
+var o = oh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40292,16 +40319,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function ah(e, t, r, o) {
+function ch(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = nh(e, t, o);
-if (s !== nh(n, t, o)) return s ? -1 : 1;
+var a, i, s = sh(e, t, o);
+if (s !== sh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function ih(e, t) {
+function uh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40385,25 +40412,25 @@ if (r) throw r.error;
 return u;
 }
 
-function sh(e, t) {
+function lh(e, t) {
 return {
-guard: Math.max(0, th(e, "guard") - t.counts.guard),
-ranger: Math.max(0, th(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, th(e, "healer") - t.counts.healer)
+guard: Math.max(0, nh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, nh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, nh(e, "healer") - t.counts.healer)
 };
 }
 
-function ch(e, t, r) {
+function mh(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function uh(e) {
+function dh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function lh(e, t) {
+function ph(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return uh(e.role);
+return dh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40416,12 +40443,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function mh(e) {
+function fh(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Jg ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === th ? e.targetRoom : void 0;
 }
 
-function dh(e) {
+function yh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40433,7 +40460,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-uh(m) && mh(l) === e && !u.spawning && $g(i, m, u.body.filter(function(e) {
+dh(m) && fh(l) === e && !u.spawning && rh(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40451,7 +40478,7 @@ if (t) throw t.error;
 return i;
 }
 
-function ph(e, t, r) {
+function vh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40481,16 +40508,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: lh(e, r)
+pendingAssist: ph(e, r)
 };
 }
 }
 
-function fh(e, t) {
+function gh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = eh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = oh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40511,7 +40538,7 @@ subsystem: "Cluster"
 }
 }
 
-function yh(e, t, r) {
+function hh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40553,20 +40580,20 @@ exitAccess: a
 };
 }
 
-function vh(e, t) {
+function Rh(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function gh(e, t, r) {
+function Eh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function hh(e) {
+function Th(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function Rh(e, t) {
+function Ch(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40577,7 +40604,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function Eh(e, t, r) {
+function Sh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40588,8 +40615,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = hh(g);
-h && (g.assistTarget || Rh(v, h) && (t.assignedCreeps.includes(v.name) || vh(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = Th(g);
+h && (g.assistTarget || Ch(v, h) && (t.assignedCreeps.includes(v.name) || Rh(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40626,7 +40653,7 @@ return e.distance - t.distance;
 });
 }
 
-function Th(e, t) {
+function wh(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40651,21 +40678,21 @@ if (r) throw r.error;
 return i;
 }
 
-function Ch(e) {
+function xh(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var Sh = {
+var bh = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, wh = function() {
+}, Oh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Sh), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, bh), e);
 }
 return e.prototype.run = function() {
-var e = mg.getClusters();
+var e = fg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40684,7 +40711,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: ug.map(function(t) {
+steps: dg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40745,7 +40772,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-gg.processCluster(t);
+Eg.processCluster(t);
 break;
 
 case "squads":
@@ -40777,7 +40804,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = yh(e, new RoomPosition(s, c, e.name), "defense");
+var u = hh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40826,9 +40853,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = mg.getSwarmState(i);
+var i = n.value, s = fg.getSwarmState(i);
 if (s) {
-var c = Hg(i, s.danger);
+var c = qg(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40859,7 +40886,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = mg.getSwarmState(m);
+var m = l.value, d = fg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -40891,7 +40918,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += Ch(l.controller.level));
+}).length, i += xh(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41008,7 +41035,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Og(i), "gathering" !== i.state || Wg(i) || Bg(i.id) || Gg(0, i), bg(i) && (i.state = "dissolving");
+kg(i), "gathering" !== i.state || Yg(i) || Hg(i.id) || Fg(0, i), Mg(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41033,7 +41060,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = xg(e, s);
+var s = i.value, c = Ag(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41050,7 +41077,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(Qg()).filter(function(e) {
+var t = (a = e.id, Object.values(Jg()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41061,22 +41088,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Vg), n), m = [], d = mg.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, zg), n), m = [], d = fg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = qg(f, y, d);
+var g = Qg(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = zg(e, f);
+var h = Zg(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = jg(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = Xg(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Mg(f, {
+var C = _g(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41111,29 +41138,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-kg(e, n.doctrine) ? function(e, t, r) {
+Ng(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = mg.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = fg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = qg(e, o, r);
+var n = Qg(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (mg.getEmpire().knownRooms || {})[t], n = null != r ? r : Mg(t, {
+var o = (fg.getEmpire().knownRooms || {})[t], n = null != r ? r : _g(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!kg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Ng(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41146,7 +41173,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-Xg(i);
+$g(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41160,13 +41187,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = wg(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Og(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: Rg(n),
+targetComposition: Cg(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41181,8 +41208,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), Xg(i), Gg(0, c), i.state = "forming", i.lastUpdate = Game.time,
-Xg(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), $g(i), Fg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+$g(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41201,11 +41228,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Ig.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Dg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Ig.delete(c));
+}), Dg.delete(c));
 }
 } catch (t) {
 e = {
@@ -41219,10 +41246,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = Qg();
-for (var t in e) Zg(e[t]);
+var e = Jg();
+for (var t in e) eh(e[t]);
 !function() {
-var e = Qg();
+var e = Jg();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41300,14 +41327,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = mg.getCluster(t, e);
+var t = "cluster_".concat(e), r = fg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = mg.getCluster(e);
+var o = fg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41336,7 +41363,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Yg(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && jg(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41353,7 +41380,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = mg.getSwarmState(t);
+var n, a, i = fg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41394,7 +41421,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = kr(g), f[g] = dh(g);
+p[g] = kr(g), f[g] = yh(g);
 }
 } catch (e) {
 r = {
@@ -41410,7 +41437,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = ph(E, m, t);
+d[E] = vh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41429,13 +41456,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = oh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = ih(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = ih(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = uh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, sh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, lh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = ah(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = ch(h, b, g.roomName, R), M = 0; M < O; M++) {
 var k = A.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41447,13 +41474,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(k.roomName, "_").con
 roomName: k.roomName,
 role: b,
 family: "military",
-priority: rh(g.urgency),
+priority: ah(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: Jg,
-defenseSquadId: ch(k.roomName, g.roomName, e.now),
+task: th,
+defenseSquadId: mh(k.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41493,7 +41520,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) fh(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) gh(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41508,7 +41535,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Ny);
+}(e, Gy);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41520,7 +41547,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = Th(f, Eh(e, f, t)), v = y.reduce(function(e, t) {
+var y = wh(f, Sh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41531,7 +41558,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-gh(f, R.role, vh(f, R.role) - 1), l.push({
+Eh(f, R.role, Rh(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41598,28 +41625,28 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), xh = new wh, bh = /^([WE])(\d+)([NS])(\d+)$/;
+}(), Ah = new Oh, Mh = /^([WE])(\d+)([NS])(\d+)$/;
 
-function Oh(e) {
-return bh.test(e);
+function kh(e) {
+return Mh.test(e);
 }
 
-var Ah = {
+var Uh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Mh = function() {
+}, _h = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ah), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Uh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
 var e = InterShardMemory.getLocal();
 if (e) {
-var t = Cp(e);
+var t = xp(e);
 if (t) {
 this.updateEnemyIntelligence(t);
-var r = Tp(t);
+var r = wp(t);
 InterShardMemory.setLocal(r);
 }
 }
@@ -41685,7 +41712,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (Oh(x)) {
+if (e.isAlly(x)) f.add(x); else if (kh(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41753,7 +41780,7 @@ subsystem: "CrossShardIntel"
 }, e.prototype.getGlobalEnemies = function() {
 var e = InterShardMemory.getLocal();
 if (!e) return [];
-var t = Cp(e);
+var t = xp(e);
 return t && t.globalTargets.enemies || [];
 }, n([ Oi("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: ha.LOW,
@@ -41761,7 +41788,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), kh = new Mh, Uh = function() {
+}(), Nh = new _h, Ph = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41838,9 +41865,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), _h = new Uh, Nh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), Ih = new Ph, Gh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Ph(e, t) {
+function Lh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41863,13 +41890,13 @@ if (r) throw r.error;
 return n;
 }
 
-function Ih(e) {
+function Dh(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function Gh(e, t, r) {
-if (!Ih(e)) return 0;
-var o = Ph(e.name, t);
+function Fh(e, t, r) {
+if (!Dh(e)) return 0;
+var o = Lh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += oc(e.mineralType),
@@ -41878,7 +41905,7 @@ n += sc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += uc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function Lh(e, t) {
+function Bh(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -41888,13 +41915,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Nh.has(e.type);
+return e.hits > 0 && Gh.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function Dh(e, t, r) {
+function Wh(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -41904,7 +41931,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function Fh(e) {
+function Kh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -41915,8 +41942,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function Bh(e) {
-var t = Fh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function Hh(e) {
+var t = Kh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -41935,14 +41962,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var Wh = {
+var Yh = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, Kh = function() {
+}, Vh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Wh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Yh), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42033,7 +42060,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = Fh(e);
+var t = Kh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42045,14 +42072,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return Bh(Hh(e));
+return Hh(qh(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = Bh(Hh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = Hh(qh(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function Hh(e) {
+function qh(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42084,11 +42111,11 @@ swamps: d
 };
 }
 
-var Yh = new Kh, Vh = /^([WE])(\d+)([NS])(\d+)$/, qh = {
+var jh = new Vh, zh = /^([WE])(\d+)([NS])(\d+)$/, Qh = {
 allies: []
-}, jh = function() {
+}, Xh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, qh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Qh), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42108,7 +42135,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!Vh.test(e)) return !1;
+if (!zh.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42216,7 +42243,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return Vh.test(e);
+return zh.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42243,7 +42270,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), zh = new jh, Qh = {
+}(), Zh = new Xh, Jh = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42256,9 +42283,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, Xh = function() {
+}, $h = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Qh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Jh), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42271,7 +42298,7 @@ t.updateExpansionQueue(o);
 }), Ji.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Ji.measureSubsystem("empire:warTargets", function() {
-zh.updateWarTargets(o);
+Zh.updateWarTargets(o);
 }), Ji.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Ji.measureSubsystem("empire:gclTracking", function() {
@@ -42279,13 +42306,13 @@ t.trackGCLProgress(o);
 }), s && Ji.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Ji.measureSubsystem("empire:intelRefresh", function() {
-Yh.refreshRoomIntel(o);
+jh.refreshRoomIntel(o);
 }), Ji.measureSubsystem("empire:roomDiscovery", function() {
-Yh.discoverNearbyRooms(o);
+jh.discoverNearbyRooms(o);
 })), s && Ji.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Ji.measureSubsystem("empire:clusterHealth", function() {
-_h.monitorClusterHealth();
+Ih.monitorClusterHealth();
 }), Ji.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42368,22 +42395,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = Lh(f, u);
+var y = Boolean(Game.rooms[f]), v = Bh(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = Ph(f, t);
+var g = Lh(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = Dh(h, u, y);
+var h = e.knownRooms[f], R = Wh(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? Gh(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? Fh(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42427,10 +42454,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && Ih(a)) {
-var i = Ph(a.name, t);
+if (a && Dh(a)) {
+var i = Lh(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = Gh(a, t, r);
+var s = Fh(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -42750,13 +42777,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), Zh = new Xh;
+}(), eR = new $h;
 
-function Jh(e) {
+function tR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var $h = {
+var rR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42764,10 +42791,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, eR = function() {
+}, oR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, $h), e);
+this.config = o(o({}, rR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -42911,7 +42938,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, Jh(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, tR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43086,7 +43113,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), tR = new eR, rR = function() {
+}(), nR = new oR, aR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new ec(o(o({}, Bs), e), {
 getEmpire: function() {
@@ -43122,7 +43149,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), oR = new rR, nR = function() {
+}(), iR = new aR, sR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -43140,9 +43167,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), aR = new (function(e) {
+}(), cR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new nR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new sR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43154,22 +43181,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Mi() ], t);
 }(Ii));
 
-function iR() {
+function uR() {
 return global;
 }
 
-function sR(e) {
+function lR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function cR(e) {
+function mR(e) {
 return Number(null != e ? e : 0);
 }
 
-var uR = function() {
+var dR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = iR();
+var e = uR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43177,12 +43204,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return iR()._pixelGenerationMemory;
+return uR()._pixelGenerationMemory;
 }, e;
-}(), lR = function(e) {
+}(), pR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new uR) || this;
+var r = e.call(this, t, new dR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43199,7 +43226,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(sR).length : Object.values(null != t ? t : {}).filter(sR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(lR).length : Object.values(null != t ? t : {}).filter(lR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43210,9 +43237,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (cR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (cR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = cR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = cR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (mR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (mR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = mR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = mR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43234,9 +43261,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Mi() ], t);
-}(Li), mR = new lR;
+}(Li), fR = new pR;
 
-function dR(e, t) {
+function yR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -43258,7 +43285,7 @@ lost: !1
 };
 }
 
-function pR(e, t, r) {
+function vR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43272,20 +43299,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var fR = Ue().cpu.bucketThresholds.highMode + 1800, yR = {
+var gR = Ue().cpu.bucketThresholds.highMode + 1800, hR = {
 updateInterval: 250,
-minBucket: fR,
+minBucket: gR,
 maxSitesPerRemotePerTick: 2
 };
 
-function vR(e, t) {
+function RR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var gR = function() {
+var ER = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, yR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, hR), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43302,8 +43329,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = dR(l);
-m.lost && m.reason && pR(e, u, m.reason);
+var m = yR(l);
+m.lost && m.reason && vR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43321,10 +43348,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = vR("remoteInfrastructure.intent", function() {
+var i = RR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-vR("remoteInfrastructure.execute", function() {
+RR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43490,13 +43517,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = vR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = RR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = vR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = RR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43529,7 +43556,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = vR("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = RR("remoteInfrastructure.calculateRemoteRoads", function() {
 return xn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43558,14 +43585,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = vR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = RR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? vR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? RR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43582,7 +43609,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? vR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? RR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43600,7 +43627,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return vR("remoteInfrastructure.findSources", function() {
+return RR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43697,10 +43724,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: ha.LOW,
 interval: 1e3,
-minBucket: fR,
+minBucket: gR,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), hR = new gR, RR = new (function(e) {
+}(), TR = new ER, CR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43712,7 +43739,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ Mi() ], t);
-}(Mp)), ER = function() {
+}(_p)), SR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43756,7 +43783,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Rf.applyDiffusion(o);
+Cf.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -43802,7 +43829,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ Mi() ], e);
-}(), TR = new ER, CR = new (function() {
+}(), wR = new SR, xR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43849,7 +43876,7 @@ if (e) throw e.error;
 Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(TR, Ns, Ds, ls, Zh, vc, tR, hR, As, aR, mR, oR, qc, Zc, RR, kh, Bc, xh, za, Pa),
+}(wR, Ns, Ds, ls, eR, vc, nR, TR, As, cR, fR, iR, qc, Zc, CR, Nh, Bc, Ah, za, Pa),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -43916,9 +43943,9 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), SR = "_ownedRooms", wR = "_ownedRoomsTick";
+}), bR = "_ownedRooms", OR = "_ownedRoomsTick";
 
-function xR(e) {
+function AR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -43928,13 +43955,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var bR = Ei("NativeCallsTracker");
+var MR = Ei("NativeCallsTracker");
 
-function OR(e, t, r) {
+function kR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) bR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) MR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -43950,7 +43977,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-bR.warn("Failed to wrap method", {
+MR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -43960,30 +43987,30 @@ error: String(e)
 }
 }
 
-var AR, MR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], kR = "shard1", UR = {
+var UR, _R = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], NR = "shard1", PR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, _R = {
+}, IR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, NR = {
+}, GR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function PR() {
+function LR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function IR() {
+function DR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: MR,
+targetShards: _R,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -43993,11 +44020,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = MR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = _R),
 Memory.interShardOperation;
 }
 
-function GR() {
+function FR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -44012,7 +44039,7 @@ lastSync: 0,
 checksum: 0
 };
 var t = InterShardMemory.getLocal();
-return t && null !== (e = Cp(t)) && void 0 !== e ? e : {
+return t && null !== (e = xp(t)) && void 0 !== e ? e : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -44038,33 +44065,33 @@ checksum: 0
 }
 }
 
-function LR(e) {
+function BR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
-InterShardMemory.setLocal(Tp(e));
+InterShardMemory.setLocal(wp(e));
 } catch (e) {}
 }
 
-function DR() {
-var e, t, r, o, n, i, s, c = GR(), u = PR();
+function WR() {
+var e, t, r, o, n, i, s, c = FR(), u = LR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: MR,
+targetShards: _R,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : MR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : _R,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && FR() ? "established" : "unreached",
+status: p === u && KR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44082,7 +44109,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === kR ? "core" : "frontier",
+role: u === NR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44099,24 +44126,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), LR(c), c.footprintOperation;
+}), BR(c), c.footprintOperation;
 }
 
-function FR() {
+function KR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function BR() {
+function HR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function WR(e, t) {
+function YR(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44135,9 +44162,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(BR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(HR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Ny.getPendingRequests(p.name).filter(function(r) {
+s += Gy.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44156,7 +44183,7 @@ if (n) throw n.error;
 return s;
 }
 
-function KR(e) {
+function VR(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44200,7 +44227,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = GR().shards[PR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = FR().shards[LR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44210,8 +44237,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function HR(e, t) {
-if (!(WR("scout", t) >= 1)) {
+function qR(e, t) {
+if (!(YR("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44249,13 +44276,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Ny.addRequest({
+r && Gy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: NR,
-priority: hy.LOW + 5,
+body: GR,
+priority: Ty.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44266,14 +44293,14 @@ task: "interShardPortalScout"
 }
 }
 
-function YR(e, t, r) {
-WR("interShardClaimer", t) >= 1 || Ny.addRequest({
+function jR(e, t, r) {
+YR("interShardClaimer", t) >= 1 || Gy.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: UR,
-priority: hy.NORMAL + 50,
+body: PR,
+priority: Ty.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44286,14 +44313,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function VR(e, t, r) {
-WR("interShardScout", t) >= 1 || Ny.addRequest({
+function zR(e, t, r) {
+YR("interShardScout", t) >= 1 || Gy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: NR,
-priority: hy.NORMAL,
+body: GR,
+priority: Ty.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44306,15 +44333,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function qR(e, t, r) {
+function QR(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (WR("interShardPioneer", t.shard) >= 3 || Ny.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (YR("interShardPioneer", t.shard) >= 3 || Gy.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: _R,
-priority: hy.NORMAL + 25,
+body: IR,
+priority: Ty.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44327,19 +44354,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function jR(e) {
+function XR(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = PR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = LR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : MR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : _R), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Cp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? xp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44371,9 +44398,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(BR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(HR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Ny.getPendingRequests(l.name).filter(function(e) {
+n += Gy.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44392,22 +44419,22 @@ return n;
 }() < o;
 }
 
-(AR = {
-optimizeBody: My,
+(UR = {
+optimizeBody: _y,
 spawnQueue: {
 addRequest: function(e) {
-return Ny.addRequest(e);
+return Gy.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: hy.LOW,
-NORMAL: hy.NORMAL,
-HIGH: hy.HIGH
+LOW: Ty.LOW,
+NORMAL: Ty.NORMAL,
+HIGH: Ty.HIGH
 }
-}).optimizeBody && (Up.optimizeBody = AR.optimizeBody), AR.spawnQueue && (Up.spawnQueue = AR.spawnQueue),
-AR.spawnPriorities && (Up.spawnPriorities = o(o({}, Up.spawnPriorities), AR.spawnPriorities));
+}).optimizeBody && (Pp.optimizeBody = UR.optimizeBody), UR.spawnQueue && (Pp.spawnQueue = UR.spawnQueue),
+UR.spawnPriorities && (Pp.spawnPriorities = o(o({}, Pp.spawnPriorities), UR.spawnPriorities));
 
-var zR, QR = function() {
+var ZR, JR = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44451,7 +44478,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function XR(e) {
+function $R(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44472,7 +44499,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function ZR(e, t, r) {
+function eE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44538,16 +44565,16 @@ return u;
 });
 }
 
-function JR(e) {
+function tE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(zR || (zR = {}));
+}(ZR || (ZR = {}));
 
-var $R = function() {
+var rE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44585,8 +44612,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = ZR(h.pos, T.pos, this.logger);
-if (JR(C)) {
+var T = E.value, C = eE(h.pos, T.pos, this.logger);
+if (tE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44613,8 +44640,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, M = ZR(A, u.pos, this.logger);
-JR(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
+var A = O.value, M = eE(A, u.pos, this.logger);
+tE(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44653,8 +44680,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = ZR(e, t, this.logger);
-if (JR(n)) {
+var n = eE(e, t, this.logger);
+if (tE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44664,7 +44691,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), eE = function() {
+}(), oE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44674,7 +44701,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = XR(s);
+var c = $R(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44700,7 +44727,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), tE = function() {
+}(), nE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44749,7 +44776,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), rE = {
+}(), aE = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -44762,7 +44789,7 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, oE = {
+}, iE = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44789,26 +44816,26 @@ direction: a
 }
 return t;
 }
-}, nE = {
+}, sE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = mm.MEDIUM), Cm.register({
+void 0 === o && (o = fm.MEDIUM), xm.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== mm.CRITICAL
+skippable: o !== fm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, aE = new $R(oE, rE), iE = new eE(rE, nE, aE), sE = new tE(rE, oE, aE, Gu.moveTo);
+}, cE = new rE(iE, aE), uE = new oE(aE, sE, cE), lE = new nE(aE, iE, cE, Gu.moveTo);
 
-function cE(e, t, r, o) {
-return sE.moveToWithRemoteCache(e, t, r, o);
+function mE(e, t, r, o) {
+return lE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var uE, lE = function() {
+var dE, pE = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -44821,12 +44848,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), mE = function() {
+}(), fE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), dE = function() {
+}(), yE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44871,28 +44898,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), pE = function() {
+}(), vE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return XR(e);
+return $R(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-aE.precacheRemoteRoutes(e, t);
+cE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), fE = new QR(new lE, new mE, new dE, new pE), yE = {
+}(), gE = new JR(new pE, new fE, new yE, new vE), hE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, vE = function() {
+}, RE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, yE), e);
+this.config = o(o({}, hE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -44986,123 +45013,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new vE, (uE = {})[FIND_STRUCTURES] = {
+new RE, (dE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, uE[FIND_MY_STRUCTURES] = {
+}, dE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, uE[FIND_HOSTILE_STRUCTURES] = {
+}, dE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, uE[FIND_SOURCES_ACTIVE] = {
+}, dE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, uE[FIND_SOURCES] = {
+}, dE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, uE[FIND_MINERALS] = {
+}, dE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, uE[FIND_DEPOSITS] = {
+}, dE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, uE[FIND_MY_CONSTRUCTION_SITES] = {
+}, dE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, uE[FIND_CONSTRUCTION_SITES] = {
+}, dE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, uE[FIND_CREEPS] = {
+}, dE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, uE[FIND_MY_CREEPS] = {
+}, dE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, uE[FIND_HOSTILE_CREEPS] = {
+}, dE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, uE[FIND_DROPPED_RESOURCES] = {
+}, dE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, uE[FIND_TOMBSTONES] = {
+}, dE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, uE[FIND_RUINS] = {
+}, dE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, uE[FIND_FLAGS] = {
+}, dE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, uE[FIND_MY_SPAWNS] = {
+}, dE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, uE[FIND_HOSTILE_SPAWNS] = {
+}, dE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, uE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, dE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, uE[FIND_NUKES] = {
+}, dE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, uE[FIND_POWER_CREEPS] = {
+}, dE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, uE[FIND_MY_POWER_CREEPS] = {
+}, dE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, uE[FIND_HOSTILE_POWER_CREEPS] = {
+}, dE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, uE[FIND_EXIT_TOP] = {
+}, dE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, uE[FIND_EXIT_RIGHT] = {
+}, dE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, uE[FIND_EXIT_BOTTOM] = {
+}, dE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, uE[FIND_EXIT_LEFT] = {
+}, dE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, uE[FIND_EXIT] = {
+}, dE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var gE = new le({}, mr), hE = new Ee({}, mr);
+var EE = new le({}, mr), TE = new Ee({}, mr);
 
-function RE(e) {
+function CE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45110,11 +45137,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var EE = !1;
+var SE = !1;
 
-function TE() {
+function wE() {
 var e, t;
-EE || (ii({
+SE || (ii({
 level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45129,11 +45156,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Py.getPendingTransfers = function(e) {
+r.getPendingTransfers && (Ly.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Py.needsCarrier = function(e) {
+}), r.needsCarrier && (Ly.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Py.getActiveRequests = function() {
+}), r.getActiveRequests && (Ly.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45147,47 +45174,47 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Iy.predictConsumption = function(e) {
+a.predictConsumption && (Dy.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Iy.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Dy.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Iy.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Dy.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Iy.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Dy.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Gy.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Fy.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Gy.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Fy.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Gy.needsCarriers = function(e) {
+}), i.needsCarriers && (Fy.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Gy.requestSpawns = function(e) {
+}), i.requestSpawns && (Fy.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-Ly.getEmergencyState = function(e) {
+By.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: bt,
 powerBankHarvestingManager: qc,
-resourceTransferCoordinator: Np,
+resourceTransferCoordinator: Gp,
 emergencyResponseManager: Ba,
 kernel: Ja
 }), function(e) {
 var t, r, o, n;
-td = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : ed.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : ed.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : ed.getLabOverflow
-} : ed;
+nd = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : od.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : od.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : od.getLabOverflow
+} : od;
 }({
 getLabResourceNeeds: function(e) {
 return Ru.getLabResourceNeeds(e);
@@ -45201,7 +45228,7 @@ return Ru.getLabOverflow(e);
 }), Ji.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) bR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) MR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45215,7 +45242,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-bR.warn("Failed to wrap PathFinder.search", {
+MR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45223,11 +45250,11 @@ error: String(e)
 }
 }
 }
-}(), OR(e = Creep.prototype, "moveTo", "moveTo"), OR(e, "move", "move"), OR(e, "harvest", "harvest"),
-OR(e, "transfer", "transfer"), OR(e, "withdraw", "withdraw"), OR(e, "build", "build"),
-OR(e, "repair", "repair"), OR(e, "upgradeController", "upgradeController"), OR(e, "attack", "attack"),
-OR(e, "rangedAttack", "rangedAttack"), OR(e, "heal", "heal"), OR(e, "dismantle", "dismantle"),
-OR(e, "say", "say")), function(e, t, r) {
+}(), kR(e = Creep.prototype, "moveTo", "moveTo"), kR(e, "move", "move"), kR(e, "harvest", "harvest"),
+kR(e, "transfer", "transfer"), kR(e, "withdraw", "withdraw"), kR(e, "build", "build"),
+kR(e, "repair", "repair"), kR(e, "upgradeController", "upgradeController"), kR(e, "attack", "attack"),
+kR(e, "rangedAttack", "rangedAttack"), kR(e, "heal", "heal"), kR(e, "dismantle", "dismantle"),
+kR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -45243,15 +45270,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, Rf), fE.initializePathCacheEvents(), iE.initialize(mm.MEDIUM), gl = cE,
-Ft.initialize(), RR.initialize(), EE = !0), mr.initialize();
-var r = CR.configureForCurrentTick();
+}(Ja, mr, Cf), gE.initializePathCacheEvents(), uE.initialize(fm.MEDIUM), El = mE,
+Ft.initialize(), CR.initialize(), SE = !0), mr.initialize();
+var r = xR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = IR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, DR(), function() {
-var e, t, r, o, n = GR(), a = n.footprintOperation, i = PR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = DR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, WR(), function() {
+var e, t, r, o, n = FR(), a = n.footprintOperation, i = LR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45264,15 +45291,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, LR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, BR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = IR();
+var e, t, r, n, i, s, c = DR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : MR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === kR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : _R), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === NR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45290,10 +45317,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !FR())) try {
+}(), !KR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || zp(s), "interShardPioneer" === c && jp(s);
+"interShardClaimer" !== c && "interShardScout" !== c || Zp(s), "interShardPioneer" === c && Xp(s);
 }
 } catch (t) {
 e = {
@@ -45317,17 +45344,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: EE
+systemsInitialized: SE
 }
-}), CR.ensureProcessesRegistered(), Ji.startTick(), Mu.clear(), CR.startEventTick();
+}), xR.ensureProcessesRegistered(), Ji.startTick(), Mu.clear(), xR.startEventTick();
 var i = function(e) {
-var t = e.cache[SR], r = e.cache[wR];
+var t = e.cache[bR], r = e.cache[OR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[SR] = o, e.cache[wR] = e.tick, o;
+return e.cache[bR] = o, e.cache[OR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45349,7 +45376,7 @@ rooms: i,
 interval: o
 })), s = n.next(); !s.done; s = n.next()) {
 var c = s.value;
-fl.refreshRoom(c);
+gl.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -45364,18 +45391,18 @@ if (e) throw e.error;
 }
 }), Ji.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = IR();
+var e, t, r, o = DR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = DR();
+var n = WR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : MR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : _R), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== PR()) try {
+if (d !== LR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Cp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = xp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45393,20 +45420,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = BR().sort(function(e, t) {
+var i = HR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : MR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : _R), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== PR()) {
+if (u !== LR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = KR(u);
+var m = VR(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? qR(i, l, m) : jR() ? YR(i, u, m) : (VR(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (HR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? QR(i, l, m) : XR() ? jR(i, u, m) : (zR(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (qR(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45423,8 +45450,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = GR();
-d.footprintOperation = n, LR(d);
+var d = FR();
+d.footprintOperation = n, BR(d);
 }
 }
 })(), function() {
@@ -45432,8 +45459,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || RE(s))) {
-var c = ng(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || CE(s))) {
+var c = sg(s, mr.getOrInitSwarmState(s.name));
 Ji.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45450,20 +45477,20 @@ if (e) throw e.error;
 }
 }();
 }), Gu.preTick(), Ji.measureSubsystem("processSync", function() {
-af.syncCreepProcesses(), iy.syncRoomProcesses();
+uf.syncCreepProcesses(), uy.syncRoomProcesses();
 }), Ji.measureSubsystem("kernel", function() {
-CR.runProcesses();
+xR.runProcesses();
 }), Ji.measureSubsystem("eventQueue", function() {
-CR.processQueuedEvents();
+xR.processQueuedEvents();
 }), Ji.measureSubsystem("ss2PacketQueue", function() {
-cg.processQueue();
+mg.processQueue();
 }), Ja.hasCpuBudget() && Ji.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && Qp(n);
+void 0 !== n.ticksToLive && Jp(n);
 }
 } catch (t) {
 e = {
@@ -45477,7 +45504,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), xR({
+}), AR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("visualizations", function() {
@@ -45487,8 +45514,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = gE.getConfig(), s = hE.getConfig();
-gE.setConfig(n.roomVisualizerConfig), n.renderMap && hE.setConfig(n.mapVisualizerConfig);
+var i = EE.getConfig(), s = TE.getConfig();
+EE.setConfig(n.roomVisualizerConfig), n.renderMap && TE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45499,7 +45526,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-gE.draw(m);
+EE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45521,14 +45548,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-hE.draw();
+TE.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-gE.setConfig(i), hE.setConfig(s);
+EE.setConfig(i), TE.setConfig(s);
 }
 }
 }
@@ -45613,19 +45640,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Gu.reconcileTraffic(), xR({
+}), Gu.reconcileTraffic(), AR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Cm.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), xm.run(e);
 }), mr.persistHeapCache(), Ji.collectProcessStats(Ja.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), Ji.collectKernelBudgetStats(Ja), Ji.setSkippedProcesses(Ja.getSkippedProcessesThisTick()),
 Ji.finalizeTick(), Ci.flush();
 }
 
-var CE = function() {
+var xE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45633,25 +45660,25 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = gE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = EE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-gE.toggle(o);
-var n = gE.getConfig()[o];
+EE.toggle(o);
+var n = EE.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = hE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = TE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-hE.toggle(o);
-var n = hE.getConfig()[o];
+TE.toggle(o);
+var n = TE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = hE.getConfig();
+var e = TE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45774,15 +45801,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), SE = function() {
+}(), bE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = RR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = CR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = RR.getAllShards();
+var e, t, r = CR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45804,9 +45831,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (RR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (CR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = RR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = CR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45831,19 +45858,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = RR.getOptimalPortalRoute(e, t);
+var r, o = CR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (RR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (CR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (RR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (CR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Np.getActiveRequests();
+var e, t, r = Gp.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -45864,7 +45891,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = RR.getCurrentShardState();
+var e, t, r = CR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45885,7 +45912,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = RR.getActiveTransferTasks();
+var e, t, r, o = CR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -45906,16 +45933,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = RR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(xp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = CR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Ap, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = RR.getMemoryStats();
+var e = CR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return RR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return CR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = GR().footprintOperation;
+var e, t, r, o = FR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46021,9 +46048,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), wE = new SE;
+}(), OE = new bE;
 
-function xE(e) {
+function AE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46053,10 +46080,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? xE(e.metadata.usage) : void 0
+params: e.metadata.usage ? AE(e.metadata.usage) : void 0
 };
 });
-return Um({
+return Pm({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46107,12 +46134,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Um.apply(void 0, s([], i(o), !1));
+return Pm.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return Am("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Um("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return km.form("spawnCreep", [ {
+return Nm.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46146,20 +46173,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return Am("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Um("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += Am("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += Am("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += km.button({
+o += '<div style="margin-bottom: 10px;">', o += Um("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Um("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Nm.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += km.button({
+}), o += " ", (o += Nm.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return km.form("configureLogging", [ {
+return Nm.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46184,7 +46211,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return km.form("configureVisualization", [ {
+return Nm.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46208,21 +46235,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += km.button({
+e += Nm.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += km.button({
+}), e += " ", e += Nm.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += km.button({
+}), e += " ", (e += Nm.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += Am("✓ Success message", "green", !0) + "\n", e += Am("⚠ Warning message", "yellow", !0) + "\n",
-e += Am("✗ Error message", "red", !0) + "\n", e += Am("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + Am("colored text", "green") + " normal text\n") + "Bold text: " + Am("important", null, !0) + "\n";
+return e += Um("✓ Success message", "green", !0) + "\n", e += Um("⚠ Warning message", "yellow", !0) + "\n",
+e += Um("✗ Error message", "red", !0) + "\n", e += Um("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Um("colored text", "green") + " normal text\n") + "Bold text: " + Um("important", null, !0) + "\n";
 }, n([ Tt({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46268,39 +46295,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var bE = new cy, OE = new CE, AE = new uy, ME = new bu, kE = new sy, UE = new ly, _E = new my, NE = "__screepsGlobalRuntimeDiagnostics";
+var ME = new my, kE = new xE, UE = new dy, _E = new bu, NE = new ly, PE = new py, IE = new fy, GE = "__screepsGlobalRuntimeDiagnostics";
 
-function PE() {
+function LE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function IE(e, t) {
+function DE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function GE(e, t) {
+function FE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function LE(e) {
+function BE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function DE(e) {
+function WE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: IE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: IE(n.switchCount, 0),
-lastTick: GE(n.lastTick, Game.time),
-lastResetTick: GE(n.lastResetTick, Game.time),
-lastSwitchTick: LE(n.lastSwitchTick),
-lastSwitchPreviousTick: LE(n.lastSwitchPreviousTick),
-lastWarningTick: LE(n.lastWarningTick)
+resetCount: DE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: DE(n.switchCount, 0),
+lastTick: FE(n.lastTick, Game.time),
+lastResetTick: FE(n.lastResetTick, Game.time),
+lastSwitchTick: BE(n.lastSwitchTick),
+lastSwitchPreviousTick: BE(n.lastSwitchPreviousTick),
+lastWarningTick: BE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46314,13 +46341,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var FE = Ei("Main");
+var KE = Ei("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(bE), Ct(OE), Ct(AE), Ct(ME), Ct(kE), Ct(UE), Ct(_E), Ct(Su),
-Ct(wu), Ct(xu), Ct(wE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
+Et.initialize(), Ct(ME), Ct(kE), Ct(UE), Ct(_E), Ct(NE), Ct(PE), Ct(IE), Ct(Su),
+Ct(wu), Ct(xu), Ct(OE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -46335,12 +46362,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : PE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[NE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : LE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[GE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[NE] = s, function(e, t) {
-var r, o = DE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[GE] = s, function(e, t) {
+var r, o = WE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46358,7 +46385,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = DE(e.heapId);
+var n, a = WE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46379,14 +46406,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = DE(s.heapId);
+var u = WE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: FE
-}), TE();
+logger: KE
+}), wE();
 } catch (e) {
-throw FE.error("Critical error in main loop: ".concat(String(e)), {
+throw KE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time


### PR DESCRIPTION
## Summary

Prunes non-consumed legacy `build`, `repair`, and `upgrade` task-board entries during task-board cleanup so live backlog metrics focus on actionable runtime task types.

## Linked issue

Closes #3185

## Changes

- Adds a legacy task-type cleanup path in `@ralphschuler/screeps-roles`.
- Clears `assignedTaskId` from creeps whose legacy task reservation is pruned.
- Reuses the same invalidation helper for expired/invalid tasks.
- Adds regression coverage proving legacy tasks are removed while active delivery/refill tasks are kept.
- Updates `packages/screeps-bot/dist/main.js` from the validated build.

## Validation

- PASS: `npm test -w @ralphschuler/screeps-roles -- --grep "prunes legacy build repair and upgrade tasks"`
- PASS: `npm test -w @ralphschuler/screeps-roles -- --grep "TaskBoard"`
- PASS: `npm run build:roles`
- PASS: `npm run lint:roles`
- PASS: `npm run test:roles`
- PASS: `npm run check:alliance-safety`
- PARTIAL: `npm run verify` passed build, typecheck, lint, private-server smoke setup, and many workspace tests, then failed in existing workspace-wide `test:all` coverage; documented on #3056.

## Deployment impact

Runtime Memory cleanup only. On deploy, old `Memory.creepTaskBoard` `build`/`repair`/`upgrade` entries are invalidated on each room board's cleanup pass; delivery/refill/store/defense/heal tasks remain intact.

## Live bot evidence

Latest live shard1 observer found task-board backlog still high (`176` total, `169` unassigned; `92` unknown/task-like records), reinforcing the need to prune non-consumed legacy task records. Evidence added to #3119 and #3185 follow-up context.

## Follow-up issues

- #3056 tracks the unrelated workspace-wide `npm run verify` / `test:all` harness failure (`PWR_DISRUPT_SPAWN` missing in pheromones integration tests).
