### PR TITLE
[codex] Preserve stateful task-board delivery amounts

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/stateMachine.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/stateMachine.ts
@@ -45,6 +45,7 @@
 import type { CreepAction, CreepContext } from "./types";
 import type { CreepState } from "../memory/schemas";
 import { createLogger } from "@ralphschuler/screeps-core";
+import { taskBoard } from "../tasks/taskBoard";
 
 const logger = createLogger("StateMachine");
 
@@ -75,6 +76,10 @@ interface StateValidityResult {
   valid: boolean;
   reason?: string;
   meta?: Record<string, unknown>;
+}
+
+function asPositiveFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
 export interface StateMachineOptions {
@@ -305,8 +310,15 @@ function actionToState(action: CreepAction, _ctx: CreepContext): CreepState {
   }
 
   // Store additional data based on action type
-  if (action.type === "withdraw" || action.type === "transfer") {
+  if (action.type === "withdraw") {
     state.data = { resourceType: action.resourceType };
+  }
+
+  if (action.type === "transfer") {
+    state.data = {
+      resourceType: action.resourceType,
+      ...(asPositiveFiniteNumber(action.amount) !== undefined ? { amount: action.amount } : {})
+    };
   }
 
   if (action.type === "remoteMoveTo" || action.type === "remoteMoveToRoom") {
@@ -362,10 +374,12 @@ function stateToAction(state: CreepState): CreepAction | null {
 
     case "transfer":
       if (target && state.data?.resourceType) {
+        const amount = asPositiveFiniteNumber(state.data.amount);
         return {
           type: "transfer",
           target: target as AnyStoreStructure,
-          resourceType: state.data.resourceType as ResourceConstant
+          resourceType: state.data.resourceType as ResourceConstant,
+          ...(amount !== undefined ? { amount } : {})
         };
       }
       return null;
@@ -514,7 +528,22 @@ export function evaluateWithStateMachine(
       // State still ongoing - try to reconstruct and continue action
       const action = stateToAction(currentState);
       if (action) {
-        return action;
+        if (action.type === "transfer" && ctx.memory.assignedTaskId) {
+          const assignedTaskId = ctx.memory.assignedTaskId;
+          const reservationAmount = taskBoard.refreshCreepReservation(ctx, action);
+          if (reservationAmount === null) {
+            logger.info("Task-board delivery reservation missing, re-evaluating behavior", {
+              room: ctx.creep.pos.roomName,
+              creep: ctx.creep.name,
+              meta: { action: currentState.action, role: ctx.memory.role, assignedTaskId }
+            });
+            delete ctx.memory.state;
+          } else {
+            return { ...action, amount: reservationAmount };
+          }
+        } else {
+          return action;
+        }
       }
       // Failed to reconstruct - clear state and evaluate new
       logger.info("State reconstruction failed, re-evaluating behavior", {

--- a/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
+++ b/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
@@ -609,6 +609,44 @@ export class TaskBoard {
     }
   }
 
+  public refreshCreepReservation(
+    ctx: CreepContext,
+    action: Extract<CreepAction, { type: "transfer" }>
+  ): number | null {
+    const assignedTaskId = ctx.memory.assignedTaskId;
+    if (!assignedTaskId) return null;
+
+    const memory = getTaskMemory();
+    const roomName = action.target.pos.roomName;
+    const board = memory.rooms[roomName] ?? memory.rooms[ctx.room.name];
+    const task = board?.tasks[assignedTaskId];
+    const reservation = task?.reservations[ctx.creep.name];
+
+    if (
+      !board ||
+      !task ||
+      !reservation ||
+      task.targetId !== action.target.id ||
+      !isEnergyDeliveryTaskType(task.type) ||
+      !isTargetStillValid(task)
+    ) {
+      delete ctx.memory.assignedTaskId;
+      return null;
+    }
+
+    const amount = getReservationAmount(task, ctx.creep.name) ?? action.amount;
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+      delete ctx.memory.assignedTaskId;
+      return null;
+    }
+
+    reservation.amount = amount;
+    reservation.expiresTick = Game.time + DEFAULT_RESERVATION_TTL;
+    task.updatedTick = Game.time;
+    recomputeReservationTotals(task);
+    return reservation.amount;
+  }
+
   public clear(roomName?: string): void {
     const memory = getTaskMemory();
     if (roomName) {

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -12,6 +12,7 @@ import {
   remoteHarvester,
   remoteWorker,
   evaluateWithStateMachine,
+  TaskPriority,
   setLabManagerProvider,
   setRemoteMoveHandler,
   soldier,
@@ -835,6 +836,263 @@ describe("Behavior Contracts", () => {
     expect((action as Extract<CreepAction, { type: "remoteMoveToRoom" }>).roomName).to.equal("W1N1");
     expect(creep.memory.state?.action).to.equal("remoteMoveToRoom");
     expect(creep.memory.state?.targetRoom).to.equal("W1N1");
+  });
+
+  it("preserves task-board transfer amounts and refreshes the reservation during stateful delivery", () => {
+    const room = createMockRoom("W1N1");
+    const extension = {
+      id: "extension1" as Id<StructureExtension>,
+      structureType: STRUCTURE_EXTENSION,
+      pos: new RoomPosition(10, 10, room.name),
+      room,
+      store: { getFreeCapacity: () => 50 }
+    } as unknown as StructureExtension;
+    const taskId = `${room.name}:refillExtension:${extension.id}`;
+    const creep = createMockCreep("hauler1", {
+      room,
+      pos: new RoomPosition(25, 25, room.name),
+      memory: {
+        role: "hauler",
+        homeRoom: room.name,
+        assignedTaskId: taskId,
+        working: true
+      },
+      store: makeEnergyStore(200, 200)
+    });
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    (Game as unknown as { getObjectById: (id: string) => unknown }).getObjectById = id =>
+      id === extension.id ? extension : null;
+    (Memory as any).creepTaskBoard = {
+      enabled: true,
+      rooms: {
+        [room.name]: {
+          roomName: room.name,
+          tasks: {
+            [taskId]: {
+              id: taskId,
+              roomName: room.name,
+              type: "refillExtension",
+              priority: TaskPriority.HIGH,
+              targetId: extension.id,
+              targetPos: { x: 10, y: 10, roomName: room.name },
+              resourceType: RESOURCE_ENERGY,
+              amount: 50,
+              reservedAmount: 50,
+              maxAssignments: 1,
+              allowedRoles: ["hauler"],
+              status: "assigned",
+              assignedCreeps: [creep.name],
+              reservations: {
+                [creep.name]: {
+                  creepName: creep.name,
+                  amount: 50,
+                  assignedTick: Game.time,
+                  expiresTick: Game.time
+                }
+              },
+              createdTick: Game.time,
+              updatedTick: Game.time,
+              expiresTick: Game.time + 50
+            }
+          },
+          lastGeneratedTick: Game.time,
+          lastCleanedTick: Game.time,
+          stats: { generated: 0, assigned: 1, completed: 0, invalidated: 0, staleReservations: 0, preemptions: 0 }
+        }
+      }
+    };
+
+    const ctx = {
+      ...createContext("hauler"),
+      creep,
+      room,
+      memory: creep.memory as CreepContext["memory"],
+      isEmpty: false,
+      isWorking: true
+    };
+
+    const firstAction = evaluateWithStateMachine(ctx, () => ({
+      type: "transfer",
+      target: extension,
+      resourceType: RESOURCE_ENERGY,
+      amount: 50
+    }));
+    expect((firstAction as Extract<CreepAction, { type: "transfer" }>).amount).to.equal(50);
+    expect(creep.memory.state?.data).to.deep.include({ resourceType: RESOURCE_ENERGY, amount: 50 });
+
+    Game.time++;
+    const continuedAction = evaluateWithStateMachine(ctx, () => ({ type: "idle" }));
+
+    expect(continuedAction.type).to.equal("transfer");
+    expect((continuedAction as Extract<CreepAction, { type: "transfer" }>).amount).to.equal(50);
+    const reservation = (Memory as any).creepTaskBoard.rooms[room.name].tasks[taskId].reservations[creep.name];
+    expect(reservation.expiresTick).to.equal(Game.time + 15);
+  });
+
+  it("hydrates legacy task-board transfer state amounts from the active reservation", () => {
+    const room = createMockRoom("W1N1");
+    const extension = {
+      id: "extension1" as Id<StructureExtension>,
+      structureType: STRUCTURE_EXTENSION,
+      pos: new RoomPosition(10, 10, room.name),
+      room,
+      store: { getFreeCapacity: () => 50 }
+    } as unknown as StructureExtension;
+    const taskId = `${room.name}:refillExtension:${extension.id}`;
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: {
+        role: "hauler",
+        homeRoom: room.name,
+        assignedTaskId: taskId,
+        working: true,
+        state: {
+          action: "transfer",
+          targetId: extension.id,
+          startTick: Game.time,
+          timeout: 25,
+          data: { resourceType: RESOURCE_ENERGY }
+        }
+      },
+      store: makeEnergyStore(200, 200)
+    });
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    (Game as unknown as { getObjectById: (id: string) => unknown }).getObjectById = id =>
+      id === extension.id ? extension : null;
+    (Memory as any).creepTaskBoard = {
+      enabled: true,
+      rooms: {
+        [room.name]: {
+          roomName: room.name,
+          tasks: {
+            [taskId]: {
+              id: taskId,
+              roomName: room.name,
+              type: "refillExtension",
+              priority: TaskPriority.HIGH,
+              targetId: extension.id,
+              targetPos: { x: 10, y: 10, roomName: room.name },
+              resourceType: RESOURCE_ENERGY,
+              amount: 50,
+              reservedAmount: 50,
+              maxAssignments: 1,
+              allowedRoles: ["hauler"],
+              status: "assigned",
+              assignedCreeps: [creep.name],
+              reservations: {
+                [creep.name]: {
+                  creepName: creep.name,
+                  amount: 50,
+                  assignedTick: Game.time,
+                  expiresTick: Game.time
+                }
+              },
+              createdTick: Game.time,
+              updatedTick: Game.time,
+              expiresTick: Game.time + 50
+            }
+          },
+          lastGeneratedTick: Game.time,
+          lastCleanedTick: Game.time,
+          stats: { generated: 0, assigned: 1, completed: 0, invalidated: 0, staleReservations: 0, preemptions: 0 }
+        }
+      }
+    };
+
+    Game.time++;
+    const action = evaluateWithStateMachine({
+      ...createContext("hauler"),
+      creep,
+      room,
+      memory: creep.memory as CreepContext["memory"],
+      isEmpty: false,
+      isWorking: true
+    }, () => ({ type: "idle" }));
+
+    expect(action.type).to.equal("transfer");
+    expect((action as Extract<CreepAction, { type: "transfer" }>).amount).to.equal(50);
+    const reservation = (Memory as any).creepTaskBoard.rooms[room.name].tasks[taskId].reservations[creep.name];
+    expect(reservation.expiresTick).to.equal(Game.time + 15);
+  });
+
+  it("clears stale task-board delivery state when its reservation no longer exists", () => {
+    const room = createMockRoom("W1N1");
+    const extension = {
+      id: "extension1" as Id<StructureExtension>,
+      structureType: STRUCTURE_EXTENSION,
+      pos: new RoomPosition(10, 10, room.name),
+      room,
+      store: { getFreeCapacity: () => 50 }
+    } as unknown as StructureExtension;
+    const taskId = `${room.name}:refillExtension:${extension.id}`;
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: {
+        role: "hauler",
+        homeRoom: room.name,
+        assignedTaskId: taskId,
+        working: true,
+        state: {
+          action: "transfer",
+          targetId: extension.id,
+          startTick: Game.time,
+          timeout: 25,
+          data: { resourceType: RESOURCE_ENERGY, amount: 50 }
+        }
+      },
+      store: makeEnergyStore(200, 200)
+    });
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    (Game as unknown as { getObjectById: (id: string) => unknown }).getObjectById = id =>
+      id === extension.id ? extension : null;
+    (Memory as any).creepTaskBoard = {
+      enabled: true,
+      rooms: {
+        [room.name]: {
+          roomName: room.name,
+          tasks: {
+            [taskId]: {
+              id: taskId,
+              roomName: room.name,
+              type: "refillExtension",
+              priority: TaskPriority.HIGH,
+              targetId: extension.id,
+              targetPos: { x: 10, y: 10, roomName: room.name },
+              resourceType: RESOURCE_ENERGY,
+              amount: 50,
+              reservedAmount: 0,
+              maxAssignments: 1,
+              allowedRoles: ["hauler"],
+              status: "open",
+              assignedCreeps: [],
+              reservations: {},
+              createdTick: Game.time,
+              updatedTick: Game.time,
+              expiresTick: Game.time + 50
+            }
+          },
+          lastGeneratedTick: Game.time,
+          lastCleanedTick: Game.time,
+          stats: { generated: 0, assigned: 1, completed: 0, invalidated: 0, staleReservations: 0, preemptions: 0 }
+        }
+      }
+    };
+
+    const action = evaluateWithStateMachine({
+      ...createContext("hauler"),
+      creep,
+      room,
+      memory: creep.memory as CreepContext["memory"],
+      isEmpty: false,
+      isWorking: true
+    }, () => ({ type: "idle" }));
+
+    expect(action.type).to.equal("idle");
+    expect(creep.memory.state).to.equal(undefined);
+    expect((creep.memory as { assignedTaskId?: string }).assignedTaskId).to.equal(undefined);
   });
 
   it("keeps room movement state active while on the target room exit", () => {

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -315,7 +315,7 @@ o.room && (n.room = o.room), o.meta)) for (var a in o.meta) O.has(a) || (n[a] = 
 h(JSON.stringify(n));
 }
 
-function M(e) {
+function k(e) {
 return {
 debug: function(t, r) {
 C(t, "string" == typeof r ? {
@@ -368,7 +368,7 @@ subsystem: e
 };
 }
 
-var k, U = {
+var M, U = {
 debug: C,
 info: S,
 warn: w,
@@ -381,38 +381,38 @@ v = o(o({}, v), e);
 getConfig: function() {
 return o({}, v);
 },
-createLogger: M,
+createLogger: k,
 flush: R
 };
 
 !function(e) {
 e[e.CRITICAL = 100] = "CRITICAL", e[e.HIGH = 75] = "HIGH", e[e.NORMAL = 50] = "NORMAL",
 e[e.LOW = 25] = "LOW", e[e.BACKGROUND = 10] = "BACKGROUND";
-}(k || (k = {}));
+}(M || (M = {}));
 
 var _ = {
-"hostile.detected": k.CRITICAL,
-"nuke.detected": k.CRITICAL,
-"safemode.activated": k.CRITICAL,
-"structure.destroyed": k.HIGH,
-"hostile.cleared": k.HIGH,
-"creep.died": k.HIGH,
-"energy.critical": k.HIGH,
-"spawn.emergency": k.HIGH,
-"posture.change": k.HIGH,
-"spawn.completed": k.NORMAL,
-"rcl.upgrade": k.NORMAL,
-"construction.complete": k.NORMAL,
-"remote.lost": k.NORMAL,
-"squad.formed": k.NORMAL,
-"squad.dissolved": k.NORMAL,
-"market.transaction": k.LOW,
-"pheromone.update": k.LOW,
-"cluster.update": k.LOW,
-"expansion.candidate": k.LOW,
-"powerbank.discovered": k.LOW,
-"cpu.spike": k.BACKGROUND,
-"bucket.modeChange": k.BACKGROUND
+"hostile.detected": M.CRITICAL,
+"nuke.detected": M.CRITICAL,
+"safemode.activated": M.CRITICAL,
+"structure.destroyed": M.HIGH,
+"hostile.cleared": M.HIGH,
+"creep.died": M.HIGH,
+"energy.critical": M.HIGH,
+"spawn.emergency": M.HIGH,
+"posture.change": M.HIGH,
+"spawn.completed": M.NORMAL,
+"rcl.upgrade": M.NORMAL,
+"construction.complete": M.NORMAL,
+"remote.lost": M.NORMAL,
+"squad.formed": M.NORMAL,
+"squad.dissolved": M.NORMAL,
+"market.transaction": M.LOW,
+"pheromone.update": M.LOW,
+"cluster.update": M.LOW,
+"expansion.candidate": M.LOW,
+"powerbank.discovered": M.LOW,
+"cpu.spike": M.BACKGROUND,
+"bucket.modeChange": M.BACKGROUND
 }, N = {
 maxEventsPerTick: 50,
 maxQueueSize: 200,
@@ -439,7 +439,7 @@ var o, n, a, i, s = this;
 void 0 === r && (r = {});
 var c = {
 handler: t,
-priority: null !== (o = r.priority) && void 0 !== o ? o : k.NORMAL,
+priority: null !== (o = r.priority) && void 0 !== o ? o : M.NORMAL,
 minBucket: null !== (n = r.minBucket) && void 0 !== n ? n : 0,
 once: null !== (a = r.once) && void 0 !== a && a,
 id: "handler_".concat(++this.handlerIdCounter)
@@ -481,7 +481,7 @@ var n, a, i, s;
 void 0 === r && (r = {});
 var c = o(o({}, t), {
 tick: Game.time
-}), u = null !== (a = null !== (n = r.priority) && void 0 !== n ? n : _[e]) && void 0 !== a ? a : k.NORMAL, l = null !== (i = r.immediate) && void 0 !== i ? i : u >= k.CRITICAL, m = null === (s = r.allowCoalescing) || void 0 === s || s;
+}), u = null !== (a = null !== (n = r.priority) && void 0 !== n ? n : _[e]) && void 0 !== a ? a : M.NORMAL, l = null !== (i = r.immediate) && void 0 !== i ? i : u >= M.CRITICAL, m = null === (s = r.allowCoalescing) || void 0 === s || s;
 if (this.config.enableCoalescing && m && !l) {
 var d = this.getCoalescingKey(e, c), p = this.tickEvents.get(d);
 if (p) return p.count++, this.stats.eventsCoalesced++, void (this.config.enableLogging && U.debug('EventBus: Coalesced "'.concat(e, '" (count: ').concat(p.count, ")"), {
@@ -498,7 +498,7 @@ this.stats.eventsEmitted++, this.config.enableLogging && U.debug('EventBus: Emit
 subsystem: "EventBus"
 });
 var f = Game.cpu.bucket;
-l || f >= this.config.lowBucketThreshold ? this.processEvent(e, c) : f >= this.config.criticalBucketThreshold ? this.queueEvent(e, c, u) : u >= k.CRITICAL ? this.processEvent(e, c) : (this.stats.eventsDropped++,
+l || f >= this.config.lowBucketThreshold ? this.processEvent(e, c) : f >= this.config.criticalBucketThreshold ? this.queueEvent(e, c, u) : u >= M.CRITICAL ? this.processEvent(e, c) : (this.stats.eventsDropped++,
 this.config.enableLogging && U.warn('EventBus: Dropped event "'.concat(e, '" due to critical bucket'), {
 subsystem: "EventBus"
 }));
@@ -555,7 +555,7 @@ event: e,
 index: t
 };
 }).filter(function(e) {
-return e.event.priority < k.HIGH;
+return e.event.priority < M.HIGH;
 }).sort(function(e, t) {
 return e.event.queuedAt - t.event.queuedAt;
 })[0];
@@ -1266,7 +1266,7 @@ var A = t.terminal;
 if (A && A.store.getUsedCapacity() > 0) {
 S = .8, w = -.8;
 try {
-for (var M = a(ce(A.store)), k = M.next(); !k.done; k = M.next()) O = k.value, e.resource(O, A.pos.x + S, A.pos.y + w, .3),
+for (var k = a(ce(A.store)), M = k.next(); !M.done; M = k.next()) O = M.value, e.resource(O, A.pos.x + S, A.pos.y + w, .3),
 S += .6;
 } catch (e) {
 u = {
@@ -1274,7 +1274,7 @@ error: e
 };
 } finally {
 try {
-k && !k.done && (l = M.return) && l.call(M);
+M && !M.done && (l = k.return) && l.call(k);
 } finally {
 if (u) throw u.error;
 }
@@ -2114,7 +2114,7 @@ opacity: .9
 });
 });
 
-var Me = {
+var ke = {
 pheromone: {
 updateInterval: 5,
 decayFactors: {
@@ -2256,14 +2256,14 @@ debug: !1,
 profiling: !0,
 visualizations: !0,
 lazyLoadConsoleCommands: !0
-}, ke = o({}, Me);
+}, Me = o({}, ke);
 
 function Ue() {
-return ke;
+return Me;
 }
 
 function _e(e) {
-ke = o(o({}, ke), e);
+Me = o(o({}, Me), e);
 }
 
 var Ne = function() {
@@ -3741,8 +3741,8 @@ return t.avg_cpu - e.avg_cpu;
 });
 try {
 for (var O = a(y.slice(0, 10)), A = O.next(); !A.done; A = O.next()) {
-var M = A.value, k = M.name || "unknown";
-d.push("  ".concat(k, ": ").concat(M.avg_cpu.toFixed(3), " CPU (calls: ").concat(M.calls, ")"));
+var k = A.value, M = k.name || "unknown";
+d.push("  ".concat(M, ": ").concat(k.avg_cpu.toFixed(3), " CPU (calls: ").concat(k.calls, ")"));
 }
 } catch (e) {
 i = {
@@ -4097,8 +4097,8 @@ return (null !== (o = null === (r = e.stats) || void 0 === r ? void 0 : r.health
 x += "Name | Health | Errors | Consecutive | Status | Last Success\n", x += "-".repeat(80) + "\n";
 try {
 for (var b = a(w), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, M = (null !== (o = null === (r = A.stats) || void 0 === r ? void 0 : r.healthScore) && void 0 !== o ? o : 0).toFixed(0), k = (null !== (c = null === (n = A.stats) || void 0 === n ? void 0 : n.healthScore) && void 0 !== c ? c : 0) >= 80 ? "✓" : (null !== (l = null === (u = A.stats) || void 0 === u ? void 0 : u.healthScore) && void 0 !== l ? l : 0) >= 50 ? "⚠" : "✗", U = (null !== (d = null === (m = A.stats) || void 0 === m ? void 0 : m.lastSuccessfulRunTick) && void 0 !== d ? d : 0) > 0 ? Game.time - (null !== (f = null === (p = A.stats) || void 0 === p ? void 0 : p.lastSuccessfulRunTick) && void 0 !== f ? f : 0) : "never", _ = "suspended" === A.state ? "SUSPENDED (".concat(null !== (v = null === (y = A.stats) || void 0 === y ? void 0 : y.suspensionReason) && void 0 !== v ? v : "unknown", ")") : A.state.toUpperCase();
-x += "".concat(A.name, " | ").concat(k, " ").concat(M, "/100 | ").concat(null !== (h = null === (g = A.stats) || void 0 === g ? void 0 : g.errorCount) && void 0 !== h ? h : 0, " | ").concat(null !== (E = null === (R = A.stats) || void 0 === R ? void 0 : R.consecutiveErrors) && void 0 !== E ? E : 0, " | ").concat(_, " | ").concat(U, "\n");
+var A = O.value, k = (null !== (o = null === (r = A.stats) || void 0 === r ? void 0 : r.healthScore) && void 0 !== o ? o : 0).toFixed(0), M = (null !== (c = null === (n = A.stats) || void 0 === n ? void 0 : n.healthScore) && void 0 !== c ? c : 0) >= 80 ? "✓" : (null !== (l = null === (u = A.stats) || void 0 === u ? void 0 : u.healthScore) && void 0 !== l ? l : 0) >= 50 ? "⚠" : "✗", U = (null !== (d = null === (m = A.stats) || void 0 === m ? void 0 : m.lastSuccessfulRunTick) && void 0 !== d ? d : 0) > 0 ? Game.time - (null !== (f = null === (p = A.stats) || void 0 === p ? void 0 : p.lastSuccessfulRunTick) && void 0 !== f ? f : 0) : "never", _ = "suspended" === A.state ? "SUSPENDED (".concat(null !== (v = null === (y = A.stats) || void 0 === y ? void 0 : y.suspensionReason) && void 0 !== v ? v : "unknown", ")") : A.state.toUpperCase();
+x += "".concat(A.name, " | ").concat(M, " ").concat(k, "/100 | ").concat(null !== (h = null === (g = A.stats) || void 0 === g ? void 0 : g.errorCount) && void 0 !== h ? h : 0, " | ").concat(null !== (E = null === (R = A.stats) || void 0 === R ? void 0 : R.consecutiveErrors) && void 0 !== E ? E : 0, " | ").concat(_, " | ").concat(U, "\n");
 }
 } catch (t) {
 e = {
@@ -4569,7 +4569,7 @@ category: "Economy"
 }) ], e.prototype, "getSpawnDelay", null), e;
 }(), At = new Ot;
 
-function Mt(e, t) {
+function kt(e, t) {
 return {
 id: e,
 coreRoom: t,
@@ -4598,14 +4598,14 @@ e[e.Traffic = 4] = "Traffic", e[e.Defense = 8] = "Defense", e[e.Economy = 16] = 
 e[e.Construction = 32] = "Construction", e[e.Performance = 64] = "Performance";
 }(St || (St = {}));
 
-var kt = -1;
+var Mt = -1;
 
 function Ut(e) {
 return void 0 !== e.value;
 }
 
 function _t(e, t) {
-return void 0 !== e.ttl && e.ttl !== kt && t - e.lastModified > e.ttl;
+return void 0 !== e.ttl && e.ttl !== Mt && t - e.lastModified > e.ttl;
 }
 
 function Nt(e, t) {
@@ -4785,7 +4785,7 @@ if (r) throw r.error;
 }
 return c;
 }, e;
-}(), Ft = new Dt, Bt = M("MemoryMonitor"), Wt = 2097152, Kt = new (function() {
+}(), Ft = new Dt, Bt = k("MemoryMonitor"), Wt = 2097152, Kt = new (function() {
 function e() {
 this.lastCheckTick = 0, this.lastStatus = "normal";
 }
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -5720,23 +5720,23 @@ e[ur] || (e[ur] = {});
 var e = "memory:".concat(cr), t = Ft.get(e);
 this.ensureEmpireMemory();
 var r = Memory;
-return t && t === r[cr] || (Ft.set(e, r[cr], kt), t = r[cr]), t;
+return t && t === r[cr] || (Ft.set(e, r[cr], Mt), t = r[cr]), t;
 }, e.prototype.getClusters = function() {
 var e = "memory:".concat(ur), t = Ft.get(e);
 if (!t) {
 this.ensureClustersMemory();
 var r = Memory;
-Ft.set(e, r[ur], kt), t = r[ur];
+Ft.set(e, r[ur], Mt), t = r[ur];
 }
 return t;
 }, e.prototype.getCluster = function(e, t) {
 var r = this.getClusters();
-return !r[e] && t && (r[e] = Mt(e, t)), r[e];
+return !r[e] && t && (r[e] = kt(e, t)), r[e];
 }, e.prototype.getSwarmState = function(e) {
 var t, r = "memory:room:".concat(e, ":swarm"), o = Ft.get(r), n = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 if (n) {
 var a = n.swarm;
-if (a) return o && o === a || (Ft.set(r, a, kt), o = a), o;
+if (a) return o && o === a || (Ft.set(r, a, Mt), o = a), o;
 }
 }, e.prototype.initSwarmState = function(e) {
 var t = "memory:room:".concat(e, ":swarm");
@@ -5788,7 +5788,7 @@ energyNeed: 0
 },
 lastUpdate: 0,
 lastHostileTick: 0
-}), Ft.set(t, r.swarm, kt), r.swarm;
+}), Ft.set(t, r.swarm, Mt), r.swarm;
 }, e.prototype.getOrInitSwarmState = function(e) {
 var t;
 return null !== (t = this.getSwarmState(e)) && void 0 !== t ? t : this.initSwarmState(e);
@@ -6075,7 +6075,7 @@ score: e.score * t
 };
 }
 
-function Mr(e) {
+function kr(e) {
 var t, r;
 if (0 === e.length) return null;
 var o = null, n = {
@@ -6110,9 +6110,9 @@ total: n
 };
 }
 
-function kr(e) {
+function Mr(e) {
 var t = Game.rooms[e];
-return t ? Mr(j(t)) : null;
+return t ? kr(j(t)) : null;
 }
 
 function Ur(e, t, r) {
@@ -7316,7 +7316,7 @@ return Co(e, t);
 })), !1));
 }
 
-var Oo = "spawn", Ao = "extension", Mo = "road", ko = "rampart", Uo = "container", _o = "tower", No = "storage", Po = "link", Io = "terminal", Go = "extractor", Lo = "lab", Do = "factory", Fo = "nuker", Bo = "observer", Wo = "powerSpawn", Ko = [ Oo, Ao, _o, No, Po, Io, Go, Lo, Do, Fo, Bo, Wo ];
+var Oo = "spawn", Ao = "extension", ko = "road", Mo = "rampart", Uo = "container", _o = "tower", No = "storage", Po = "link", Io = "terminal", Go = "extractor", Lo = "lab", Do = "factory", Fo = "nuker", Bo = "observer", Wo = "powerSpawn", Ko = [ Oo, Ao, _o, No, Po, Io, Go, Lo, Do, Fo, Bo, Wo ];
 
 function Ho(e) {
 return Math.min(8, Math.max(1, Math.floor(Number.isFinite(e) ? e : 1)));
@@ -8671,8 +8671,8 @@ var r, o, n, i, s, c = e.controller;
 if (!c) return null;
 var u = e.find(FIND_SOURCES), l = c.pos.x, m = c.pos.y;
 try {
-for (var d = a(u), p = d.next(); !p.done; p = d.next()) l += (k = p.value).pos.x,
-m += k.pos.y;
+for (var d = a(u), p = d.next(); !p.done; p = d.next()) l += (M = p.value).pos.x,
+m += M.pos.y;
 } catch (e) {
 r = {
 error: e
@@ -8694,9 +8694,9 @@ var x = 1e3, b = S.getRangeTo(c);
 b >= 4 && b <= 8 ? x += 100 : b < 4 ? x -= 50 : b > 12 && (x -= 30);
 var O = 0;
 try {
-for (var A = (n = void 0, a(u)), M = A.next(); !M.done; M = A.next()) {
-var k = M.value;
-O += S.getRangeTo(k);
+for (var A = (n = void 0, a(u)), k = A.next(); !k.done; k = A.next()) {
+var M = k.value;
+O += S.getRangeTo(M);
 }
 } catch (e) {
 n = {
@@ -8704,7 +8704,7 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (i = A.return) && i.call(A);
+k && !k.done && (i = A.return) && i.call(A);
 } finally {
 if (n) throw n.error;
 }
@@ -9360,9 +9360,9 @@ if (c) throw c.error;
 return l;
 }
 
-var An = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], Mn = new Set(An);
+var An = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], kn = new Set(An);
 
-var kn = {
+var Mn = {
 id: "EXT10_DIAMOND",
 name: "EXT10 diamond extension pod",
 members: [ {
@@ -10132,7 +10132,7 @@ var o, n, i;
 try {
 for (var s = a(null != t ? t : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== Mo && u.structureType !== ko && Fn(e.facts, u.x, u.y)) {
+if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== ko && u.structureType !== Mo && Fn(e.facts, u.x, u.y)) {
 var l = "".concat(u.x, ",").concat(u.y);
 if (!e.occupied.has(l)) {
 var m = {
@@ -10386,7 +10386,7 @@ case Po:
 return "P1";
 
 case _o:
-case ko:
+case Mo:
 return "P2";
 
 case Io:
@@ -10456,7 +10456,7 @@ var C = T.value;
 C.minRcl > d || (R = {
 x: C.x,
 y: C.y,
-structureType: Mo,
+structureType: ko,
 minRcl: C.minRcl,
 priority: "P1",
 score: 360 + C.priority,
@@ -10480,7 +10480,7 @@ var x = w.value;
 x.minRcl > d || (R = {
 x: x.x,
 y: x.y,
-structureType: ko,
+structureType: Mo,
 minRcl: x.minRcl,
 priority: "P2",
 score: 300 + x.priority,
@@ -11226,8 +11226,8 @@ if (!S) break;
 if (T.size > 0) {
 try {
 for (var O = a(T), A = O.next(); !A.done; A = O.next()) {
-var M = A.value;
-E.push(M);
+var k = A.value;
+E.push(k);
 }
 } catch (e) {
 c = {
@@ -11618,9 +11618,9 @@ return Ta;
 
 new Oa(ba(o({}, Ca).cpu));
 
-var Aa, Ma = new Set;
+var Aa, ka = new Set;
 
-function ka(e, t, r) {
+function Ma(e, t, r) {
 return o({
 id: e,
 name: t,
@@ -11644,7 +11644,7 @@ interval: 20
 
 function _a() {
 return function(e) {
-return Ma.add(e), e;
+return ka.add(e), e;
 };
 }
 
@@ -11825,7 +11825,7 @@ t && delete t.memory.assistTarget, this.assignments.delete(e), U.info("Cancelled
 subsystem: "Defense"
 });
 }
-}, n([ ka("cluster:defense", "Defense Coordinator", {
+}, n([ Ma("cluster:defense", "Defense Coordinator", {
 priority: ha.HIGH,
 interval: 3,
 minBucket: 0,
@@ -12536,7 +12536,7 @@ return void 0 !== t && !t.complete;
 return Array.from(this.evacuations.values()).filter(function(e) {
 return !e.complete;
 });
-}, n([ ka("cluster:evacuation", "Evacuation Manager", {
+}, n([ Ma("cluster:evacuation", "Evacuation Manager", {
 priority: ha.HIGH,
 interval: 5,
 minBucket: 0,
@@ -12849,13 +12849,13 @@ interval: 100
 }, r));
 }
 
-function Mi() {
+function ki() {
 return function(e) {
 return wi.add(e), e;
 };
 }
 
-function ki(e) {
+function Mi(e) {
 var t = Math.floor(.1 * e), r = Math.floor(Math.random() * (2 * t + 1)) - t;
 return {
 interval: Math.max(1, e + r),
@@ -12871,7 +12871,7 @@ var l = u.value;
 if (l.target === s || Object.getPrototypeOf(l.target) === s || l.target === Object.getPrototypeOf(s)) {
 var m = e[l.methodName];
 if ("function" == typeof m) {
-var d = m.bind(e), p = null !== (o = l.options.interval) && void 0 !== o ? o : 5, f = ki(p), y = f.interval, v = f.jitter;
+var d = m.bind(e), p = null !== (o = l.options.interval) && void 0 !== o ? o : 5, f = Mi(p), y = f.interval, v = f.jitter;
 Ja.registerProcess({
 id: l.options.id,
 name: l.options.name,
@@ -13546,10 +13546,10 @@ return "string" == typeof e;
 }) : [], h = this.getMyUsername(), R = null !== (i = null === (n = Memory.empire) || void 0 === n ? void 0 : n.knownRooms) && void 0 !== i ? i : {}, E = 0, T = 0, C = 0, S = 1 / 0, w = 0;
 try {
 for (var x = a(g), b = x.next(); !b.done; b = x.next()) {
-var O = b.value, A = Game.rooms[O], M = R[O];
+var O = b.value, A = Game.rooms[O], k = R[O];
 A && E++;
-var k = null !== (u = null === (c = null === (s = null == A ? void 0 : A.controller) || void 0 === s ? void 0 : s.owner) || void 0 === c ? void 0 : c.username) && void 0 !== u ? u : null == M ? void 0 : M.owner, U = null !== (d = null === (m = null === (l = null == A ? void 0 : A.controller) || void 0 === l ? void 0 : l.reservation) || void 0 === m ? void 0 : m.username) && void 0 !== d ? d : null == M ? void 0 : M.reserver, _ = null === (f = null === (p = null == A ? void 0 : A.controller) || void 0 === p ? void 0 : p.reservation) || void 0 === f ? void 0 : f.ticksToEnd;
-U === h ? (T++, "number" == typeof _ && (S = Math.min(S, _))) : U && C++, (k && k !== h || U && U !== h || (null !== (y = null == M ? void 0 : M.threatLevel) && void 0 !== y ? y : 0) >= 2) && w++;
+var M = null !== (u = null === (c = null === (s = null == A ? void 0 : A.controller) || void 0 === s ? void 0 : s.owner) || void 0 === c ? void 0 : c.username) && void 0 !== u ? u : null == k ? void 0 : k.owner, U = null !== (d = null === (m = null === (l = null == A ? void 0 : A.controller) || void 0 === l ? void 0 : l.reservation) || void 0 === m ? void 0 : m.username) && void 0 !== d ? d : null == k ? void 0 : k.reserver, _ = null === (f = null === (p = null == A ? void 0 : A.controller) || void 0 === p ? void 0 : p.reservation) || void 0 === f ? void 0 : f.ticksToEnd;
+U === h ? (T++, "number" == typeof _ && (S = Math.min(S, _))) : U && C++, (M && M !== h || U && U !== h || (null !== (y = null == k ? void 0 : k.threatLevel) && void 0 !== y ? y : 0) >= 2) && w++;
 }
 } catch (e) {
 r = {
@@ -13733,9 +13733,9 @@ idleSpawnTicks: n.idleSpawnTicks
 }, e.prototype.recordRoom = function(e, t) {
 var r, o, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, A;
 if (this.config.enabled) {
-var M = Fi(e.name), k = Object.values(Game.creeps).filter(function(t) {
+var k = Fi(e.name), M = Object.values(Game.creeps).filter(function(t) {
 return t.room.name === e.name;
-}).length, U = j(e), _ = this.getRoomTaskBoardStats(e.name), N = this.getRemoteStats(e.name, M), P = this.getDefenseStats(e, U, M), I = this.getControllerDowngradeStats(e), G = this.currentSnapshot.rooms[e.name];
+}).length, U = j(e), _ = this.getRoomTaskBoardStats(e.name), N = this.getRemoteStats(e.name, k), P = this.getDefenseStats(e, U, k), I = this.getControllerDowngradeStats(e), G = this.currentSnapshot.rooms[e.name];
 G || (G = {
 name: e.name,
 rcl: null !== (s = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== s ? s : 0,
@@ -13752,12 +13752,12 @@ progressPercent: 0,
 ticksToDowngrade: I.ticksToDowngrade,
 downgradeRisk: I.downgradeRisk
 },
-creeps: k,
+creeps: M,
 hostiles: U.length,
 brain: {
-danger: null !== (v = null == M ? void 0 : M.danger) && void 0 !== v ? v : 0,
-postureCode: this.postureToCode(null !== (g = null == M ? void 0 : M.posture) && void 0 !== g ? g : "eco"),
-colonyLevelCode: this.colonyLevelToCode(null !== (h = null == M ? void 0 : M.colonyLevel) && void 0 !== h ? h : "seedNest")
+danger: null !== (v = null == k ? void 0 : k.danger) && void 0 !== v ? v : 0,
+postureCode: this.postureToCode(null !== (g = null == k ? void 0 : k.posture) && void 0 !== g ? g : "eco"),
+colonyLevelCode: this.colonyLevelToCode(null !== (h = null == k ? void 0 : k.colonyLevel) && void 0 !== h ? h : "seedNest")
 },
 pheromones: {},
 metrics: {
@@ -13789,10 +13789,10 @@ G.energy.available = e.energyAvailable, G.energy.capacity = e.energyCapacityAvai
 G.energy.storage = F, G.energy.terminal = null !== (b = null === (x = e.terminal) || void 0 === x ? void 0 : x.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== b ? b : 0,
 G.controller.progress = D, G.controller.progressTotal = null !== (A = null === (O = e.controller) || void 0 === O ? void 0 : O.progressTotal) && void 0 !== A ? A : 1,
 G.controller.ticksToDowngrade = I.ticksToDowngrade, G.controller.downgradeRisk = I.downgradeRisk,
-G.creeps = k, G.hostiles = U.length, G.controller.progressPercent = G.controller.progressTotal > 0 ? G.controller.progress / G.controller.progressTotal * 100 : 0,
-M) {
-if (M.pheromones && "object" == typeof M.pheromones) try {
-for (var B = a(Object.entries(M.pheromones)), W = B.next(); !W.done; W = B.next()) {
+G.creeps = M, G.hostiles = U.length, G.controller.progressPercent = G.controller.progressTotal > 0 ? G.controller.progress / G.controller.progressTotal * 100 : 0,
+k) {
+if (k.pheromones && "object" == typeof k.pheromones) try {
+for (var B = a(Object.entries(k.pheromones)), W = B.next(); !W.done; W = B.next()) {
 var K = i(W.value, 2), H = K[0], Y = K[1];
 G.pheromones[H] = Y;
 }
@@ -13807,19 +13807,19 @@ W && !W.done && (o = B.return) && o.call(B);
 if (r) throw r.error;
 }
 }
-M.metrics && "object" == typeof M.metrics && (G.metrics = {
-energyHarvested: M.metrics.energyHarvested,
-energySpawning: M.metrics.energySpawning,
-energyConstruction: M.metrics.energyConstruction,
-energyRepair: M.metrics.energyRepair,
-energyTower: M.metrics.energyTower,
-energyAvailableForSharing: M.metrics.energyAvailable,
-energyCapacityTotal: M.metrics.energyCapacity,
-energyNeed: M.metrics.energyNeed,
-controllerProgress: M.metrics.controllerProgress,
-hostileCount: M.metrics.hostileCount,
-damageReceived: M.metrics.damageReceived,
-constructionSites: M.metrics.constructionSites
+k.metrics && "object" == typeof k.metrics && (G.metrics = {
+energyHarvested: k.metrics.energyHarvested,
+energySpawning: k.metrics.energySpawning,
+energyConstruction: k.metrics.energyConstruction,
+energyRepair: k.metrics.energyRepair,
+energyTower: k.metrics.energyTower,
+energyAvailableForSharing: k.metrics.energyAvailable,
+energyCapacityTotal: k.metrics.energyCapacity,
+energyNeed: k.metrics.energyNeed,
+controllerProgress: k.metrics.controllerProgress,
+hostileCount: k.metrics.hostileCount,
+damageReceived: k.metrics.damageReceived,
+constructionSites: k.metrics.constructionSites
 });
 }
 var V = void 0 !== (null == L ? void 0 : L.controllerProgress) ? Math.max(0, D - L.controllerProgress) : 0, q = void 0 !== (null == L ? void 0 : L.storageEnergy) ? Math.max(0, F - L.storageEnergy) : 0;
@@ -14158,8 +14158,8 @@ return e.memory.role === v;
 }), h = g.length, R = 0, E = 0, T = 0, C = 0, S = 0;
 try {
 for (var w = (i = void 0, a(g)), x = w.next(); !x.done; x = w.next()) {
-var b = x.value, O = b.memory, A = null !== (o = null === (r = O.state) || void 0 === r ? void 0 : r.action) && void 0 !== o ? o : "idle", M = null !== (n = O.working) && void 0 !== n ? n : "idle" !== A;
-S += b.body.length, C += null !== (s = b.ticksToLive) && void 0 !== s ? s : 0, b.spawning ? R++ : M && "idle" !== A ? T++ : E++;
+var b = x.value, O = b.memory, A = null !== (o = null === (r = O.state) || void 0 === r ? void 0 : r.action) && void 0 !== o ? o : "idle", k = null !== (n = O.working) && void 0 !== n ? n : "idle" !== A;
+S += b.body.length, C += null !== (s = b.ticksToLive) && void 0 !== s ? s : 0, b.spawning ? R++ : k && "idle" !== A ? T++ : E++;
 }
 } catch (e) {
 i = {
@@ -14172,7 +14172,7 @@ x && !x.done && (d = w.return) && d.call(w);
 if (i) throw i.error;
 }
 }
-var k = t.length > 0 ? f / t.length : 0, U = (N = null === (c = m.roles) || void 0 === c ? void 0 : c[v]) ? N.avgCpu * (1 - p.config.smoothingFactor) + k * p.config.smoothingFactor : k, _ = N ? Math.max(N.peakCpu, k) : k;
+var M = t.length > 0 ? f / t.length : 0, U = (N = null === (c = m.roles) || void 0 === c ? void 0 : c[v]) ? N.avgCpu * (1 - p.config.smoothingFactor) + M * p.config.smoothingFactor : M, _ = N ? Math.max(N.peakCpu, M) : M;
 p.currentSnapshot.roles[v] = {
 name: v,
 count: h,
@@ -14591,18 +14591,18 @@ if (r) throw r.error;
 }
 try {
 for (var b = a(Object.entries(f.roles)), O = b.next(); !O.done; O = b.next()) {
-var A = i(O.value, 2), M = (w = A[0], A[1]);
+var A = i(O.value, 2), k = (w = A[0], A[1]);
 p.stats.roles[w] = {
-count: M.count,
-avg_cpu: M.avgCpu,
-peak_cpu: M.peakCpu,
-calls: M.calls,
-samples: M.samples,
-spawning_count: M.spawningCount,
-idle_count: M.idleCount,
-active_count: M.activeCount,
-avg_ticks_to_live: M.avgTicksToLive,
-total_body_parts: M.totalBodyParts
+count: k.count,
+avg_cpu: k.avgCpu,
+peak_cpu: k.peakCpu,
+calls: k.calls,
+samples: k.samples,
+spawning_count: k.spawningCount,
+idle_count: k.idleCount,
+active_count: k.activeCount,
+avg_ticks_to_live: k.avgTicksToLive,
+total_body_parts: k.totalBodyParts
 };
 }
 } catch (e) {
@@ -14618,7 +14618,7 @@ if (s) throw s.error;
 }
 p.stats.processes = {};
 try {
-for (var k = a(Object.entries(f.processes)), U = k.next(); !U.done; U = k.next()) {
+for (var M = a(Object.entries(f.processes)), U = M.next(); !U.done; U = M.next()) {
 var _ = i(U.value, 2), N = _[0], P = _[1];
 p.stats.processes[N] = {
 name: P.name,
@@ -14642,7 +14642,7 @@ error: e
 };
 } finally {
 try {
-U && !U.done && (l = k.return) && l.call(k);
+U && !U.done && (l = M.return) && l.call(M);
 } finally {
 if (u) throw u.error;
 }
@@ -14815,8 +14815,8 @@ return t.cpu - e.cpu;
 if (A.length > 0) {
 Di.info("Top Creeps by CPU:");
 try {
-for (var M = a(A), k = M.next(); !k.done; k = M.next()) {
-var U = k.value;
+for (var k = a(A), M = k.next(); !M.done; M = k.next()) {
+var U = M.value;
 Di.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
 }
 } catch (e) {
@@ -14825,7 +14825,7 @@ error: e
 };
 } finally {
 try {
-k && !k.done && (l = M.return) && l.call(M);
+M && !M.done && (l = k.return) && l.call(k);
 } finally {
 if (u) throw u.error;
 }
@@ -15454,7 +15454,7 @@ return e.role === as.SOURCE;
 return e.role === as.CONTROLLER || e.role === as.STORAGE;
 });
 return n && a;
-}, n([ ka("link:manager", "Link Manager", {
+}, n([ Ma("link:manager", "Link Manager", {
 priority: ha.MEDIUM,
 interval: 5,
 minBucket: 0,
@@ -16307,9 +16307,9 @@ var T = E.value, C = T.terminal;
 if (!((null !== (o = C.store.getFreeCapacity(e)) && void 0 !== o ? o : 0) < h)) {
 var S = Game.market.calcTransactionCost(h, T.name, v.roomName) + Game.market.calcTransactionCost(h, T.name, y.roomName), w = S * d.config.energyCreditValue, x = (y.price - v.price) * h - w, b = v.price * h, O = b > 0 ? x / b : 0, A = b > 0 ? w / b : 1 / 0;
 if (!(x < d.config.minArbitrageProfit || O < d.config.minArbitrageMargin || A > d.config.maxTransportCostRatio || C.store.getUsedCapacity(RESOURCE_ENERGY) - S < d.config.terminalEnergyReserve)) {
-var M = v.price * h;
-if (!(Game.market.credits - M < d.config.minCredits) && Game.market.deal(v.id, h, T.name) === OK) {
-var k = {
+var k = v.price * h;
+if (!(Game.market.credits - k < d.config.minCredits) && Game.market.deal(v.id, h, T.name) === OK) {
+var M = {
 id: "".concat(e, "-").concat(Game.time, "-").concat(v.id),
 resource: e,
 amount: h,
@@ -16321,7 +16321,7 @@ expectedArrival: Game.time + (null !== (n = C.cooldown) && void 0 !== n ? n : 0)
 buyPrice: v.price,
 transportCost: S
 };
-null === (i = s.pendingArbitrage) || void 0 === i || i.push(k), l++, U.info("Arbitrage started: bought ".concat(h, " ").concat(e, " at ").concat(v.price.toFixed(3), " to sell @ ").concat(y.price.toFixed(3), " (net profit ~").concat(x.toFixed(2), ")"), {
+null === (i = s.pendingArbitrage) || void 0 === i || i.push(M), l++, U.info("Arbitrage started: bought ".concat(h, " ").concat(e, " at ").concat(v.price.toFixed(3), " to sell @ ").concat(y.price.toFixed(3), " (net profit ~").concat(x.toFixed(2), ")"), {
 subsystem: "Market"
 });
 break;
@@ -16422,7 +16422,7 @@ interval: 100,
 minBucket: 2e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), As = new Os, Ms = function() {
+}(), As = new Os, ks = function() {
 function e() {
 this.costCache = new Map, this.COST_CACHE_TTL = 100, this.MAX_HOPS = 3;
 }
@@ -16489,12 +16489,12 @@ if (i) throw i.error;
 if (!C || S === 1 / 0) break;
 if (C === t) break;
 if (h.delete(C), !(this.getPathLength(C, g) >= this.MAX_HOPS)) try {
-for (var A = (c = void 0, a(y)), M = A.next(); !M.done; M = A.next()) {
-var k = M.value;
-if (h.has(k.roomName) && k.roomName !== C) {
-var _ = this.calculateTransferCost(r, C, k.roomName), N = (null !== (m = v.get(C)) && void 0 !== m ? m : 1 / 0) + _;
-N < (null !== (d = v.get(k.roomName)) && void 0 !== d ? d : 1 / 0) && (v.set(k.roomName, N),
-g.set(k.roomName, C));
+for (var A = (c = void 0, a(y)), k = A.next(); !k.done; k = A.next()) {
+var M = k.value;
+if (h.has(M.roomName) && M.roomName !== C) {
+var _ = this.calculateTransferCost(r, C, M.roomName), N = (null !== (m = v.get(C)) && void 0 !== m ? m : 1 / 0) + _;
+N < (null !== (d = v.get(M.roomName)) && void 0 !== d ? d : 1 / 0) && (v.set(M.roomName, N),
+g.set(M.roomName, C));
 }
 }
 } catch (e) {
@@ -16503,7 +16503,7 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (u = A.return) && u.call(A);
+k && !k.done && (u = A.return) && u.call(A);
 } finally {
 if (c) throw c.error;
 }
@@ -16549,7 +16549,7 @@ if (e) throw e.error;
 var r = e.path.indexOf(t);
 return -1 === r || r === e.path.length - 1 ? null : e.path[r + 1] || null;
 }, e;
-}(), ks = new Ms, Us = {
+}(), Ms = new ks, Us = {
 minBucket: 0,
 minStorageEnergy: 5e4,
 terminalEnergyTarget: 2e4,
@@ -16592,7 +16592,7 @@ var e = Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.terminal && e.terminal.my && e.terminal.isActive();
 });
-0 !== e.length && (ks.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
+0 !== e.length && (Ms.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
 e.length < 2 || (this.checkEmergencyTransfers(e), this.balanceEnergy(e), this.balanceMinerals(e),
 this.executeTransfers(e)));
 }
@@ -16620,7 +16620,7 @@ var l = u[0];
 if (!c.transferQueue.some(function(e) {
 return e.toRoom === t.name && e.resourceType === RESOURCE_ENERGY && e.isEmergency;
 })) {
-var m = ks.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
+var m = Ms.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
 m && (c.transferQueue.push({
 fromRoom: l.name,
 toRoom: t.name,
@@ -16711,7 +16711,7 @@ var w = C - S;
 if (u && u !== e.name) {
 var x = null === (c = Game.rooms[u]) || void 0 === c ? void 0 : c.terminal;
 if (x && x.store.getFreeCapacity() > w) {
-var b = ks.findOptimalRoute(e.name, u, w);
+var b = Ms.findOptimalRoute(e.name, u, w);
 if (b) {
 this.transferQueue.push({
 fromRoom: e.name,
@@ -16772,7 +16772,7 @@ return r.fromRoom === t.room.name && r.toRoom === e.room.name && r.resourceType 
 })) return "continue";
 var r = Math.min(Math.floor((t.totalEnergy - u.config.energySendThreshold) / 2), u.config.energyRequestThreshold - e.totalEnergy, t.terminal.store.getUsedCapacity(RESOURCE_ENERGY));
 if (r < u.config.minTransferAmount) return "continue";
-var o = ks.findOptimalRoute(t.room.name, e.room.name, r);
+var o = Ms.findOptimalRoute(t.room.name, e.room.name, r);
 if (!o) return "continue";
 var n = o.cost / r;
 if (n > u.config.maxTransferCostRatio) return U.debug("Skipping terminal transfer from ".concat(t.room.name, " to ").concat(e.room.name, ": cost ratio ").concat(n.toFixed(2), " too high"), {
@@ -16907,7 +16907,7 @@ var a = r.terminal;
 if (a.cooldown > 0) return "continue";
 var i = t.toRoom;
 if (t.route && !t.route.isDirect) {
-var c = ks.getNextHop(t.route, t.fromRoom);
+var c = Ms.getNextHop(t.route, t.fromRoom);
 c && (i = c);
 }
 var u = null === (o = Game.rooms[i]) || void 0 === o ? void 0 : o.terminal;
@@ -17065,7 +17065,7 @@ S && !S.done && (u = C.return) && u.call(C);
 if (c) throw c.error;
 }
 }
-}, n([ ka("terminal:manager", "Terminal Manager", {
+}, n([ Ma("terminal:manager", "Terminal Manager", {
 priority: ha.MEDIUM,
 interval: 20,
 minBucket: 0,
@@ -17275,7 +17275,7 @@ return e.structureType === STRUCTURE_LAB;
 return t.filter(function(e) {
 return e.cooldown > 0;
 }).length < t.length / 2 || 0 === t.length;
-}, n([ ka("factory:manager", "Factory Manager", {
+}, n([ Ma("factory:manager", "Factory Manager", {
 priority: ha.LOW,
 interval: 30,
 minBucket: 0,
@@ -19011,7 +19011,7 @@ priority: ha.LOW,
 interval: 500,
 minBucket: pc,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Mi() ], e);
+}) ], e.prototype, "run", null), n([ ki() ], e);
 }(), vc = new yc, gc = function() {
 function e() {}
 return e.prototype.status = function() {
@@ -19052,21 +19052,21 @@ if (E > 0) {
 C += "=== Active Expansion Attempts ===\n";
 var A = m.claimQueue.filter(function(e) {
 return e.claimed;
-}), M = function(e) {
+}), k = function(e) {
 var t = Game.time - e.lastEvaluated, r = T.find(function(t) {
 return t.memory.targetRoom === e.roomName;
 }), o = r ? "".concat(r.name, " en route") : "No claimer assigned";
 C += "  ".concat(e.roomName, ": ").concat(o, ", Age ").concat(t, " ticks\n");
 };
 try {
-for (var k = a(A), U = k.next(); !U.done; U = k.next()) M(b = U.value);
+for (var M = a(A), U = M.next(); !U.done; U = M.next()) k(b = U.value);
 } catch (e) {
 r = {
 error: e
 };
 } finally {
 try {
-U && !U.done && (o = k.return) && o.call(k);
+U && !U.done && (o = M.return) && o.call(M);
 } finally {
 if (r) throw r.error;
 }
@@ -19246,7 +19246,7 @@ function Ac(e) {
 return wc.SUPPORTED_TYPES.includes(e);
 }
 
-function Mc(e, t, r) {
+function kc(e, t, r) {
 var o, n;
 if (!Oc()) return U.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
@@ -19288,7 +19288,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function kc(e) {
+function Mc(e) {
 var t = Sc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (U.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
@@ -19566,7 +19566,7 @@ if (s) {
 if (U.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-kc(s);
+Mc(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19679,7 +19679,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return U.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void Mc(u, n);
+}), void kc(u, n);
 }
 } catch (t) {
 e = {
@@ -19700,7 +19700,7 @@ return Uc();
 }, e.prototype.getActiveQuests = function() {
 return bc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return Mc(e, t, r);
+return kc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -19718,7 +19718,7 @@ return n.join("\n");
 priority: ha.LOW,
 interval: 100,
 minBucket: Lc
-}) ], e.prototype, "run", null), n([ Mi() ], e);
+}) ], e.prototype, "run", null), n([ ki() ], e);
 }(), Bc = new Fc, Wc = {
 status: function() {
 return Bc.getStatus();
@@ -19756,7 +19756,7 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return Mc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return kc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
@@ -20274,7 +20274,7 @@ priority: ha.LOW,
 interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Mi() ], e);
+}) ], e.prototype, "run", null), n([ ki() ], e);
 }(), qc = new Vc, jc = {
 minGPL: 1,
 minPowerReserve: 1e4,
@@ -20581,7 +20581,7 @@ priority: ha.LOW,
 interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
-}) ], e.prototype, "run", null), n([ Mi() ], e);
+}) ], e.prototype, "run", null), n([ ki() ], e);
 }(), Zc = new Xc, Jc = {
 info: function() {},
 warn: function() {},
@@ -20880,8 +20880,8 @@ var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = tu(T, t), x = w -
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), A = {};
 try {
-for (var M = (c = void 0, a(Object.entries(g.store))), k = M.next(); !k.done; k = M.next()) {
-var U = i(k.value, 2), _ = U[0], N = U[1];
+for (var k = (c = void 0, a(Object.entries(g.store))), M = k.next(); !M.done; M = k.next()) {
+var U = i(M.value, 2), _ = U[0], N = U[1];
 A[_] = N;
 }
 } catch (e) {
@@ -20890,7 +20890,7 @@ error: e
 };
 } finally {
 try {
-k && !k.done && (u = M.return) && u.call(M);
+M && !M.done && (u = k.return) && u.call(k);
 } finally {
 if (c) throw c.error;
 }
@@ -21693,14 +21693,14 @@ var r = Memory.rooms[e];
 if (r) {
 r.labConfig = t;
 var o = "memory:room:".concat(e, ":labConfig");
-Ft.set(o, t, kt);
+Ft.set(o, t, Mt);
 }
 }
 }, e.prototype.loadFromMemory = function(e) {
 var t = "memory:room:".concat(e, ":labConfig"), r = Ft.get(t);
 if (!r) {
 var o = Memory.rooms[e], n = null == o ? void 0 : o.labConfig;
-n && (Ft.set(t, n, kt), r = n);
+n && (Ft.set(t, n, Mt), r = n);
 }
 r && this.manager.importConfig(r);
 }, e.prototype.getConfiguredRooms = function() {
@@ -22300,11 +22300,11 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Ou = M("CreepContext"), Au = ((mu = {})[STRUCTURE_SPAWN] = 100, mu[STRUCTURE_EXTENSION] = 90,
+}(), Ou = k("CreepContext"), Au = ((mu = {})[STRUCTURE_SPAWN] = 100, mu[STRUCTURE_EXTENSION] = 90,
 mu[STRUCTURE_TOWER] = 80, mu[STRUCTURE_RAMPART] = 75, mu[STRUCTURE_WALL] = 70, mu[STRUCTURE_STORAGE] = 70,
-mu[STRUCTURE_CONTAINER] = 60, mu[STRUCTURE_ROAD] = 30, mu), Mu = new Map;
+mu[STRUCTURE_CONTAINER] = 60, mu[STRUCTURE_ROAD] = 30, mu), ku = new Map;
 
-function ku(e) {
+function Mu(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
@@ -22316,14 +22316,14 @@ return (null !== (o = Au[t.structureType]) && void 0 !== o ? o : 50) - n;
 }
 
 function _u(e) {
-return void 0 === e._repairTargets && (ku(e), e._repairTargets = e.allStructures.filter(function(e) {
+return void 0 === e._repairTargets && (Mu(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
 function Nu(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = Mu.get(e.name);
+var t = ku.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22332,7 +22332,7 @@ hostiles: j(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return Mu.set(e.name, r), r;
+return ku.set(e.name, r), r;
 }(o);
 void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Ou.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
@@ -22413,13 +22413,13 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return void 0 === (e = i)._containers && (ku(e), e._containers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._containers && (Mu(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 var e;
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (ku(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (Mu(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -22531,16 +22531,16 @@ return R.apply(e, arguments);
 };
 }, C = T, S = C({}.toString), w = C("".slice), x = function(e) {
 return w(S(e), 8, -1);
-}, b = n, O = x, A = Object, M = T("".split), k = b(function() {
+}, b = n, O = x, A = Object, k = T("".split), M = b(function() {
 return !A("z").propertyIsEnumerable(0);
 }) ? function(e) {
-return "String" === O(e) ? M(e, "") : A(e);
+return "String" === O(e) ? k(e, "") : A(e);
 } : A, U = function(e) {
 return null == e;
 }, _ = U, N = TypeError, P = function(e) {
 if (_(e)) throw new N("Can't call method on " + e);
 return e;
-}, I = k, G = P, L = function(e) {
+}, I = M, G = P, L = function(e) {
 return I(G(e));
 }, D = "object" == typeof document && document.all, F = void 0 === D && void 0 !== D ? function(e) {
 return "function" == typeof e || e === D;
@@ -22591,15 +22591,15 @@ copyright: "© 2013–2025 Denis Pushkarev (zloirock.ru), 2025–2026 CoreJS Com
 license: "https://github.com/zloirock/core-js/blob/v3.48.0/LICENSE",
 source: "https://github.com/zloirock/core-js"
 });
-var Ae = Ee.exports, Me = Ae, ke = function(e, t) {
-return Me[e] || (Me[e] = t || {});
+var Ae = Ee.exports, ke = Ae, Me = function(e, t) {
+return ke[e] || (ke[e] = t || {});
 }, Ue = P, _e = Object, Ne = function(e) {
 return _e(Ue(e));
 }, Pe = Ne, Ie = T({}.hasOwnProperty), Ge = Object.hasOwn || function(e, t) {
 return Ie(Pe(e), t);
 }, Le = T, De = 0, Fe = Math.random(), Be = Le(1.1.toString), We = function(e) {
 return "Symbol(" + (void 0 === e ? "" : e) + ")_" + Be(++De + Fe, 36);
-}, Ke = ke, He = Ge, Ye = We, Ve = oe, qe = ne, je = r.Symbol, ze = Ke("wks"), Qe = qe ? je.for || je : je && je.withoutSetter || Ye, Xe = function(e) {
+}, Ke = Me, He = Ge, Ye = We, Ve = oe, qe = ne, je = r.Symbol, ze = Ke("wks"), Qe = qe ? je.for || je : je && je.withoutSetter || Ye, Xe = function(e) {
 return He(ze, e) || (ze[e] = Ve && He(je, e) ? je[e] : Qe("Symbol." + e)), ze[e];
 }, Ze = u, Je = W, $e = ue, et = TypeError, tt = Xe("toPrimitive"), rt = ue, ot = function(e) {
 var t = function(e, t) {
@@ -22641,9 +22641,9 @@ writable: !1
 }), Tt = W, Ct = String, St = TypeError, wt = function(e) {
 if (Tt(e)) return e;
 throw new St(Ct(e) + " is not an object");
-}, xt = a, bt = ut, Ot = Et, At = wt, Mt = ot, kt = TypeError, Ut = Object.defineProperty, _t = Object.getOwnPropertyDescriptor, Nt = "enumerable", Pt = "configurable", It = "writable";
+}, xt = a, bt = ut, Ot = Et, At = wt, kt = ot, Mt = TypeError, Ut = Object.defineProperty, _t = Object.getOwnPropertyDescriptor, Nt = "enumerable", Pt = "configurable", It = "writable";
 Rt.f = xt ? Ot ? function(e, t, r) {
-if (At(e), t = Mt(t), At(r), "function" == typeof e && "prototype" === t && "value" in r && It in r && !r[It]) {
+if (At(e), t = kt(t), At(r), "function" == typeof e && "prototype" === t && "value" in r && It in r && !r[It]) {
 var o = _t(e, t);
 o && o[It] && (e[t] = r.value, r = {
 configurable: Pt in r ? r[Pt] : o[Pt],
@@ -22653,10 +22653,10 @@ writable: !1
 }
 return Ut(e, t, r);
 } : Ut : function(e, t, r) {
-if (At(e), t = Mt(t), At(r), bt) try {
+if (At(e), t = kt(t), At(r), bt) try {
 return Ut(e, t, r);
 } catch (e) {}
-if ("get" in r || "set" in r) throw new kt("Accessors not supported");
+if ("get" in r || "set" in r) throw new Mt("Accessors not supported");
 return "value" in r && (e[t] = r.value), e;
 };
 var Gt = Rt, Lt = v, Dt = a ? function(e, t, r) {
@@ -22671,7 +22671,7 @@ CONFIGURABLE: Wt(Kt, "name") && (!Bt || Bt && Ht(Kt, "name").configurable)
 Vt(jt.inspectSource) || (jt.inspectSource = function(e) {
 return zt(e);
 });
-var Qt, Xt, Zt, Jt = jt.inspectSource, $t = F, er = r.WeakMap, tr = $t(er) && /native code/.test(String(er)), rr = We, or = ke("keys"), nr = function(e) {
+var Qt, Xt, Zt, Jt = jt.inspectSource, $t = F, er = r.WeakMap, tr = $t(er) && /native code/.test(String(er)), rr = We, or = Me("keys"), nr = function(e) {
 return or[e] || (or[e] = rr(e));
 }, ar = {}, ir = tr, sr = r, cr = Dt, ur = Ge, lr = Ae, mr = nr, dr = ar, pr = "Object already initialized", fr = sr.TypeError, yr = sr.WeakMap;
 if (ir || lr.state) {
@@ -22700,20 +22700,20 @@ get: Xt,
 enforce: function(e) {
 return Zt(e) ? Xt(e) : Qt(e, {});
 }
-}, Rr = T, Er = n, Tr = F, Cr = Ge, Sr = a, wr = Yt.CONFIGURABLE, xr = Jt, br = hr.enforce, Or = hr.get, Ar = String, Mr = Object.defineProperty, kr = Rr("".slice), Ur = Rr("".replace), _r = Rr([].join), Nr = Sr && !Er(function() {
-return 8 !== Mr(function() {}, "length", {
+}, Rr = T, Er = n, Tr = F, Cr = Ge, Sr = a, wr = Yt.CONFIGURABLE, xr = Jt, br = hr.enforce, Or = hr.get, Ar = String, kr = Object.defineProperty, Mr = Rr("".slice), Ur = Rr("".replace), _r = Rr([].join), Nr = Sr && !Er(function() {
+return 8 !== kr(function() {}, "length", {
 value: 8
 }).length;
 }), Pr = String(String).split("String"), Ir = Ft.exports = function(e, t, r) {
-"Symbol(" === kr(Ar(t), 0, 7) && (t = "[" + Ur(Ar(t), /^Symbol\(([^)]*)\).*$/, "$1") + "]"),
-r && r.getter && (t = "get " + t), r && r.setter && (t = "set " + t), (!Cr(e, "name") || wr && e.name !== t) && (Sr ? Mr(e, "name", {
+"Symbol(" === Mr(Ar(t), 0, 7) && (t = "[" + Ur(Ar(t), /^Symbol\(([^)]*)\).*$/, "$1") + "]"),
+r && r.getter && (t = "get " + t), r && r.setter && (t = "set " + t), (!Cr(e, "name") || wr && e.name !== t) && (Sr ? kr(e, "name", {
 value: t,
 configurable: !0
-}) : e.name = t), Nr && r && Cr(r, "arity") && e.length !== r.arity && Mr(e, "length", {
+}) : e.name = t), Nr && r && Cr(r, "arity") && e.length !== r.arity && kr(e, "length", {
 value: r.arity
 });
 try {
-r && Cr(r, "constructor") && r.constructor ? Sr && Mr(e, "prototype", {
+r && Cr(r, "constructor") && r.constructor ? Sr && kr(e, "prototype", {
 writable: !1
 }) : e.prototype && (e.prototype = void 0);
 } catch (e) {}
@@ -22758,10 +22758,10 @@ var t = po.f(yo(e)), r = fo.f;
 return r ? vo(t, r(e)) : t;
 }, ho = Ge, Ro = go, Eo = o, To = Rt, Co = n, So = F, wo = /#|\.prototype\./, xo = function(e, t) {
 var r = Oo[bo(e)];
-return r === Mo || r !== Ao && (So(t) ? Co(t) : !!t);
+return r === ko || r !== Ao && (So(t) ? Co(t) : !!t);
 }, bo = xo.normalize = function(e) {
 return String(e).replace(wo, ".").toLowerCase();
-}, Oo = xo.data = {}, Ao = xo.NATIVE = "N", Mo = xo.POLYFILL = "P", ko = xo, Uo = r, _o = o.f, No = Dt, Po = function(e, t, r, o) {
+}, Oo = xo.data = {}, Ao = xo.NATIVE = "N", ko = xo.POLYFILL = "P", Mo = xo, Uo = r, _o = o.f, No = Dt, Po = function(e, t, r, o) {
 o || (o = {});
 var n = o.enumerable, a = void 0 !== o.name ? o.name : t;
 if (Lr(r) && Fr(r, a, o), o.global) n ? e[t] = r : Br(t, r); else {
@@ -22781,7 +22781,7 @@ for (var o = Ro(t), n = To.f, a = Eo.f, i = 0; i < o.length; i++) {
 var s = o[i];
 ho(e, s) || r && ho(r, s) || n(e, s, a(t, s));
 }
-}, Lo = ko, Do = function(e, t) {
+}, Lo = Mo, Do = function(e, t) {
 var r, o, n, a, i, s = e.target, c = e.global, u = e.stat;
 if (r = c ? Uo : u ? Uo[s] || Io(s, {}) : Uo[s] && Uo[s].prototype) for (o in t) {
 if (a = t[o], n = e.dontCallGetSet ? (i = _o(r, o)) && i.value : r[o], !Lo(c ? o : s + (u ? "." : "#") + o, e.forced) && void 0 !== n) {
@@ -22845,13 +22845,13 @@ var e;
 return Cn(Cn.call) || !Cn(Object) || !Cn(function() {
 e = !0;
 }) || e;
-}) ? Sn : Cn, xn = Bo, bn = wn, On = W, An = Xe("species"), Mn = Array, kn = function(e, t) {
+}) ? Sn : Cn, xn = Bo, bn = wn, On = W, An = Xe("species"), kn = Array, Mn = function(e, t) {
 return new (function(e) {
 var t;
-return xn(e) && (t = e.constructor, (bn(t) && (t === Mn || xn(t.prototype)) || On(t) && null === (t = t[An])) && (t = void 0)),
-void 0 === t ? Mn : t;
+return xn(e) && (t = e.constructor, (bn(t) && (t === kn || xn(t.prototype)) || On(t) && null === (t = t[An])) && (t = void 0)),
+void 0 === t ? kn : t;
 }(e))(0 === t ? 0 : t);
-}, Un = rn, _n = pe, Nn = Ne, Pn = Zr, In = kn;
+}, Un = rn, _n = pe, Nn = Ne, Pn = Zr, In = Mn;
 Do({
 target: "Array",
 proto: !0
@@ -22906,7 +22906,7 @@ var pa = r, fa = T, ya = function(e, t) {
 return fa(pa[e].prototype[t]);
 };
 ya("Array", "flatMap");
-var va = rn, ga = Ne, ha = Zr, Ra = Vr, Ea = kn;
+var va = rn, ga = Ne, ha = Zr, Ra = Vr, Ea = Mn;
 Do({
 target: "Array",
 proto: !0
@@ -23078,7 +23078,7 @@ if (void 0 !== e) return ba.encode(e);
 deserialize(e) {
 if (void 0 !== e) return ba.decode(e);
 }
-}, Aa = (e, t) => `cg_${e.key}_${t}`, Ma = (e, t) => Object.assign(Object.assign({}, e), {
+}, Aa = (e, t) => `cg_${e.key}_${t}`, ka = (e, t) => Object.assign(Object.assign({}, e), {
 get(r) {
 var o;
 const n = e.get(r);
@@ -23099,9 +23099,9 @@ delete(r) {
 const o = e.get(r);
 o && wa.delete(Aa(t, o)), e.delete(r);
 },
-with: t => Ma(e, t)
+with: t => ka(e, t)
 });
-function ka() {
+function Ma() {
 var e, t;
 return null !== (e = Memory[t = Ta.MEMORY_CACHE_PATH]) && void 0 !== e || (Memory[t] = {}),
 Memory[Ta.MEMORY_CACHE_PATH];
@@ -23113,17 +23113,17 @@ Memory[Ta.MEMORY_CACHE_EXPIRATION_PATH];
 }
 const _a = {
 set(e, t, r) {
-if (ka()[e] = t, void 0 !== r) {
+if (Ma()[e] = t, void 0 !== r) {
 const t = Oa.serialize(r);
 t && (Ua()[e] = t);
 }
 },
-get: e => ka()[e],
+get: e => Ma()[e],
 expires: e => Oa.deserialize(Ua()[e]),
 delete(e) {
-delete ka()[e];
+delete Ma()[e];
 },
-with: e => Ma(_a, e),
+with: e => ka(_a, e),
 clean() {
 const e = Ua();
 for (const t in e) {
@@ -23444,9 +23444,9 @@ let t = e.match(/^[WE]([0-9]+)[NS]([0-9]+)$/);
 if (!t) throw new Error("Invalid room name");
 let r = Number(t[1]) % 10, o = Number(t[2]) % 10;
 return !(5 === r && 5 === o) && r >= 4 && r <= 6 && o >= 4 && o <= 6;
-}, Mi = (e, t, r) => r ? e.slice(0, t) : e.slice(t + 1), ki = e => "_ck" + e;
+}, ki = (e, t, r) => r ? e.slice(0, t) : e.slice(t + 1), Mi = e => "_ck" + e;
 function Ui(e) {
-Ai(e) && !_a.get(ki(e)) && _a.with(di).set(ki(e), [ ...Game.rooms[e].find(FIND_SOURCES), ...Game.rooms[e].find(FIND_MINERALS) ].map(e => e.pos));
+Ai(e) && !_a.get(Mi(e)) && _a.with(di).set(Mi(e), [ ...Game.rooms[e].find(FIND_SOURCES), ...Game.rooms[e].find(FIND_MINERALS) ].map(e => e.pos));
 }
 class _i extends Map {
 get(e) {
@@ -23597,7 +23597,7 @@ if (r.avoidCreeps && (null === (o = Game.rooms[t]) || void 0 === o || o.find(FIN
 null === (n = Game.rooms[t]) || void 0 === n || n.find(FIND_POWER_CREEPS).forEach(t => e.set(t.pos.x, t.pos.y, 255))),
 r.avoidSourceKeepers && function(e, t) {
 var r;
-const o = null !== (r = _a.with(di).get(ki(e))) && void 0 !== r ? r : [];
+const o = null !== (r = _a.with(di).get(Mi(e))) && void 0 !== r ? r : [];
 for (const e of o) Si(e, 5, !0).forEach(e => t.set(e.x, e.y, 255));
 }(t, e), (r.avoidObstacleStructures || r.roadCost) && (r.avoidObstacleStructures && (null === (a = Game.rooms[t]) || void 0 === a || a.find(FIND_MY_CONSTRUCTION_SITES).forEach(t => {
 OBSTACLE_OBJECT_TYPES.includes(t.structureType) && e.set(t.pos.x, t.pos.y, 255);
@@ -24057,7 +24057,7 @@ void 0 === c) return ERR_NOT_FOUND;
 wa.set(qi(e, fs), c);
 let u = Math.max(0, Math.min(s.length - 1, (null == r ? void 0 : r.reverse) ? c - 1 : c + 1));
 if (null == r ? void 0 : r.visualizePathStyle) {
-const t = Object.assign(Object.assign({}, Ta.DEFAULT_VISUALIZE_OPTS), r.visualizePathStyle), o = Mi(s, c, null == r ? void 0 : r.reverse);
+const t = Object.assign(Object.assign({}, Ta.DEFAULT_VISUALIZE_OPTS), r.visualizePathStyle), o = ki(s, c, null == r ? void 0 : r.reverse);
 null === (i = e.room) || void 0 === i || i.visual.poly(o.filter(t => {
 var r;
 return t.roomName === (null === (r = e.room) || void 0 === r ? void 0 : r.name);
@@ -24085,7 +24085,7 @@ gs(qi(e, ws), {
 cache: t
 }), t.delete(qi(e, xs)), t.delete(qi(e, bs));
 }
-const Ms = (e, t, r, o = {
+const ks = (e, t, r, o = {
 avoidCreeps: !0
 }) => {
 var n, a, i, s;
@@ -24119,7 +24119,7 @@ u.with(li).set(qi(e, xs), l, y), u.with(Ss).set(qi(e, bs), Os.reduce((e, t) => (
 e), {}), y);
 const v = vs(qi(e, ws), {
 cache: u
-}), g = wa.get(qi(e, "_cpi")), h = v && Mi(v, null != g ? g : 0), R = null !== (i = null === (a = c.avoidTargets) || void 0 === a ? void 0 : a.call(c, e.pos.roomName)) && void 0 !== i ? i : [];
+}), g = wa.get(qi(e, "_cpi")), h = v && ki(v, null != g ? g : 0), R = null !== (i = null === (a = c.avoidTargets) || void 0 === a ? void 0 : a.call(c, e.pos.roomName)) && void 0 !== i ? i : [];
 if (c.repathIfStuck && v && Cs(e, c.repathIfStuck)) gs(qi(e, ws), {
 cache: u
 }), c = Object.assign(Object.assign({}, c), o); else if ((null == h ? void 0 : h.length) && Rs(h, R)) {
@@ -24163,7 +24163,7 @@ cache: u
 reverse: !1,
 cache: u
 }))), T;
-}, ks = "_rsi";
+}, Ms = "_rsi";
 return Iu.CachingStrategies = vi, Iu.CoordListSerializer = fi, Iu.CoordSerializer = pi,
 Iu.Keys = ji, Iu.MoveTargetListSerializer = li, Iu.MoveTargetSerializer = ui, Iu.NumberSerializer = Oa,
 Iu.PositionListSerializer = di, Iu.PositionSerializer = mi, Iu.adjacentWalkablePositions = xi,
@@ -24195,7 +24195,7 @@ Iu.getMoveIntents = ns, Iu.getRangeTo = ri, Iu.globalPosition = ei, Iu.isExit = 
 Iu.isPositionWalkable = bi, Iu.move = ds, Iu.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
-let u = wa.get(qi(e, ks));
+let u = wa.get(qi(e, Ms));
 const l = vs(t, r);
 if ((s || c.length) && void 0 !== u) {
 let t = l ? function(e, t, r = !1) {
@@ -24210,18 +24210,18 @@ t > 1 && (n += r ? 1 - t : t - 1);
 }
 return -1;
 }(e.pos, l, (null == r ? void 0 : r.reverse) || !1) : void 0;
--1 === t && (t = void 0), void 0 !== t && ((null == r ? void 0 : r.reverse) ? t <= u : t >= u) && (wa.delete(qi(e, ks)),
+-1 === t && (t = void 0), void 0 !== t && ((null == r ? void 0 : r.reverse) ? t <= u : t >= u) && (wa.delete(qi(e, Ms)),
 u = void 0);
 }
 let m = ERR_NOT_FOUND;
 if (void 0 === u && (m = hs(e, t, r)), m !== ERR_NOT_FOUND) {
 const t = wa.get(qi(e, "_cpi"));
-if (!(s && Cs(e, s) || l && Rs(Mi(l, null != t ? t : 0, null == r ? void 0 : r.reverse), c))) return m;
-void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi(e, ks), u));
+if (!(s && Cs(e, s) || l && Rs(ki(l, null != t ? t : 0, null == r ? void 0 : r.reverse), c))) return m;
+void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi(e, Ms), u));
 }
 let d = vs(t, r);
-return d ? (void 0 !== u && (d = Mi(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : Ms(e, d, r)) : ERR_NO_PATH;
-}, Iu.moveTo = Ms, Iu.normalizeTargets = Ri, Iu.offsetRoomPosition = Da, Iu.packCoord = qa,
+return d ? (void 0 !== u && (d = ki(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : ks(e, d, r)) : ERR_NO_PATH;
+}, Iu.moveTo = ks, Iu.normalizeTargets = Ri, Iu.offsetRoomPosition = Da, Iu.packCoord = qa,
 Iu.packCoordList = za, Iu.packPos = Ya, Iu.packPosList = Xa, Iu.packRoomName = ii,
 Iu.packRoomNames = ni, Iu.posAtDirection = oi, Iu.preTick = function() {
 yi(), function() {
@@ -24876,6 +24876,16 @@ l && !l.done && (o = u.return) && o.call(u);
 if (r) throw r.error;
 }
 }
+}, e.prototype.refreshCreepReservation = function(e, t) {
+var r, o, n = e.memory.assignedTaskId;
+if (!n) return null;
+var a = ju(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && Zu(c.type) && cl(c))) return delete e.memory.assignedTaskId,
+null;
+var l = null !== (o = el(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
+null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
+il(c), u.amount);
 }, e.prototype.clear = function(e) {
 var t = ju();
 e ? delete t.rooms[e] : t.rooms = {};
@@ -24993,7 +25003,7 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var Tl, Cl = M("ActionExecutor");
+var Tl, Cl = k("ActionExecutor");
 
 function Sl(e, t, r) {
 var o;
@@ -25355,7 +25365,11 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Ol, Al = M("StateMachine");
+var Ol, Al = k("StateMachine");
+
+function kl(e) {
+return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
+}
 
 function Ml(e, t, r) {
 var n;
@@ -25375,9 +25389,13 @@ y: n.y,
 roomName: n.roomName
 };
 }
-return "withdraw" !== e.type && "transfer" !== e.type || (r.data = {
+return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
-}), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
+}), "transfer" === e.type && (r.data = o({
+resourceType: e.resourceType
+}, void 0 !== kl(e.amount) ? {
+amount: e.amount
+} : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
 }(t), Al.info(r, {
@@ -25405,7 +25423,7 @@ type: "idle"
 });
 }
 
-function kl(e, t, r) {
+function Ul(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
@@ -25498,74 +25516,80 @@ role: e.memory.role
 }
 }), delete e.memory.state; else {
 var c = function(e) {
-var t, r, o, n, a = null;
+var t, r, n, a, i = null;
 if (e.targetId) {
-var i = Game.getObjectById(e.targetId);
-if (!i) return null;
-if ("object" != typeof i || !("pos" in i) || !("room" in i)) return null;
-a = i;
+var s = Game.getObjectById(e.targetId);
+if (!s) return null;
+if ("object" != typeof s || !("pos" in s) || !("room" in s)) return null;
+i = s;
 }
 switch (e.action) {
 case "harvest":
-return a ? {
+return i ? {
 type: "harvest",
-target: a
+target: i
 } : null;
 
 case "harvestMineral":
-return a ? {
+return i ? {
 type: "harvestMineral",
-target: a
+target: i
 } : null;
 
 case "harvestDeposit":
-return a ? {
+return i ? {
 type: "harvestDeposit",
-target: a
+target: i
 } : null;
 
 case "pickup":
-return a ? {
+return i ? {
 type: "pickup",
-target: a
+target: i
 } : null;
 
 case "withdraw":
-return a && (null === (t = e.data) || void 0 === t ? void 0 : t.resourceType) ? {
+return i && (null === (t = e.data) || void 0 === t ? void 0 : t.resourceType) ? {
 type: "withdraw",
-target: a,
+target: i,
 resourceType: e.data.resourceType
 } : null;
 
 case "transfer":
-return a && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType) ? {
+if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
+var c = kl(e.data.amount);
+return o({
 type: "transfer",
-target: a,
+target: i,
 resourceType: e.data.resourceType
-} : null;
+}, void 0 !== c ? {
+amount: c
+} : {});
+}
+return null;
 
 case "build":
-return a ? {
+return i ? {
 type: "build",
-target: a
+target: i
 } : null;
 
 case "repair":
-return a ? {
+return i ? {
 type: "repair",
-target: a
+target: i
 } : null;
 
 case "upgrade":
-return a ? {
+return i ? {
 type: "upgrade",
-target: a
+target: i
 } : null;
 
 case "moveTo":
-return a ? {
+return i ? {
 type: "moveTo",
-target: a
+target: i
 } : e.targetPos ? {
 type: "moveTo",
 target: new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName)
@@ -25578,22 +25602,22 @@ roomName: e.targetRoom
 } : null;
 
 case "remoteMoveTo":
-return "harvester" !== (s = null === (o = e.data) || void 0 === o ? void 0 : o.routeType) && "hauler" !== s && "reserver" !== s && "guard" !== s ? null : a ? {
+return "harvester" !== (u = null === (n = e.data) || void 0 === n ? void 0 : n.routeType) && "hauler" !== u && "reserver" !== u && "guard" !== u ? null : i ? {
 type: "remoteMoveTo",
-target: a,
-routeType: s
+target: i,
+routeType: u
 } : e.targetPos ? {
 type: "remoteMoveTo",
 target: new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName),
-routeType: s
+routeType: u
 } : null;
 
 case "remoteMoveToRoom":
-var s;
-return "harvester" !== (s = null === (n = e.data) || void 0 === n ? void 0 : n.routeType) && "hauler" !== s && "reserver" !== s && "guard" !== s ? null : e.targetRoom ? {
+var u;
+return "harvester" !== (u = null === (a = e.data) || void 0 === a ? void 0 : a.routeType) && "hauler" !== u && "reserver" !== u && "guard" !== u ? null : e.targetRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.targetRoom,
-routeType: s
+routeType: u
 } : null;
 
 case "idle":
@@ -25605,7 +25629,22 @@ default:
 return null;
 }
 }(a);
-if (c) return c;
+if (c) {
+if ("transfer" !== c.type || !e.memory.assignedTaskId) return c;
+var u = e.memory.assignedTaskId, l = hl.refreshCreepReservation(e, c);
+if (null !== l) return o(o({}, c), {
+amount: l
+});
+Al.info("Task-board delivery reservation missing, re-evaluating behavior", {
+room: e.creep.pos.roomName,
+creep: e.creep.name,
+meta: {
+action: a.action,
+role: e.memory.role,
+assignedTaskId: u
+}
+}), delete e.memory.state;
+}
 Al.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
@@ -25626,7 +25665,7 @@ invalidReason: s.reason
 return Ml(e, t(e), "Committed new state action");
 }
 
-function Ul(e) {
+function _l(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -25635,7 +25674,7 @@ var n = e.memory.working;
 return o !== n && et(e.creep), n;
 }
 
-function _l(e) {
+function Nl(e) {
 e.memory.working = !1, et(e.creep);
 }
 
@@ -25646,23 +25685,23 @@ Ol[FIND_CREEPS] = 5, Ol[FIND_MY_CREEPS] = 5, Ol[FIND_HOSTILE_CREEPS] = 3, Ol[FIN
 Ol[FIND_TOMBSTONES] = 10, Ol[FIND_RUINS] = 10, Ol[FIND_FLAGS] = 50, Ol[FIND_NUKES] = 20,
 Ol[FIND_POWER_CREEPS] = 10, Ol[FIND_MY_POWER_CREEPS] = 10;
 
-var Nl, Pl, Il = {}, Gl = {}, Ll = {}, Dl = {};
-
-function Fl() {
-if (Nl) return Dl;
-Nl = 1;
-const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Dl.encode = function(t) {
-if (0 <= t && t < e.length) return e[t];
-throw new TypeError("Must be between 0 and 63: " + t);
-}, Dl;
-}
+var Pl, Il, Gl = {}, Ll = {}, Dl = {}, Fl = {};
 
 function Bl() {
-if (Pl) return Ll;
+if (Pl) return Fl;
 Pl = 1;
-const e = Fl();
-return Ll.encode = function(t) {
+const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
+return Fl.encode = function(t) {
+if (0 <= t && t < e.length) return e[t];
+throw new TypeError("Must be between 0 and 63: " + t);
+}, Fl;
+}
+
+function Wl() {
+if (Il) return Dl;
+Il = 1;
+const e = Bl();
+return Dl.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25670,23 +25709,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Ll;
+}, Dl;
 }
 
-var Wl, Kl, Hl, Yl = {}, Vl = jt(Object.freeze({
+var Kl, Hl, Yl, Vl = {}, ql = jt(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function ql() {
-return Kl ? Wl : (Kl = 1, Wl = "function" == typeof URL ? URL : Vl.URL);
+function jl() {
+return Hl ? Kl : (Hl = 1, Kl = "function" == typeof URL ? URL : ql.URL);
 }
 
-function jl() {
-if (Hl) return Yl;
-Hl = 1;
-const e = ql();
-Yl.getArg = function(e, t, r) {
+function zl() {
+if (Yl) return Vl;
+Yl = 1;
+const e = jl();
+Vl.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25706,16 +25745,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Yl.toSetString = t ? r : function(e) {
+Vl.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Yl.fromSetString = t ? r : function(e) {
+}, Vl.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Yl.compareByGeneratedPositionsInflated = function(e, t) {
+}, Vl.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Yl.parseSourceMapInput = function(e) {
+}, Vl.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25769,7 +25808,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Yl.normalize = f, Yl.join = y, Yl.relative = function(t, r) {
+return Vl.normalize = f, Vl.join = y, Vl.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25781,18 +25820,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Yl.computeSourceURL = function(e, t, r) {
+}, Vl.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Yl;
+}, Vl;
 }
 
-var zl, Ql = {};
+var Ql, Xl = {};
 
-function Xl() {
-if (zl) return Ql;
-zl = 1;
+function Zl() {
+if (Ql) return Xl;
+Ql = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -25825,19 +25864,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Ql.ArraySet = e, Ql;
+return Xl.ArraySet = e, Xl;
 }
 
-var Zl, Jl, $l = {};
+var Jl, $l, em = {};
 
-function em() {
-if (Jl) return Gl;
+function tm() {
+if ($l) return Ll;
+$l = 1;
+const e = Wl(), t = zl(), r = Zl().ArraySet, o = function() {
+if (Jl) return em;
 Jl = 1;
-const e = Bl(), t = jl(), r = Xl().ArraySet, o = function() {
-if (Zl) return $l;
-Zl = 1;
-const e = jl();
-return $l.MappingList = class {
+const e = zl();
+return em.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -25857,7 +25896,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, $l;
+}, em;
 }().MappingList;
 class n {
 constructor(e) {
@@ -25986,13 +26025,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Gl.SourceMapGenerator = n, Gl;
+return n.prototype._version = 3, Ll.SourceMapGenerator = n, Ll;
 }
 
-var tm, rm = {}, om = {};
+var rm, om = {}, nm = {};
 
-function nm() {
-return tm || (tm = 1, function(e) {
+function am() {
+return rm || (rm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26004,36 +26043,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(om)), om;
+}(nm)), nm;
 }
 
-var am, im, sm, cm, um = {
+var im, sm, cm, um, lm = {
 exports: {}
 };
 
-function lm() {
-if (am) return um.exports;
-am = 1;
+function mm() {
+if (im) return lm.exports;
+im = 1;
 let e = null;
-return um.exports = function() {
+return lm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, um.exports.initialize = t => {
+}, lm.exports.initialize = t => {
 e = t;
-}, um.exports;
+}, lm.exports;
 }
 
-function mm() {
-if (sm) return im;
-sm = 1;
-const e = lm();
+function dm() {
+if (cm) return sm;
+cm = 1;
+const e = mm();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return im = function() {
+return sm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26100,28 +26139,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, im;
+}, sm;
 }
 
-var dm, pm, fm, ym, vm = {};
+var pm, fm, ym, vm, gm = {};
 
-function gm(e, t, r) {
+function hm(e, t, r) {
 return e - t >= r;
 }
 
-function hm(e, t) {
+function Rm(e, t) {
 return e.priority - t.priority;
 }
 
-function Rm(e, t, r, o) {
+function Em(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function Em(e, t, r, o) {
+function Tm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Tm(e) {
+function Cm(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26139,12 +26178,12 @@ if (t) throw t.error;
 return o;
 }
 
-pm || (pm = 1, Il.SourceMapGenerator = em().SourceMapGenerator, Il.SourceMapConsumer = function() {
-if (cm) return rm;
-cm = 1;
-const e = jl(), t = nm(), r = Xl().ArraySet;
-Bl();
-const o = lm(), n = mm(), a = Symbol("smcInternal");
+fm || (fm = 1, Gl.SourceMapGenerator = tm().SourceMapGenerator, Gl.SourceMapConsumer = function() {
+if (um) return om;
+um = 1;
+const e = zl(), t = am(), r = Zl().ArraySet;
+Wl();
+const o = mm(), n = dm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26181,7 +26220,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, rm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, om.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26371,7 +26410,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, rm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, om.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26480,11 +26519,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return rm.IndexedSourceMapConsumer = c, rm;
-}().SourceMapConsumer, Il.SourceNode = function() {
-if (dm) return vm;
-dm = 1;
-const e = em().SourceMapGenerator, t = jl(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return om.IndexedSourceMapConsumer = c, om;
+}().SourceMapConsumer, Gl.SourceNode = function() {
+if (pm) return gm;
+pm = 1;
+const e = tm().SourceMapGenerator, t = zl(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26623,27 +26662,27 @@ map: o
 };
 }
 }
-return vm.SourceNode = n, vm;
+return gm.SourceNode = n, gm;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(ym || (ym = {}));
+}(vm || (vm = {}));
 
-var Cm, Sm = [ ym.CRITICAL, ym.HIGH, ym.MEDIUM, ym.LOW ], wm = {
-bucketThresholds: (fm = {}, fm[ym.CRITICAL] = 0, fm[ym.HIGH] = 2e3, fm[ym.MEDIUM] = 5e3,
-fm[ym.LOW] = 8e3, fm),
+var Sm, wm = [ vm.CRITICAL, vm.HIGH, vm.MEDIUM, vm.LOW ], xm = {
+bucketThresholds: (ym = {}, ym[vm.CRITICAL] = 0, ym[vm.HIGH] = 2e3, ym[vm.MEDIUM] = 5e3,
+ym[vm.LOW] = 8e3, ym),
 defaultMaxCpu: 5,
 logExecution: !1
-}, xm = function() {
+}, bm = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Tm(Sm),
+tasksByPriority: Cm(wm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, wm), e);
+}, this.config = o(o({}, xm), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26657,13 +26696,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(hm), l = 0;
+var u = Array.from(this.tasks.values()).sort(Rm), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (gm(Game.time, p.lastRun, p.interval)) if (Rm(p.priority, s, this.config.bucketThresholds, ym.CRITICAL)) this.stats.skippedThisTick++; else {
+if (hm(Game.time, p.lastRun, p.interval)) if (Em(p.priority, s, this.config.bucketThresholds, vm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (Em(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Tm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26711,7 +26750,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Tm(Sm);
+var t, r, o = Cm(wm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26728,22 +26767,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), bm = ((Cm = global)._computationScheduler || (Cm._computationScheduler = new xm),
-Cm._computationScheduler), Om = new Map;
+}(), Om = ((Sm = global)._computationScheduler || (Sm._computationScheduler = new bm),
+Sm._computationScheduler), Am = new Map;
 
-function Am(e) {
-var t = Om.get(e);
+function km(e) {
+var t = Am.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Om.set(e, t)), t;
+}, Am.set(e, t)), t;
 }
 
 function Mm(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return km(e, t[0], r), t[0];
-var i = Am(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Um(e, t[0], r), t[0];
+var i = km(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26760,32 +26799,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && km(e, s, r), s;
+return s && Um(e, s, r), s;
 }
 
-function km(e, t, r) {
-var o = Am(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Um(e, t, r) {
+var o = km(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var Um = {
+var _m = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function _m(e, t, r) {
+function Nm(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(Um[t], ";") : "";
+var o = t ? "color: ".concat(_m[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function Nm(e) {
+function Pm(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Pm = {
+var Im = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26799,7 +26838,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(Nm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(Pm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -26816,44 +26855,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(Nm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(Pm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Im() {
+function Gm() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Dm() + Fm() + '<div class="module-help">'.concat(e.map(Gm).join(""), "</div>");
+return Fm() + Bm() + '<div class="module-help">'.concat(e.map(Lm).join(""), "</div>");
 }
 
-var Gm = function(e) {
-var t = e.api.map(Lm).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(_m(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(_m(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Lm = function(e) {
+var Lm = function(e) {
+var t = e.api.map(Dm).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Nm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Nm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Dm = function(e) {
 var t = [];
-e.describe && t.push(_m(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(_m(e.name, "blue"), ": ").concat(_m(e.desc, "green"));
+e.describe && t.push(Nm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Nm(e.name, "blue"), ": ").concat(Nm(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return _m(e.name, "blue");
-}).join(", ") : "", o = _m(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Nm(e.name, "blue");
+}).join(", ") : "", o = Nm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(_m(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Dm = function() {
-return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Nm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
 }, Fm = function() {
+return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+}, Bm = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Bm = M("EnergyCollection"), Wm = [ "refillSpawn", "refillExtension", "refillTower" ];
+}, Wm = k("EnergyCollection"), Km = [ "refillSpawn", "refillExtension", "refillTower" ];
 
-function Km(e) {
+function Hm(e) {
 if (e.droppedResources.length > 0) {
 var t = Je(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Bm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -26864,21 +26903,21 @@ return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
 var o = Mm(e.creep, r, "energy_container");
-if (o) return Bm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+if (o) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Bm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(r)) return Bm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
+if (Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(r)) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "withdraw",
 target: a,
 resourceType: RESOURCE_ENERGY
 };
 }
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Bm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -26889,34 +26928,34 @@ return e.energy > 0;
 });
 if (n.length > 0) {
 var a, i = Mm(e.creep, n, "energy_source");
-if (i) return Bm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
+if (i) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
-if (Bm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(n)) return Bm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
+if (Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(n)) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "harvest",
 target: a
 };
 }
-return Bm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Hm(e) {
-var t = hl.getAssignedAction(e, Wm);
+function Ym(e) {
+var t = hl.getAssignedAction(e, Km);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Ym(e) {
-return hl.hasActiveTask(e.room.name, Wm);
+function Vm(e) {
+return hl.hasActiveTask(e.room.name, Km);
 }
 
-function Vm(e, t) {
+function qm(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -26943,11 +26982,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function qm(e) {
+function jm(e) {
 var t = hl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Ym(e)) {
-var r = Vm(e, "deliver");
+if (!Vm(e)) {
+var r = qm(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -26969,7 +27008,7 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var jm = function() {
+var zm = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27064,16 +27103,16 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), zm = new jm, Qm = M("LarvaWorkerBehavior");
+}(), Qm = new zm, Xm = k("LarvaWorkerBehavior");
 
-function Xm(e) {
-if (Ul(e)) {
-Qm.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var t = qm(e);
-if (t) return Qm.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
+function Zm(e) {
+if (_l(e)) {
+Xm.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var t = jm(e);
+if (t) return Xm.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
 t;
 var r = function(e) {
-var t, r = zm.getSwarmState(e.room.name);
+var t, r = Qm.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (r) {
@@ -27090,7 +27129,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Qm.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Xm.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27099,20 +27138,14 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Qm.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Xm.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Qm.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-_l(e);
+Xm.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+Nl(e);
 }
-return Km(e);
-}
-
-function Zm(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
+return Hm(e);
 }
 
 function Jm(e) {
@@ -27122,20 +27155,26 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 }
 
 function $m(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
+
+function ed(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var ed = M("HarvesterBehavior"), td = M("HaulerBehavior"), rd = [ "refillSpawn", "refillExtension" ];
+var td = k("HarvesterBehavior"), rd = k("HaulerBehavior"), od = [ "refillSpawn", "refillExtension" ];
 
-function od(e, t, r) {
+function nd(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return km(e, c, r), c;
+if (c) return Um(e, c, r), c;
 }
 var u = Mm(e, t, r);
 return u ? i[r] = {
@@ -27144,7 +27183,7 @@ tick: Game.time
 } : delete i[r], u;
 }
 
-var nd = {
+var ad = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27154,11 +27193,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, ad = nd, id = function(e) {
-return ad.getLabResourceNeeds(e);
+}, id = ad, sd = function(e) {
+return id.getLabResourceNeeds(e);
 };
 
-function sd(e) {
+function cd(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27180,7 +27219,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = id(e.room.name);
+var n = sd(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27208,7 +27247,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, ad.getLabOverflow(r));
+var t, r, o = (r = e.room.name, id.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27223,7 +27262,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = id(e.room.name);
+var i = sd(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27242,8 +27281,8 @@ type: "idle"
 }(e);
 }
 
-var cd = {
-larvaWorker: Xm,
+var ud = {
+larvaWorker: Zm,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27254,12 +27293,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(Zm).length > 0) return {
+if (e.hostiles.filter(Jm).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (Ul(e)) {
+if (_l(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27278,7 +27317,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Km(e);
+return Hm(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27312,10 +27351,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(Jm)) return {
+if (e.hostiles.some($m)) return {
 type: "idle"
 };
-if (Ul(e)) {
+if (_l(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27334,10 +27373,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Km(e);
+return Hm(e);
 },
 harvester: function(e) {
-var t, r = (t = $m(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = ed(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27386,8 +27425,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), ed.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return ed.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), td.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return td.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -27415,7 +27454,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return ed.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return td.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -27436,20 +27475,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (ed.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (td.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (ed.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (td.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = Ul(e), o = "defenseRefuel" === e.memory.task;
-if (td.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = _l(e), o = "defenseRefuel" === e.memory.task;
+if (rd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -27462,9 +27501,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = hl.getAssignedAction(e, rd);
+var t = hl.getAssignedAction(e, od);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (hl.hasActiveTask(e.room.name, rd)) return null;
+if (hl.hasActiveTask(e.room.name, od)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27486,11 +27525,11 @@ if (s) return s;
 }
 var c = hl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Ym(e)) {
+if (!Vm(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return td.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return rd.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
 {
 type: "transfer",
 target: p,
@@ -27543,12 +27582,12 @@ type: "transfer",
 target: p,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return td.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return rd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-td.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-_l(e);
+rd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+Nl(e);
 }
 if (o) {
 var y = function(e) {
@@ -27556,7 +27595,7 @@ var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = od(e.creep, t, "energy_container");
+var r = nd(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -27600,16 +27639,16 @@ var R = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (R.length > 0) {
-var E = od(e.creep, R, "energy_container");
-if (E) return td.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var E = nd(e.creep, R, "energy_container");
+if (E) return rd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: E,
 resourceType: RESOURCE_ENERGY
 };
-td.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+rd.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
 var T = e.creep.pos.findClosestByRange(R);
-if (T) return td.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+if (T) return rd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
 {
 type: "withdraw",
 target: T,
@@ -27617,7 +27656,7 @@ resourceType: RESOURCE_ENERGY
 };
 }
 if (e.mineralContainers.length > 0) {
-var C = od(e.creep, e.mineralContainers, "mineral_container");
+var C = nd(e.creep, e.mineralContainers, "mineral_container");
 if (C) {
 if (S = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
@@ -27627,11 +27666,11 @@ target: C,
 resourceType: S
 };
 } else {
-td.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+rd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var S, w = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (w && (S = Object.keys(w.store).find(function(e) {
 return e !== RESOURCE_ENERGY && w.store.getUsedCapacity(e) > 0;
-}))) return td.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
+}))) return rd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
 {
 type: "withdraw",
 target: w,
@@ -27676,27 +27715,27 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (td.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (rd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
 {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : (td.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+}) : (rd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 }));
 },
 builder: function(e) {
-if (Ul(e)) {
-var t = Hm(e);
+if (_l(e)) {
+var t = Ym(e);
 if (t) return t;
-if (!Ym(e)) {
-var r = Vm(e, "builder");
+if (!Vm(e)) {
+var r = qm(e, "builder");
 if (r) return r;
 }
 var o = function(e) {
 if (!e.room) return null;
-var t = $m(e);
+var t = ed(e);
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r) return r;
@@ -27719,10 +27758,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Km(e);
+return Hm(e);
 },
 upgrader: function(e) {
-if (Ul(e)) {
+if (_l(e)) {
 if (function(e) {
 return !function(e) {
 var t = globalThis.Game;
@@ -27736,10 +27775,10 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 });
 }(e);
 }(e)) {
-var t = Hm(e);
+var t = Ym(e);
 if (t) return t;
-if (!Ym(e)) {
-var r = Vm(e, "upgrader");
+if (!Vm(e)) {
+var r = qm(e, "upgrader");
 if (r) return r;
 }
 }
@@ -27812,7 +27851,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (Ul(e)) {
+if (_l(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -27836,7 +27875,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : qm(e) || (e.storage ? {
+} : jm(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -27956,15 +27995,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : sd(e);
+} : cd(e);
 },
-labSupply: sd,
+labSupply: cd,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (Ul(e)) {
+if (_l(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28144,7 +28183,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = Ul(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = _l(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28167,9 +28206,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : qm(e) || (e.isEmpty || e.room.name !== o ? {
+} : jm(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (_l(e), {
+} : (Nl(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28268,12 +28307,12 @@ roomName: o
 }
 };
 
-function ud(e) {
+function ld(e) {
 var t;
-return (null !== (t = cd[e.memory.role]) && void 0 !== t ? t : Xm)(e);
+return (null !== (t = ud[e.memory.role]) && void 0 !== t ? t : Zm)(e);
 }
 
-var ld = "patrol", md = [ {
+var md = "patrol", dd = [ {
 x: 10,
 y: 5
 }, {
@@ -28309,7 +28348,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], dd = [ {
+} ], pd = [ {
 x: 10,
 y: 10
 }, {
@@ -28326,7 +28365,7 @@ x: 25,
 y: 25
 } ];
 
-function pd(e) {
+function fd(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28334,7 +28373,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function fd(e) {
+function yd(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28344,9 +28383,9 @@ roomName: e.roomName
 });
 }
 
-function yd(e) {
+function vd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Fe.get(e.name, {
-namespace: ld
+namespace: md
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28366,25 +28405,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(md), !1), i(dd), !1);
-}(t).map(pd).filter(function(e) {
+}(e)), !1), i(dd), !1), i(pd), !1);
+}(t).map(fd).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Fe.set(e.name, {
-waypoints: fd(n),
+waypoints: yd(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: ld,
+namespace: md,
 ttl: 1e3
 }), n;
 }
 
-function vd(e, t) {
+function gd(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28394,54 +28433,54 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var gd = M("MilitaryBehaviors"), hd = "defenseAssist";
-
-function Rd(e) {
-var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === hd ? e.targetRoom : void 0;
-}
+var hd = k("MilitaryBehaviors"), Rd = "defenseAssist";
 
 function Ed(e) {
+var t;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Rd ? e.targetRoom : void 0;
+}
+
+function Td(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === hd && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === Rd && (delete e.task,
 delete e.targetRoom);
 }
 
-function Td(e, t) {
+function Cd(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function Cd(e) {
-return Ir(kr(e));
-}
-
 function Sd(e) {
-return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
+return Ir(Mr(e));
 }
 
 function wd(e) {
+return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
+}
+
+function xd(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function xd(e, t) {
+function bd(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function bd(e) {
-return xd(e, "guard") + xd(e, "ranger") + xd(e, "healer");
+function Od(e) {
+return bd(e, "guard") + bd(e, "ranger") + bd(e, "healer");
 }
 
-function Od(e, t, r) {
+function Ad(e, t, r) {
 var o = e.memory;
-return Rd(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
+return Ed(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function Ad(e, t) {
+function kd(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return Od(r, e, t);
+return Ad(r, e, t);
 });
 }
 
@@ -28449,32 +28488,32 @@ function Md(e, t) {
 return "defenseAssist:".concat(e, ":").concat(t, ":active");
 }
 
-function kd(e, t, r) {
-return xd(e, t) > function(e, t) {
+function Ud(e, t, r) {
+return bd(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
-return !r.spawning && o.role === t && Rd(o) === e;
+return !r.spawning && o.role === t && Ed(o) === e;
 }).length;
-}(e.roomName, t) || bd(e) > 0 && Cd(e.roomName) && function(e, t) {
-return Ad(e, t).length;
+}(e.roomName, t) || Od(e) > 0 && Sd(e.roomName) && function(e, t) {
+return kd(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Ud(e, t) {
+function _d(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== hd) return null;
-if (Sd(e)) return null;
+if (t.task && t.task !== Rd) return null;
+if (wd(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(wd).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(xd).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== j(l).length && kd(u, t.role, e.homeRoom)) return t.task = hd, t.targetRoom = u.roomName,
-t.assistTarget = u.roomName, t.defenseSquadId = Md(e.homeRoom, u.roomName), t.defenseSquadSize = Cd(u.roomName) ? Math.max(5, bd(u)) : Math.max(1, bd(u)),
+if (l && 0 !== j(l).length && Ud(u, t.role, e.homeRoom)) return t.task = Rd, t.targetRoom = u.roomName,
+t.assistTarget = u.roomName, t.defenseSquadId = Md(e.homeRoom, u.roomName), t.defenseSquadSize = Sd(u.roomName) ? Math.max(5, Od(u)) : Math.max(1, Od(u)),
 t.defenseSquadCreatedAt = Game.time, u.roomName;
 }
 } catch (e) {
@@ -28491,7 +28530,7 @@ if (r) throw r.error;
 return null;
 }
 
-function _d(e) {
+function Nd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28499,19 +28538,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Nd(e, t) {
+function Pd(e, t) {
 if (!function(e) {
-return Boolean(Rd(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(Ed(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = Rd(t);
+var r = Ed(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = kr(r), n = Ir(o), a = n ? Ad(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = Rd(e);
+var o = Mr(r), n = Ir(o), a = n ? kd(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = Ed(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Od(e, r, o);
+return e.memory.defenseSquadId === t && Ad(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28525,7 +28564,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return Ad(e, t).reduce(function(e, t) {
+return kd(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = br(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28547,16 +28586,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return Td(t, "parity-ready"), null;
-if (c >= u) return Td(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Cd(t, "parity-ready"), null;
+if (c >= u) return Cd(t, "squad-quorum"), null;
 if (l) {
-if (!n) return Td(t, "expired-staging"), null;
+if (!n) return Cd(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = _d(e) - _d(t);
+var r = Nd(e) - Nd(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28564,11 +28603,11 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return Td(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Cd(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return Td(t, "squad-quorum"), null;
-if (l) return Td(t, "expired-staging"), null;
+if (c >= u) return Cd(t, "squad-quorum"), null;
+if (l) return Cd(t, "expired-staging"), null;
 }
 var m = Lu(e.room.name);
 return {
@@ -28577,7 +28616,7 @@ position: null != m ? m : e.creep.pos
 };
 }
 
-function Pd(e) {
+function Id(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28609,21 +28648,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Id(e, t) {
+function Gd(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Gd(e, t) {
+function Ld(e, t) {
 if (!e.swarmState) return null;
 var r = Lu(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (gd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+return r && e.creep.pos.getRangeTo(r) > 2 ? (hd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Ld(e) {
+function Dd(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28647,7 +28686,7 @@ if (t) throw t.error;
 }
 }
 
-function Dd(e) {
+function Fd(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28655,23 +28694,23 @@ return Boolean(e);
 });
 }
 
-function Fd(e) {
+function Bd(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Bd(e) {
+function Wd(e) {
 var t, r = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Ld(e.memory.squadId);
-if (o) return Wd(e, o);
+var o = Dd(e.memory.squadId);
+if (o) return Kd(e, o);
 }
-var n = null !== (t = Ud(e, r)) && void 0 !== t ? t : Rd(r);
-if (n && !Sd(e)) {
-var a = Nd(e, r);
+var n = null !== (t = _d(e, r)) && void 0 !== t ? t : Ed(r);
+if (n && !wd(e)) {
+var a = Pd(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28684,9 +28723,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Pd(e);
+var s = Id(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Id(e.creep, RANGED_ATTACK), l = Id(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Gd(e.creep, RANGED_ATTACK), l = Gd(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28698,7 +28737,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Id(e.creep, RANGED_ATTACK), l = Id(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Gd(e.creep, RANGED_ATTACK), l = Gd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28709,7 +28748,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (Ed(r), e.creep.room.name !== e.homeRoom) return {
+} else if (Td(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28718,8 +28757,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Pd(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Id(e.creep, RANGED_ATTACK), l = Id(e.creep, ATTACK),
+var m = Id(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Gd(e.creep, RANGED_ATTACK), l = Gd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28730,7 +28769,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = yd(e.room), p = vd(e.creep, d);
+var d = vd(e.room), p = gd(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28744,7 +28783,7 @@ type: "idle"
 };
 }
 
-function Wd(e, t) {
+function Kd(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28752,7 +28791,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Fd(t);
+var n = Bd(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28760,7 +28799,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Dd(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Fd(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -28783,7 +28822,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Dd(e).filter(function(t) {
+var t, r, o = Fd(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -28812,7 +28851,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Dd(t).filter(function(t) {
+var r = Fd(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -28828,7 +28867,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Dd(t).sort(function(e, t) {
+var a = Fd(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -28865,7 +28904,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Dd(t).filter(function(e) {
+var l = Fd(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -28882,7 +28921,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Dd(e).find(function(e) {
+return null !== (t = Fd(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -28893,7 +28932,7 @@ target: m
 type: "idle"
 };
 }
-var d = Pd(e);
+var d = Id(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -28905,10 +28944,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Id(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Gd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Id(e.creep, ATTACK) && p <= 1 ? {
+} : Gd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -28924,10 +28963,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Id(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Gd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Id(e.creep, ATTACK) && p <= 1 ? {
+} : Gd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -28943,7 +28982,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Fd(t)
+target: Bd(t)
 };
 
 case "dissolving":
@@ -28961,8 +29000,8 @@ type: "idle"
 }
 }
 
-var Kd = {
-guard: Bd,
+var Hd = {
+guard: Wd,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -28971,8 +29010,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = yd(e.room);
-return (o = vd(e.creep, r)) ? {
+var r = vd(e.room);
+return (o = gd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -28993,7 +29032,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = yd(e.room), (o = vd(e.creep, r)) ? {
+} : (r = vd(e.room), (o = gd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29007,11 +29046,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Id(e, HEAL);
+return Gd(e, HEAL);
 }), t.filter(function(e) {
-return Id(e, RANGED_ATTACK);
+return Gd(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Id(e, ATTACK);
+return Gd(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29032,7 +29071,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Id(e.creep, RANGED_ATTACK), u = Id(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Gd(e.creep, RANGED_ATTACK), u = Gd(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29063,19 +29102,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Ld(e.memory.squadId);
-if (o) return Wd(e, o);
+var o = Dd(e.memory.squadId);
+if (o) return Kd(e, o);
 }
-var n = null !== (t = Ud(e, r)) && void 0 !== t ? t : Rd(r);
-if (n && !Sd(e)) {
-var a = Nd(e, r);
+var n = null !== (t = _d(e, r)) && void 0 !== t ? t : Ed(r);
+if (n && !wd(e)) {
+var a = Pd(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === j(i).length) return Ed(r), {
+if (0 === j(i).length) return Td(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29083,7 +29122,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== hd && !r.assistTarget) {
+if (r.targetRoom && r.task !== Rd && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -29143,7 +29182,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || Rd(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || Ed(r) === t);
 }(e, t);
 }
 });
@@ -29169,7 +29208,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = yd(e.room), v = vd(e.creep, y);
+var y = vd(e.room), v = gd(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29180,8 +29219,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Ld(e.memory.squadId);
-if (r) return Wd(e, r);
+var r = Dd(e.memory.squadId);
+if (r) return Kd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29203,9 +29242,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Pd(e);
+var a = Id(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Id(e.creep, RANGED_ATTACK), c = Id(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Gd(e.creep, RANGED_ATTACK), c = Gd(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29224,7 +29263,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = yd(e.room), m = vd(e.creep, l);
+var l = vd(e.room), m = gd(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29246,8 +29285,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Ld(e.memory.squadId);
-if (r) return Wd(e, r);
+var r = Dd(e.memory.squadId);
+if (r) return Kd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29308,9 +29347,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Gd(e, "siegeUnit");
+var p = Ld(e, "siegeUnit");
 if (p) return p;
-var f = yd(e.room), y = vd(e.creep, f);
+var f = vd(e.room), y = gd(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29321,8 +29360,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Ld(e.memory.squadId);
-if (r) return Wd(e, r);
+var r = Dd(e.memory.squadId);
+if (r) return Kd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29339,7 +29378,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Gd(e, "harasser (no target)") || {
+if (!t) return Ld(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29381,9 +29420,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Gd(e, "harasser (no targets)");
+var c = Ld(e, "harasser (no targets)");
 if (c) return c;
-var u = yd(e.room), l = vd(e.creep, u);
+var u = vd(e.room), l = gd(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29396,9 +29435,9 @@ var t, r, o = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Ld(e.memory.squadId))) return Wd(e, a);
+if (e.memory.squadId && (a = Dd(e.memory.squadId))) return Kd(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (Rd(o) && Ed(o), e.room.name !== e.homeRoom) return {
+if (Ed(o) && Td(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29412,9 +29451,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Ud(e, o)) && void 0 !== t ? t : Rd(o);
-if (i && !Sd(e)) {
-var s = Nd(e, o);
+var a, i = null !== (t = _d(e, o)) && void 0 !== t ? t : Ed(o);
+if (i && !wd(e)) {
+var s = Pd(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29424,14 +29463,14 @@ roomName: i
 var u = j(c), l = z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return Ed(o), {
+if (0 === u.length && 0 === l.length) return Td(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Pd(e);
+var m = Id(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29451,8 +29490,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Ld(e.memory.squadId))) return Wd(e, a);
-var p, f = Pd(e);
+if (e.memory.squadId && (a = Dd(e.memory.squadId))) return Kd(e, a);
+var p, f = Id(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29463,7 +29502,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = yd(e.room), v = vd(e.creep, y);
+var y = vd(e.room), v = gd(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29484,21 +29523,21 @@ type: "idle"
 }
 };
 
-function Hd(e) {
+function Yd(e) {
 var t;
-return hl.getAssignedAction(e) || (null !== (t = Kd[e.memory.role]) && void 0 !== t ? t : Bd)(e);
+return hl.getAssignedAction(e) || (null !== (t = Hd[e.memory.role]) && void 0 !== t ? t : Wd)(e);
 }
 
-var Yd = M("PowerExecutor");
+var Vd = k("PowerExecutor");
 
-function Vd(e, t) {
+function qd(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function qd(e) {
+function jd(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29540,8 +29579,8 @@ type: "idle"
 };
 }
 
-var jd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), zd = {
-powerHarvester: qd,
+var zd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Qd = {
+powerHarvester: jd,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29613,65 +29652,65 @@ roomName: e.homeRoom
 }
 };
 
-function Qd(e) {
+function Xd(e) {
 var t;
-return (null !== (t = zd[e.memory.role]) && void 0 !== t ? t : qd)(e);
+return (null !== (t = Qd[e.memory.role]) && void 0 !== t ? t : jd)(e);
 }
 
-function Xd(e) {
+function Zd(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var Zd = {
+var Jd = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, Jd = {
+}, $d = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, $d = {
+}, ep = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, ep = {
+}, tp = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, tp = {
+}, rp = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, rp = {
+}, op = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, op = {
+}, np = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, np = {
+}, ap = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function ap(e) {
+function ip(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function ip(e) {
+function sp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29679,7 +29718,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function sp(e) {
+function cp(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29687,12 +29726,12 @@ y: parseInt(n, 10)
 };
 }
 
-function cp(e) {
+function up(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = up(s);
+o[s.n] = lp(s);
 }
 } catch (e) {
 t = {
@@ -29708,23 +29747,23 @@ if (t) throw t.error;
 return o;
 }
 
-function up(e) {
+function lp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = Jd[e.r]) && void 0 !== t ? t : "core",
-health: lp(e.h),
+role: null !== (t = $d[e.r]) && void 0 !== t ? t : "core",
+health: mp(e.h),
 activeTasks: e.t,
-portals: e.p.map(mp),
+portals: e.p.map(dp),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(dp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(pp)
 };
 }
 
-function lp(e) {
+function mp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = ep[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = tp[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29737,11 +29776,11 @@ lastUpdate: e.u
 };
 }
 
-function mp(e) {
+function dp(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: ip(e.sp),
+sourcePos: sp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29751,7 +29790,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function dp(e) {
+function pp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29760,7 +29799,7 @@ bucketLevel: e.b
 };
 }
 
-function pp(e) {
+function fp(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -29770,12 +29809,12 @@ isAlly: 1 === e.a
 };
 }
 
-function fp(e) {
+function yp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = yp(u);
+i[u.n] = vp(u);
 }
 } catch (e) {
 t = {
@@ -29798,13 +29837,13 @@ updatedAt: e.u
 };
 }
 
-function yp(e) {
+function vp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: sp(e.pp),
+portalPos: cp(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -29815,46 +29854,46 @@ lastUpdate: e.u
 };
 }
 
-function vp(e) {
+function gp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = rp[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = op[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = np[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = ap[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function gp(e, t) {
+function hp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
-}
-
-function hp(e) {
-var t;
-return {
-c: null !== (t = $d[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: gp(e.cpuUsage, 2),
-b: e.bucketLevel,
-e: Math.round(e.economyIndex),
-w: Math.round(e.warIndex),
-m: Math.round(e.commodityIndex),
-rc: e.roomCount,
-rl: gp(e.avgRCL, 1),
-cc: e.creepCount,
-u: e.lastUpdate
-};
 }
 
 function Rp(e) {
 var t;
 return {
+c: null !== (t = ep[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: hp(e.cpuUsage, 2),
+b: e.bucketLevel,
+e: Math.round(e.economyIndex),
+w: Math.round(e.warIndex),
+m: Math.round(e.commodityIndex),
+rc: e.roomCount,
+rl: hp(e.avgRCL, 1),
+cc: e.creepCount,
+u: e.lastUpdate
+};
+}
+
+function Ep(e) {
+var t;
+return {
 sr: e.sourceRoom,
-sp: ap(e.sourcePos),
+sp: ip(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -29863,27 +29902,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function Ep(e) {
+function Tp(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: gp(e.cpuUsed, 2),
+u: hp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function Tp(e) {
+function Cp(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Cp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Sp)
 };
 }
 
-function Cp(e) {
+function Sp(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -29893,23 +29932,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Sp(e) {
+function wp(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = tp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = rp[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = op[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = np[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function wp(e) {
+function xp(e) {
 return {
 name: e,
 role: "core",
@@ -29932,7 +29971,7 @@ cpuLimit: 0
 };
 }
 
-function xp(e) {
+function bp(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -29942,16 +29981,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = Zd[t.role]) && void 0 !== r ? r : t.role[0],
-h: hp(t.health),
+r: null !== (r = Jd[t.role]) && void 0 !== r ? r : t.role[0],
+h: Rp(t.health),
 t: t.activeTasks,
-p: t.portals.map(Rp),
+p: t.portals.map(Ep),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Ep)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Tp)
 };
 }(t[0], t[1]);
 }),
-g: Tp(e.globalTargets),
+g: Cp(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -29965,7 +30004,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? ap(t.portalPos) : void 0,
+pp: t.portalPos ? ip(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -29977,20 +30016,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Sp),
+k: e.tasks.map(wp),
 ls: e.lastSync
 };
 var t;
-}(e), r = Xd(JSON.stringify(t));
+}(e), r = Zd(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function bp(e) {
+function Op(e) {
 try {
-var t = JSON.parse(e), r = Xd(JSON.stringify(t.d));
+var t = JSON.parse(e), r = Zd(JSON.stringify(t.d));
 return t.c !== r ? (va.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -29999,13 +30038,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: cp(a.s),
+shards: up(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(pp)), n),
-footprintOperation: a.o ? fp(a.o) : void 0,
-tasks: a.k.map(vp),
+o.en && (n.enemies = o.en.map(fp)), n),
+footprintOperation: a.o ? yp(a.o) : void 0,
+tasks: a.k.map(gp),
 lastSync: a.ls,
 checksum: i
 });
@@ -30017,34 +30056,34 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Op, Ap, Mp = 102400;
+var Ap, kp, Mp = 102400;
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Op || (Op = {})), function(e) {
+}(Ap || (Ap = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(Ap || (Ap = {}));
+}(kp || (kp = {}));
 
-var kp = null != va ? va : {
+var Up = null != va ? va : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Up = {
+}, _p = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, _p = {
+}, Np = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Np = function() {
+}, Pp = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Up), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, _p), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30061,19 +30100,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = bp(r);
-o && (this.interShardMemory = o, kp.debug("Loaded InterShardMemory", {
+var o = Op(r);
+o && (this.interShardMemory = o, Up.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-kp.error("Failed to load InterShardMemory: ".concat(n), {
+Up.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = wp(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = xp(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30234,25 +30273,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-kp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Up.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-kp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Up.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", kp.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Up.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-kp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Up.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30285,7 +30324,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-kp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Up.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30315,12 +30354,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", kp.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Up.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-kp.info("War ended, transitioning to ".concat(i), {
+Up.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, kp.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Up.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30346,7 +30385,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = _p[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Np[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30398,13 +30437,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && kp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Up.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-kp.debug("Could not set shard limits: ".concat(S), {
+Up.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30412,27 +30451,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (kp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Up.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
 try {
-var t = InterShardMemory.getLocal(), r = t ? bp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
+var t = InterShardMemory.getLocal(), r = t ? Op(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
 o && (!n || o.updatedAt >= n.updatedAt) && (this.interShardMemory.footprintOperation = o);
 } catch (e) {}
-var a = xp(this.interShardMemory);
+var a = bp(this.interShardMemory);
 if (a.length > Mp) {
-kp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Mp), {
+Up.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Mp), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var i = xp(this.interShardMemory);
-return i.length > Mp ? (kp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Mp), {
+var i = bp(this.interShardMemory);
+return i.length > Mp ? (Up.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Mp), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(i);
 }
 InterShardMemory.setLocal(a), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var s = e instanceof Error ? e.message : String(e);
-kp.error("Failed to sync InterShardMemory: ".concat(s), {
+Up.error("Failed to sync InterShardMemory: ".concat(s), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30470,7 +30509,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = wp(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = xp(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30488,40 +30527,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-kp.info("Repaired InterShardMemory structure", {
+Up.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void kp.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Up.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = bp(r);
-if (!o) return void kp.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Op(r);
+if (!o) return void Up.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || kp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Up.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-kp.warn("InterShardMemory verification failed: ".concat(a), {
+Up.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-kp.info("Attempting InterShardMemory recovery", {
+Up.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = bp(r);
-if (o) return this.interShardMemory = o, void kp.info("Recovered InterShardMemory from storage", {
+var o = Op(r);
+if (o) return this.interShardMemory = o, void Up.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30536,12 +30575,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = wp(n), kp.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = xp(n), Up.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-kp.error("InterShardMemory recovery failed: ".concat(a), {
+Up.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30551,7 +30590,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), kp.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Up.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30567,7 +30606,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-kp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Up.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30583,7 +30622,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), kp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Up.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30598,7 +30637,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, kp.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Up.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30617,7 +30656,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), kp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Up.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30663,11 +30702,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, kp.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Up.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = xp(this.interShardMemory).length, o = r / Mp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = bp(this.interShardMemory).length, o = r / Mp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30694,11 +30733,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-kp.info("Forcing InterShardMemory sync with validation", {
+Up.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = xp(this.interShardMemory).length, n = xp(o(o({}, this.interShardMemory), {
+var e, t, r = bp(this.interShardMemory).length, n = bp(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -30731,10 +30770,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Op.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Ap.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), Pp = new Np, Ip = {
+}(), Ip = new Pp, Gp = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -30745,11 +30784,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: Ap.LOW,
-NORMAL: Ap.NORMAL,
-HIGH: Ap.HIGH
+LOW: kp.LOW,
+NORMAL: kp.NORMAL,
+HIGH: kp.HIGH
 }
-}, Gp = function() {
+}, Lp = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -30759,7 +30798,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = Pp.getActiveTransferTasks();
+var n = Ip.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -30786,7 +30825,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = Pp.getOptimalPortalRoute(e.targetShard);
+var t = Ip.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -30854,7 +30893,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-Pp.updateTaskProgress(e.taskId, t);
+Ip.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -30870,7 +30909,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = Ip.optimizeBody({
+i = Gp.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -30881,8 +30920,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Ip.spawnPriorities.LOW;
-e.priority >= 80 ? d = Ip.spawnPriorities.HIGH : e.priority >= 50 && (d = Ip.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Gp.spawnPriorities.LOW;
+e.priority >= 80 ? d = Gp.spawnPriorities.HIGH : e.priority >= 50 && (d = Gp.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -30900,7 +30939,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-Ip.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Gp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -30927,7 +30966,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void Pp.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Ip.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", va.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -30939,8 +30978,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, Pp.updateTaskProgress(e.taskId, 100, "complete"),
-Pp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Ip.updateTaskProgress(e.taskId, 100, "complete"),
+Ip.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -30970,12 +31009,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Lp = new Gp;
+}(), Dp = new Lp;
 
-function Dp(e, t, r) {
+function Fp(e, t, r) {
 var o, n, a, i;
 try {
-var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = bp(c)) && void 0 !== a ? a : {
+var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Op(c)) && void 0 !== a ? a : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30990,11 +31029,11 @@ if (!(null == l ? void 0 : l.targets[s])) return;
 var m = l.targets[s];
 m.status = e, null !== (i = m.arrivedAt) && void 0 !== i || (m.arrivedAt = Game.time),
 m.claimTargetRoom = null != t ? t : m.claimTargetRoom, m.blockedReason = r, m.lastUpdate = Game.time,
-"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(xp(u));
+"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(bp(u));
 } catch (e) {}
 }
 
-function Fp(e) {
+function Bp(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31022,15 +31061,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Dp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Fp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || j(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Dp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Fp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Dp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Fp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31047,24 +31086,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Dp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Fp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Dp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Fp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Bp(e) {
+function Wp(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Wp(e, t) {
+function Kp(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31098,14 +31137,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (A.mineralType = y.mineralType), u[e.name] = A;
 }
 
-function Kp(e, t) {
+function Hp(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function Hp(e) {
-var t = zm.getEmpire();
-if (Gu.isExit(e.creep.pos)) return Bp(e.room.name);
+function Yp(e) {
+var t = Qm.getEmpire();
+if (Gu.isExit(e.creep.pos)) return Wp(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31120,7 +31159,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Kp(t.x, t.y - 1), Kp(t.x + 1, t.y), Kp(t.x, t.y + 1), Kp(t.x - 1, t.y) ] : [];
+return t ? [ Hp(t.x, t.y - 1), Hp(t.x + 1, t.y), Hp(t.x, t.y + 1), Hp(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31183,13 +31222,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Wp(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Kp(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Wp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Kp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31199,19 +31238,19 @@ type: "idle"
 };
 }
 
-function Yp(e) {
+function Vp(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function Vp(e) {
-return e.hostiles.some(Yp);
-}
-
 function qp(e) {
-return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+return e.hostiles.some(Vp);
 }
 
 function jp(e) {
+return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+}
+
+function zp(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31234,8 +31273,8 @@ type: "idle"
 };
 }
 
-var zp = {
-scout: Hp,
+var Qp = {
+scout: Yp,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31269,7 +31308,7 @@ return {
 type: "idle"
 };
 }
-if (Gu.isExit(e.creep.pos)) return Bp(e.room.name);
+if (Gu.isExit(e.creep.pos)) return Wp(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31291,8 +31330,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Fp,
-interShardScout: Fp,
+interShardClaimer: Bp,
+interShardScout: Bp,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31368,8 +31407,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return jp(e);
-if (Vp(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return zp(e);
+if (qp(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31410,7 +31449,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return qp(t) - qp(e);
+return jp(t) - jp(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31430,7 +31469,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : jp(e);
+} : zp(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31519,9 +31558,9 @@ type: "idle"
 }
 };
 
-function Qp(e, t) {
+function Xp(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Vp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : qp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31529,24 +31568,24 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function Xp(e) {
-var t;
-return (null !== (t = zp[e.memory.role]) && void 0 !== t ? t : Hp)(e);
-}
-
 function Zp(e) {
-var t = Nu(e);
-wl(e, kl(t, ud), t);
+var t;
+return (null !== (t = Qp[e.memory.role]) && void 0 !== t ? t : Yp)(e);
 }
 
 function Jp(e) {
 var t = Nu(e);
-wl(e, kl(t, Xp, {
-interrupt: Qp
-}), t);
+wl(e, Ul(t, ld), t);
 }
 
 function $p(e) {
+var t = Nu(e);
+wl(e, Ul(t, Zp, {
+interrupt: Xp
+}), t);
+}
+
+function ef(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31587,8 +31626,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && jd.has(i) && V(s))) {
-Yd.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && zd.has(i) && V(s))) {
+Vd.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31653,7 +31692,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Vd(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !qd(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31663,7 +31702,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Vd(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !qd(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31674,7 +31713,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Vd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !qd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -31727,7 +31766,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Vd(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !qd(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -31769,7 +31808,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Vd(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !qd(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -31779,7 +31818,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Vd(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !qd(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -31787,7 +31826,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && j(e.room).length > 0) {
 var o = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Vd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !qd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -31799,7 +31838,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Vd(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !qd(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -31807,12 +31846,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Vd(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !qd(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Vd(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !qd(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -31846,18 +31885,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function ef(e) {
+function tf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var tf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), rf = -1, of = Object.create(null);
+var rf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), of = -1, nf = Object.create(null);
 
-function nf(e) {
+function af(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var af = {
+var sf = {
 harvester: ha.CRITICAL,
 queenCarrier: ha.CRITICAL,
 hauler: ha.HIGH,
@@ -31892,12 +31931,12 @@ labTech: ha.IDLE,
 factoryWorker: ha.IDLE
 };
 
-function sf(e) {
+function cf(e) {
 var t;
-return null !== (t = af[e]) && void 0 !== t ? t : ha.MEDIUM;
+return null !== (t = sf[e]) && void 0 !== t ? t : ha.MEDIUM;
 }
 
-function cf(e) {
+function uf(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -31913,20 +31952,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && nf(o) === e && t++;
+o && af(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (rf !== Game.time && (rf = Game.time, of = function() {
+}(e) : null !== (r = (of !== Game.time && (of = Game.time, nf = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = nf(o);
+var n = af(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), of)[e]) && void 0 !== r ? r : 0;
+}()), nf)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Ue().cpu.disableCreepBootstrapCountCache
@@ -31936,7 +31975,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!tf.has(t.role)) return !1;
+if (!rf.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -31946,7 +31985,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !ef(r)) return !1;
+if (!r || !tf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -31960,7 +31999,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !ef(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !tf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -31968,7 +32007,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !ef(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !tf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -31976,7 +32015,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !ef(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !tf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -31984,7 +32023,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && ef(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && tf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32000,7 +32039,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !ef(r)) return !1;
+if (!r || !tf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32041,28 +32080,28 @@ case "economy":
 default:
 !function(e) {
 var t = Nu(e);
-wl(e, kl(t, ud), t);
+wl(e, Ul(t, ld), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
 var t = Nu(e);
-wl(e, kl(t, Hd), t);
+wl(e, Ul(t, Yd), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
 var t = Nu(e);
-wl(e, kl(t, Xp), t);
+wl(e, Ul(t, Zp), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
 var t = Nu(e);
-wl(e, kl(t, Qd), t);
+wl(e, Ul(t, Xd), t);
 }(e);
 }
 });
@@ -32083,7 +32122,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var uf = function() {
+var lf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32124,7 +32163,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = sf(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = cf(r), n = "creep:".concat(e.name);
 Ja.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -32140,7 +32179,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && cf(t);
+t && !t.spawning && uf(t);
 }
 }), this.registeredCreeps.add(e.name), Ci.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32165,7 +32204,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = sf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = cf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32190,20 +32229,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), lf = new uf;
-
-function mf(e) {
-var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, df(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
-}
+}(), mf = new lf;
 
 function df(e) {
+var t, r, o;
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, pf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+}
+
+function pf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function pf(e) {
+function ff(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32216,14 +32255,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function ff(e, t) {
+function yf(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var yf = {
+var vf = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32251,11 +32290,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function vf(e, t) {
+function gf(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function gf(e) {
+function hf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32265,9 +32304,9 @@ tick: Game.time
 }, a;
 }
 
-var hf = [ "defense", "war", "expand", "siege" ];
+var Rf = [ "defense", "war", "expand", "siege" ];
 
-function Rf(e) {
+function Ef(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32280,11 +32319,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function Ef(e, t, r) {
-t >= 2 && (e.pheromones.war = vf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = vf(e.pheromones.siege + 20, r));
+function Tf(e, t, r) {
+t >= 2 && (e.pheromones.war = gf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = gf(e.pheromones.siege + 20, r));
 }
 
-var Tf = function() {
+var Cf = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32299,27 +32338,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), Cf = function() {
+}(), Sf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, yf), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, vf), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new Tf(10),
-energySpawning: new Tf(10),
-energyConstruction: new Tf(10),
-energyRepair: new Tf(10),
-energyTower: new Tf(10),
-controllerProgress: new Tf(10),
-hostileCount: new Tf(5),
-damageReceived: new Tf(5),
-idleWorkers: new Tf(10),
+energyHarvested: new Cf(10),
+energySpawning: new Cf(10),
+energyConstruction: new Cf(10),
+energyRepair: new Cf(10),
+energyTower: new Cf(10),
+controllerProgress: new Cf(10),
+hostileCount: new Cf(5),
+damageReceived: new Cf(5),
+idleWorkers: new Cf(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = gf(e);
+var o = hf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32392,7 +32431,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = vf(e[s] * c, t);
+e[s] = gf(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32408,43 +32447,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = gf(t);
+var o = hf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = vf(e.harvest + n / 3e3 * 10, r);
+e.harvest = gf(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = vf(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = gf(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = vf(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = gf(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = vf(e.defense + 10 * o, r));
+o > 0 && (e.defense = gf(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = vf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = vf(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = gf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = gf(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = vf(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = gf(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = vf(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = gf(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = vf(e.pheromones.defense + 5 * t, o), Ef(e, r, o),
+e.danger = r, e.pheromones.defense = gf(e.pheromones.defense + 5 * t, o), Tf(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32452,7 +32491,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = vf(t / 10, o), Ef(e, r, o);
+e.danger = r, e.pheromones.defense = gf(t / 10, o), Tf(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32465,8 +32504,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = vf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = vf(f + y, o);
+var p = gf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = gf(f + y, o);
 }
 }
 }
@@ -32485,18 +32524,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = vf(e.pheromones.defense + 5, r), e.pheromones.build = vf(e.pheromones.build + 10, r),
+e.pheromones.defense = gf(e.pheromones.defense + 5, r), e.pheromones.build = gf(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = vf(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = gf(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = vf(e.pheromones.siege + 50, t), e.pheromones.defense = vf(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = gf(e.pheromones.siege + 50, t), e.pheromones.defense = gf(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = vf(e.pheromones.expand - 10, t), e.pheromones.defense = vf(e.pheromones.defense + 5, t);
+e.pheromones.expand = gf(e.pheromones.expand - 10, t), e.pheromones.defense = gf(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32506,10 +32545,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Rf(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(Ef(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(hf)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(Rf)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32563,7 +32602,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = vf(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = gf(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32598,7 +32637,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), Sf = new Cf, wf = {
+}(), wf = new Sf, xf = {
 seedNest: {
 rcl: 1
 },
@@ -32639,7 +32678,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, xf = {
+}, bf = {
 eco: {
 economy: .75,
 military: .05,
@@ -32682,7 +32721,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, bf = {
+}, Of = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -32739,13 +32778,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Of = function() {
+}, Af = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = wf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = wf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= wf.fortifiedHive.rcl ? "fortifiedHive" : s >= wf.matureColony.rcl ? "matureColony" : s >= wf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = xf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = xf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= xf.fortifiedHive.rcl ? "fortifiedHive" : s >= xf.matureColony.rcl ? "matureColony" : s >= xf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Fe.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -32780,7 +32819,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = wf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = xf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -32793,7 +32832,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Af = function() {
+}(), kf = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -32815,9 +32854,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return xf[e];
-}, e.prototype.getResourcePriorities = function(e) {
 return bf[e];
+}, e.prototype.getResourcePriorities = function(e) {
+return Of[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -32827,15 +32866,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Mf = new Of, kf = new Af;
+}(), Mf = new Af, Uf = new kf;
 
-function Uf(e) {
+function _f(e) {
 return !Y(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function _f(e, t, r) {
+function Nf(e, t, r) {
 if (!e) return null;
 var o = mr.getEmpire();
 if (Y(e, {
@@ -32874,11 +32913,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Nf() {
+function Pf() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var Pf = new Map, If = function() {
+var If = new Map, Gf = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = j(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33022,7 +33061,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: Pf.get(e.name),
+previousStructures: If.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33052,7 +33091,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && Pf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && If.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33061,7 +33100,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Uf(u) && o.add(u.owner.username);
+_f(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33075,7 +33114,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) _f(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Nf(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33091,7 +33130,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? Sf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Sf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Sf.onNukeDetected(t);
+"danger" === y.type ? wf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? wf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && wf.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33151,10 +33190,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Nf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = Pf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Nf()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = Pf()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33197,7 +33236,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: kf.isCombatPosture(t.posture),
+isCombatPosture: Uf.isCombatPosture(t.posture),
 wallRepairTarget: so(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33221,27 +33260,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Gf = new If, Lf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Lf = new Gf, Df = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Df() {
+function Ff() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Ff(e, t, r, o) {
+function Bf(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Df()
+selectedAt: Ff()
 });
 }
 
-function Bf(e) {
+function Wf(e) {
 return e >= 2 && e <= 3;
 }
 
-function Wf(e, t) {
+function Kf(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33254,10 +33293,10 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-var Kf = function() {
+var Hf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Bf(e) ? 5 : 10;
+return Wf(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33352,7 +33391,7 @@ O && !O.done && (n = b.return) && n.call(b);
 if (o) throw o.error;
 }
 }
-var M = function(e) {
+var k = function(e) {
 var t, r, o = e.find(FIND_MY_SPAWNS)[0], n = null !== (r = null !== (t = e.terminal) && void 0 !== t ? t : e.storage) && void 0 !== r ? r : o;
 return n ? {
 x: n.pos.x,
@@ -33361,7 +33400,7 @@ y: n.pos.y
 x: 25,
 y: 25
 };
-}(e), k = new Map, U = s(s(s([], i(y.map(function(e) {
+}(e), M = new Map, U = s(s(s([], i(y.map(function(e) {
 return {
 x: e.pos.x,
 y: e.pos.y
@@ -33380,11 +33419,11 @@ y: e.storage.pos.y
 } : void 0, e.find(FIND_MY_SPAWNS)[0] ? {
 x: e.find(FIND_MY_SPAWNS)[0].pos.x,
 y: e.find(FIND_MY_SPAWNS)[0].pos.y
-} : void 0, M ], !1).filter(function(e) {
+} : void 0, k ], !1).filter(function(e) {
 return void 0 !== e;
 });
 try {
-for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) xo(k, e, P.x + I, P.y + G, M, h, R, C);
+for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) xo(M, e, P.x + I, P.y + G, k, h, R, C);
 } catch (e) {
 c = {
 error: e
@@ -33399,7 +33438,7 @@ if (c) throw c.error;
 try {
 for (var L = a(E), D = L.next(); !D.done; D = L.next()) {
 var F = D.value;
-if (!k.has(F)) return null;
+if (!M.has(F)) return null;
 }
 } catch (e) {
 l = {
@@ -33424,7 +33463,7 @@ var o = bo(e, r) - bo(t, r);
 return 0 !== o ? o : e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
 });
 return s(s([], i(r), !1), i(o), !1).slice(0, 80);
-}(k, E);
+}(M, E);
 if (B.length < f) return null;
 var W = B.slice(0, 40), K = null, H = function(e) {
 var t, r, o = function(t) {
@@ -33443,7 +33482,7 @@ var l = new Map;
 l.set(e.key, e), l.set(t.key, t);
 try {
 for (var m = (r = void 0, a(E)), d = m.next(); !d.done; d = m.next()) {
-var p = d.value, y = k.get(p);
+var p = d.value, y = M.get(p);
 y && l.set(y.key, y);
 }
 } catch (e) {
@@ -33690,7 +33729,7 @@ y: o.y - 6
 x: o.x + 6,
 y: o.y + 6
 } ]), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = aa(e, kn, l);
+var l = u.value, m = aa(e, Mn, l);
 n.push.apply(n, s([], i(m.missing), !1));
 }
 } catch (e) {
@@ -33800,11 +33839,11 @@ if (r) throw r.error;
 }
 try {
 for (var S = a(Object.keys(v)), w = S.next(); !w.done; w = S.next()) {
-var x = null !== (l = v[M = w.value]) && void 0 !== l ? l : 0, b = null !== (m = f[M]) && void 0 !== m ? m : 0;
+var x = null !== (l = v[k = w.value]) && void 0 !== l ? l : 0, b = null !== (m = f[k]) && void 0 !== m ? m : 0;
 x > b && g.push({
 type: "RCL_LIMIT_EXCEEDED",
-structureType: M,
-reason: "".concat(M, " count ").concat(x, " exceeds RCL").concat(t.rcl, " limit ").concat(b),
+structureType: k,
+reason: "".concat(k, " count ").concat(x, " exceeds RCL").concat(t.rcl, " limit ").concat(b),
 rcl: t.rcl
 });
 }
@@ -33821,11 +33860,11 @@ if (n) throw n.error;
 }
 try {
 for (var O = a(Object.keys(y)), A = O.next(); !A.done; A = O.next()) {
-var M, k = null !== (d = y[M = A.value]) && void 0 !== d ? d : 0;
-(x = null !== (p = v[M]) && void 0 !== p ? p : 0) < k && g.push({
+var k, M = null !== (d = y[k = A.value]) && void 0 !== d ? d : 0;
+(x = null !== (p = v[k]) && void 0 !== p ? p : 0) < M && g.push({
 type: "UNPLACEABLE_STRUCTURE",
-structureType: M,
-reason: "".concat(M, " count ").concat(x, " below RCL").concat(t.rcl, " target ").concat(k),
+structureType: k,
+reason: "".concat(k, " count ").concat(x, " below RCL").concat(t.rcl, " target ").concat(M),
 rcl: t.rcl
 });
 }
@@ -33958,7 +33997,7 @@ y: e.y - T.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Ff(t, v, C.name, f);
+Bf(t, v, C.name, f);
 var S = t.danger >= 1 && f >= 3 ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f, y, v, g;
 if (r <= 0) return 0;
@@ -33997,9 +34036,9 @@ if (n) throw n.error;
 }
 }
 try {
-for (var A = a(e.find(FIND_MY_CONSTRUCTION_SITES)), M = A.next(); !M.done; M = A.next()) {
-var k = M.value;
-w.add("".concat(k.structureType, ":").concat(k.pos.x, ",").concat(k.pos.y));
+for (var A = a(e.find(FIND_MY_CONSTRUCTION_SITES)), k = A.next(); !k.done; k = A.next()) {
+var M = k.value;
+w.add("".concat(M.structureType, ":").concat(M.pos.x, ",").concat(M.pos.y));
 }
 } catch (e) {
 s = {
@@ -34007,7 +34046,7 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (c = A.return) && c.call(A);
+k && !k.done && (c = A.return) && c.call(A);
 } finally {
 if (s) throw s.error;
 }
@@ -34073,7 +34112,7 @@ var r, o, n, i = Vo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && Wf(e, u) < l) return !0;
+if (!(l <= 0) && Kf(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34089,8 +34128,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + g + h + S >= 10 && !w) t.metrics.constructionSites = p.length + g + h + S; else {
-if (!kf.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Df());
+if (!Uf.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Ff());
 }(t, v)) {
 var x = function(e, t, r, o, n) {
 var i, s;
@@ -34122,11 +34161,11 @@ var b = On(e, t, r.roads, o);
 if (R.set(STRUCTURE_ROAD, b), y >= 6) {
 var O = e.find(FIND_MINERALS);
 if (O.length > 0) {
-var A = O[0], M = new Set;
-M.add("".concat(A.pos.x, ",").concat(A.pos.y)), R.set(STRUCTURE_EXTRACTOR, M);
+var A = O[0], k = new Set;
+k.add("".concat(A.pos.x, ",").concat(A.pos.y)), R.set(STRUCTURE_EXTRACTOR, k);
 }
 }
-var k = function(e) {
+var M = function(e) {
 var t, r, o = function(e) {
 return new Set(Ro(e).placements.map(function(e) {
 return vo(e.x, e.y);
@@ -34150,10 +34189,10 @@ if (t) throw t.error;
 }
 return o;
 }(e);
-if (k.size > 0) {
+if (M.size > 0) {
 var U = null !== (f = R.get(STRUCTURE_LINK)) && void 0 !== f ? f : new Set;
 try {
-for (var _ = a(k), N = _.next(); !N.done; N = _.next()) x = N.value, U.add(x);
+for (var _ = a(M), N = _.next(); !N.done; N = _.next()) x = N.value, U.add(x);
 } catch (e) {
 s = {
 error: e
@@ -34169,7 +34208,7 @@ R.set(STRUCTURE_LINK, U);
 }
 var P = e.find(FIND_STRUCTURES, {
 filter: function(e) {
-return Mn.has(e.structureType) && (!0 === e.my || e.structureType === STRUCTURE_ROAD);
+return kn.has(e.structureType) && (!0 === e.my || e.structureType === STRUCTURE_ROAD);
 }
 });
 try {
@@ -34248,7 +34287,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Lf.has(e.structureType);
+return Df.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34257,7 +34296,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = Bf(f) ? 2 : 3;
+var k = Wf(f) ? 2 : 3;
 (A = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -34359,10 +34398,10 @@ try {
 for (var C = a(h), S = C.next(); !S.done; S = C.next()) {
 for (var w = i(S.value, 2), x = w[0], b = s([], i(w[1]), !1).sort(function(e, t) {
 return e.x === t.x ? e.y - t.y : e.x - t.x;
-}), O = [], A = [], M = 0; M < b.length; M++) {
-T = b[M];
-var k = b[M - 1];
-!(k && Math.abs(T.x - k.x) <= 1 && Math.abs(T.y - k.y) <= 1) && A.length > 0 && (O.push(A),
+}), O = [], A = [], k = 0; k < b.length; k++) {
+T = b[k];
+var M = b[k - 1];
+!(M && Math.abs(T.x - M.x) <= 1 && Math.abs(T.y - M.y) <= 1) && A.length > 0 && (O.push(A),
 A = []), A.push(T);
 }
 A.length > 0 && O.push(A);
@@ -34390,8 +34429,8 @@ for (L = 1; L <= 1; L++) y(47, P.y - L, x), y(47, I.y + L, x), y(48, P.y - L, x)
 y(48, I.y + L, x);
 }
 var D = Math.floor(N.length / 2);
-for (M = 0; M < N.length; M++) {
-var F = (T = N[M]).x, B = T.y;
+for (k = 0; k < N.length; k++) {
+var F = (T = N[k]).x, B = T.y;
 switch (x) {
 case "top":
 B = 2;
@@ -34408,7 +34447,7 @@ break;
 case "right":
 F = 47;
 }
-N.length >= 4 && M === D ? v(F, B, x) : y(F, B, x);
+N.length >= 4 && k === D ? v(F, B, x) : y(F, B, x);
 }
 }
 } catch (e) {
@@ -34540,14 +34579,14 @@ subsystem: "Defense"
 }));
 };
 try {
-for (var M = a(y.walls), k = M.next(); !k.done && "break" !== A(k.value); k = M.next()) ;
+for (var k = a(y.walls), M = k.next(); !M.done && "break" !== A(M.value); M = k.next()) ;
 } catch (e) {
 m = {
 error: e
 };
 } finally {
 try {
-k && !k.done && (d = M.return) && d.call(M);
+M && !M.done && (d = k.return) && d.call(k);
 } finally {
 if (m) throw m.error;
 }
@@ -34591,9 +34630,9 @@ return {
 sitesPlaced: h,
 wallsRemoved: R
 };
-}(e, v, C.roads, f, M, t.remoteAssignments)).wallsRemoved > 0 && mr.addRoomEvent(e.name, "wallRemoved", "".concat(A.wallsRemoved, " wall(s) removed to allow road passage"));
+}(e, v, C.roads, f, k, t.remoteAssignments)).wallsRemoved > 0 && mr.addRoomEvent(e.name, "wallRemoved", "".concat(A.wallsRemoved, " wall(s) removed to allow road passage"));
 }
-var k = function(e, t) {
+var M = function(e, t) {
 var r, o, n, i, s, c, u = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, l = "undefined" == typeof Game ? 0 : Object.keys(Game.constructionSites).length;
 if (l >= u) return 0;
 var m = function(e) {
@@ -34793,7 +34832,7 @@ subsystem: "Defense"
 }), u;
 }(e, f, t.danger, P)).placed > 0 && mr.addRoomEvent(e.name, "rampartPlaced", "".concat(N.placed, " rampart(s) placed on critical structures"));
 }
-t.metrics.constructionSites = p.length + S + k + g + h + _ + A.sitesPlaced + N.placed;
+t.metrics.constructionSites = p.length + S + M + g + h + _ + A.sitesPlaced + N.placed;
 }
 }
 } else {
@@ -34933,13 +34972,13 @@ anchor: l
 }
 return null;
 }(e, f);
-G && (Ff(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
+G && (Bf(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), Hf = new Kf;
+}(), Yf = new Hf;
 
-function Yf(e) {
+function Vf(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -34961,7 +35000,7 @@ siege: e.pheromones.siege
 };
 }
 
-var Vf = {
+var qf = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -34974,10 +35013,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, qf = new (function() {
+}, jf = new (function() {
 function e() {
 this.manager = new ou({
-logger: Vf
+logger: qf
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -34987,23 +35026,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = Yf(t);
+var r = Vf(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = Yf(t);
+var r = Vf(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), jf = {
+}()), zf = {
 labManager: Ru,
 boostManager: fu,
-chemistryPlanner: qf,
+chemistryPlanner: jf,
 labConfigManager: gu,
 logger: Ci
-}, zf = function() {
+}, Qf = function() {
 function e(e) {
-void 0 === e && (e = jf), this.deps = e;
+void 0 === e && (e = zf), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35042,9 +35081,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), Qf = new zf, Xf = function() {
+}(), Xf = new Qf, Zf = function() {
 function e(e) {
-void 0 === e && (e = Qf), this.labWorkflow = e;
+void 0 === e && (e = Xf), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35089,27 +35128,27 @@ if (r) throw r.error;
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), Zf = new Xf, Jf = {
+}(), Jf = new Zf, $f = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, $f = new Map;
+}, ey = new Map;
 
-function ey(e) {
+function ty(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function ty(e) {
+function ry(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var ry = function() {
+var oy = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Jf), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, $f), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35151,7 +35190,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = $f.get(e.name);
+var t = ey.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35173,28 +35212,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return $f.set(e.name, o), o;
+return ey.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Sf.updateMetrics(i, c),
-Gf.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && wf.updateMetrics(i, c),
+Lf.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
 }), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Mf.updateEvolutionStage(c, i, e),
-s || Mf.updateMissingStructures(c, i)), kf.updatePosture(c), this.config.enablePheromones && !s && Sf.updatePheromones(c, i),
-this.config.enableTowers && Gf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Hf.getConstructionInterval(l), d = kf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+s || Mf.updateMissingStructures(c, i)), Uf.updatePosture(c), this.config.enablePheromones && !s && wf.updatePheromones(c, i),
+this.config.enableTowers && Lf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Yf.getConstructionInterval(l), d = Uf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = ey(r), n = ty(e);
+var o = ty(r), n = ry(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Hf.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (Yf.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = ey(r), n = ty(e);
+var o = ty(r), n = ry(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && Zf.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && Jf.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35204,7 +35243,7 @@ var f = Game.cpu.getUsed() - n;
 Ji.recordRoom(i, f), Ji.endRoom(this.roomName, n);
 } else Ji.endRoom(this.roomName, n);
 }, e;
-}(), oy = function() {
+}(), ny = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35218,7 +35257,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new ry(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new oy(v.name));
 }
 } catch (t) {
 e = {
@@ -35281,7 +35320,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new ry(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new oy(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35302,9 +35341,9 @@ stack: c
 }
 }
 }, e;
-}(), ny = new oy;
+}(), ay = new ny;
 
-function ay(e) {
+function iy(e) {
 var t, r, o;
 if (j(e).length > 0) return ha.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
@@ -35315,14 +35354,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
 }
 
-function iy(e) {
+function sy(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function sy(e, t, r) {
+function cy(e, t, r) {
 var o;
 return t === ha.CRITICAL ? {
 tickModulo: void 0,
@@ -35342,7 +35381,7 @@ tickOffset: void 0
 };
 }
 
-var cy, uy = function() {
+var uy, ly = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35358,7 +35397,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = ay(n), u = iy(n);
+var i = "room:".concat(o), s = Ja.getProcess(i), c = iy(n), u = sy(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35377,7 +35416,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = ay(e), o = iy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = sy(e, r, a);
+var t, r = iy(e), o = sy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = cy(e, r, a);
 Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35394,7 +35433,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ny.runRoom(t);
+t && ay.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35402,7 +35441,7 @@ Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = sy(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = cy(e, t, a);
 Ja.unregisterProcess(n), Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35419,7 +35458,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ny.runRoom(t);
+t && ay.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35441,7 +35480,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = ay(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = iy(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35468,7 +35507,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), ly = new uy, my = function() {
+}(), my = new ly, dy = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Ja.getStatsSummary(), t = Ja.getConfig();
@@ -35545,11 +35584,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(pf(e.summary.byLayer)), "Groups: ".concat(pf(e.summary.byGroup)), "States: ".concat(pf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(ff(e.summary.byLayer)), "Groups: ".concat(ff(e.summary.byGroup)), "States: ".concat(ff(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(ff)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(yf)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(mf(m));
+c.push(df(m));
 }
 } catch (e) {
 t = {
@@ -35648,7 +35687,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = lf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = mf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35667,7 +35706,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = ly.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = my.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35814,7 +35853,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), dy = function() {
+}(), py = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -35847,7 +35886,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), py = function() {
+}(), fy = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -35965,7 +36004,7 @@ if (e) throw e.error;
 }
 return 0 === m.length && p.push("  No detail samples this tick"), p.join("\n");
 }, e.prototype.cpuBreakdown = function(e) {
-var t, r, o, n, i, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, A, M, k, U, _ = this, N = Memory.stats;
+var t, r, o, n, i, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, A, k, M, U, _ = this, N = Memory.stats;
 if (!N) return "No stats available. Stats collection may be disabled.";
 var P = !e, I = [ "=== CPU Breakdown ===" ], G = this.asRecord(N.cpu), L = this.toNumberOrZero(null !== (m = null !== (l = this.getStatsValue(G, "used")) && void 0 !== l ? l : this.getStatsValue(G, "getUsed")) && void 0 !== m ? m : this.sumNumericValues(this.asRecord(null == G ? void 0 : G.usage))), D = this.toNumberOrZero(null !== (d = this.getStatsValue(G, "limit")) && void 0 !== d ? d : this.toNumberOrZero(null == G ? void 0 : G.tickLimit)), F = this.toNumberOrZero(null !== (p = this.getStatsValue(N.cpu, "percent")) && void 0 !== p ? p : D > 0 ? L / D * 100 : 0), B = this.toNumberOrZero(this.getStatsValue(N.cpu, "bucket"));
 if (I.push("Tick: ".concat(this.toNumberOrZero(N.tick))), I.push("Total CPU: ".concat(L.toFixed(2), "/").concat(D.toFixed(0), " (").concat(F.toFixed(1), "%)")),
@@ -36059,8 +36098,8 @@ try {
 for (var le = a(K.slice(0, 10)), me = le.next(); !me.done; me = le.next()) {
 var de = me.value, pe = this.toNumberOrZero(this.getStatsValue(de, "cpu"));
 if (pe > 0) {
-var fe = null !== (A = de.role) && void 0 !== A ? A : "unknown", ye = null !== (M = de.name) && void 0 !== M ? M : "".concat(String(fe), "_unknown");
-J = null !== (U = null !== (k = de.current_room) && void 0 !== k ? k : de.currentRoom) && void 0 !== U ? U : "unknown",
+var fe = null !== (A = de.role) && void 0 !== A ? A : "unknown", ye = null !== (k = de.name) && void 0 !== k ? k : "".concat(String(fe), "_unknown");
+J = null !== (U = null !== (M = de.current_room) && void 0 !== M ? M : de.currentRoom) && void 0 !== U ? U : "unknown",
 I.push("  ".concat(String(ye), " (").concat(String(fe), "): ").concat(pe.toFixed(3), " CPU in ").concat(String(J)));
 }
 }
@@ -36372,7 +36411,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), fy = function() {
+}(), yy = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36391,7 +36430,7 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), yy = function() {
+}(), vy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
@@ -36426,21 +36465,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), vy = ((cy = {})[MOVE] = 50, cy[WORK] = 100, cy[CARRY] = 50, cy[ATTACK] = 80,
-cy[RANGED_ATTACK] = 150, cy[HEAL] = 250, cy[CLAIM] = 600, cy[TOUGH] = 10, cy);
+}(), gy = ((uy = {})[MOVE] = 50, uy[WORK] = 100, uy[CARRY] = 50, uy[ATTACK] = 80,
+uy[RANGED_ATTACK] = 150, uy[HEAL] = 250, uy[CLAIM] = 600, uy[TOUGH] = 10, uy);
 
-function gy(e, t) {
+function hy(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, vy), t);
+var r = o(o({}, gy), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : vy[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : gy[t]);
 }, 0);
 }
 
-function hy(e, t) {
+function Ry(e, t) {
 void 0 === t && (t = 0);
-var r = gy(e);
+var r = hy(e);
 return {
 parts: e,
 cost: r,
@@ -36448,7 +36487,7 @@ minCapacity: t || r
 };
 }
 
-function Ry() {
+function Ey() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36456,11 +36495,11 @@ return Array(o).fill(r);
 });
 }
 
-var Ey, Ty, Cy, Sy = {
+var Ty, Cy, Sy, wy = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ hy([ WORK, CARRY ], 150), hy([ WORK, CARRY, MOVE ], 200), hy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), hy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), hy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Ry([ WORK, CARRY ], 150), Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ry([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Ry([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36468,7 +36507,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ hy([ WORK, CARRY, MOVE ], 200), hy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), hy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), hy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ry([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Ry([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36476,7 +36515,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ hy([ WORK, CARRY, MOVE, MOVE ], 250), hy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Ry([ WORK, CARRY, MOVE, MOVE ], 250), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36484,7 +36523,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ hy([ WORK, CARRY, MOVE ], 200), hy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), hy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), hy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), hy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Ry([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ry([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36492,7 +36531,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ hy([ CARRY, CARRY, MOVE, MOVE ], 200), hy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), hy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Ry([ CARRY, CARRY, MOVE, MOVE ], 200), Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ry(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36500,7 +36539,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ hy([ WORK, CARRY, MOVE ], 200), hy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), hy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), hy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36508,7 +36547,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ hy([ WORK, CARRY, MOVE, MOVE ], 250), hy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), hy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ Ry([ WORK, CARRY, MOVE, MOVE ], 250), Ry([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36516,7 +36555,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ hy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36524,7 +36563,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ hy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), hy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ Ry([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36532,7 +36571,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ hy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36540,7 +36579,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ hy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36548,7 +36587,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ hy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), hy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), hy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), hy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ Ry([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Ry([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36556,7 +36595,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ hy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), hy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ry(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36564,7 +36603,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ hy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), hy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36572,16 +36611,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ hy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), hy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), hy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), hy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Ry(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Ry(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Ry(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Ry(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, wy = {
+}, xy = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ hy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), hy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), hy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), hy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ Ry([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Ry([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36589,7 +36628,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ hy([ TOUGH, ATTACK, MOVE, MOVE ], 190), hy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), hy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ Ry([ TOUGH, ATTACK, MOVE, MOVE ], 190), Ry([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Ry([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36597,7 +36636,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ hy([ HEAL, MOVE, MOVE ], 350), hy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), hy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), hy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ Ry([ HEAL, MOVE, MOVE ], 350), Ry([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Ry([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36605,7 +36644,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ hy([ ATTACK, ATTACK, MOVE, MOVE ], 260), hy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), hy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ Ry([ ATTACK, ATTACK, MOVE, MOVE ], 260), Ry([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36613,7 +36652,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ hy([ WORK, WORK, MOVE, MOVE ], 300), hy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), hy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ Ry([ WORK, WORK, MOVE, MOVE ], 300), Ry([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36621,7 +36660,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ hy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), hy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), hy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), hy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ Ry([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Ry([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Ry([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36629,16 +36668,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ hy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), hy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), hy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ Ry([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Ry([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Ry([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, xy = {
+}, by = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ hy(Ry([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), hy(Ry([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ Ry(Ey([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Ry(Ey([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36646,16 +36685,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ hy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), hy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ Ry(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Ry(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, by = {
+}, Oy = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ hy([ MOVE ], 50) ],
+bodies: [ Ry([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36663,7 +36702,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ hy([ MOVE ], 50) ],
+bodies: [ Ry([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36671,7 +36710,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ hy([ CLAIM, MOVE ], 650) ],
+bodies: [ Ry([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36679,7 +36718,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ hy([ CLAIM, MOVE ], 650), hy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ Ry([ CLAIM, MOVE ], 650), Ry([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36687,7 +36726,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ hy([ WORK, CARRY, MOVE, MOVE ], 250), hy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Ry([ WORK, CARRY, MOVE, MOVE ], 250), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36695,30 +36734,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ hy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), hy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Ry([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Oy = o(o(o(o({}, Sy), wy), by), xy);
+}, Ay = o(o(o(o({}, wy), xy), Oy), by);
 
 try {
-for (var Ay = a(Object.values(Oy)), My = Ay.next(); !My.done; My = Ay.next()) My.value.bodies.sort(function(e, t) {
+for (var ky = a(Object.values(Ay)), My = ky.next(); !My.done; My = ky.next()) My.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Ey = {
+Ty = {
 error: e
 };
 } finally {
 try {
-My && !My.done && (Ty = Ay.return) && Ty.call(Ay);
+My && !My.done && (Cy = ky.return) && Cy.call(ky);
 } finally {
-if (Ey) throw Ey.error;
+if (Ty) throw Ty.error;
 }
 }
 
-function ky(e) {
+function Uy(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36733,11 +36772,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Uy(o);
+return _y(o);
 }
 
-function Uy(e) {
-var t = gy(e);
+function _y(e) {
+var t = hy(e);
 return {
 parts: e,
 cost: t,
@@ -36745,16 +36784,16 @@ minCapacity: t
 };
 }
 
-function _y(e, t) {
+function Ny(e, t) {
 var r;
-return null !== (r = e.map(Uy).filter(function(e) {
+return null !== (r = e.map(_y).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Ny(e) {
+function Py(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36768,7 +36807,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = gy(a);
+var s = hy(a);
 return {
 parts: a,
 cost: s,
@@ -36793,8 +36832,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: gy(p),
-minCapacity: gy(p)
+cost: hy(p),
+minCapacity: hy(p)
 };
 }(e);
 
@@ -36805,7 +36844,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return ky([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Uy([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -36826,7 +36865,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return ky([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Uy([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -36835,13 +36874,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Uy).filter(function(e) {
+var u = n.map(_y).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = _y(n, t);
+var l = Ny(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -36851,7 +36890,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = _y(n, t);
+var u = Ny(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -36860,14 +36899,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = _y(r, t);
+var a = Ny(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Py(e) {
+function Iy(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -36878,9 +36917,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Iy(e, t) {
+function Gy(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Py(t)
+memory: Iy(t)
 });
 var r;
 }
@@ -36888,9 +36927,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Cy || (Cy = {}));
+}(Sy || (Sy = {}));
 
-var Gy = function() {
+var Ly = function() {
 function e() {
 this.queues = new Map;
 }
@@ -36985,7 +37024,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Iy(m, d);
+var p = Gy(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37005,7 +37044,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Cy.EMERGENCY;
+return e.priority >= Sy.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37023,7 +37062,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Cy.EMERGENCY ? n.emergency++ : c.priority >= Cy.HIGH ? n.high++ : c.priority >= Cy.NORMAL ? n.normal++ : n.low++;
+c.priority >= Sy.EMERGENCY ? n.emergency++ : c.priority >= Sy.HIGH ? n.high++ : c.priority >= Sy.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37038,14 +37077,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Ly = new Gy, Dy = {
+}(), Dy = new Ly, Fy = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Fy = {
+}, By = {
 predictConsumption: function() {
 return 0;
 },
@@ -37064,7 +37103,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, By = {
+}, Wy = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37081,44 +37120,44 @@ healers: 0,
 powerCarriers: 0
 };
 }
-}, Wy = {
+}, Ky = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Ky(e, t, r, o, n) {
+function Hy(e, t, r, o, n) {
 return rc(e, t, r, o, n);
 }
 
-var Hy = new Map, Yy = -1, Vy = null;
+var Yy = new Map, Vy = -1, qy = null;
 
-function qy() {
-Yy === Game.time && Vy === Game.creeps || (Hy.clear(), Yy = Game.time, Vy = Game.creeps);
+function jy() {
+Vy === Game.time && qy === Game.creeps || (Yy.clear(), Vy = Game.time, qy = Game.creeps);
 }
 
-function jy(e) {
+function zy(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function zy(e, t) {
+function Qy(e, t) {
 var r;
-void 0 === t && (t = !1), qy();
-var o = t ? "".concat(e, "_active") : e, n = Hy.get(o);
+void 0 === t && (t = !1), jy();
+var o = t ? "".concat(e, "_active") : e, n = Yy.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = jy(c);
+var u = zy(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Hy.set(o, a), a;
+return Yy.set(o, a), a;
 }
 
-function Qy(e, t, r) {
+function Xy(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37139,22 +37178,22 @@ if (o) throw o.error;
 return i;
 }
 
-function Xy(e) {
+function Zy(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var Zy = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
-
-function Jy(e) {
-return Zy.includes(e);
-}
+var Jy = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
 function $y(e) {
+return Jy.includes(e);
+}
+
+function ev(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function ev(e, t, r, o) {
+function tv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37167,10 +37206,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Ky(e, t, ze(r).length, o, {
-reserved: $y(r)
+if (r) return Hy(e, t, ze(r).length, o, {
+reserved: ev(r)
 }).recommendedHaulers;
-var n = Ky(e, t, 2, o, {
+var n = Hy(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37181,7 +37220,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: Xy
+filter: Zy
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37192,7 +37231,7 @@ return 2;
 }
 }
 
-function tv(e, t) {
+function rv(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37202,13 +37241,13 @@ return null;
 }
 }
 
-function rv() {
+function ov() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function ov(e) {
-var t = rv(), r = function(e) {
+function nv(e) {
+var t = ov(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37220,14 +37259,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function nv(e) {
+function av(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = rv();
+var r = ov();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function av(e) {
+function iv(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37235,11 +37274,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function iv(e) {
+function sv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function sv() {
+function cv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37249,7 +37288,7 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-function cv(e, t) {
+function uv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37261,8 +37300,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(sv()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Ly.getPendingRequests(c).some(function(r) {
+for (var i = a(cv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Dy.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37282,7 +37321,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function uv(e, t) {
+function lv(e, t) {
 var r, o, n, c = mr.getEmpire(), u = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37292,15 +37331,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !cv(e.roomName, "claim");
+return !uv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || av(t));
+return !(!r || r.my || r.owner || r.reservation || iv(t));
 }
-return !nv(e);
+return !av(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37319,7 +37358,7 @@ return e.roomName;
 })), !1)) : new Set;
 if (l) {
 var p = c.claimQueue.find(function(e) {
-return !e.claimed && !cv(e.roomName, "claim");
+return !e.claimed && !uv(e.roomName, "claim");
 });
 if (p) return {
 targetRoom: p.roomName,
@@ -37331,20 +37370,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = rv();
+var l = ov();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !cv(p, "claim")) {
+if (!t.has(p) && !uv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || ov(y)) continue;
-if (av(f)) continue;
+if (y.owner || nv(y)) continue;
+if (iv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !cv(p, "reserve")) return p;
-} else if (!nv(p) && !cv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !uv(p, "reserve")) return p;
+} else if (!av(p) && !uv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37366,34 +37405,34 @@ task: "reserve"
 } : null;
 }
 
-function lv(e) {
+function mv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function mv(e) {
-return lv(e) ? Cy.EMERGENCY : Cy.HIGH;
+function dv(e) {
+return mv(e) ? Sy.EMERGENCY : Sy.HIGH;
 }
 
-function dv(e, t, r) {
+function pv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!iv(e)) return !1;
+if (!sv(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function pv(e, t, r) {
+function fv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return dv(e, t, r);
+return pv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = tv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = rv(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37401,18 +37440,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function fv(e, t) {
+function yv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !dv(n, e, t)) return null;
+if (!n || !pv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !iv(e);
+return !sv(e);
 }).filter(function(e) {
-return !av(e);
+return !iv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37433,9 +37472,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(sv()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(cv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Ly.getPendingRequests(d).filter(function(t) {
+i += Dy.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37452,12 +37491,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (lv(e) ? 3 : 1);
+}(e.name) < (mv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = tv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = rv(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37465,10 +37504,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (pv(u.room, e, t) === e) return {
+if (fv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: mv(u.room)
+priority: dv(u.room)
 };
 }
 } catch (e) {
@@ -37485,10 +37524,10 @@ if (r) throw r.error;
 return null;
 }
 
-function yv(e, t) {
+function vv(e, t) {
 if (t <= 0) return null;
 try {
-var r = Ny({
+var r = Py({
 maxEnergy: t,
 role: e
 });
@@ -37498,18 +37537,18 @@ return null;
 }
 }
 
-function vv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : yv(e, t);
+function gv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : vv(e, t);
 }
 
-function gv(e) {
+function hv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function hv(e) {
+function Rv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37523,7 +37562,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += gv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += hv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37544,7 +37583,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += gv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += hv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37560,23 +37599,23 @@ return i;
 }(e)) : r;
 }
 
-var Rv = "defenseAssist", Ev = [ "guard", "ranger", "healer" ];
+var Ev = "defenseAssist", Tv = [ "guard", "ranger", "healer" ];
 
-function Tv(e, t) {
+function Cv(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function Cv(e, t, r, o) {
-void 0 === o && (o = kr(e.roomName));
-var n = Tv(e, t);
+function Sv(e, t, r, o) {
+void 0 === o && (o = Mr(e.roomName));
+var n = Cv(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = bv(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, Tv(e, "guard") - i.guard),
-ranger: Math.max(0, Tv(e, "ranger") - i.ranger),
-healer: Math.max(0, Tv(e, "healer") - i.healer)
-}, Av(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = Ov(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, Cv(e, "guard") - i.guard),
+ranger: Math.max(0, Cv(e, "ranger") - i.ranger),
+healer: Math.max(0, Cv(e, "healer") - i.healer)
+}, kv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37586,7 +37625,7 @@ return Math.min(8, Math.max(1, i, s, u, l));
 }(e, t, r);
 }(t, r, o) : 0, u = n > 0 ? function(e, t, r) {
 var o, n;
-if (void 0 === r && (r = kr(e.roomName)), !Br(t)) return 0;
+if (void 0 === r && (r = Mr(e.roomName)), !Br(t)) return 0;
 var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
@@ -37609,30 +37648,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function Sv(e) {
+function wv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function wv(e) {
+function xv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Rv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Ev ? e.targetRoom : void 0;
 }
 
-function xv(e, t) {
-var r = kr(e.roomName), o = bv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, Tv(e, "guard") - o.guard),
-ranger: Math.max(0, Tv(e, "ranger") - o.ranger),
-healer: Math.max(0, Tv(e, "healer") - o.healer)
-}, Av(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function bv(e, t) {
+var r = Mr(e.roomName), o = Ov(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, Cv(e, "guard") - o.guard),
+ranger: Math.max(0, Cv(e, "ranger") - o.ranger),
+healer: Math.max(0, Cv(e, "healer") - o.healer)
+}, kv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = Ev.filter(function(o) {
-return !(Cv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = Tv.filter(function(o) {
+return !(Sv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function bv(e) {
+function Ov(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37641,7 +37680,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && wv(d) === e && u[p]++;
+Br(p) && xv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37655,9 +37694,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Ly.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Dy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Rv && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Ev && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37673,21 +37712,21 @@ if (o) throw o.error;
 return u;
 }
 
-function Ov(e, t, r) {
+function Av(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function Av(e) {
+function kv(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && wv(f) === e) {
+if (Br(y) && xv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && Ov(l, y, v);
+v.length > 0 && Av(l, y, v);
 }
 }
 } catch (e) {
@@ -37702,9 +37741,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Ly.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Dy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Rv && E.targetRoom === e) && Ov(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Ev && E.targetRoom === e) && Av(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37725,16 +37764,16 @@ var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function kv(e, t, r) {
+function Uv(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function Uv(e, t, r, o) {
+function _v(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && vv("guard", hv(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && gv("guard", Rv(r), o) ? 1 : 0;
 }
 
-function _v(e, t) {
+function Nv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
@@ -37765,23 +37804,23 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Sv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(wv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var r = kr(e.roomName);
+var r = Mr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(Cv(e, t, n, r), Uv(e, t, o, r))
+helperNeed: Math.max(Sv(e, t, n, r), _v(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return Sv(e.request);
+return wv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? bv(e)[t] : 0;
+return Br(t) ? Ov(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37806,28 +37845,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: Rv,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Cy.EMERGENCY : Cy.HIGH,
-defenseSquadId: kv(e, r, n.createdAt),
-defenseSquadSize: xv(r, t),
+task: Ev,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Sy.EMERGENCY : Sy.HIGH,
+defenseSquadId: Uv(e, r, n.createdAt),
+defenseSquadSize: bv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var Nv = "defenseRefuel", Pv = {
+var Pv = "defenseRefuel", Iv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Iv(e, t) {
+function Gv(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Pv.cost);
-}(n) ? hv(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Iv.cost);
+}(n) ? Rv(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -37864,9 +37903,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Ly.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Dy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Nv && s++;
+"hauler" === p.role && f === Pv && s++;
 }
 } catch (e) {
 o = {
@@ -37881,24 +37920,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Nv,
-priority: Cy.EMERGENCY,
-body: Pv
+task: Pv,
+priority: Sy.EMERGENCY,
+body: Iv
 } : null : null;
-}
-
-function Gv(e) {
-var t = Game.rooms[e];
-return t ? !!t.controller && !ov(t.controller) && !av(t) : !nv(e);
 }
 
 function Lv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !ov(t.controller) : !nv(e);
+return t ? !!t.controller && !nv(t.controller) && !iv(t) : !av(e);
 }
 
-function Dv(e, t, r) {
-var o = Oy[t];
+function Dv(e) {
+var t = Game.rooms[e];
+return (null == t ? void 0 : t.controller) ? !nv(t.controller) : !av(e);
+}
+
+function Fv(e, t, r) {
+var o = Ay[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -37910,13 +37949,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Fv(e, t, r) {
+function Bv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Gv(l) && Qy(e, t, l) < ev(e, l, t, Game.rooms[l])) return l;
+if (Lv(l) && Xy(e, t, l) < tv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37932,10 +37971,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Bv(e, t, r, o) {
+function Wv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Oy[t];
+var p = Ay[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -37949,32 +37988,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Oy[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Oy[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Ay[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Ay[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, zy(e), y)) return !1;
+}(t, Qy(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (Jy(t)) return !("remoteWorker" === t && function(e, t) {
-qy();
-var r = "".concat(e, ":").concat(t), o = Hy.get(r);
+if ($y(t)) return !("remoteWorker" === t && function(e, t) {
+jy();
+var r = "".concat(e, ":").concat(t), o = Yy.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Hy.set(r, n), n;
-}(e, t) >= Dv(e, t, r)) && null !== Fv(e, t, r);
+return Yy.set(r, n), n;
+}(e, t) >= Fv(e, t, r)) && null !== Bv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Lv(R)) {
+if (Dv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -37982,7 +38021,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && Qy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && Xy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -37999,9 +38038,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = zy(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== fv(e, r);
-if (C >= Dv(e, t, r)) return !1;
+var C = null !== (u = Qy(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== yv(e, r);
+if (C >= Fv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38013,14 +38052,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = tv(e, o);
+var a = rv(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== uv(0, r);
+if ("claimer" === t) return null !== lv(0, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38056,7 +38095,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Dy.getActiveRequests) || void 0 === m ? void 0 : m.call(Dy)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = Fy.getActiveRequests) || void 0 === m ? void 0 : m.call(Fy)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38084,16 +38123,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Wv(e) {
+function Kv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Kv(e) {
-return 0 === Wv(zy(e, !0));
+function Hv(e) {
+return 0 === Kv(Qy(e, !0));
 }
 
-function Hv(e) {
+function Yv(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -38116,14 +38155,14 @@ minCount: 1
 } ];
 }
 
-function Yv(e, t) {
-var r, o, n, i, s = zy(e, !0);
-if (0 === Wv(s)) return !0;
+function Vv(e, t) {
+var r, o, n, i, s = Qy(e, !0);
+if (0 === Kv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = zy(e, !1), u = Hv(t);
+var c = Qy(e, !1), u = Yv(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38143,57 +38182,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function Vv(e) {
+function qv(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function qv(e, t, r) {
-var n = Dv(e.name, r.roleName, t);
+function jv(e, t, r) {
+var n = Fv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function jv(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Cy.EMERGENCY;
+function zv(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Sy.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Cy.HIGH;
-if (Wy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Sy.HIGH;
+if (Ky.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Cy.EMERGENCY;
-if (a > 0) return Cy.HIGH;
+if (a >= 100) return Sy.EMERGENCY;
+if (a > 0) return Sy.HIGH;
 }
 return function(e) {
-return e >= 90 ? Cy.HIGH : e >= 60 ? Cy.NORMAL : Cy.LOW;
+return e >= 90 ? Sy.HIGH : e >= 60 ? Sy.NORMAL : Sy.LOW;
 }(o);
 }
 
-function zv(e, t) {
+function Qv(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-Vv(e);
-var l = zy(e.name), m = Kv(e.name), d = [];
-if (Yv(e.name, e)) {
+qv(e);
+var l = Qy(e.name), m = Hv(e.name), d = [];
+if (Vv(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Wv(zy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Kv(Qy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = zy(e, !1), c = Hv(t);
+var s = Qy(e, !1), c = Yv(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38208,7 +38247,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Bv(e, m.role, r, !0);
+var p = Wv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38239,17 +38278,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = Oy[p]) && Bv(e.name, p, t, !0) ? (d.push(qv(e, t, {
+return p && (g = Ay[p]) && Wv(e.name, p, t, !0) ? (d.push(jv(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: jv(e, 0, p, g.priority, m),
+priority: zv(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(Oy)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Iv(e.name, p);
+for (var f = a(Object.entries(Ay)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Gv(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38260,7 +38299,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = _v(e.name, p);
+var E = Nv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38274,8 +38313,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Bv(e.name, p, t, m)) {
-var T = Jy(p), C = T ? Fv(e.name, p, t) : null, S = "claimer" === p ? uv(e.name, t) : null, w = "pioneer" === p ? fv(e.name, t) : null;
+}); else if (Wv(e.name, p, t, m)) {
+var T = $y(p), C = T ? Bv(e.name, p, t) : null, S = "claimer" === p ? lv(e.name, t) : null, w = "pioneer" === p ? yv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38285,11 +38324,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(qv(e, t, {
+}) : d.push(jv(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: jv(e, 0, p, g.priority, m),
+priority: zv(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38311,7 +38350,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Qv(e, l.value);
+var m = Xv(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38332,10 +38371,10 @@ requests: c
 };
 }
 
-function Qv(e, t) {
+function Xv(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Fy.getMaxAffordableInTicks(e, l), d = hv(e), p = t.priority >= Cy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Cy.EMERGENCY, g = t.assistTarget ? kr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : vv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = By.getMaxAffordableInTicks(e, l), d = Rv(e), p = t.priority >= Sy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Sy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : gv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38356,7 +38395,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : Ny({
+}(t.def, p)) && void 0 !== c ? c : Py({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38392,44 +38431,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Xv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Zv = new Set([ "guard", "ranger", "healer" ]);
+var Zv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Jv = new Set([ "guard", "ranger", "healer" ]);
 
-function Jv() {
+function $v() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function $v(e) {
+function eg(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function eg(e) {
-var t;
-return e.priority >= Cy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
-}
-
 function tg(e) {
 var t;
-return e.priority >= Cy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Sy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function rg(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = hv(e), m = r.urgency >= 2 || t.danger >= 3 ? Cy.EMERGENCY : Cy.HIGH, d = Mr(j(e)), p = function(e) {
+function rg(e) {
+var t;
+return e.priority >= Sy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+}
+
+function og(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Rv(e), m = r.urgency >= 2 || t.danger >= 3 ? Sy.EMERGENCY : Sy.HIGH, d = kr(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === Cy.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === Sy.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Ly.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Dy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || og(u, e) && ("guard" === u.role && (n.guards++,
-ag(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, ag(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, ag(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || ng(u, e) && ("guard" === u.role && (n.guards++,
+ig(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, ig(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, ig(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38457,7 +38496,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && ag(n, u, l);
+0 !== l.length && ig(n, u, l);
 }
 }
 }
@@ -38496,26 +38535,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ng("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) ig(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ng("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) ig(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ng("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) ig(e, "healer", "military", Cy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ag("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) sg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ag("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) sg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ag("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) sg(e, "healer", "military", Sy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < Cy.EMERGENCY || function(e, t) {
+if (!(t < Sy.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Zv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Jv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Ly.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Dy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Cy.EMERGENCY || Zv.has(c.role) && og(c, e.name) && c.body.cost <= t && n++;
+c.priority < Sy.EMERGENCY || Jv.has(c.role) && ng(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38532,7 +38571,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = yv(t, e);
+var r = vv(t, e);
 return r ? {
 role: t,
 body: r
@@ -38547,38 +38586,38 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && ig(e, n.role, "military", Cy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && sg(e, n.role, "military", Sy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function og(e, t) {
+function ng(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function ng(e, t, r) {
+function ag(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function ag(e, t, r) {
+function ig(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function ig(e, t, r, o, n, a, i) {
+function sg(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
-var s = null != i ? i : Ny({
+var s = null != i ? i : Py({
 maxEnergy: n,
 role: t
 });
 if (s.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(s.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Ly.addRequest({
+Dy.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38594,34 +38633,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function sg(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Cy.HIGH) return !1;
+function cg(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Sy.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Cy.NORMAL) {
-if (Fy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Sy.NORMAL) {
+if (By.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Cy.NORMAL && o / e.energyCapacityAvailable < .3 && Fy.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Sy.NORMAL && o / e.energyCapacityAvailable < .3 && By.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function cg(e, t) {
+function ug(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Vv(e);
-var s = Ly.getQueueSize(e.name);
+qv(e);
+var s = Dy.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Yv(e.name, e), u = Kv(e.name) && !Ly.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = Vv(e.name, e), u = Hv(e.name) && !Dy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && Ly.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && rg(e, t, l, m);
+s > 0 && Dy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && og(e, t, l, m);
 try {
-for (var d = a(zv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Qv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Ly.addRequest(f);
+Dy.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38634,7 +38673,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && rg(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && og(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38643,13 +38682,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Ly.getPendingRequests(e.name).map($v));
+var c = new Set(Dy.getPendingRequests(e.name).map(eg));
 try {
-for (var u = a(zv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Cy.HIGH, p = "claimer" === m.role && Jv(), f = eg(m), y = tg(m);
-if (Xv.has(m.role) || d || p || f || y) {
-var v = $v(m);
-c.has(v) || (Ly.addRequest(m), c.add(v));
+for (var u = a(Qv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Sy.HIGH, p = "claimer" === m.role && $v(), f = tg(m), y = rg(m);
+if (Zv.has(m.role) || d || p || f || y) {
+var v = eg(m);
+c.has(v) || (Dy.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38666,19 +38705,19 @@ if (r) throw r.error;
 }
 }(e, t); else {
 !function(e) {
-var t = By.requestSpawns(e.name);
+var t = Wy.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = Cy.NORMAL, n = 0; n < t.powerHarvesters; n++) ig(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) ig(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) ig(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = Sy.NORMAL, n = 0; n < t.powerHarvesters; n++) sg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) sg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) sg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a(zv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Ly.addRequest(f);
+for (var y = a(Qv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Dy.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38690,32 +38729,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Ly.getQueueStats(e.name);
+var g = Dy.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Ly.clearQueue(e.name);
+} else s > 0 && Dy.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Ly.getAvailableSpawns(e.name);
+var t, r, o = Dy.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = hv(e);
+var n = 0, i = Rv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Ly.getNextRequest(e.name, i);
+var u = c.value, l = Dy.getNextRequest(e.name, i);
 if (!l) break;
-if (sg(e, l, i)) {
+if (cg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Iy(u, l);
-m === OK ? (n++, i -= l.body.cost, Ly.markInProgress(e.name, l.id, u.id), Ly.removeRequest(e.name, l.id),
+var m = Gy(u, l);
+m === OK ? (n++, i -= l.body.cost, Dy.markInProgress(e.name, l.id, u.id), Dy.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Ly.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Dy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -38731,7 +38770,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Ly.getQueueStats(e.name);
+}(e), o = Dy.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -38745,7 +38784,7 @@ stats: o
 }(e, t);
 }
 
-var ug = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, lg = /^(\d{1,2})\|(.+)$/, mg = M("SS2TerminalComms"), dg = function() {
+var lg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, mg = /^(\d{1,2})\|(.+)$/, dg = k("SS2TerminalComms"), pg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38805,11 +38844,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(ug);
+var t = e.match(lg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(lg);
+var i = a.match(mg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38844,7 +38883,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-mg.warn("Missing packet in multi-packet message", {
+dg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38860,7 +38899,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), mg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), dg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38884,7 +38923,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && mg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && dg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38896,7 +38935,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return mg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return dg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38904,14 +38943,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), mg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), dg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (mg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (dg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38936,7 +38975,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-mg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+dg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -38948,7 +38987,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-mg.info("Completed sending multi-packet message", {
+dg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -38956,25 +38995,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? mg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? dg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (mg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (dg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else mg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else dg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else mg.warn("Terminal not found for queue item, removing from queue", {
+} else dg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39008,7 +39047,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && mg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && dg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39018,7 +39057,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-mg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+dg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39109,7 +39148,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (mg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (dg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39131,7 +39170,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return mg.error("Error parsing JSON", {
+return dg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39142,7 +39181,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), pg = [ {
+}(), fg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39162,7 +39201,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], fg = function() {
+} ], yg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39200,7 +39239,7 @@ return e.clusters || (e.clusters = {}), e.clusters;
 }, e.prototype.getCluster = function(e, t) {
 var r = this.getClusters();
 if (!r[e] && t) {
-r[e] = Mt(e, t);
+r[e] = kt(e, t);
 var o = this.getEmpire();
 o.clusters.includes(e) || o.clusters.push(e);
 }
@@ -39209,9 +39248,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), yg = new fg;
+}(), vg = new yg;
 
-function vg(e) {
+function gg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39219,19 +39258,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function gg(e, t) {
+function hg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function hg(e, t) {
+function Rg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var Rg = {
+var Eg = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39242,9 +39281,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, Eg = function() {
+}, Tg = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Rg), e);
+void 0 === e && (e = {}), this.config = o(o({}, Eg), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39265,7 +39304,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = yg.getSwarmState(r.toRoom);
+var o = vg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39278,7 +39317,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = yg.getSwarmState(c);
+var l = vg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39348,9 +39387,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(gg), u = n.filter(function(e) {
+}).sort(hg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(hg), l = [], m = [], d = function(t) {
+}).sort(Rg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39372,11 +39411,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return vg({
+return gg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + vg({
+}) + gg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39475,7 +39514,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), Tg = new Eg, Cg = {
+}(), Cg = new Tg, Sg = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39496,14 +39535,14 @@ siegeUnits: 1
 }
 };
 
-function Sg(e) {
+function wg(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function wg(e) {
+function xg(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39526,9 +39565,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function xg(e) {
+function bg(e) {
 var t, r, o;
-wg(e);
+xg(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39552,20 +39591,20 @@ if (t) throw t.error;
 return n;
 }
 
-function bg(e) {
+function Og(e) {
 var t;
-wg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = xg(e);
+xg(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = bg(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function Og(e) {
-return !!bg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function Ag(e) {
+return !!Og(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-wg(e);
+xg(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39576,12 +39615,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = xg(e);
+var d = bg(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function Ag(e, t) {
+function kg(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39604,18 +39643,18 @@ return n;
 
 function Mg(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Cg[r]) && void 0 !== t ? t : Cg[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Sg[r]) && void 0 !== t ? t : Sg[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Ag(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = kg(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: Sg(r),
+targetComposition: wg(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39627,7 +39666,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function kg(e) {
+function Ug(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39647,9 +39686,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function Ug(e) {
+function _g(e) {
 var t = e.members.length;
-wg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+xg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39663,7 +39702,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && Og(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && Ag(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39692,7 +39731,7 @@ subsystem: "Squad"
 }
 }
 
-var _g = {
+var Ng = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39779,7 +39818,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Ng(e, t) {
+function Pg(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39794,8 +39833,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Pg(e, t) {
-var r, o, n, i = _g[t], s = 0;
+function Ig(e, t) {
+var r, o, n, i = Ng[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39821,7 +39860,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Ig, Gg, Lg, Dg = {
+var Gg, Lg, Dg, Fg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39830,11 +39869,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Fg = new Map;
+}, Bg = new Map;
 
-function Bg(e, t) {
+function Wg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Fg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Bg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39846,7 +39885,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = _g[p].composition;
+d = Ng[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39861,19 +39900,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Fg.set(m, y), function(e, t, r, o) {
+v ? (Bg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = _g[s].useBoosts;
+i = Ng[s].useBoosts;
 }
-var c = Cy.NORMAL;
-"siege" === t.type ? c = Cy.HIGH : "defense" === t.type && (c = Cy.EMERGENCY);
+var c = Sy.NORMAL;
+"siege" === t.type ? c = Sy.HIGH : "defense" === t.type && (c = Sy.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = Wg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Dg[t];
-}, 0), m = i ? Hg(r) : [], d = {
+var u = Kg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Fg[t];
+}, 0), m = i ? Yg(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39902,7 +39941,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Ly.addRequest(d), o.spawnRequests.add(d.id);
+Dy.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -39916,42 +39955,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function Wg(e, t, r) {
+function Kg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Kg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return Hg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Kg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Hg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Kg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Hg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Kg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return Hg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Kg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return Hg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Kg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return Hg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Kg(e, t, r) {
+function Hg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Dg[t];
+return e + Fg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Dg[t];
+return e + Fg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Hg(e) {
+function Yg(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -39982,45 +40021,45 @@ return [];
 }
 }
 
-function Yg(e) {
-return Fg.has(e);
-}
-
 function Vg(e) {
-return bg(e) || Og(e);
+return Bg.has(e);
 }
 
-(Ig = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Ig[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Ig[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Gg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Gg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Gg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Gg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Lg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Lg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Lg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Lg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Lg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+function qg(e) {
+return Og(e) || Ag(e);
+}
 
-var qg = {
+(Gg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Gg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Gg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Lg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Lg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Lg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Lg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Dg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Dg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Dg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Dg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Dg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+
+var jg = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function jg(e, t) {
-var r = qg[t], o = yg.getClusters();
+function zg(e, t) {
+var r = jg[t], o = vg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function zg(e, t, r) {
+function Qg(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = yg.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = vg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: jg(e, i.danger),
+reservedEnergy: zg(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40110,7 +40149,7 @@ success: !1
 });
 }
 
-var Qg = {
+var Xg = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40120,7 +40159,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Xg(e, t, r) {
+function Zg(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40151,7 +40190,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function Zg(e, t, r, o) {
+function Jg(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40161,7 +40200,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function Jg(e, t) {
+function $g(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40182,19 +40221,19 @@ if (r) throw r.error;
 return n;
 }
 
-function $g() {
-var e = yg.getEmpire();
+function eh() {
+var e = vg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function eh(e) {
-$g()[e.id] = e;
+function th(e) {
+eh()[e.id] = e;
 }
 
-function th(e) {
+function rh(e) {
 e.lastUpdate = Game.time;
-var t = yg.getCluster(e.clusterId);
-if (!t) return e.state = "failed", eh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = vg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", th(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40204,12 +40243,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (Vg(r) || Yg(e) || Bg(0, r), Vg(r));
+return !!r && (qg(r) || Vg(e) || Wg(0, r), qg(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), eh(e);
+})), th(e);
 }(e, t);
 break;
 
@@ -40220,7 +40259,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (Ug(o), kg(o)) {
+if (_g(o), Ug(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40249,7 +40288,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = yg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = vg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40276,14 +40315,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), eh(e);
+})), th(e);
 }(e, t);
 }
 }
 
-var rh = "defenseAssist";
+var oh = "defenseAssist";
 
-function oh(e, t, r) {
+function nh(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40302,11 +40341,11 @@ score: n.score + o.score
 }
 }
 
-function nh(e, t, r) {
+function ah(e, t, r) {
 return Gr(e, t, r);
 }
 
-function ah(e, t) {
+function ih(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40319,11 +40358,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function ih(e) {
+function sh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function sh(e, t, r) {
+function ch(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40336,8 +40375,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function ch(e, t, r) {
-var o = nh(t, e.energyCapacityAvailable, r);
+function uh(e, t, r) {
+var o = ah(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40345,16 +40384,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function uh(e, t, r, o) {
+function lh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = ch(e, t, o);
-if (s !== ch(n, t, o)) return s ? -1 : 1;
+var a, i, s = uh(e, t, o);
+if (s !== uh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function lh(e, t) {
+function mh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40438,25 +40477,25 @@ if (r) throw r.error;
 return u;
 }
 
-function mh(e, t) {
+function dh(e, t) {
 return {
-guard: Math.max(0, ah(e, "guard") - t.counts.guard),
-ranger: Math.max(0, ah(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, ah(e, "healer") - t.counts.healer)
+guard: Math.max(0, ih(e, "guard") - t.counts.guard),
+ranger: Math.max(0, ih(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, ih(e, "healer") - t.counts.healer)
 };
 }
 
-function dh(e, t, r) {
+function ph(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function ph(e) {
+function fh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function fh(e, t) {
+function yh(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return ph(e.role);
+return fh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40469,12 +40508,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function yh(e) {
+function vh(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === rh ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === oh ? e.targetRoom : void 0;
 }
 
-function vh(e) {
+function gh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40486,7 +40525,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-ph(m) && yh(l) === e && !u.spawning && oh(i, m, u.body.filter(function(e) {
+fh(m) && vh(l) === e && !u.spawning && nh(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40504,7 +40543,7 @@ if (t) throw t.error;
 return i;
 }
 
-function gh(e, t, r) {
+function hh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40534,16 +40573,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: fh(e, r)
+pendingAssist: yh(e, r)
 };
 }
 }
 
-function hh(e, t) {
+function Rh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = nh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = ah(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40564,7 +40603,7 @@ subsystem: "Cluster"
 }
 }
 
-function Rh(e, t, r) {
+function Eh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40606,20 +40645,20 @@ exitAccess: a
 };
 }
 
-function Eh(e, t) {
+function Th(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function Th(e, t, r) {
+function Ch(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function Ch(e) {
+function Sh(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function Sh(e, t) {
+function wh(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40630,7 +40669,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function wh(e, t, r) {
+function xh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40641,8 +40680,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = Ch(g);
-h && (g.assistTarget || Sh(v, h) && (t.assignedCreeps.includes(v.name) || Eh(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = Sh(g);
+h && (g.assistTarget || wh(v, h) && (t.assignedCreeps.includes(v.name) || Th(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40679,7 +40718,7 @@ return e.distance - t.distance;
 });
 }
 
-function xh(e, t) {
+function bh(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40704,21 +40743,21 @@ if (r) throw r.error;
 return i;
 }
 
-function bh(e) {
+function Oh(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var Oh = {
+var Ah = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, Ah = function() {
+}, kh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Oh), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Ah), e);
 }
 return e.prototype.run = function() {
-var e = yg.getClusters();
+var e = vg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40737,7 +40776,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: pg.map(function(t) {
+steps: fg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40798,7 +40837,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-Tg.processCluster(t);
+Cg.processCluster(t);
 break;
 
 case "squads":
@@ -40830,7 +40869,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = Rh(e, new RoomPosition(s, c, e.name), "defense");
+var u = Eh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40879,9 +40918,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = yg.getSwarmState(i);
+var i = n.value, s = vg.getSwarmState(i);
 if (s) {
-var c = jg(i, s.danger);
+var c = zg(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40912,7 +40951,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = yg.getSwarmState(m);
+var m = l.value, d = vg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -40944,7 +40983,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += bh(l.controller.level));
+}).length, i += Oh(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41061,7 +41100,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Ug(i), "gathering" !== i.state || Vg(i) || Yg(i.id) || Bg(0, i), kg(i) && (i.state = "dissolving");
+_g(i), "gathering" !== i.state || qg(i) || Vg(i.id) || Wg(0, i), Ug(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41103,7 +41142,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values($g()).filter(function(e) {
+var t = (a = e.id, Object.values(eh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41114,22 +41153,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Qg), n), m = [], d = yg.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, Xg), n), m = [], d = vg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = Xg(f, y, d);
+var g = Zg(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = Jg(e, f);
+var h = $g(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = Zg(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = Jg(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Ng(f, {
+var C = Pg(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41164,29 +41203,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Pg(e, n.doctrine) ? function(e, t, r) {
+Ig(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = yg.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = vg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = Xg(e, o, r);
+var n = Zg(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (yg.getEmpire().knownRooms || {})[t], n = null != r ? r : Ng(t, {
+var o = (vg.getEmpire().knownRooms || {})[t], n = null != r ? r : Pg(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Pg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Ig(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41199,7 +41238,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-eh(i);
+th(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41213,13 +41252,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Ag(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = kg(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: Sg(n),
+targetComposition: wg(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41234,8 +41273,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), eh(i), Bg(0, c), i.state = "forming", i.lastUpdate = Game.time,
-eh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), th(i), Wg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+th(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41254,11 +41293,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Fg.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Bg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Fg.delete(c));
+}), Bg.delete(c));
 }
 } catch (t) {
 e = {
@@ -41272,10 +41311,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = $g();
-for (var t in e) th(e[t]);
+var e = eh();
+for (var t in e) rh(e[t]);
 !function() {
-var e = $g();
+var e = eh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41353,14 +41392,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = yg.getCluster(t, e);
+var t = "cluster_".concat(e), r = vg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = yg.getCluster(e);
+var o = vg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41389,7 +41428,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && zg(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Qg(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41406,7 +41445,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = yg.getSwarmState(t);
+var n, a, i = vg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41447,7 +41486,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = kr(g), f[g] = vh(g);
+p[g] = Mr(g), f[g] = gh(g);
 }
 } catch (e) {
 r = {
@@ -41463,7 +41502,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = gh(E, m, t);
+d[E] = hh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41482,31 +41521,31 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = sh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = ch(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = lh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = mh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, mh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, dh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = uh(h, b, g.roomName, R), M = 0; M < O; M++) {
-var k = A.find(function(e) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = lh(h, b, g.roomName, R), k = 0; k < O; k++) {
+var M = A.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
 });
-if (!k) break;
-p.set(k.roomName, (null !== (l = p.get(k.roomName)) && void 0 !== l ? l : 0) + 1),
+if (!M) break;
+p.set(M.roomName, (null !== (l = p.get(M.roomName)) && void 0 !== l ? l : 0) + 1),
 d.push({
-id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(k.roomName, "_").concat(e.now, "_").concat(M),
-roomName: k.roomName,
+id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").concat(e.now, "_").concat(k),
+roomName: M.roomName,
 role: b,
 family: "military",
-priority: ih(g.urgency),
+priority: sh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: rh,
-defenseSquadId: dh(k.roomName, g.roomName, e.now),
+task: oh,
+defenseSquadId: ph(M.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41546,7 +41585,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) hh(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) Rh(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41561,7 +41600,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Ly);
+}(e, Dy);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41573,7 +41612,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = xh(f, wh(e, f, t)), v = y.reduce(function(e, t) {
+var y = bh(f, xh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41584,7 +41623,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-Th(f, R.role, Eh(f, R.role) - 1), l.push({
+Ch(f, R.role, Th(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41645,34 +41684,34 @@ c && !c.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-}, n([ ka("cluster:manager", "Cluster Manager", {
+}, n([ Ma("cluster:manager", "Cluster Manager", {
 priority: ha.MEDIUM,
 interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Mh = new Ah, kh = /^([WE])(\d+)([NS])(\d+)$/;
+}(), Mh = new kh, Uh = /^([WE])(\d+)([NS])(\d+)$/;
 
-function Uh(e) {
-return kh.test(e);
+function _h(e) {
+return Uh.test(e);
 }
 
-var _h = {
+var Nh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Nh = function() {
+}, Ph = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, _h), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Nh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
 var e = InterShardMemory.getLocal();
 if (e) {
-var t = bp(e);
+var t = Op(e);
 if (t) {
 this.updateEnemyIntelligence(t);
-var r = xp(t);
+var r = bp(t);
 InterShardMemory.setLocal(r);
 }
 }
@@ -41690,7 +41729,7 @@ lastSeen: null !== (r = null == a ? void 0 : a.lastSeen) && void 0 !== r ? r : 0
 }), l = function(e) {
 var t, r, n, c, u, l, m, d, p = new Map, f = new Set, y = new Set, v = new Map;
 try {
-for (var g = a(e.knownRooms), h = g.next(); !h.done; h = g.next()) (M = h.value).owner && v.set(M.roomName, M.owner);
+for (var g = a(e.knownRooms), h = g.next(); !h.done; h = g.next()) (k = h.value).owner && v.set(k.roomName, k.owner);
 } catch (e) {
 t = {
 error: e
@@ -41738,7 +41777,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (Uh(x)) {
+if (e.isAlly(x)) f.add(x); else if (_h(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41761,9 +41800,9 @@ if (u) throw u.error;
 }
 try {
 for (var O = a(e.knownRooms), A = O.next(); !A.done; A = O.next()) {
-var M;
-(M = A.value).owner && (M.owner.includes("Source Keeper") ? y.add(M.owner) : e.isAlly(M.owner) ? f.add(M.owner) : ((C = R(M.owner)).rooms.includes(M.roomName) || (C.rooms.push(M.roomName),
-C.rooms.sort()), C.lastSeen = Math.max(C.lastSeen, M.lastSeen), C.threatLevel = Math.max(C.threatLevel, M.threatLevel)));
+var k;
+(k = A.value).owner && (k.owner.includes("Source Keeper") ? y.add(k.owner) : e.isAlly(k.owner) ? f.add(k.owner) : ((C = R(k.owner)).rooms.includes(k.roomName) || (C.rooms.push(k.roomName),
+C.rooms.sort()), C.lastSeen = Math.max(C.lastSeen, k.lastSeen), C.threatLevel = Math.max(C.threatLevel, k.threatLevel)));
 }
 } catch (e) {
 m = {
@@ -41806,15 +41845,15 @@ subsystem: "CrossShardIntel"
 }, e.prototype.getGlobalEnemies = function() {
 var e = InterShardMemory.getLocal();
 if (!e) return [];
-var t = bp(e);
+var t = Op(e);
 return t && t.globalTargets.enemies || [];
 }, n([ Oi("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: ha.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
-}) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), Ph = new Nh, Ih = function() {
+}) ], e.prototype, "run", null), n([ ki() ], e);
+}(), Ih = new Ph, Gh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41891,9 +41930,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), Gh = new Ih, Lh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), Lh = new Gh, Dh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Dh(e, t) {
+function Fh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41916,13 +41955,13 @@ if (r) throw r.error;
 return n;
 }
 
-function Fh(e) {
+function Bh(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function Bh(e, t, r) {
-if (!Fh(e)) return 0;
-var o = Dh(e.name, t);
+function Wh(e, t, r) {
+if (!Bh(e)) return 0;
+var o = Fh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += oc(e.mineralType),
@@ -41931,7 +41970,7 @@ n += sc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += uc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function Wh(e, t) {
+function Kh(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -41941,13 +41980,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Lh.has(e.type);
+return e.hits > 0 && Dh.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function Kh(e, t, r) {
+function Hh(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -41957,7 +41996,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function Hh(e) {
+function Yh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -41968,8 +42007,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function Yh(e) {
-var t = Hh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function Vh(e) {
+var t = Yh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -41988,14 +42027,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var Vh = {
+var qh = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, qh = function() {
+}, jh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Vh), e);
+void 0 === e && (e = {}), this.config = o(o({}, qh), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42086,7 +42125,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = Hh(e);
+var t = Yh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42098,14 +42137,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return Yh(jh(e));
+return Vh(zh(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = Yh(jh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = Vh(zh(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function jh(e) {
+function zh(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42137,11 +42176,11 @@ swamps: d
 };
 }
 
-var zh = new qh, Qh = /^([WE])(\d+)([NS])(\d+)$/, Xh = {
+var Qh = new jh, Xh = /^([WE])(\d+)([NS])(\d+)$/, Zh = {
 allies: []
-}, Zh = function() {
+}, Jh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Xh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Zh), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42161,7 +42200,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!Qh.test(e)) return !1;
+if (!Xh.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42269,7 +42308,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return Qh.test(e);
+return Xh.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42296,7 +42335,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), Jh = new Zh, $h = {
+}(), $h = new Jh, eR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42309,9 +42348,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, eR = function() {
+}, tR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, $h), e);
+void 0 === e && (e = {}), this.config = o(o({}, eR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42324,7 +42363,7 @@ t.updateExpansionQueue(o);
 }), Ji.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Ji.measureSubsystem("empire:warTargets", function() {
-Jh.updateWarTargets(o);
+$h.updateWarTargets(o);
 }), Ji.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Ji.measureSubsystem("empire:gclTracking", function() {
@@ -42332,13 +42371,13 @@ t.trackGCLProgress(o);
 }), s && Ji.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Ji.measureSubsystem("empire:intelRefresh", function() {
-zh.refreshRoomIntel(o);
+Qh.refreshRoomIntel(o);
 }), Ji.measureSubsystem("empire:roomDiscovery", function() {
-zh.discoverNearbyRooms(o);
+Qh.discoverNearbyRooms(o);
 })), s && Ji.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Ji.measureSubsystem("empire:clusterHealth", function() {
-Gh.monitorClusterHealth();
+Lh.monitorClusterHealth();
 }), Ji.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42421,22 +42460,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = Wh(f, u);
+var y = Boolean(Game.rooms[f]), v = Kh(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = Dh(f, t);
+var g = Fh(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = Kh(h, u, y);
+var h = e.knownRooms[f], R = Hh(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? Bh(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? Wh(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42480,10 +42519,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && Fh(a)) {
-var i = Dh(a.name, t);
+if (a && Bh(a)) {
+var i = Fh(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = Bh(a, t, r);
+var s = Wh(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -42640,14 +42679,14 @@ if (n) throw n.error;
 }
 }
 try {
-for (var A = a(C), M = A.next(); !M.done; M = A.next()) delete S[O = M.value];
+for (var A = a(C), k = A.next(); !k.done; k = A.next()) delete S[O = k.value];
 } catch (e) {
 c = {
 error: e
 };
 } finally {
 try {
-M && !M.done && (u = A.return) && u.call(A);
+k && !k.done && (u = A.return) && u.call(A);
 } finally {
 if (c) throw c.error;
 }
@@ -42802,14 +42841,14 @@ priority: ha.MEDIUM,
 interval: 30,
 minBucket: 0,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), tR = new eR;
+}) ], e.prototype, "run", null), n([ ki() ], e);
+}(), rR = new tR;
 
-function rR(e) {
+function oR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var oR = {
+var nR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42817,10 +42856,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, nR = function() {
+}, aR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, oR), e);
+this.config = o(o({}, nR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -42964,7 +43003,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, rR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, oR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -42986,18 +43025,18 @@ return e.username.localeCompare(t.username);
 };
 }(Game.time, g);
 try {
-for (var A = a(O.enemies), M = A.next(); !M.done; M = A.next()) {
-var k = M.value;
-(B = null !== (v = this.enemyPlayers.get(k.username)) && void 0 !== v ? v : {
-username: k.username,
+for (var A = a(O.enemies), k = A.next(); !k.done; k = A.next()) {
+var M = k.value;
+(B = null !== (v = this.enemyPlayers.get(M.username)) && void 0 !== v ? v : {
+username: M.username,
 lastSeen: Game.time,
 rooms: [],
 threatLevel: 0,
 aggressionCount: 0,
 isAlly: !1
-}).lastSeen = k.lastSeen;
+}).lastSeen = M.lastSeen;
 try {
-for (var U = (n = void 0, a(k.rooms)), _ = U.next(); !_.done; _ = U.next()) R = _.value,
+for (var U = (n = void 0, a(M.rooms)), _ = U.next(); !_.done; _ = U.next()) R = _.value,
 B.rooms.includes(R) || B.rooms.push(R);
 } catch (e) {
 n = {
@@ -43010,7 +43049,7 @@ _ && !_.done && (c = U.return) && c.call(U);
 if (n) throw n.error;
 }
 }
-B.isAlly = k.isAlly, this.enemyPlayers.set(B.username, B);
+B.isAlly = M.isAlly, this.enemyPlayers.set(B.username, B);
 }
 } catch (e) {
 r = {
@@ -43018,7 +43057,7 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (o = A.return) && o.call(A);
+k && !k.done && (o = A.return) && o.call(A);
 } finally {
 if (r) throw r.error;
 }
@@ -43138,8 +43177,8 @@ priority: ha.MEDIUM,
 interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), aR = new nR, iR = function() {
+}) ], e.prototype, "run", null), n([ ki() ], e);
+}(), iR = new aR, sR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new ec(o(o({}, Bs), e), {
 getEmpire: function() {
@@ -43174,8 +43213,8 @@ priority: ha.LOW,
 interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
-}) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), sR = new iR, cR = function() {
+}) ], e.prototype, "run", null), n([ ki() ], e);
+}(), cR = new sR, uR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -43193,9 +43232,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), uR = new (function(e) {
+}(), lR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new cR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new uR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43204,25 +43243,25 @@ priority: ha.IDLE,
 interval: 200,
 minBucket: 9e3,
 cpuBudget: .01
-}) ], t.prototype, "run", null), n([ Mi() ], t);
+}) ], t.prototype, "run", null), n([ ki() ], t);
 }(Ii));
 
-function lR() {
+function mR() {
 return global;
 }
 
-function mR(e) {
+function dR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function dR(e) {
+function pR(e) {
 return Number(null != e ? e : 0);
 }
 
-var pR = function() {
+var fR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = lR();
+var e = mR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43230,12 +43269,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return lR()._pixelGenerationMemory;
+return mR()._pixelGenerationMemory;
 }, e;
-}(), fR = function(e) {
+}(), yR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new pR) || this;
+var r = e.call(this, t, new fR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43252,7 +43291,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(mR).length : Object.values(null != t ? t : {}).filter(mR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(dR).length : Object.values(null != t ? t : {}).filter(dR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43263,9 +43302,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (dR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (dR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = dR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = dR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (pR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (pR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = pR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = pR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43286,10 +43325,10 @@ priority: ha.IDLE,
 interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
-}) ], t.prototype, "run", null), n([ Mi() ], t);
-}(Li), yR = new fR;
+}) ], t.prototype, "run", null), n([ ki() ], t);
+}(Li), vR = new yR;
 
-function vR(e, t) {
+function gR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -43311,7 +43350,7 @@ lost: !1
 };
 }
 
-function gR(e, t, r) {
+function hR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43325,20 +43364,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var hR = Ue().cpu.bucketThresholds.highMode + 1800, RR = {
+var RR = Ue().cpu.bucketThresholds.highMode + 1800, ER = {
 updateInterval: 250,
-minBucket: hR,
+minBucket: RR,
 maxSitesPerRemotePerTick: 2
 };
 
-function ER(e, t) {
+function TR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var TR = function() {
+var CR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, RR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, ER), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43355,8 +43394,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = vR(l);
-m.lost && m.reason && gR(e, u, m.reason);
+var m = gR(l);
+m.lost && m.reason && hR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43374,10 +43413,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = ER("remoteInfrastructure.intent", function() {
+var i = TR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-ER("remoteInfrastructure.execute", function() {
+TR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43498,14 +43537,14 @@ if (T) {
 var C = new Set(T.roadKeys), S = new Set(T.roadSiteKeys), w = new Set(T.wallKeys), x = null !== (d = f.get(E)) && void 0 !== d ? d : 0, b = 0;
 try {
 for (var O = (u = void 0, a(T.roadPositions)), A = O.next(); !A.done; A = O.next()) {
-var M = A.value;
+var k = A.value;
 if (b >= e.maxRoadSitesPerRoomPerTick) break;
 if (T.constructionSiteCount + x >= e.maxConstructionSitesPerRoom) break;
-var k = "".concat(M.x, ",").concat(M.y);
-C.has(k) || S.has(k) || w.has(k) || (p.push({
+var M = "".concat(k.x, ",").concat(k.y);
+C.has(M) || S.has(M) || w.has(M) || (p.push({
 roomName: E,
-x: M.x,
-y: M.y,
+x: k.x,
+y: k.y,
 structureType: STRUCTURE_ROAD
 }), b++, x++);
 }
@@ -43543,13 +43582,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = ER("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = TR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = ER("remoteInfrastructure.roomSnapshot", function() {
+u[t] = TR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43582,7 +43621,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = ER("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = TR("remoteInfrastructure.calculateRemoteRoads", function() {
 return xn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43611,14 +43650,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = ER("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = TR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? ER("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? TR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43635,7 +43674,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? ER("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? TR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43653,7 +43692,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return ER("remoteInfrastructure.findSources", function() {
+return TR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43750,10 +43789,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: ha.LOW,
 interval: 1e3,
-minBucket: hR,
+minBucket: RR,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ Mi() ], e);
-}(), CR = new TR, SR = new (function(e) {
+}) ], e.prototype, "run", null), n([ ki() ], e);
+}(), SR = new CR, wR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43764,8 +43803,8 @@ priority: ha.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
-}) ], t.prototype, "run", null), n([ Mi() ], t);
-}(Np)), wR = function() {
+}) ], t.prototype, "run", null), n([ ki() ], t);
+}(Pp)), xR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43809,7 +43848,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Sf.applyDiffusion(o);
+wf.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -43854,8 +43893,8 @@ cpuBudget: .01
 }) ], e.prototype, "initializeLabConfigs", null), n([ Ai("room:pathCachePrecache", "Path Cache Precache (Disabled)", {
 interval: 1e3,
 cpuBudget: .01
-}) ], e.prototype, "precacheRoomPaths", null), n([ Mi() ], e);
-}(), xR = new wR, bR = new (function() {
+}) ], e.prototype, "precacheRoomPaths", null), n([ ki() ], e);
+}(), bR = new xR, OR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43902,7 +43941,7 @@ if (e) throw e.error;
 Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(xR, Ns, Ds, ls, tR, vc, aR, CR, As, uR, yR, sR, qc, Zc, SR, Ph, Bc, Mh, za, Pa),
+}(bR, Ns, Ds, ls, rR, vc, iR, SR, As, lR, vR, cR, qc, Zc, wR, Ih, Bc, Mh, za, Pa),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -43969,7 +44008,7 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), OR = "_ownedRooms", AR = "_ownedRoomsTick";
+}), AR = "_ownedRooms", kR = "_ownedRoomsTick";
 
 function MR(e) {
 var t = function(e) {
@@ -43981,13 +44020,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var kR = Ei("NativeCallsTracker");
+var UR = Ei("NativeCallsTracker");
 
-function UR(e, t, r) {
+function _R(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) kR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) UR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44003,7 +44042,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-kR.warn("Failed to wrap method", {
+UR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44013,30 +44052,30 @@ error: String(e)
 }
 }
 
-var _R, NR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], PR = "shard1", IR = {
+var NR, PR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], IR = "shard1", GR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, GR = {
+}, LR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, LR = {
+}, DR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function DR() {
+function FR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function FR() {
+function BR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: NR,
+targetShards: PR,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44046,11 +44085,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = NR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = PR),
 Memory.interShardOperation;
 }
 
-function BR() {
+function WR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -44065,7 +44104,7 @@ lastSync: 0,
 checksum: 0
 };
 var t = InterShardMemory.getLocal();
-return t && null !== (e = bp(t)) && void 0 !== e ? e : {
+return t && null !== (e = Op(t)) && void 0 !== e ? e : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -44091,33 +44130,33 @@ checksum: 0
 }
 }
 
-function WR(e) {
+function KR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
-InterShardMemory.setLocal(xp(e));
+InterShardMemory.setLocal(bp(e));
 } catch (e) {}
 }
 
-function KR() {
-var e, t, r, o, n, i, s, c = BR(), u = DR();
+function HR() {
+var e, t, r, o, n, i, s, c = WR(), u = FR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: NR,
+targetShards: PR,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : NR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : PR,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && HR() ? "established" : "unreached",
+status: p === u && YR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44135,7 +44174,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === PR ? "core" : "frontier",
+role: u === IR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44152,24 +44191,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), WR(c), c.footprintOperation;
+}), KR(c), c.footprintOperation;
 }
 
-function HR() {
+function YR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function YR() {
+function VR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function VR(e, t) {
+function qR(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44188,9 +44227,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(YR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(VR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Ly.getPendingRequests(p.name).filter(function(r) {
+s += Dy.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44209,7 +44248,7 @@ if (n) throw n.error;
 return s;
 }
 
-function qR(e) {
+function jR(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44253,7 +44292,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = BR().shards[DR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = WR().shards[FR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44263,8 +44302,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function jR(e, t) {
-if (!(VR("scout", t) >= 1)) {
+function zR(e, t) {
+if (!(qR("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44302,13 +44341,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Ly.addRequest({
+r && Dy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: LR,
-priority: Cy.LOW + 5,
+body: DR,
+priority: Sy.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44319,14 +44358,14 @@ task: "interShardPortalScout"
 }
 }
 
-function zR(e, t, r) {
-VR("interShardClaimer", t) >= 1 || Ly.addRequest({
+function QR(e, t, r) {
+qR("interShardClaimer", t) >= 1 || Dy.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: IR,
-priority: Cy.NORMAL + 50,
+body: GR,
+priority: Sy.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44339,14 +44378,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function QR(e, t, r) {
-VR("interShardScout", t) >= 1 || Ly.addRequest({
+function XR(e, t, r) {
+qR("interShardScout", t) >= 1 || Dy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: LR,
-priority: Cy.NORMAL,
+body: DR,
+priority: Sy.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44359,15 +44398,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function XR(e, t, r) {
+function ZR(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (VR("interShardPioneer", t.shard) >= 3 || Ly.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (qR("interShardPioneer", t.shard) >= 3 || Dy.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: GR,
-priority: Cy.NORMAL + 25,
+body: LR,
+priority: Sy.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44380,19 +44419,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function ZR(e) {
+function JR(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = DR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = FR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : NR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : PR), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? bp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Op(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44424,9 +44463,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(YR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(VR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Ly.getPendingRequests(l.name).filter(function(e) {
+n += Dy.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44445,22 +44484,22 @@ return n;
 }() < o;
 }
 
-(_R = {
-optimizeBody: Ny,
+(NR = {
+optimizeBody: Py,
 spawnQueue: {
 addRequest: function(e) {
-return Ly.addRequest(e);
+return Dy.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Cy.LOW,
-NORMAL: Cy.NORMAL,
-HIGH: Cy.HIGH
+LOW: Sy.LOW,
+NORMAL: Sy.NORMAL,
+HIGH: Sy.HIGH
 }
-}).optimizeBody && (Ip.optimizeBody = _R.optimizeBody), _R.spawnQueue && (Ip.spawnQueue = _R.spawnQueue),
-_R.spawnPriorities && (Ip.spawnPriorities = o(o({}, Ip.spawnPriorities), _R.spawnPriorities));
+}).optimizeBody && (Gp.optimizeBody = NR.optimizeBody), NR.spawnQueue && (Gp.spawnQueue = NR.spawnQueue),
+NR.spawnPriorities && (Gp.spawnPriorities = o(o({}, Gp.spawnPriorities), NR.spawnPriorities));
 
-var JR, $R = function() {
+var $R, eE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44504,7 +44543,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function eE(e) {
+function tE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44525,7 +44564,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function tE(e, t, r) {
+function rE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44591,16 +44630,16 @@ return u;
 });
 }
 
-function rE(e) {
+function oE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(JR || (JR = {}));
+}($R || ($R = {}));
 
-var oE = function() {
+var nE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44638,8 +44677,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = tE(h.pos, T.pos, this.logger);
-if (rE(C)) {
+var T = E.value, C = rE(h.pos, T.pos, this.logger);
+if (oE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44666,8 +44705,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, M = tE(A, u.pos, this.logger);
-rE(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
+var A = O.value, k = rE(A, u.pos, this.logger);
+oE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44706,8 +44745,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = tE(e, t, this.logger);
-if (rE(n)) {
+var n = rE(e, t, this.logger);
+if (oE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44717,7 +44756,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), nE = function() {
+}(), aE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44727,7 +44766,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = eE(s);
+var c = tE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44753,7 +44792,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), aE = function() {
+}(), iE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44802,20 +44841,20 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), iE = {
+}(), sE = {
 debug: function(e, t) {
-return M("RemoteMining").debug(e, t);
+return k("RemoteMining").debug(e, t);
 },
 info: function(e, t) {
-return M("RemoteMining").info(e, t);
+return k("RemoteMining").info(e, t);
 },
 warn: function(e, t) {
-return M("RemoteMining").warn(e, t);
+return k("RemoteMining").warn(e, t);
 },
 error: function(e, t) {
-return M("RemoteMining").error(e, t);
+return k("RemoteMining").error(e, t);
 }
-}, sE = {
+}, cE = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44842,28 +44881,28 @@ direction: a
 }
 return t;
 }
-}, cE = {
+}, uE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = ym.MEDIUM), bm.register({
+void 0 === o && (o = vm.MEDIUM), Om.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== ym.CRITICAL
+skippable: o !== vm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, uE = new oE(sE, iE), lE = new nE(iE, cE, uE), mE = new aE(iE, sE, uE, Gu.moveTo);
+}, lE = new nE(cE, sE), mE = new aE(sE, uE, lE), dE = new iE(sE, cE, lE, Gu.moveTo);
 
-function dE(e, t, r, o) {
-return mE.moveToWithRemoteCache(e, t, r, o);
+function pE(e, t, r, o) {
+return dE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var pE, fE = function() {
+var fE, yE = function() {
 function e() {
-this.logger = M("Pathfinding");
+this.logger = k("Pathfinding");
 }
 return e.prototype.debug = function(e, t) {
 this.logger.debug(e, t);
@@ -44874,12 +44913,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), yE = function() {
+}(), vE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), vE = function() {
+}(), gE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44924,28 +44963,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), gE = function() {
+}(), hE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return eE(e);
+return tE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-uE.precacheRemoteRoutes(e, t);
+lE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), hE = new $R(new fE, new yE, new vE, new gE), RE = {
+}(), RE = new eE(new yE, new vE, new gE, new hE), EE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, EE = function() {
+}, TE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, RE), e);
+this.config = o(o({}, EE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45039,123 +45078,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new EE, (pE = {})[FIND_STRUCTURES] = {
+new TE, (fE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, pE[FIND_MY_STRUCTURES] = {
+}, fE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, pE[FIND_HOSTILE_STRUCTURES] = {
+}, fE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, pE[FIND_SOURCES_ACTIVE] = {
+}, fE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, pE[FIND_SOURCES] = {
+}, fE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, pE[FIND_MINERALS] = {
+}, fE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, pE[FIND_DEPOSITS] = {
+}, fE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, pE[FIND_MY_CONSTRUCTION_SITES] = {
+}, fE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, pE[FIND_CONSTRUCTION_SITES] = {
+}, fE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, pE[FIND_CREEPS] = {
+}, fE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, pE[FIND_MY_CREEPS] = {
+}, fE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, pE[FIND_HOSTILE_CREEPS] = {
+}, fE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, pE[FIND_DROPPED_RESOURCES] = {
+}, fE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, pE[FIND_TOMBSTONES] = {
+}, fE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, pE[FIND_RUINS] = {
+}, fE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, pE[FIND_FLAGS] = {
+}, fE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, pE[FIND_MY_SPAWNS] = {
+}, fE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, pE[FIND_HOSTILE_SPAWNS] = {
+}, fE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, pE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, fE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, pE[FIND_NUKES] = {
+}, fE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, pE[FIND_POWER_CREEPS] = {
+}, fE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, pE[FIND_MY_POWER_CREEPS] = {
+}, fE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, pE[FIND_HOSTILE_POWER_CREEPS] = {
+}, fE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, pE[FIND_EXIT_TOP] = {
+}, fE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, pE[FIND_EXIT_RIGHT] = {
+}, fE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, pE[FIND_EXIT_BOTTOM] = {
+}, fE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, pE[FIND_EXIT_LEFT] = {
+}, fE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, pE[FIND_EXIT] = {
+}, fE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var TE = new le({}, mr), CE = new Ee({}, mr);
+var CE = new le({}, mr), SE = new Ee({}, mr);
 
-function SE(e) {
+function wE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45163,11 +45202,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var wE = !1;
+var xE = !1;
 
-function xE() {
+function bE() {
 var e, t;
-wE || (ii({
+xE || (ii({
 level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45182,11 +45221,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Dy.getPendingTransfers = function(e) {
+r.getPendingTransfers && (Fy.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Dy.needsCarrier = function(e) {
+}), r.needsCarrier && (Fy.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Dy.getActiveRequests = function() {
+}), r.getActiveRequests && (Fy.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45200,47 +45239,47 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Fy.predictConsumption = function(e) {
+a.predictConsumption && (By.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Fy.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (By.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Fy.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (By.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Fy.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (By.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (By.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Wy.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (By.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Wy.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (By.needsCarriers = function(e) {
+}), i.needsCarriers && (Wy.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (By.requestSpawns = function(e) {
+}), i.requestSpawns && (Wy.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-Wy.getEmergencyState = function(e) {
+Ky.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: bt,
 powerBankHarvestingManager: qc,
-resourceTransferCoordinator: Lp,
+resourceTransferCoordinator: Dp,
 emergencyResponseManager: Ba,
 kernel: Ja
 }), function(e) {
 var t, r, o, n;
-ad = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : nd.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : nd.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : nd.getLabOverflow
-} : nd;
+id = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : ad.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : ad.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : ad.getLabOverflow
+} : ad;
 }({
 getLabResourceNeeds: function(e) {
 return Ru.getLabResourceNeeds(e);
@@ -45254,7 +45293,7 @@ return Ru.getLabOverflow(e);
 }), Ji.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) kR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) UR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45268,7 +45307,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-kR.warn("Failed to wrap PathFinder.search", {
+UR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45276,11 +45315,11 @@ error: String(e)
 }
 }
 }
-}(), UR(e = Creep.prototype, "moveTo", "moveTo"), UR(e, "move", "move"), UR(e, "harvest", "harvest"),
-UR(e, "transfer", "transfer"), UR(e, "withdraw", "withdraw"), UR(e, "build", "build"),
-UR(e, "repair", "repair"), UR(e, "upgradeController", "upgradeController"), UR(e, "attack", "attack"),
-UR(e, "rangedAttack", "rangedAttack"), UR(e, "heal", "heal"), UR(e, "dismantle", "dismantle"),
-UR(e, "say", "say")), function(e, t, r) {
+}(), _R(e = Creep.prototype, "moveTo", "moveTo"), _R(e, "move", "move"), _R(e, "harvest", "harvest"),
+_R(e, "transfer", "transfer"), _R(e, "withdraw", "withdraw"), _R(e, "build", "build"),
+_R(e, "repair", "repair"), _R(e, "upgradeController", "upgradeController"), _R(e, "attack", "attack"),
+_R(e, "rangedAttack", "rangedAttack"), _R(e, "heal", "heal"), _R(e, "dismantle", "dismantle"),
+_R(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -45296,15 +45335,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, Sf), hE.initializePathCacheEvents(), lE.initialize(ym.MEDIUM), Tl = dE,
-Ft.initialize(), SR.initialize(), wE = !0), mr.initialize();
-var r = bR.configureForCurrentTick();
+}(Ja, mr, wf), RE.initializePathCacheEvents(), mE.initialize(vm.MEDIUM), Tl = pE,
+Ft.initialize(), wR.initialize(), xE = !0), mr.initialize();
+var r = OR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = FR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, KR(), function() {
-var e, t, r, o, n = BR(), a = n.footprintOperation, i = DR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = BR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, HR(), function() {
+var e, t, r, o, n = WR(), a = n.footprintOperation, i = FR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45317,15 +45356,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, WR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, KR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = FR();
+var e, t, r, n, i, s, c = BR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : NR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === PR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : PR), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === IR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45343,10 +45382,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !HR())) try {
+}(), !YR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || Jp(s), "interShardPioneer" === c && Zp(s);
+"interShardClaimer" !== c && "interShardScout" !== c || $p(s), "interShardPioneer" === c && Jp(s);
 }
 } catch (t) {
 e = {
@@ -45370,17 +45409,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: wE
+systemsInitialized: xE
 }
-}), bR.ensureProcessesRegistered(), Ji.startTick(), Mu.clear(), bR.startEventTick();
+}), OR.ensureProcessesRegistered(), Ji.startTick(), ku.clear(), OR.startEventTick();
 var i = function(e) {
-var t = e.cache[OR], r = e.cache[AR];
+var t = e.cache[AR], r = e.cache[kR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[OR] = o, e.cache[AR] = e.tick, o;
+return e.cache[AR] = o, e.cache[kR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45417,18 +45456,18 @@ if (e) throw e.error;
 }
 }), Ji.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = FR();
+var e, t, r, o = BR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = KR();
+var n = HR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : NR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : PR), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== DR()) try {
+if (d !== FR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = bp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Op(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45446,20 +45485,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = YR().sort(function(e, t) {
+var i = VR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : NR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : PR), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== DR()) {
+if (u !== FR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = qR(u);
+var m = jR(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? XR(i, l, m) : ZR() ? zR(i, u, m) : (QR(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (jR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? ZR(i, l, m) : JR() ? QR(i, u, m) : (XR(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (zR(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45476,8 +45515,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = BR();
-d.footprintOperation = n, WR(d);
+var d = WR();
+d.footprintOperation = n, KR(d);
 }
 }
 })(), function() {
@@ -45485,8 +45524,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || SE(s))) {
-var c = cg(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || wE(s))) {
+var c = ug(s, mr.getOrInitSwarmState(s.name));
 Ji.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45503,20 +45542,20 @@ if (e) throw e.error;
 }
 }();
 }), Gu.preTick(), Ji.measureSubsystem("processSync", function() {
-lf.syncCreepProcesses(), ly.syncRoomProcesses();
+mf.syncCreepProcesses(), my.syncRoomProcesses();
 }), Ji.measureSubsystem("kernel", function() {
-bR.runProcesses();
+OR.runProcesses();
 }), Ji.measureSubsystem("eventQueue", function() {
-bR.processQueuedEvents();
+OR.processQueuedEvents();
 }), Ji.measureSubsystem("ss2PacketQueue", function() {
-dg.processQueue();
+pg.processQueue();
 }), Ja.hasCpuBudget() && Ji.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && $p(n);
+void 0 !== n.ticksToLive && ef(n);
 }
 } catch (t) {
 e = {
@@ -45540,8 +45579,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = TE.getConfig(), s = CE.getConfig();
-TE.setConfig(n.roomVisualizerConfig), n.renderMap && CE.setConfig(n.mapVisualizerConfig);
+var i = CE.getConfig(), s = SE.getConfig();
+CE.setConfig(n.roomVisualizerConfig), n.renderMap && SE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45552,7 +45591,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-TE.draw(m);
+CE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45574,14 +45613,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-CE.draw();
+SE.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-TE.setConfig(i), CE.setConfig(s);
+CE.setConfig(i), SE.setConfig(s);
 }
 }
 }
@@ -45671,14 +45710,14 @@ hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), bm.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Om.run(e);
 }), mr.persistHeapCache(), Ji.collectProcessStats(Ja.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), Ji.collectKernelBudgetStats(Ja), Ji.setSkippedProcesses(Ja.getSkippedProcessesThisTick()),
 Ji.finalizeTick(), Ci.flush();
 }
 
-var bE = function() {
+var OE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45686,15 +45725,6 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = TE.getConfig(), r = Object.keys(t).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof t[e];
-});
-if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
-var o = e;
-TE.toggle(o);
-var n = TE.getConfig()[o];
-return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t = CE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
@@ -45702,9 +45732,18 @@ if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.
 var o = e;
 CE.toggle(o);
 var n = CE.getConfig()[o];
+return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t = SE.getConfig(), r = Object.keys(t).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof t[e];
+});
+if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
+var o = e;
+SE.toggle(o);
+var n = SE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = CE.getConfig();
+var e = SE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45827,15 +45866,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), OE = function() {
+}(), AE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = SR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = wR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = SR.getAllShards();
+var e, t, r = wR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45857,9 +45896,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (SR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (wR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = SR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = wR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45884,19 +45923,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = SR.getOptimalPortalRoute(e, t);
+var r, o = wR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (SR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (wR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (SR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (wR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Lp.getActiveRequests();
+var e, t, r = Dp.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -45917,7 +45956,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = SR.getCurrentShardState();
+var e, t, r = wR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45938,7 +45977,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = SR.getActiveTransferTasks();
+var e, t, r, o = wR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -45959,16 +45998,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = SR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+var e = wR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
 return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Mp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = SR.getMemoryStats();
+var e = wR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return SR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return wR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = BR().footprintOperation;
+var e, t, r, o = WR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46074,7 +46113,7 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), AE = new OE;
+}(), kE = new AE;
 
 function ME(e) {
 var t = e.match(/\((.*?)\)/);
@@ -46109,7 +46148,7 @@ commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.incl
 params: e.metadata.usage ? ME(e.metadata.usage) : void 0
 };
 });
-return Im({
+return Gm({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46160,12 +46199,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Im.apply(void 0, s([], i(o), !1));
+return Gm.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return _m("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Nm("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Pm.form("spawnCreep", [ {
+return Im.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46199,20 +46238,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return _m("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Nm("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += _m("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += _m("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Pm.button({
+o += '<div style="margin-bottom: 10px;">', o += Nm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Nm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Im.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Pm.button({
+}), o += " ", (o += Im.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Pm.form("configureLogging", [ {
+return Im.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46237,7 +46276,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Pm.form("configureVisualization", [ {
+return Im.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46261,21 +46300,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Pm.button({
+e += Im.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += Pm.button({
+}), e += " ", e += Im.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Pm.button({
+}), e += " ", (e += Im.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += _m("✓ Success message", "green", !0) + "\n", e += _m("⚠ Warning message", "yellow", !0) + "\n",
-e += _m("✗ Error message", "red", !0) + "\n", e += _m("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + _m("colored text", "green") + " normal text\n") + "Bold text: " + _m("important", null, !0) + "\n";
+return e += Nm("✓ Success message", "green", !0) + "\n", e += Nm("⚠ Warning message", "yellow", !0) + "\n",
+e += Nm("✗ Error message", "red", !0) + "\n", e += Nm("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Nm("colored text", "green") + " normal text\n") + "Bold text: " + Nm("important", null, !0) + "\n";
 }, n([ Tt({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46321,39 +46360,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var kE = new dy, UE = new bE, _E = new py, NE = new bu, PE = new my, IE = new fy, GE = new yy, LE = "__screepsGlobalRuntimeDiagnostics";
+var UE = new py, _E = new OE, NE = new fy, PE = new bu, IE = new dy, GE = new yy, LE = new vy, DE = "__screepsGlobalRuntimeDiagnostics";
 
-function DE() {
+function FE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function FE(e, t) {
+function BE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function BE(e, t) {
+function WE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function WE(e) {
+function KE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function KE(e) {
+function HE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: FE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: FE(n.switchCount, 0),
-lastTick: BE(n.lastTick, Game.time),
-lastResetTick: BE(n.lastResetTick, Game.time),
-lastSwitchTick: WE(n.lastSwitchTick),
-lastSwitchPreviousTick: WE(n.lastSwitchPreviousTick),
-lastWarningTick: WE(n.lastWarningTick)
+resetCount: BE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: BE(n.switchCount, 0),
+lastTick: WE(n.lastTick, Game.time),
+lastResetTick: WE(n.lastResetTick, Game.time),
+lastSwitchTick: KE(n.lastSwitchTick),
+lastSwitchPreviousTick: KE(n.lastSwitchPreviousTick),
+lastWarningTick: KE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46367,13 +46406,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var HE = Ei("Main");
+var YE = Ei("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(kE), Ct(UE), Ct(_E), Ct(NE), Ct(PE), Ct(IE), Ct(GE), Ct(Su),
-Ct(wu), Ct(xu), Ct(AE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
+Et.initialize(), Ct(UE), Ct(_E), Ct(NE), Ct(PE), Ct(IE), Ct(GE), Ct(LE), Ct(Su),
+Ct(wu), Ct(xu), Ct(kE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -46388,12 +46427,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : DE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[LE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : FE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[DE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[LE] = s, function(e, t) {
-var r, o = KE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[DE] = s, function(e, t) {
+var r, o = HE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46411,7 +46450,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = KE(e.heapId);
+var n, a = HE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46432,14 +46471,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = KE(s.heapId);
+var u = HE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: HE
-}), xE();
+logger: YE
+}), bE();
 } catch (e) {
-throw HE.error("Critical error in main loop: ".concat(String(e)), {
+throw YE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time


### PR DESCRIPTION
## Summary

Preserves task-board delivery amounts across stateful movement and refreshes the matching reservation lease while the creep remains committed to that delivery.

## Linked issue

Closes #3249

## Changes

- Store optional transfer `amount` in creep state and restore it on continuation.
- Refresh task-board delivery reservations during stateful transfer continuation.
- Hydrate legacy amount-less transfer states from the active reservation amount.
- Clear stale delivery state when the task-board reservation no longer exists.
- Add regression coverage for amount preservation, legacy state hydration, and stale reservation clearing.
- Rebuild `packages/screeps-bot/dist/main.js`.

## Validation

- `source ~/.nvm/nvm.sh && nvm use --silent && npm test -w @ralphschuler/screeps-roles -- --grep "task-board transfer amounts|legacy task-board transfer|stale task-board delivery"` ✅
- `source ~/.nvm/nvm.sh && nvm use --silent && npm test -w @ralphschuler/screeps-roles` ✅ (130 passing)
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run lint:roles` ✅
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run build` ✅
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run check-versions` ✅
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run sync:deps:check` ✅
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run check:alliance-safety` ✅
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run test:server:smoke` ✅ (`packages/screeps-server/artifacts/smoke/summary.md`: passed; 49/49 assertions)

## Deployment impact

Affects screeps.com runtime delivery behavior. Deploy after merge via `npm run push`.

## Live bot evidence

Read-only live analysis at 2026-07-04T06:16Z showed #3119 still active: shard1 had 82 task-board tasks across W17S29/W18S29/W18S28, mostly amount-bearing delivery work, with 80 effectively unassigned. This PR targets the #3249 focused stateful-reservation slice.

## Follow-up issues

No new issues created per run constraint. Existing live/code-refinement issues updated with current evidence where relevant.
