### PR TITLE
[codex] Redact structural snapshot CLI errors

### DIFF
--- a/packages/screeps-server/scripts/export-live-structural-snapshot.js
+++ b/packages/screeps-server/scripts/export-live-structural-snapshot.js
@@ -8,7 +8,7 @@ import {
   safeObject,
   writeJson,
 } from "./cpu-benchmark-model.js";
-import { formatScreepsApiError } from "../../../scripts/live-redaction.mjs";
+import { formatScreepsApiError, redactScreepsApiMessage } from "../../../scripts/live-redaction.mjs";
 
 const require = createRequire(import.meta.url);
 const { ScreepsAPI } = require("screeps-api");
@@ -46,6 +46,11 @@ function unwrapMemory(response) {
 
 export function redactedSnapshotError(fields, error) {
   return { ...fields, message: formatScreepsApiError(error) };
+}
+
+export function formatStructuralSnapshotCliError(error) {
+  const message = error instanceof Error ? error.stack || error.message : String(error);
+  return redactScreepsApiMessage(message);
 }
 
 export function evaluateStructuralSnapshotHealth(snapshot, { failOnMemoryErrors = false } = {}) {
@@ -152,7 +157,7 @@ async function main() {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((error) => {
-    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    console.error(formatStructuralSnapshotCliError(error));
     process.exitCode = 1;
   });
 }

--- a/scripts/test/export-live-structural-snapshot-redaction.test.mjs
+++ b/scripts/test/export-live-structural-snapshot-redaction.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   evaluateStructuralSnapshotHealth,
+  formatStructuralSnapshotCliError,
   parseOptions,
   redactedSnapshotError
 } from "../../packages/screeps-server/scripts/export-live-structural-snapshot.js";
@@ -35,6 +36,30 @@ test("structural snapshot room endpoint errors redact token fragments", () => {
     assert.equal(entry.message.includes("6ea62d57"), false);
     assert.equal(entry.message.includes("token=<redacted>"), true);
   }
+});
+
+test("structural snapshot top-level CLI errors redact token fragments", () => {
+  const error = new Error(`X-Token: abc123 ${RATE_LIMIT_MESSAGE}`);
+  error.stack = `Error: X-Token: abc123 SCREEPS_TOKEN=secret123 ${RATE_LIMIT_MESSAGE}\n    at fetch (https://screeps.com/api/user/memory?access_token=abcd&path=stats)`;
+
+  const message = formatStructuralSnapshotCliError(error);
+
+  assert.equal(message.includes("abc123"), false);
+  assert.equal(message.includes("secret123"), false);
+  assert.equal(message.includes("6ea62d57"), false);
+  assert.equal(message.includes("access_token=abcd"), false);
+  assert.equal(message.includes("token=<redacted>"), true);
+  assert.equal(message.includes("access_token=<redacted>"), true);
+  assert.equal(message.includes("path=stats"), true);
+});
+
+test("structural snapshot top-level CLI errors redact non-Error token fragments", () => {
+  const message = formatStructuralSnapshotCliError(`X-Token: abc123 ${RATE_LIMIT_MESSAGE} SCREEPS_TOKEN=secret123`);
+
+  assert.equal(message.includes("abc123"), false);
+  assert.equal(message.includes("secret123"), false);
+  assert.equal(message.includes("6ea62d57"), false);
+  assert.equal(message.includes("token=<redacted>"), true);
 });
 
 test("structural snapshot parser supports deploy-gate memory error failure flag", () => {


### PR DESCRIPTION
## Summary

Redacts top-level structural snapshot CLI errors before they reach stderr.

## Linked issue

Closes #3244

## Changes

- Added `formatStructuralSnapshotCliError()` for top-level CLI error formatting.
- Routed `main().catch(...)` through shared Screeps API redaction.
- Added regression coverage for token URL, `X-Token`, `SCREEPS_TOKEN=`, `access_token`, and non-`Error` top-level failures.

## Validation

- ✅ `node --test scripts/test/export-live-structural-snapshot-redaction.test.mjs`
- ✅ `npm run test:scripts`
- ✅ `npm run build`

## Deployment impact

No bot runtime behavior change. This only affects local/live diagnostic tooling stderr redaction.

## Live bot evidence

Pre-implementation live analysis ran via read-only Screeps API and updated existing live issues #3242, #3105, #3184, and #3104. No new issues created per operator constraint.

## Follow-up issues

None created.
