### PR TITLE
[codex] Honor task-board transfer amounts

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
@@ -53,7 +53,33 @@ export type RemoteMoveHandler = (
 
 type MetricsCreepMemory = CreepMemory & { _metrics?: metrics.CreepMetrics };
 
+type TransferAmountResolution =
+  | { amount?: number; error?: undefined }
+  | { amount?: undefined; error: ScreepsReturnCode };
+
 let remoteMoveHandler: RemoteMoveHandler | undefined;
+
+function resolveTransferAmount(
+  creep: Creep,
+  target: AnyStoreStructure,
+  resourceType: ResourceConstant,
+  requestedAmount?: number,
+): TransferAmountResolution {
+  if (requestedAmount === undefined) return {};
+
+  const carriedAmount = creep.store.getUsedCapacity(resourceType);
+  if (carriedAmount <= 0) return { error: ERR_NOT_ENOUGH_RESOURCES };
+
+  const freeCapacity = target.store?.getFreeCapacity(resourceType);
+  if (typeof freeCapacity === "number" && freeCapacity <= 0) return { error: ERR_FULL };
+
+  const amount = Math.min(
+    requestedAmount,
+    carriedAmount,
+    freeCapacity ?? requestedAmount,
+  );
+  return amount > 0 ? { amount } : { error: ERR_INVALID_ARGS };
+}
 
 function shouldBlockHarmfulActionAgainstAlly(
   ctx: CreepContext,
@@ -203,17 +229,27 @@ export function executeAction(
       break;
 
     // Resource delivery
-    case "transfer":
+    case "transfer": {
+      const transferAmount = resolveTransferAmount(
+        creep,
+        optimizedAction.target,
+        optimizedAction.resourceType,
+        optimizedAction.amount,
+      );
       shouldClearState = executeWithRange(
         creep,
-        () =>
-          creep.transfer(optimizedAction.target, optimizedAction.resourceType),
+        () => transferAmount.error ?? creep.transfer(
+          optimizedAction.target,
+          optimizedAction.resourceType,
+          transferAmount.amount,
+        ),
         optimizedAction.target,
         PATH_COLORS.transfer,
         optimizedAction.type,
-        { resourceType: optimizedAction.resourceType },
+        { resourceType: optimizedAction.resourceType, amount: transferAmount.amount },
       );
       break;
+    }
 
     case "drop":
       creep.drop(optimizedAction.resourceType);
@@ -572,7 +608,7 @@ function executeWithRange(
   target: RoomObject,
   _pathColor: string,
   actionLabel?: string,
-  actionData?: { resourceType?: ResourceConstant },
+  actionData?: { resourceType?: ResourceConstant; amount?: number },
 ): boolean {
   const result = action();
 
@@ -628,7 +664,7 @@ function trackActionMetrics(
   creep: Creep,
   actionType: string,
   target: RoomObject,
-  actionData?: { resourceType?: ResourceConstant },
+  actionData?: { resourceType?: ResourceConstant; amount?: number },
 ): void {
   const metricsMemory = creep.memory as MetricsCreepMemory;
 
@@ -651,12 +687,14 @@ function trackActionMetrics(
     }
 
     case "transfer": {
-      // For transfer, track the actual amount transferred
-      // Use the specific resource type from the action
+      // For transfer, track the intended amount. Screeps intents do not mutate
+      // store state until tick end, so explicit reserved amounts are the best
+      // available estimate for amount-aware task-board deliveries.
       const resourceType = actionData?.resourceType ?? RESOURCE_ENERGY;
       const transferAmount = Math.min(
+        actionData?.amount ?? creep.store.getUsedCapacity(resourceType),
         creep.store.getUsedCapacity(resourceType),
-        (target as AnyStoreStructure).store?.getFreeCapacity(resourceType) ?? 0,
+        (target as AnyStoreStructure).store?.getFreeCapacity(resourceType) ?? Infinity,
       );
       if (transferAmount > 0) {
         metrics.recordTransfer(metricsMemory, transferAmount);

--- a/packages/@ralphschuler/screeps-roles/src/framework/types.ts
+++ b/packages/@ralphschuler/screeps-roles/src/framework/types.ts
@@ -52,7 +52,7 @@ export type CreepAction =
   | { type: "withdraw"; target: AnyStoreStructure | Tombstone | Ruin; resourceType: ResourceConstant }
 
   // Resource delivery actions
-  | { type: "transfer"; target: AnyStoreStructure; resourceType: ResourceConstant }
+  | { type: "transfer"; target: AnyStoreStructure; resourceType: ResourceConstant; amount?: number }
   | { type: "drop"; resourceType: ResourceConstant }
 
   // Construction and maintenance actions

--- a/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
+++ b/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
@@ -125,6 +125,11 @@ function getAssignmentAmount(creep: Creep, task: CreepTask): number {
   return Math.max(1, getCreepEnergy(creep));
 }
 
+function getReservationAmount(task: CreepTask, creepName: string): number | undefined {
+  const amount = task.reservations[creepName]?.amount;
+  return typeof amount === "number" && Number.isFinite(amount) && amount > 0 ? amount : undefined;
+}
+
 function canPerformTask(ctx: CreepContext, task: CreepTask): boolean {
   if (!task.allowedRoles.includes(ctx.memory.role)) return false;
 
@@ -514,7 +519,12 @@ function convertTaskToAction(task: CreepTask, ctx: CreepContext): CreepAction | 
     case "refillTower":
     case "fillTerminalEnergy":
     case "storeEnergy":
-      return { type: "transfer", target: target as AnyStoreStructure, resourceType: RESOURCE_ENERGY };
+      return {
+        type: "transfer",
+        target: target as AnyStoreStructure,
+        resourceType: RESOURCE_ENERGY,
+        amount: getReservationAmount(task, ctx.creep.name),
+      };
     case "build":
       return { type: "build", target: target as ConstructionSite };
     case "repair":

--- a/packages/@ralphschuler/screeps-roles/test/executorSafety.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/executorSafety.test.ts
@@ -107,6 +107,77 @@ describe("Action execution ally-safety guard", () => {
     expect(attackCalled).to.equal(true);
   });
 
+  it("passes bounded explicit transfer amounts to creep.transfer", () => {
+    const room = createMockRoom("W1N1");
+    let transferArgs: [AnyStoreStructure, ResourceConstant, number | undefined] | undefined;
+    const extension = {
+      id: "extension1" as Id<StructureExtension>,
+      structureType: STRUCTURE_EXTENSION,
+      pos: new RoomPosition(10, 10, room.name),
+      store: { getFreeCapacity: () => 50 },
+    } as unknown as StructureExtension;
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", homeRoom: room.name, working: true },
+      store: {
+        getUsedCapacity: () => 200,
+        getFreeCapacity: () => 0,
+        getCapacity: () => 200,
+      } as Creep["store"],
+    });
+    (creep as unknown as { transfer: typeof creep.transfer }).transfer = (
+      target,
+      resourceType,
+      amount,
+    ) => {
+      transferArgs = [target as AnyStoreStructure, resourceType, amount];
+      return OK;
+    };
+    Game.creeps[creep.name] = creep;
+    Game.rooms[room.name] = room;
+
+    executeAction(
+      creep,
+      { type: "transfer", target: extension, resourceType: RESOURCE_ENERGY, amount: 80 },
+      createTestContext(creep, room),
+    );
+
+    expect(transferArgs).to.deep.equal([extension, RESOURCE_ENERGY, 50]);
+  });
+
+  it("leaves direct transfer actions unbounded when no amount is provided", () => {
+    const room = createMockRoom("W1N1");
+    let transferArgs: [AnyStoreStructure, ResourceConstant, number | undefined] | undefined;
+    const storage = {
+      id: "storage1" as Id<StructureStorage>,
+      structureType: STRUCTURE_STORAGE,
+      pos: new RoomPosition(10, 10, room.name),
+      store: { getFreeCapacity: () => 1000 },
+    } as unknown as StructureStorage;
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", homeRoom: room.name, working: true },
+    });
+    (creep as unknown as { transfer: typeof creep.transfer }).transfer = (
+      target,
+      resourceType,
+      amount,
+    ) => {
+      transferArgs = [target as AnyStoreStructure, resourceType, amount];
+      return OK;
+    };
+    Game.creeps[creep.name] = creep;
+    Game.rooms[room.name] = room;
+
+    executeAction(
+      creep,
+      { type: "transfer", target: storage, resourceType: RESOURCE_ENERGY },
+      createTestContext(creep, room),
+    );
+
+    expect(transferArgs).to.deep.equal([storage, RESOURCE_ENERGY, undefined]);
+  });
+
   it("clears stale controller-action state when the creep has no active CLAIM parts", () => {
     const room = createMockRoom("W1N1");
     const controller = {

--- a/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
@@ -184,6 +184,26 @@ describe("TaskBoard", () => {
     expect(taskBoard.describeAssignments(room.name)).to.contain("hauler2 -> refillExtension");
   });
 
+  it("includes the reserved amount on delivery transfer actions", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const room = createMockRoom("W1N1");
+    (room as any).find = (type: number) => type === FIND_MY_STRUCTURES ? [extension] : [];
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : null;
+
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1 },
+      store: makeStore(200, 200),
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const action = taskBoard.getAssignedDeliveryAction(makeContext(creep, room));
+
+    expect(action?.type).to.equal("transfer");
+    expect((action as Extract<CreepAction, { type: "transfer" }>).amount).to.equal(50);
+  });
+
   it("cleans dead creep reservations", () => {
     const spawn = makeSpawn("spawn1" as Id<StructureSpawn>, 100);
     const room = createMockRoom("W1N1");


### PR DESCRIPTION
## Summary

Adds amount-aware task-board delivery execution so reserved refill/store amounts flow from task-board assignment into `CreepAction` transfer intents and are bounded before `creep.transfer`.

## Linked issue

Closes #3182

## Changes

- Extends roles `CreepAction` transfer actions with optional `amount`.
- Includes the assigned reservation amount when task-board delivery tasks convert to transfer actions.
- Bounds explicit transfer amounts by carried resources and target free capacity before execution.
- Keeps direct/non-task-board transfer actions unbounded when no amount is provided.

## Validation

- `npm test -w @ralphschuler/screeps-roles -- --grep "reserved amount|explicit transfer amounts|direct transfer actions"` ✅
- `npm test -w @ralphschuler/screeps-roles` ✅
- `npm run build -w @ralphschuler/screeps-roles` ✅
- `npm run lint -w @ralphschuler/screeps-roles` ✅ (existing MODULE_TYPELESS_PACKAGE_JSON warnings only)
- `npm run build` ✅
- `npm run lint:all` ✅ (existing MODULE_TYPELESS_PACKAGE_JSON warnings only)

## Deployment impact

Runtime behavior change in `@ralphschuler/screeps-roles`: task-board delivery creeps transfer only their reserved amount, reducing over-transfer and reservation skew. Deploy path still builds; `npm run build` was successful in build-only mode.

## Live bot evidence

Latest live analysis (`artifacts/live-analysis-20260704T002741Z-autonomous/`) showed shard1 task-board delivery pressure: `79` tasks, `0` assigned, `79` unassigned, mostly `refillExtension`/`refillTower`/`storeEnergy`. This PR implements the #3182 amount-execution slice linked from #3119.

## Follow-up issues

- #3119 remains open for live task-board backlog reduction verification after deploy.
- #3105 remains open for mature-room storage/terminal energy depletion.
- #3245 remains open for stale/missing live stats checks.
