### PR TITLE
[codex] Prioritize peaceful tower recovery

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -33293,7 +33293,21 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-var Hf = function() {
+function Hf(e, t) {
+var r, o, n;
+return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
+1: 0,
+2: 0,
+3: 1,
+4: 1,
+5: 2,
+6: 2,
+7: 3,
+8: 6
+}, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
+}
+
+var Yf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
 return Wf(e) ? 5 : 10;
@@ -33302,313 +33316,10 @@ var u, l, m, d;
 void 0 === c && (c = {});
 var p = r, f = null !== (l = null === (u = e.controller) || void 0 === u ? void 0 : u.level) && void 0 !== l ? l : 1, y = n[0], v = null == y || y.pos;
 if (y) {
-var g = 0;
-f >= 5 && (g = function(e) {
-var t, r, o = Ro(e);
-if (0 === o.placements.length) return 0;
-var n = e.find(FIND_MY_CONSTRUCTION_SITES), c = ho(e), u = n.filter(function(e) {
-return e.structureType === STRUCTURE_LINK;
-}), l = c.length + u.length, m = 0, d = function(e, t) {
-return new Set(s(s([], i(e.map(function(e) {
-return vo(e.pos.x, e.pos.y);
-})), !1), i(t.map(function(e) {
-return vo(e.pos.x, e.pos.y);
-})), !1));
-}(c, u);
-try {
-for (var p = a(o.placements), f = p.next(); !f.done; f = p.next()) {
-var y = f.value;
-if (m >= 2 || l >= o.linkLimit) break;
-var v = vo(y.x, y.y);
-d.has(v) || e.createConstructionSite(y.x, y.y, STRUCTURE_LINK) === OK && (m += 1,
-l += 1, d.add(v));
-}
-} catch (e) {
-t = {
-error: e
-};
-} finally {
-try {
-f && !f.done && (r = p.return) && r.call(p);
-} finally {
-if (t) throw t.error;
-}
-}
-return m;
-}(e));
-var h = 0;
-f >= 6 && (h = function(e) {
-var t, r, o = e.find(FIND_MY_CONSTRUCTION_SITES);
-if (o.length >= 10) return 0;
-var n = function(e) {
-var t, r, o, n, c, u, l, m, d, p, f = function(e) {
-var t, r, o;
-return null !== (o = yo(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
-}(e);
-if (f < 3) return null;
-var y = e.find(FIND_MY_STRUCTURES, {
-filter: function(e) {
-return e.structureType === STRUCTURE_LAB;
-}
-}), v = e.find(FIND_MY_CONSTRUCTION_SITES), g = v.filter(function(e) {
-return e.structureType === STRUCTURE_LAB;
-}), h = new Set(y.map(function(e) {
-return To(e.pos.x, e.pos.y);
-})), R = new Set(g.map(function(e) {
-return To(e.pos.x, e.pos.y);
-})), E = new Set(s(s([], i(h), !1), i(R), !1));
-if (E.size > f) return null;
-var T = e.find(FIND_STRUCTURES), C = new Set;
-try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) {
-var x = w.value;
-So(x, h) && C.add(To(x.pos.x, x.pos.y));
-}
-} catch (e) {
-t = {
-error: e
-};
-} finally {
-try {
-w && !w.done && (r = S.return) && r.call(S);
-} finally {
-if (t) throw t.error;
-}
-}
-try {
-for (var b = a(v), O = b.next(); !O.done; O = b.next()) {
-var A = O.value;
-wo(A, R) && C.add(To(A.pos.x, A.pos.y));
-}
-} catch (e) {
-o = {
-error: e
-};
-} finally {
-try {
-O && !O.done && (n = b.return) && n.call(b);
-} finally {
-if (o) throw o.error;
-}
-}
-var k = function(e) {
-var t, r, o = e.find(FIND_MY_SPAWNS)[0], n = null !== (r = null !== (t = e.terminal) && void 0 !== t ? t : e.storage) && void 0 !== r ? r : o;
-return n ? {
-x: n.pos.x,
-y: n.pos.y
-} : {
-x: 25,
-y: 25
-};
-}(e), M = new Map, U = s(s(s([], i(y.map(function(e) {
-return {
-x: e.pos.x,
-y: e.pos.y
-};
-})), !1), i(g.map(function(e) {
-return {
-x: e.pos.x,
-y: e.pos.y
-};
-})), !1), [ e.terminal ? {
-x: e.terminal.pos.x,
-y: e.terminal.pos.y
-} : void 0, e.storage ? {
-x: e.storage.pos.x,
-y: e.storage.pos.y
-} : void 0, e.find(FIND_MY_SPAWNS)[0] ? {
-x: e.find(FIND_MY_SPAWNS)[0].pos.x,
-y: e.find(FIND_MY_SPAWNS)[0].pos.y
-} : void 0, k ], !1).filter(function(e) {
-return void 0 !== e;
-});
-try {
-for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) xo(M, e, P.x + I, P.y + G, k, h, R, C);
-} catch (e) {
-c = {
-error: e
-};
-} finally {
-try {
-N && !N.done && (u = _.return) && u.call(_);
-} finally {
-if (c) throw c.error;
-}
-}
-try {
-for (var L = a(E), D = L.next(); !D.done; D = L.next()) {
-var F = D.value;
-if (!M.has(F)) return null;
-}
-} catch (e) {
-l = {
-error: e
-};
-} finally {
-try {
-D && !D.done && (m = L.return) && m.call(L);
-} finally {
-if (l) throw l.error;
-}
-}
-var B = function(e, t) {
-var r = s([], i(t), !1).map(function(t) {
-return e.get(t);
-}).filter(function(e) {
-return void 0 !== e;
-}), o = s([], i(e.values()), !1).filter(function(e) {
-return !t.has(e.key);
-}).sort(function(e, t) {
-var o = bo(e, r) - bo(t, r);
-return 0 !== o ? o : e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
-});
-return s(s([], i(r), !1), i(o), !1).slice(0, 80);
-}(M, E);
-if (B.length < f) return null;
-var W = B.slice(0, 40), K = null, H = function(e) {
-var t, r, o = function(t) {
-var r, o, n, c;
-if (e.key === t.key) return "continue";
-var u = B.filter(function(r) {
-return r.key === e.key || r.key === t.key || Co(r, e) <= 2 && Co(r, t) <= 2;
-});
-if (u.length < f) return "continue";
-if (s([], i(E), !1).some(function(e) {
-return !u.some(function(t) {
-return t.key === e;
-});
-})) return "continue";
-var l = new Map;
-l.set(e.key, e), l.set(t.key, t);
-try {
-for (var m = (r = void 0, a(E)), d = m.next(); !d.done; d = m.next()) {
-var p = d.value, y = M.get(p);
-y && l.set(y.key, y);
-}
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-d && !d.done && (o = m.return) && o.call(m);
-} finally {
-if (r) throw r.error;
-}
-}
-var v = u.filter(function(e) {
-return !l.has(e.key);
-}).sort(function(e, t) {
-return e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
-});
-try {
-for (var g = (n = void 0, a(v)), h = g.next(); !h.done; h = g.next()) {
-var R = h.value;
-if (l.size >= f) break;
-l.set(R.key, R);
-}
-} catch (e) {
-n = {
-error: e
-};
-} finally {
-try {
-h && !h.done && (c = g.return) && c.call(g);
-} finally {
-if (n) throw n.error;
-}
-}
-if (l.size < f) return "continue";
-var T = s([], i(l.values()), !1), C = function(e, t, r) {
-return 1e3 * e.filter(function(e) {
-return e.existingLab;
-}).length + 300 * e.filter(function(e) {
-return e.existingSite;
-}).length - e.reduce(function(e, t) {
-return e + t.distanceToHub;
-}, 0) - 5 * Co(t, r);
-}(T, e, t);
-(!K || C > K.score) && (K = {
-positions: T,
-score: C
-});
-};
-try {
-for (var n = (t = void 0, a(W)), c = n.next(); !c.done; c = n.next()) o(c.value);
-} catch (e) {
-t = {
-error: e
-};
-} finally {
-try {
-c && !c.done && (r = n.return) && r.call(n);
-} finally {
-if (t) throw t.error;
-}
-}
-};
-try {
-for (var Y = a(W), V = Y.next(); !V.done; V = Y.next()) H(V.value);
-} catch (e) {
-d = {
-error: e
-};
-} finally {
-try {
-V && !V.done && (p = Y.return) && p.call(Y);
-} finally {
-if (d) throw d.error;
-}
-}
-if (!K) return null;
-var q = K.positions.filter(function(e) {
-return e.existingLab;
-}).length, j = K.positions.filter(function(e) {
-return e.existingSite;
-}).length;
-return {
-desiredCount: f,
-positions: K.positions.map(function(e) {
-return {
-x: e.x,
-y: e.y,
-roomName: e.roomName,
-existingLab: e.existingLab,
-existingSite: e.existingSite
-};
-}),
-existingCount: q,
-siteCount: j,
-missingCount: Math.max(0, f - q - j)
-};
-}(e);
-if (!n || n.missingCount <= 0) return 0;
-var c = 0;
-try {
-for (var u = a(n.positions), l = u.next(); !l.done; l = u.next()) {
-var m = l.value;
-if (!m.existingLab && !m.existingSite) {
-if (o.length + c >= 10 || c >= 3) break;
-e.createConstructionSite(m.x, m.y, STRUCTURE_LAB) === OK && c++;
-}
-}
-} catch (e) {
-t = {
-error: e
-};
-} finally {
-try {
-l && !l.done && (r = u.return) && r.call(u);
-} finally {
-if (t) throw t.error;
-}
-}
-return c;
-}(e));
-var R = function(e, t) {
+var g = function(e, t) {
 var r = t.layoutAnchor;
 if (r && !(r.x < 1 || r.x > 48 || r.y < 1 || r.y > 48) && e.getTerrain().get(r.x, r.y) !== TERRAIN_MASK_WALL) return new RoomPosition(r.x, r.y, e.name);
-}(e, t), E = function(e, t, r) {
+}(e, t), h = function(e, t, r) {
 var n, c;
 return void 0 === t && (t = null !== (c = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== c ? c : 1),
 void 0 === r && (r = {}), function(e, t, r) {
@@ -33961,122 +33672,110 @@ existingStructures: m,
 existingConstructionSites: d
 };
 }(e, t, r), t, r);
-}(e, f, R ? {
+}(e, f, g ? {
 anchor: {
-x: R.x,
-y: R.y
+x: g.x,
+y: g.y
 }
 } : {});
-v = new RoomPosition(E.anchor.x, E.anchor.y, e.name);
-var T, C = (T = E, {
-name: "".concat(jn, "-rcl-").concat(T.rcl),
-rcl: T.rcl,
+v = new RoomPosition(h.anchor.x, h.anchor.y, e.name);
+var R, E = (R = h, {
+name: "".concat(jn, "-rcl-").concat(R.rcl),
+rcl: R.rcl,
 anchor: {
-x: T.anchor.x,
-y: T.anchor.y
+x: R.anchor.x,
+y: R.anchor.y
 },
-structures: T.structures.map(function(e) {
+structures: R.structures.map(function(e) {
 return {
-x: e.x - T.anchor.x,
-y: e.y - T.anchor.y,
+x: e.x - R.anchor.x,
+y: e.y - R.anchor.y,
 structureType: e.structureType
 };
 }),
-roads: T.roads.map(function(e) {
+roads: R.roads.map(function(e) {
 return {
-x: e.x - T.anchor.x,
-y: e.y - T.anchor.y
+x: e.x - R.anchor.x,
+y: e.y - R.anchor.y
 };
 }),
-ramparts: T.ramparts.map(function(e) {
+ramparts: R.ramparts.map(function(e) {
 return {
-x: e.x - T.anchor.x,
-y: e.y - T.anchor.y
+x: e.x - R.anchor.x,
+y: e.y - R.anchor.y
 };
 }),
 type: "dynamic",
 minSpaceRadius: 3
 });
-Bf(t, v, C.name, f);
-var S = t.danger >= 1 && f >= 3 ? function(e, t, r) {
-var o, n, i, s, c, u, l, m, d, p, f, y, v, g;
+Bf(t, v, E.name, f);
+var T = f >= 3 && (t.danger >= 1 || function(e, t) {
+var r = Hf(STRUCTURE_TOWER, t);
+return r > 0 && Kf(e, STRUCTURE_TOWER) < r;
+}(e, f)), C = T ? function(e, t, r) {
+var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
-var h = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, R = "undefined" == typeof Game ? 0 : Object.keys(null !== (m = Game.constructionSites) && void 0 !== m ? m : {}).length;
-if (R >= h) return 0;
-var E = null !== (p = null === (d = e.controller) || void 0 === d ? void 0 : d.level) && void 0 !== p ? p : t.rcl, T = null !== (y = null === (f = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((o = {})[STRUCTURE_TOWER] = {
-1: 0,
-2: 0,
-3: 1,
-4: 1,
-5: 2,
-6: 2,
-7: 3,
-8: 6
-}, o) : CONTROLLER_STRUCTURES)[STRUCTURE_TOWER]) || void 0 === f ? void 0 : f[E]) && void 0 !== y ? y : 0, C = function(e, t) {
-return e.find(FIND_MY_STRUCTURES, {
-filter: function(e) {
-return e.structureType === t;
-}
-}).length;
-}(e, STRUCTURE_TOWER), S = new Set, w = new Set;
+var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
+if (v >= y) return 0;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Hf(STRUCTURE_TOWER, g), R = Kf(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
-for (var x = a(e.find(FIND_STRUCTURES)), b = x.next(); !b.done; b = x.next()) {
+for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
+var w = S.value;
+E.add("".concat(w.structureType, ":").concat(w.pos.x, ",").concat(w.pos.y));
+}
+} catch (e) {
+o = {
+error: e
+};
+} finally {
+try {
+S && !S.done && (n = C.return) && n.call(C);
+} finally {
+if (o) throw o.error;
+}
+}
+try {
+for (var x = a(e.find(FIND_MY_CONSTRUCTION_SITES)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-S.add("".concat(O.structureType, ":").concat(O.pos.x, ",").concat(O.pos.y));
+T.add("".concat(O.structureType, ":").concat(O.pos.x, ",").concat(O.pos.y));
 }
 } catch (e) {
-n = {
+i = {
 error: e
 };
 } finally {
 try {
-b && !b.done && (i = x.return) && i.call(x);
+b && !b.done && (s = x.return) && s.call(x);
 } finally {
-if (n) throw n.error;
+if (i) throw i.error;
 }
 }
-try {
-for (var A = a(e.find(FIND_MY_CONSTRUCTION_SITES)), k = A.next(); !k.done; k = A.next()) {
-var M = k.value;
-w.add("".concat(M.structureType, ":").concat(M.pos.x, ",").concat(M.pos.y));
-}
-} catch (e) {
-s = {
-error: e
-};
-} finally {
-try {
-k && !k.done && (c = A.return) && c.call(A);
-} finally {
-if (s) throw s.error;
-}
-}
-var U = fa(t, {
-existingStructureKeys: S,
-existingSiteKeys: w,
-currentRcl: E
+var A = fa(t, {
+existingStructureKeys: E,
+existingSiteKeys: T,
+currentRcl: g
 }).filter(function(e) {
-return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_RAMPART && (C < T || E >= 3);
+return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_RAMPART && (R < h || g >= 3);
 }).sort(function(e, t) {
 return e.structureType === STRUCTURE_TOWER && t.structureType !== STRUCTURE_TOWER ? -1 : t.structureType === STRUCTURE_TOWER && e.structureType !== STRUCTURE_TOWER ? 1 : t.score - e.score;
 });
-if (C < T && !U.some(function(e) {
+if (R < h && !A.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
 })) {
-var _ = e.find(FIND_MY_SPAWNS)[0], N = null !== (v = null == _ ? void 0 : _.pos) && void 0 !== v ? v : null === (g = e.controller) || void 0 === g ? void 0 : g.pos;
-if (N) for (var P = e.getTerrain(), I = 1; I <= 4 && !U.some(function(e) {
+var k = e.find(FIND_MY_SPAWNS)[0], M = null !== (p = null == k ? void 0 : k.pos) && void 0 !== p ? p : null === (f = e.controller) || void 0 === f ? void 0 : f.pos;
+if (M) for (var U = e.getTerrain(), _ = 1; _ <= 4 && !A.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
-}); I++) for (var G = -I; G <= I && !U.some(function(e) {
+}); _++) for (var N = -_; N <= _ && !A.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
-}); G++) for (var L = -I; L <= I && !U.some(function(e) {
+}); N++) for (var P = -_; P <= _ && !A.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
-}); L++) {
-var D = N.x + G, F = N.y + L;
-if (!(D <= 1 || D >= 48 || F <= 1 || F >= 48) && P.get(D, F) !== TERRAIN_MASK_WALL) {
-var B = "".concat(STRUCTURE_TOWER, ":").concat(D, ",").concat(F);
-S.has(B) || w.has(B) || U.unshift({
-x: D,
-y: F,
+}); P++) {
+var I = M.x + N, G = M.y + P;
+if (!(I <= 1 || I >= 48 || G <= 1 || G >= 48) && U.get(I, G) !== TERRAIN_MASK_WALL) {
+var L = "".concat(STRUCTURE_TOWER, ":").concat(I, ",").concat(G);
+E.has(L) || T.has(L) || A.unshift({
+x: I,
+y: G,
 structureType: STRUCTURE_TOWER,
 minRcl: 3,
 priority: "P0",
@@ -34086,28 +33785,331 @@ source: "critical-defense-fallback"
 }
 }
 }
-var W = 0;
+var D = 0;
 try {
-for (var K = a(U), H = K.next(); !H.done; H = K.next()) {
-var Y = H.value;
-if (W >= r || R + W >= h) break;
-e.createConstructionSite(Y.x, Y.y, Y.structureType) === OK && W++;
+for (var F = a(A), B = F.next(); !B.done; B = F.next()) {
+var W = B.value;
+if (D >= r || v + D >= y) break;
+e.createConstructionSite(W.x, W.y, W.structureType) === OK && D++;
 }
 } catch (e) {
-u = {
+c = {
 error: e
 };
 } finally {
 try {
-H && !H.done && (l = K.return) && l.call(K);
+B && !B.done && (u = F.return) && u.call(F);
 } finally {
-if (u) throw u.error;
+if (c) throw c.error;
 }
 }
-return W;
-}(e, E, t.danger >= 2 ? 3 : 1) : 0;
-if (c.criticalOnly) t.metrics.constructionSites = p.length + S; else {
-var w = function(e, t) {
+return D;
+}(e, h, t.danger >= 2 ? 3 : 1) : 0;
+if (c.criticalOnly) t.metrics.constructionSites = p.length + C; else {
+var S = 0;
+f >= 5 && (S = function(e) {
+var t, r, o = Ro(e);
+if (0 === o.placements.length) return 0;
+var n = e.find(FIND_MY_CONSTRUCTION_SITES), c = ho(e), u = n.filter(function(e) {
+return e.structureType === STRUCTURE_LINK;
+}), l = c.length + u.length, m = 0, d = function(e, t) {
+return new Set(s(s([], i(e.map(function(e) {
+return vo(e.pos.x, e.pos.y);
+})), !1), i(t.map(function(e) {
+return vo(e.pos.x, e.pos.y);
+})), !1));
+}(c, u);
+try {
+for (var p = a(o.placements), f = p.next(); !f.done; f = p.next()) {
+var y = f.value;
+if (m >= 2 || l >= o.linkLimit) break;
+var v = vo(y.x, y.y);
+d.has(v) || e.createConstructionSite(y.x, y.y, STRUCTURE_LINK) === OK && (m += 1,
+l += 1, d.add(v));
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+f && !f.done && (r = p.return) && r.call(p);
+} finally {
+if (t) throw t.error;
+}
+}
+return m;
+}(e));
+var w = 0;
+f >= 6 && (w = function(e) {
+var t, r, o = e.find(FIND_MY_CONSTRUCTION_SITES);
+if (o.length >= 10) return 0;
+var n = function(e) {
+var t, r, o, n, c, u, l, m, d, p, f = function(e) {
+var t, r, o;
+return null !== (o = yo(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
+}(e);
+if (f < 3) return null;
+var y = e.find(FIND_MY_STRUCTURES, {
+filter: function(e) {
+return e.structureType === STRUCTURE_LAB;
+}
+}), v = e.find(FIND_MY_CONSTRUCTION_SITES), g = v.filter(function(e) {
+return e.structureType === STRUCTURE_LAB;
+}), h = new Set(y.map(function(e) {
+return To(e.pos.x, e.pos.y);
+})), R = new Set(g.map(function(e) {
+return To(e.pos.x, e.pos.y);
+})), E = new Set(s(s([], i(h), !1), i(R), !1));
+if (E.size > f) return null;
+var T = e.find(FIND_STRUCTURES), C = new Set;
+try {
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) {
+var x = w.value;
+So(x, h) && C.add(To(x.pos.x, x.pos.y));
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+w && !w.done && (r = S.return) && r.call(S);
+} finally {
+if (t) throw t.error;
+}
+}
+try {
+for (var b = a(v), O = b.next(); !O.done; O = b.next()) {
+var A = O.value;
+wo(A, R) && C.add(To(A.pos.x, A.pos.y));
+}
+} catch (e) {
+o = {
+error: e
+};
+} finally {
+try {
+O && !O.done && (n = b.return) && n.call(b);
+} finally {
+if (o) throw o.error;
+}
+}
+var k = function(e) {
+var t, r, o = e.find(FIND_MY_SPAWNS)[0], n = null !== (r = null !== (t = e.terminal) && void 0 !== t ? t : e.storage) && void 0 !== r ? r : o;
+return n ? {
+x: n.pos.x,
+y: n.pos.y
+} : {
+x: 25,
+y: 25
+};
+}(e), M = new Map, U = s(s(s([], i(y.map(function(e) {
+return {
+x: e.pos.x,
+y: e.pos.y
+};
+})), !1), i(g.map(function(e) {
+return {
+x: e.pos.x,
+y: e.pos.y
+};
+})), !1), [ e.terminal ? {
+x: e.terminal.pos.x,
+y: e.terminal.pos.y
+} : void 0, e.storage ? {
+x: e.storage.pos.x,
+y: e.storage.pos.y
+} : void 0, e.find(FIND_MY_SPAWNS)[0] ? {
+x: e.find(FIND_MY_SPAWNS)[0].pos.x,
+y: e.find(FIND_MY_SPAWNS)[0].pos.y
+} : void 0, k ], !1).filter(function(e) {
+return void 0 !== e;
+});
+try {
+for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) xo(M, e, P.x + I, P.y + G, k, h, R, C);
+} catch (e) {
+c = {
+error: e
+};
+} finally {
+try {
+N && !N.done && (u = _.return) && u.call(_);
+} finally {
+if (c) throw c.error;
+}
+}
+try {
+for (var L = a(E), D = L.next(); !D.done; D = L.next()) {
+var F = D.value;
+if (!M.has(F)) return null;
+}
+} catch (e) {
+l = {
+error: e
+};
+} finally {
+try {
+D && !D.done && (m = L.return) && m.call(L);
+} finally {
+if (l) throw l.error;
+}
+}
+var B = function(e, t) {
+var r = s([], i(t), !1).map(function(t) {
+return e.get(t);
+}).filter(function(e) {
+return void 0 !== e;
+}), o = s([], i(e.values()), !1).filter(function(e) {
+return !t.has(e.key);
+}).sort(function(e, t) {
+var o = bo(e, r) - bo(t, r);
+return 0 !== o ? o : e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
+});
+return s(s([], i(r), !1), i(o), !1).slice(0, 80);
+}(M, E);
+if (B.length < f) return null;
+var W = B.slice(0, 40), K = null, H = function(e) {
+var t, r, o = function(t) {
+var r, o, n, c;
+if (e.key === t.key) return "continue";
+var u = B.filter(function(r) {
+return r.key === e.key || r.key === t.key || Co(r, e) <= 2 && Co(r, t) <= 2;
+});
+if (u.length < f) return "continue";
+if (s([], i(E), !1).some(function(e) {
+return !u.some(function(t) {
+return t.key === e;
+});
+})) return "continue";
+var l = new Map;
+l.set(e.key, e), l.set(t.key, t);
+try {
+for (var m = (r = void 0, a(E)), d = m.next(); !d.done; d = m.next()) {
+var p = d.value, y = M.get(p);
+y && l.set(y.key, y);
+}
+} catch (e) {
+r = {
+error: e
+};
+} finally {
+try {
+d && !d.done && (o = m.return) && o.call(m);
+} finally {
+if (r) throw r.error;
+}
+}
+var v = u.filter(function(e) {
+return !l.has(e.key);
+}).sort(function(e, t) {
+return e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
+});
+try {
+for (var g = (n = void 0, a(v)), h = g.next(); !h.done; h = g.next()) {
+var R = h.value;
+if (l.size >= f) break;
+l.set(R.key, R);
+}
+} catch (e) {
+n = {
+error: e
+};
+} finally {
+try {
+h && !h.done && (c = g.return) && c.call(g);
+} finally {
+if (n) throw n.error;
+}
+}
+if (l.size < f) return "continue";
+var T = s([], i(l.values()), !1), C = function(e, t, r) {
+return 1e3 * e.filter(function(e) {
+return e.existingLab;
+}).length + 300 * e.filter(function(e) {
+return e.existingSite;
+}).length - e.reduce(function(e, t) {
+return e + t.distanceToHub;
+}, 0) - 5 * Co(t, r);
+}(T, e, t);
+(!K || C > K.score) && (K = {
+positions: T,
+score: C
+});
+};
+try {
+for (var n = (t = void 0, a(W)), c = n.next(); !c.done; c = n.next()) o(c.value);
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+c && !c.done && (r = n.return) && r.call(n);
+} finally {
+if (t) throw t.error;
+}
+}
+};
+try {
+for (var Y = a(W), V = Y.next(); !V.done; V = Y.next()) H(V.value);
+} catch (e) {
+d = {
+error: e
+};
+} finally {
+try {
+V && !V.done && (p = Y.return) && p.call(Y);
+} finally {
+if (d) throw d.error;
+}
+}
+if (!K) return null;
+var q = K.positions.filter(function(e) {
+return e.existingLab;
+}).length, j = K.positions.filter(function(e) {
+return e.existingSite;
+}).length;
+return {
+desiredCount: f,
+positions: K.positions.map(function(e) {
+return {
+x: e.x,
+y: e.y,
+roomName: e.roomName,
+existingLab: e.existingLab,
+existingSite: e.existingSite
+};
+}),
+existingCount: q,
+siteCount: j,
+missingCount: Math.max(0, f - q - j)
+};
+}(e);
+if (!n || n.missingCount <= 0) return 0;
+var c = 0;
+try {
+for (var u = a(n.positions), l = u.next(); !l.done; l = u.next()) {
+var m = l.value;
+if (!m.existingLab && !m.existingSite) {
+if (o.length + c >= 10 || c >= 3) break;
+e.createConstructionSite(m.x, m.y, STRUCTURE_LAB) === OK && c++;
+}
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+l && !l.done && (r = u.return) && r.call(u);
+} finally {
+if (t) throw t.error;
+}
+}
+return c;
+}(e));
+var x = function(e, t) {
 var r, o, n, i = Vo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
@@ -34127,11 +34129,11 @@ if (r) throw r.error;
 }
 return !1;
 }(e, f);
-if (p.length + g + h + S >= 10 && !w) t.metrics.constructionSites = p.length + g + h + S; else {
+if (p.length + S + w + C >= 10 && !x) t.metrics.constructionSites = p.length + S + w + C; else {
 if (!Uf.isCombatPosture(t.posture) && function(e, t) {
 return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Ff());
 }(t, v)) {
-var x = function(e, t, r, o, n) {
+var b = function(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = []);
 var c = function(e, t, r, o) {
@@ -34258,13 +34260,13 @@ if (i) throw i.error;
 }
 }
 return u;
-}(e, v, C, 1, t.remoteAssignments);
-if (x > 0) {
-var b = 1 === x ? "structure" : "structures";
-mr.addRoomEvent(e.name, "structureDestroyed", "".concat(x, " misplaced ").concat(b, " destroyed for blueprint compliance"));
+}(e, v, E, 1, t.remoteAssignments);
+if (b > 0) {
+var O = 1 === b ? "structure" : "structures";
+mr.addRoomEvent(e.name, "structureDestroyed", "".concat(b, " misplaced ").concat(O, " destroyed for blueprint compliance"));
 }
 }
-var O = function(e) {
+var A = function(e) {
 if (e.danger >= 1) return {
 allowPerimeter: !0,
 allowRamparts: !0
@@ -34279,7 +34281,7 @@ rcl: f,
 danger: t.danger,
 hasStorage: Boolean(e.storage),
 remoteAssignments: null !== (d = t.remoteAssignments) && void 0 !== d ? d : []
-}), A = {
+}), k = {
 sitesPlaced: 0,
 wallsRemoved: 0
 };
@@ -34291,13 +34293,13 @@ return Df.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
-allowPerimeter: O.allowPerimeter,
+allowPerimeter: A.allowPerimeter,
 rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var k = Wf(f) ? 2 : 3;
-(A = function(e, t, r, o, n, c) {
+var M = Wf(f) ? 2 : 3;
+(k = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
 sitesPlaced: 0,
@@ -34630,9 +34632,9 @@ return {
 sitesPlaced: h,
 wallsRemoved: R
 };
-}(e, v, C.roads, f, k, t.remoteAssignments)).wallsRemoved > 0 && mr.addRoomEvent(e.name, "wallRemoved", "".concat(A.wallsRemoved, " wall(s) removed to allow road passage"));
+}(e, v, E.roads, f, M, t.remoteAssignments)).wallsRemoved > 0 && mr.addRoomEvent(e.name, "wallRemoved", "".concat(k.wallsRemoved, " wall(s) removed to allow road passage"));
 }
-var M = function(e, t) {
+var _ = function(e, t) {
 var r, o, n, i, s, c, u = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, l = "undefined" == typeof Game ? 0 : Object.keys(Game.constructionSites).length;
 if (l >= u) return 0;
 var m = function(e) {
@@ -34699,7 +34701,7 @@ if (r) throw r.error;
 }
 }
 return p;
-}(e, E), _ = function(e, t) {
+}(e, h), N = function(e, t) {
 var r, o, n = e.find(FIND_MY_CONSTRUCTION_SITES);
 if (n.length >= 10) return 0;
 var i = hn(e, t), s = e.getTerrain(), c = function(e) {
@@ -34738,12 +34740,12 @@ if (r) throw r.error;
 }
 }
 return l;
-}(e, v), N = {
+}(e, v), P = {
 placed: 0
 };
-if (O.allowRamparts && f >= 2 && p.length < 9) {
-var P = t.danger >= 2 ? 3 : 2;
-(N = function(e, t, r, o) {
+if (A.allowRamparts && f >= 2 && p.length < 9) {
+var I = t.danger >= 2 ? 3 : 2;
+(P = function(e, t, r, o) {
 var n, i, s, c;
 void 0 === o && (o = 5);
 var u = {
@@ -34830,17 +34832,17 @@ if (s) throw s.error;
 return (u.placed > 0 || y.length > 0) && U.info("Rampart automation for ".concat(e.name, ": ") + "".concat(u.protected, "/").concat(u.totalCritical, " protected, ") + "".concat(u.placed, " placed, ") + "".concat(y.length - u.placed, " pending"), {
 subsystem: "Defense"
 }), u;
-}(e, f, t.danger, P)).placed > 0 && mr.addRoomEvent(e.name, "rampartPlaced", "".concat(N.placed, " rampart(s) placed on critical structures"));
+}(e, f, t.danger, I)).placed > 0 && mr.addRoomEvent(e.name, "rampartPlaced", "".concat(P.placed, " rampart(s) placed on critical structures"));
 }
-t.metrics.constructionSites = p.length + S + M + g + h + _ + A.sitesPlaced + N.placed;
+t.metrics.constructionSites = p.length + C + _ + S + w + N + k.sitesPlaced + P.placed;
 }
 }
 } else {
-var I = p.some(function(e) {
+var G = p.some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
-if (!0 === (null === (m = e.controller) || void 0 === m ? void 0 : m.my) && !I) {
-var G = function(e, t) {
+if (!0 === (null === (m = e.controller) || void 0 === m ? void 0 : m.my) && !G) {
+var L = function(e, t) {
 if (t >= 8) {
 var r = rn(e, $o);
 if (r) return {
@@ -34972,13 +34974,13 @@ anchor: l
 }
 return null;
 }(e, f);
-G && (Bf(t, G.anchor, G.blueprint.name, f), e.createConstructionSite(G.anchor.x, G.anchor.y, STRUCTURE_SPAWN));
+L && (Bf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), Yf = new Hf;
+}(), Vf = new Yf;
 
-function Vf(e) {
+function qf(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35000,7 +35002,7 @@ siege: e.pheromones.siege
 };
 }
 
-var qf = {
+var jf = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35013,10 +35015,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, jf = new (function() {
+}, zf = new (function() {
 function e() {
 this.manager = new ou({
-logger: qf
+logger: jf
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35026,23 +35028,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = Vf(t);
+var r = qf(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = Vf(t);
+var r = qf(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), zf = {
+}()), Qf = {
 labManager: Ru,
 boostManager: fu,
-chemistryPlanner: jf,
+chemistryPlanner: zf,
 labConfigManager: gu,
 logger: Ci
-}, Qf = function() {
+}, Xf = function() {
 function e(e) {
-void 0 === e && (e = zf), this.deps = e;
+void 0 === e && (e = Qf), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35081,9 +35083,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), Xf = new Qf, Zf = function() {
+}(), Zf = new Xf, Jf = function() {
 function e(e) {
-void 0 === e && (e = Xf), this.labWorkflow = e;
+void 0 === e && (e = Zf), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35128,27 +35130,27 @@ if (r) throw r.error;
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), Jf = new Zf, $f = {
+}(), $f = new Jf, ey = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, ey = new Map;
+}, ty = new Map;
 
-function ty(e) {
+function ry(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function ry(e) {
+function oy(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var oy = function() {
+var ny = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, $f), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, ey), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35190,7 +35192,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = ey.get(e.name);
+var t = ty.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35212,7 +35214,7 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return ey.set(e.name, o), o;
+return ty.set(e.name, o), o;
 }(i);
 if (this.config.enablePheromones && !s && Game.time % 5 == 0 && wf.updateMetrics(i, c),
 Lf.updateThreatAssessment(i, c, {
@@ -35221,19 +35223,19 @@ towers: u.towers
 }), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Mf.updateEvolutionStage(c, i, e),
 s || Mf.updateMissingStructures(c, i)), Uf.updatePosture(c), this.config.enablePheromones && !s && wf.updatePheromones(c, i),
 this.config.enableTowers && Lf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Yf.getConstructionInterval(l), d = Uf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Vf.getConstructionInterval(l), d = Uf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = ty(r), n = ry(e);
+var o = ry(r), n = oy(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Yf.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (Vf.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = ty(r), n = ry(e);
+var o = ry(r), n = oy(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && Jf.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && $f.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35243,7 +35245,7 @@ var f = Game.cpu.getUsed() - n;
 Ji.recordRoom(i, f), Ji.endRoom(this.roomName, n);
 } else Ji.endRoom(this.roomName, n);
 }, e;
-}(), ny = function() {
+}(), ay = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35257,7 +35259,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new oy(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new ny(v.name));
 }
 } catch (t) {
 e = {
@@ -35320,7 +35322,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new oy(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new ny(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35341,9 +35343,9 @@ stack: c
 }
 }
 }, e;
-}(), ay = new ny;
+}(), iy = new ay;
 
-function iy(e) {
+function sy(e) {
 var t, r, o;
 if (j(e).length > 0) return ha.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
@@ -35354,14 +35356,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
 }
 
-function sy(e) {
+function cy(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function cy(e, t, r) {
+function uy(e, t, r) {
 var o;
 return t === ha.CRITICAL ? {
 tickModulo: void 0,
@@ -35381,7 +35383,7 @@ tickOffset: void 0
 };
 }
 
-var uy, ly = function() {
+var ly, my = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35397,7 +35399,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = iy(n), u = sy(n);
+var i = "room:".concat(o), s = Ja.getProcess(i), c = sy(n), u = cy(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35416,7 +35418,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = iy(e), o = sy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = cy(e, r, a);
+var t, r = sy(e), o = cy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = uy(e, r, a);
 Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35433,7 +35435,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ay.runRoom(t);
+t && iy.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35441,7 +35443,7 @@ Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = cy(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = uy(e, t, a);
 Ja.unregisterProcess(n), Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35458,7 +35460,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ay.runRoom(t);
+t && iy.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35480,7 +35482,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = iy(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = sy(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35507,7 +35509,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), my = new ly, dy = function() {
+}(), dy = new my, py = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Ja.getStatsSummary(), t = Ja.getConfig();
@@ -35706,7 +35708,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = my.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = dy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35853,7 +35855,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), py = function() {
+}(), fy = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -35886,7 +35888,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), fy = function() {
+}(), yy = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36411,7 +36413,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), yy = function() {
+}(), vy = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36430,7 +36432,7 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), vy = function() {
+}(), gy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
@@ -36465,21 +36467,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), gy = ((uy = {})[MOVE] = 50, uy[WORK] = 100, uy[CARRY] = 50, uy[ATTACK] = 80,
-uy[RANGED_ATTACK] = 150, uy[HEAL] = 250, uy[CLAIM] = 600, uy[TOUGH] = 10, uy);
+}(), hy = ((ly = {})[MOVE] = 50, ly[WORK] = 100, ly[CARRY] = 50, ly[ATTACK] = 80,
+ly[RANGED_ATTACK] = 150, ly[HEAL] = 250, ly[CLAIM] = 600, ly[TOUGH] = 10, ly);
 
-function hy(e, t) {
+function Ry(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, gy), t);
+var r = o(o({}, hy), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : gy[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : hy[t]);
 }, 0);
 }
 
-function Ry(e, t) {
+function Ey(e, t) {
 void 0 === t && (t = 0);
-var r = hy(e);
+var r = Ry(e);
 return {
 parts: e,
 cost: r,
@@ -36487,7 +36489,7 @@ minCapacity: t || r
 };
 }
 
-function Ey() {
+function Ty() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36495,11 +36497,11 @@ return Array(o).fill(r);
 });
 }
 
-var Ty, Cy, Sy, wy = {
+var Cy, Sy, wy, xy = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Ry([ WORK, CARRY ], 150), Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ry([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Ry([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Ey([ WORK, CARRY ], 150), Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ey([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Ey([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36507,7 +36509,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ry([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Ry([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ey([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Ey([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36515,7 +36517,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Ry([ WORK, CARRY, MOVE, MOVE ], 250), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Ey([ WORK, CARRY, MOVE, MOVE ], 250), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36523,7 +36525,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Ry([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ry([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Ey([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ey([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36531,7 +36533,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Ry([ CARRY, CARRY, MOVE, MOVE ], 200), Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ry(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Ey([ CARRY, CARRY, MOVE, MOVE ], 200), Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ey(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36539,7 +36541,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Ry([ WORK, CARRY, MOVE ], 200), Ry([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36547,7 +36549,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Ry([ WORK, CARRY, MOVE, MOVE ], 250), Ry([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ Ey([ WORK, CARRY, MOVE, MOVE ], 250), Ey([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36555,7 +36557,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36563,7 +36565,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Ry([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ Ey([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36571,7 +36573,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36579,7 +36581,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36587,7 +36589,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Ry([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Ry([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Ry([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ Ey([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Ey([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36595,7 +36597,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ry(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ey(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36603,7 +36605,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Ry([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Ry([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36611,16 +36613,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Ry(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Ry(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Ry(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Ry(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Ey(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Ey(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Ey(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Ey(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, xy = {
+}, by = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Ry([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Ry([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ Ey([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Ey([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36628,7 +36630,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Ry([ TOUGH, ATTACK, MOVE, MOVE ], 190), Ry([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Ry([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ Ey([ TOUGH, ATTACK, MOVE, MOVE ], 190), Ey([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Ey([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36636,7 +36638,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Ry([ HEAL, MOVE, MOVE ], 350), Ry([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Ry([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ Ey([ HEAL, MOVE, MOVE ], 350), Ey([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Ey([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36644,7 +36646,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Ry([ ATTACK, ATTACK, MOVE, MOVE ], 260), Ry([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ Ey([ ATTACK, ATTACK, MOVE, MOVE ], 260), Ey([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36652,7 +36654,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Ry([ WORK, WORK, MOVE, MOVE ], 300), Ry([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ Ey([ WORK, WORK, MOVE, MOVE ], 300), Ey([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36660,7 +36662,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Ry([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Ry([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Ry([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Ry([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ Ey([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Ey([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Ey([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36668,16 +36670,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Ry([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Ry([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Ry([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ Ey([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Ey([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Ey([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, by = {
+}, Oy = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Ry(Ey([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Ry(Ey([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ Ey(Ty([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Ey(Ty([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36685,16 +36687,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Ry(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Ry(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ Ey(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Ey(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Oy = {
+}, Ay = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Ry([ MOVE ], 50) ],
+bodies: [ Ey([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36702,7 +36704,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Ry([ MOVE ], 50) ],
+bodies: [ Ey([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36710,7 +36712,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Ry([ CLAIM, MOVE ], 650) ],
+bodies: [ Ey([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36718,7 +36720,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Ry([ CLAIM, MOVE ], 650), Ry([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ Ey([ CLAIM, MOVE ], 650), Ey([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36726,7 +36728,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Ry([ WORK, CARRY, MOVE, MOVE ], 250), Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Ey([ WORK, CARRY, MOVE, MOVE ], 250), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36734,30 +36736,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Ry([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Ry([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Ey([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Ay = o(o(o(o({}, wy), xy), Oy), by);
+}, ky = o(o(o(o({}, xy), by), Ay), Oy);
 
 try {
-for (var ky = a(Object.values(Ay)), My = ky.next(); !My.done; My = ky.next()) My.value.bodies.sort(function(e, t) {
+for (var My = a(Object.values(ky)), Uy = My.next(); !Uy.done; Uy = My.next()) Uy.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Ty = {
+Cy = {
 error: e
 };
 } finally {
 try {
-My && !My.done && (Cy = ky.return) && Cy.call(ky);
+Uy && !Uy.done && (Sy = My.return) && Sy.call(My);
 } finally {
-if (Ty) throw Ty.error;
+if (Cy) throw Cy.error;
 }
 }
 
-function Uy(e) {
+function _y(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36772,11 +36774,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return _y(o);
+return Ny(o);
 }
 
-function _y(e) {
-var t = hy(e);
+function Ny(e) {
+var t = Ry(e);
 return {
 parts: e,
 cost: t,
@@ -36784,16 +36786,16 @@ minCapacity: t
 };
 }
 
-function Ny(e, t) {
+function Py(e, t) {
 var r;
-return null !== (r = e.map(_y).filter(function(e) {
+return null !== (r = e.map(Ny).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Py(e) {
+function Iy(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36807,7 +36809,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = hy(a);
+var s = Ry(a);
 return {
 parts: a,
 cost: s,
@@ -36832,8 +36834,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: hy(p),
-minCapacity: hy(p)
+cost: Ry(p),
+minCapacity: Ry(p)
 };
 }(e);
 
@@ -36844,7 +36846,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return Uy([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return _y([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -36865,7 +36867,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return Uy([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return _y([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -36874,13 +36876,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(_y).filter(function(e) {
+var u = n.map(Ny).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Ny(n, t);
+var l = Py(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -36890,7 +36892,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Ny(n, t);
+var u = Py(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -36899,14 +36901,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Ny(r, t);
+var a = Py(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Iy(e) {
+function Gy(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -36917,9 +36919,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Gy(e, t) {
+function Ly(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Iy(t)
+memory: Gy(t)
 });
 var r;
 }
@@ -36927,9 +36929,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Sy || (Sy = {}));
+}(wy || (wy = {}));
 
-var Ly = function() {
+var Dy = function() {
 function e() {
 this.queues = new Map;
 }
@@ -37024,7 +37026,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Gy(m, d);
+var p = Ly(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37044,7 +37046,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Sy.EMERGENCY;
+return e.priority >= wy.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37062,7 +37064,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Sy.EMERGENCY ? n.emergency++ : c.priority >= Sy.HIGH ? n.high++ : c.priority >= Sy.NORMAL ? n.normal++ : n.low++;
+c.priority >= wy.EMERGENCY ? n.emergency++ : c.priority >= wy.HIGH ? n.high++ : c.priority >= wy.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37077,14 +37079,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Dy = new Ly, Fy = {
+}(), Fy = new Dy, By = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, By = {
+}, Wy = {
 predictConsumption: function() {
 return 0;
 },
@@ -37103,7 +37105,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Wy = {
+}, Ky = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37120,44 +37122,44 @@ healers: 0,
 powerCarriers: 0
 };
 }
-}, Ky = {
+}, Hy = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Hy(e, t, r, o, n) {
+function Yy(e, t, r, o, n) {
 return rc(e, t, r, o, n);
 }
 
-var Yy = new Map, Vy = -1, qy = null;
+var Vy = new Map, qy = -1, jy = null;
 
-function jy() {
-Vy === Game.time && qy === Game.creeps || (Yy.clear(), Vy = Game.time, qy = Game.creeps);
+function zy() {
+qy === Game.time && jy === Game.creeps || (Vy.clear(), qy = Game.time, jy = Game.creeps);
 }
 
-function zy(e) {
+function Qy(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Qy(e, t) {
+function Xy(e, t) {
 var r;
-void 0 === t && (t = !1), jy();
-var o = t ? "".concat(e, "_active") : e, n = Yy.get(o);
+void 0 === t && (t = !1), zy();
+var o = t ? "".concat(e, "_active") : e, n = Vy.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = zy(c);
+var u = Qy(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Yy.set(o, a), a;
+return Vy.set(o, a), a;
 }
 
-function Xy(e, t, r) {
+function Zy(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37178,22 +37180,22 @@ if (o) throw o.error;
 return i;
 }
 
-function Zy(e) {
+function Jy(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var Jy = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
-
-function $y(e) {
-return Jy.includes(e);
-}
+var $y = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
 function ev(e) {
+return $y.includes(e);
+}
+
+function tv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function tv(e, t, r, o) {
+function rv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37206,10 +37208,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Hy(e, t, ze(r).length, o, {
-reserved: ev(r)
+if (r) return Yy(e, t, ze(r).length, o, {
+reserved: tv(r)
 }).recommendedHaulers;
-var n = Hy(e, t, 2, o, {
+var n = Yy(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37220,7 +37222,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: Zy
+filter: Jy
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37231,7 +37233,7 @@ return 2;
 }
 }
 
-function rv(e, t) {
+function ov(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37241,13 +37243,13 @@ return null;
 }
 }
 
-function ov() {
+function nv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function nv(e) {
-var t = ov(), r = function(e) {
+function av(e) {
+var t = nv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37259,14 +37261,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function av(e) {
+function iv(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = ov();
+var r = nv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function iv(e) {
+function sv(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37274,11 +37276,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function sv(e) {
+function cv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function cv() {
+function uv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37288,7 +37290,7 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-function uv(e, t) {
+function lv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37300,8 +37302,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(cv()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Dy.getPendingRequests(c).some(function(r) {
+for (var i = a(uv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Fy.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37321,7 +37323,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function lv(e, t) {
+function mv(e, t) {
 var r, o, n, c = mr.getEmpire(), u = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37331,15 +37333,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !uv(e.roomName, "claim");
+return !lv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || iv(t));
+return !(!r || r.my || r.owner || r.reservation || sv(t));
 }
-return !av(e);
+return !iv(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37358,7 +37360,7 @@ return e.roomName;
 })), !1)) : new Set;
 if (l) {
 var p = c.claimQueue.find(function(e) {
-return !e.claimed && !uv(e.roomName, "claim");
+return !e.claimed && !lv(e.roomName, "claim");
 });
 if (p) return {
 targetRoom: p.roomName,
@@ -37370,20 +37372,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = ov();
+var l = nv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !uv(p, "claim")) {
+if (!t.has(p) && !lv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || nv(y)) continue;
-if (iv(f)) continue;
+if (y.owner || av(y)) continue;
+if (sv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !uv(p, "reserve")) return p;
-} else if (!av(p) && !uv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !lv(p, "reserve")) return p;
+} else if (!iv(p) && !lv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37405,34 +37407,34 @@ task: "reserve"
 } : null;
 }
 
-function mv(e) {
+function dv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function dv(e) {
-return mv(e) ? Sy.EMERGENCY : Sy.HIGH;
+function pv(e) {
+return dv(e) ? wy.EMERGENCY : wy.HIGH;
 }
 
-function pv(e, t, r) {
+function fv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!sv(e)) return !1;
+if (!cv(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function fv(e, t, r) {
+function yv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return pv(e, t, r);
+return fv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = rv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = ov(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37440,18 +37442,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function yv(e, t) {
+function vv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !pv(n, e, t)) return null;
+if (!n || !fv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !sv(e);
+return !cv(e);
 }).filter(function(e) {
-return !iv(e);
+return !sv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37472,9 +37474,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(cv()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(uv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Dy.getPendingRequests(d).filter(function(t) {
+i += Fy.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37491,12 +37493,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (mv(e) ? 3 : 1);
+}(e.name) < (dv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = rv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = ov(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37504,10 +37506,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (fv(u.room, e, t) === e) return {
+if (yv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: dv(u.room)
+priority: pv(u.room)
 };
 }
 } catch (e) {
@@ -37524,10 +37526,10 @@ if (r) throw r.error;
 return null;
 }
 
-function vv(e, t) {
+function gv(e, t) {
 if (t <= 0) return null;
 try {
-var r = Py({
+var r = Iy({
 maxEnergy: t,
 role: e
 });
@@ -37537,18 +37539,18 @@ return null;
 }
 }
 
-function gv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : vv(e, t);
+function hv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : gv(e, t);
 }
 
-function hv(e) {
+function Rv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Rv(e) {
+function Ev(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37562,7 +37564,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += hv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Rv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37583,7 +37585,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += hv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Rv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37599,23 +37601,23 @@ return i;
 }(e)) : r;
 }
 
-var Ev = "defenseAssist", Tv = [ "guard", "ranger", "healer" ];
+var Tv = "defenseAssist", Cv = [ "guard", "ranger", "healer" ];
 
-function Cv(e, t) {
+function Sv(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function Sv(e, t, r, o) {
+function wv(e, t, r, o) {
 void 0 === o && (o = Mr(e.roomName));
-var n = Cv(e, t);
+var n = Sv(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = Ov(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, Cv(e, "guard") - i.guard),
-ranger: Math.max(0, Cv(e, "ranger") - i.ranger),
-healer: Math.max(0, Cv(e, "healer") - i.healer)
-}, kv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = Av(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, Sv(e, "guard") - i.guard),
+ranger: Math.max(0, Sv(e, "ranger") - i.ranger),
+healer: Math.max(0, Sv(e, "healer") - i.healer)
+}, Mv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37630,7 +37632,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && Mv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Uv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37648,30 +37650,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function wv(e) {
+function xv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function xv(e) {
+function bv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Ev ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Tv ? e.targetRoom : void 0;
 }
 
-function bv(e, t) {
-var r = Mr(e.roomName), o = Ov(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, Cv(e, "guard") - o.guard),
-ranger: Math.max(0, Cv(e, "ranger") - o.ranger),
-healer: Math.max(0, Cv(e, "healer") - o.healer)
-}, kv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function Ov(e, t) {
+var r = Mr(e.roomName), o = Av(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, Sv(e, "guard") - o.guard),
+ranger: Math.max(0, Sv(e, "ranger") - o.ranger),
+healer: Math.max(0, Sv(e, "healer") - o.healer)
+}, Mv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = Tv.filter(function(o) {
-return !(Sv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = Cv.filter(function(o) {
+return !(wv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function Ov(e) {
+function Av(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37680,7 +37682,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && xv(d) === e && u[p]++;
+Br(p) && bv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37694,9 +37696,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Dy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Fy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Ev && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Tv && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37712,21 +37714,21 @@ if (o) throw o.error;
 return u;
 }
 
-function Av(e, t, r) {
+function kv(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function kv(e) {
+function Mv(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && xv(f) === e) {
+if (Br(y) && bv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && Av(l, y, v);
+v.length > 0 && kv(l, y, v);
 }
 }
 } catch (e) {
@@ -37741,9 +37743,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Dy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Fy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Ev && E.targetRoom === e) && Av(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Tv && E.targetRoom === e) && kv(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37759,27 +37761,27 @@ if (o) throw o.error;
 return l;
 }
 
-function Mv(e) {
+function Uv(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function Uv(e, t, r) {
+function _v(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function _v(e, t, r, o) {
+function Nv(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && gv("guard", Rv(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && hv("guard", Ev(r), o) ? 1 : 0;
 }
 
-function Nv(e, t) {
+function Pv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !Mv(o)) return null;
+if (!o || !Uv(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -37804,7 +37806,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(wv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(xv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -37812,15 +37814,15 @@ return t.roomName !== e;
 var r = Mr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(Sv(e, t, n, r), _v(e, t, o, r))
+helperNeed: Math.max(wv(e, t, n, r), Nv(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return wv(e.request);
+return xv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? Ov(e)[t] : 0;
+return Br(t) ? Av(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37845,28 +37847,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: Ev,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Sy.EMERGENCY : Sy.HIGH,
-defenseSquadId: Uv(e, r, n.createdAt),
-defenseSquadSize: bv(r, t),
+task: Tv,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? wy.EMERGENCY : wy.HIGH,
+defenseSquadId: _v(e, r, n.createdAt),
+defenseSquadSize: Ov(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var Pv = "defenseRefuel", Iv = {
+var Iv = "defenseRefuel", Gv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Gv(e, t) {
+function Lv(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Iv.cost);
-}(n) ? Rv(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Gv.cost);
+}(n) ? Ev(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -37903,9 +37905,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Dy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Fy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Pv && s++;
+"hauler" === p.role && f === Iv && s++;
 }
 } catch (e) {
 o = {
@@ -37920,24 +37922,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Pv,
-priority: Sy.EMERGENCY,
-body: Iv
+task: Iv,
+priority: wy.EMERGENCY,
+body: Gv
 } : null : null;
-}
-
-function Lv(e) {
-var t = Game.rooms[e];
-return t ? !!t.controller && !nv(t.controller) && !iv(t) : !av(e);
 }
 
 function Dv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !nv(t.controller) : !av(e);
+return t ? !!t.controller && !av(t.controller) && !sv(t) : !iv(e);
 }
 
-function Fv(e, t, r) {
-var o = Ay[t];
+function Fv(e) {
+var t = Game.rooms[e];
+return (null == t ? void 0 : t.controller) ? !av(t.controller) : !iv(e);
+}
+
+function Bv(e, t, r) {
+var o = ky[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -37949,13 +37951,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Bv(e, t, r) {
+function Wv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Lv(l) && Xy(e, t, l) < tv(e, l, t, Game.rooms[l])) return l;
+if (Dv(l) && Zy(e, t, l) < rv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37971,10 +37973,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Wv(e, t, r, o) {
+function Kv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Ay[t];
+var p = ky[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -37988,32 +37990,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Ay[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Ay[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = ky[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = ky[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Qy(e), y)) return !1;
+}(t, Xy(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if ($y(t)) return !("remoteWorker" === t && function(e, t) {
-jy();
-var r = "".concat(e, ":").concat(t), o = Yy.get(r);
+if (ev(t)) return !("remoteWorker" === t && function(e, t) {
+zy();
+var r = "".concat(e, ":").concat(t), o = Vy.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Yy.set(r, n), n;
-}(e, t) >= Fv(e, t, r)) && null !== Bv(e, t, r);
+return Vy.set(r, n), n;
+}(e, t) >= Bv(e, t, r)) && null !== Wv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Dv(R)) {
+if (Fv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -38021,7 +38023,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && Xy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && Zy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38038,9 +38040,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Qy(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== yv(e, r);
-if (C >= Fv(e, t, r)) return !1;
+var C = null !== (u = Xy(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== vv(e, r);
+if (C >= Bv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38052,14 +38054,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = rv(e, o);
+var a = ov(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== lv(0, r);
+if ("claimer" === t) return null !== mv(0, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38095,7 +38097,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Fy.getActiveRequests) || void 0 === m ? void 0 : m.call(Fy)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = By.getActiveRequests) || void 0 === m ? void 0 : m.call(By)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38123,16 +38125,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Kv(e) {
+function Hv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Hv(e) {
-return 0 === Kv(Qy(e, !0));
+function Yv(e) {
+return 0 === Hv(Xy(e, !0));
 }
 
-function Yv(e) {
+function Vv(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -38155,14 +38157,14 @@ minCount: 1
 } ];
 }
 
-function Vv(e, t) {
-var r, o, n, i, s = Qy(e, !0);
-if (0 === Kv(s)) return !0;
+function qv(e, t) {
+var r, o, n, i, s = Xy(e, !0);
+if (0 === Hv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Qy(e, !1), u = Yv(t);
+var c = Xy(e, !1), u = Vv(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38182,57 +38184,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function qv(e) {
+function jv(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function jv(e, t, r) {
-var n = Fv(e.name, r.roleName, t);
+function zv(e, t, r) {
+var n = Bv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function zv(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Sy.EMERGENCY;
+function Qv(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return wy.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Sy.HIGH;
-if (Ky.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return wy.HIGH;
+if (Hy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Sy.EMERGENCY;
-if (a > 0) return Sy.HIGH;
+if (a >= 100) return wy.EMERGENCY;
+if (a > 0) return wy.HIGH;
 }
 return function(e) {
-return e >= 90 ? Sy.HIGH : e >= 60 ? Sy.NORMAL : Sy.LOW;
+return e >= 90 ? wy.HIGH : e >= 60 ? wy.NORMAL : wy.LOW;
 }(o);
 }
 
-function Qv(e, t) {
+function Xv(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-qv(e);
-var l = Qy(e.name), m = Hv(e.name), d = [];
-if (Vv(e.name, e)) {
+jv(e);
+var l = Xy(e.name), m = Yv(e.name), d = [];
+if (qv(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Kv(Qy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Hv(Xy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Qy(e, !1), c = Yv(t);
+var s = Xy(e, !1), c = Vv(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38247,7 +38249,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Wv(e, m.role, r, !0);
+var p = Kv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38278,17 +38280,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = Ay[p]) && Wv(e.name, p, t, !0) ? (d.push(jv(e, t, {
+return p && (g = ky[p]) && Kv(e.name, p, t, !0) ? (d.push(zv(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: zv(e, 0, p, g.priority, m),
+priority: Qv(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(Ay)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Gv(e.name, p);
+for (var f = a(Object.entries(ky)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Lv(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38299,7 +38301,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Nv(e.name, p);
+var E = Pv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38313,8 +38315,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Wv(e.name, p, t, m)) {
-var T = $y(p), C = T ? Bv(e.name, p, t) : null, S = "claimer" === p ? lv(e.name, t) : null, w = "pioneer" === p ? yv(e.name, t) : null;
+}); else if (Kv(e.name, p, t, m)) {
+var T = ev(p), C = T ? Wv(e.name, p, t) : null, S = "claimer" === p ? mv(e.name, t) : null, w = "pioneer" === p ? vv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38324,11 +38326,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(jv(e, t, {
+}) : d.push(zv(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: zv(e, 0, p, g.priority, m),
+priority: Qv(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38350,7 +38352,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Xv(e, l.value);
+var m = Zv(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38371,10 +38373,10 @@ requests: c
 };
 }
 
-function Xv(e, t) {
+function Zv(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = By.getMaxAffordableInTicks(e, l), d = Rv(e), p = t.priority >= Sy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Sy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : gv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Wy.getMaxAffordableInTicks(e, l), d = Ev(e), p = t.priority >= wy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= wy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : hv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38395,7 +38397,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : Py({
+}(t.def, p)) && void 0 !== c ? c : Iy({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38431,44 +38433,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Zv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Jv = new Set([ "guard", "ranger", "healer" ]);
+var Jv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), $v = new Set([ "guard", "ranger", "healer" ]);
 
-function $v() {
+function eg() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function eg(e) {
+function tg(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function tg(e) {
-var t;
-return e.priority >= Sy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
-}
-
 function rg(e) {
 var t;
-return e.priority >= Sy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= wy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function og(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Rv(e), m = r.urgency >= 2 || t.danger >= 3 ? Sy.EMERGENCY : Sy.HIGH, d = kr(j(e)), p = function(e) {
+function og(e) {
+var t;
+return e.priority >= wy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+}
+
+function ng(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Ev(e), m = r.urgency >= 2 || t.danger >= 3 ? wy.EMERGENCY : wy.HIGH, d = kr(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === Sy.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === wy.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Dy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Fy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || ng(u, e) && ("guard" === u.role && (n.guards++,
-ig(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, ig(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, ig(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || ag(u, e) && ("guard" === u.role && (n.guards++,
+sg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, sg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, sg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38496,7 +38498,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && ig(n, u, l);
+0 !== l.length && sg(n, u, l);
 }
 }
 }
@@ -38535,26 +38537,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ag("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) sg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ag("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) sg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ag("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) sg(e, "healer", "military", Sy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ig("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) cg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ig("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) cg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ig("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) cg(e, "healer", "military", wy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < Sy.EMERGENCY || function(e, t) {
+if (!(t < wy.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Jv.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !$v.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Dy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Fy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Sy.EMERGENCY || Jv.has(c.role) && ng(c, e.name) && c.body.cost <= t && n++;
+c.priority < wy.EMERGENCY || $v.has(c.role) && ag(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38571,7 +38573,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = vv(t, e);
+var r = gv(t, e);
 return r ? {
 role: t,
 body: r
@@ -38586,38 +38588,38 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && sg(e, n.role, "military", Sy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && cg(e, n.role, "military", wy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function ng(e, t) {
+function ag(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function ag(e, t, r) {
+function ig(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function ig(e, t, r) {
+function sg(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function sg(e, t, r, o, n, a, i) {
+function cg(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
-var s = null != i ? i : Py({
+var s = null != i ? i : Iy({
 maxEnergy: n,
 role: t
 });
 if (s.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(s.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Dy.addRequest({
+Fy.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38633,34 +38635,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function cg(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Sy.HIGH) return !1;
+function ug(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= wy.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Sy.NORMAL) {
-if (By.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < wy.NORMAL) {
+if (Wy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Sy.NORMAL && o / e.energyCapacityAvailable < .3 && By.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === wy.NORMAL && o / e.energyCapacityAvailable < .3 && Wy.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function ug(e, t) {
+function lg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-qv(e);
-var s = Dy.getQueueSize(e.name);
+jv(e);
+var s = Fy.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Vv(e.name, e), u = Hv(e.name) && !Dy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = qv(e.name, e), u = Yv(e.name) && !Fy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && Dy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && og(e, t, l, m);
+s > 0 && Fy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && ng(e, t, l, m);
 try {
-for (var d = a(Qv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Xv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Dy.addRequest(f);
+Fy.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38673,7 +38675,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && og(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && ng(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38682,13 +38684,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Dy.getPendingRequests(e.name).map(eg));
+var c = new Set(Fy.getPendingRequests(e.name).map(tg));
 try {
-for (var u = a(Qv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Sy.HIGH, p = "claimer" === m.role && $v(), f = tg(m), y = rg(m);
-if (Zv.has(m.role) || d || p || f || y) {
-var v = eg(m);
-c.has(v) || (Dy.addRequest(m), c.add(v));
+for (var u = a(Xv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= wy.HIGH, p = "claimer" === m.role && eg(), f = rg(m), y = og(m);
+if (Jv.has(m.role) || d || p || f || y) {
+var v = tg(m);
+c.has(v) || (Fy.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38705,19 +38707,19 @@ if (r) throw r.error;
 }
 }(e, t); else {
 !function(e) {
-var t = Wy.requestSpawns(e.name);
+var t = Ky.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = Sy.NORMAL, n = 0; n < t.powerHarvesters; n++) sg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) sg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) sg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = wy.NORMAL, n = 0; n < t.powerHarvesters; n++) cg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) cg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) cg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a(Qv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Dy.addRequest(f);
+for (var y = a(Xv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Fy.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38729,32 +38731,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Dy.getQueueStats(e.name);
+var g = Fy.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Dy.clearQueue(e.name);
+} else s > 0 && Fy.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Dy.getAvailableSpawns(e.name);
+var t, r, o = Fy.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Rv(e);
+var n = 0, i = Ev(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Dy.getNextRequest(e.name, i);
+var u = c.value, l = Fy.getNextRequest(e.name, i);
 if (!l) break;
-if (cg(e, l, i)) {
+if (ug(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Gy(u, l);
-m === OK ? (n++, i -= l.body.cost, Dy.markInProgress(e.name, l.id, u.id), Dy.removeRequest(e.name, l.id),
+var m = Ly(u, l);
+m === OK ? (n++, i -= l.body.cost, Fy.markInProgress(e.name, l.id, u.id), Fy.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Dy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Fy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -38770,7 +38772,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Dy.getQueueStats(e.name);
+}(e), o = Fy.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -38784,7 +38786,7 @@ stats: o
 }(e, t);
 }
 
-var lg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, mg = /^(\d{1,2})\|(.+)$/, dg = k("SS2TerminalComms"), pg = function() {
+var mg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, dg = /^(\d{1,2})\|(.+)$/, pg = k("SS2TerminalComms"), fg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38844,11 +38846,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(lg);
+var t = e.match(mg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(mg);
+var i = a.match(dg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38883,7 +38885,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-dg.warn("Missing packet in multi-packet message", {
+pg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38899,7 +38901,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), dg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), pg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38923,7 +38925,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && dg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && pg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38935,7 +38937,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return dg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return pg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38943,14 +38945,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), dg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), pg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (dg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (pg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38975,7 +38977,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-dg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+pg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -38987,7 +38989,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-dg.info("Completed sending multi-packet message", {
+pg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -38995,25 +38997,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? dg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? pg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (dg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (pg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else dg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else pg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else dg.warn("Terminal not found for queue item, removing from queue", {
+} else pg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39047,7 +39049,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && dg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && pg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39057,7 +39059,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-dg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+pg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39148,7 +39150,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (dg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (pg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39170,7 +39172,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return dg.error("Error parsing JSON", {
+return pg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39181,7 +39183,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), fg = [ {
+}(), yg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39201,7 +39203,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], yg = function() {
+} ], vg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39248,9 +39250,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), vg = new yg;
+}(), gg = new vg;
 
-function gg(e) {
+function hg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39258,19 +39260,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function hg(e, t) {
+function Rg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Rg(e, t) {
+function Eg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var Eg = {
+var Tg = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39281,9 +39283,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, Tg = function() {
+}, Cg = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Eg), e);
+void 0 === e && (e = {}), this.config = o(o({}, Tg), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39304,7 +39306,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = vg.getSwarmState(r.toRoom);
+var o = gg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39317,7 +39319,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = vg.getSwarmState(c);
+var l = gg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39387,9 +39389,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(hg), u = n.filter(function(e) {
+}).sort(Rg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Rg), l = [], m = [], d = function(t) {
+}).sort(Eg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39411,11 +39413,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return gg({
+return hg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + gg({
+}) + hg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39514,7 +39516,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), Cg = new Tg, Sg = {
+}(), Sg = new Cg, wg = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39535,14 +39537,14 @@ siegeUnits: 1
 }
 };
 
-function wg(e) {
+function xg(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function xg(e) {
+function bg(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39565,9 +39567,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function bg(e) {
+function Og(e) {
 var t, r, o;
-xg(e);
+bg(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39591,20 +39593,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Og(e) {
+function Ag(e) {
 var t;
-xg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = bg(e);
+bg(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Og(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function Ag(e) {
-return !!Og(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function kg(e) {
+return !!Ag(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-xg(e);
+bg(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39615,12 +39617,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = bg(e);
+var d = Og(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function kg(e, t) {
+function Mg(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39641,20 +39643,20 @@ if (r) throw r.error;
 return n;
 }
 
-function Mg(e, t) {
+function Ug(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Sg[r]) && void 0 !== t ? t : Sg[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = wg[r]) && void 0 !== t ? t : wg[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = kg(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Mg(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: wg(r),
+targetComposition: xg(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39666,7 +39668,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function Ug(e) {
+function _g(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39686,9 +39688,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function _g(e) {
+function Ng(e) {
 var t = e.members.length;
-xg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+bg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39702,7 +39704,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && Ag(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && kg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39731,7 +39733,7 @@ subsystem: "Squad"
 }
 }
 
-var Ng = {
+var Pg = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39818,7 +39820,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Pg(e, t) {
+function Ig(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39833,8 +39835,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Ig(e, t) {
-var r, o, n, i = Ng[t], s = 0;
+function Gg(e, t) {
+var r, o, n, i = Pg[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39860,7 +39862,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Gg, Lg, Dg, Fg = {
+var Lg, Dg, Fg, Bg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39869,11 +39871,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Bg = new Map;
+}, Wg = new Map;
 
-function Wg(e, t) {
+function Kg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Bg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Wg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39885,7 +39887,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Ng[p].composition;
+d = Pg[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39900,19 +39902,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Bg.set(m, y), function(e, t, r, o) {
+v ? (Wg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Ng[s].useBoosts;
+i = Pg[s].useBoosts;
 }
-var c = Sy.NORMAL;
-"siege" === t.type ? c = Sy.HIGH : "defense" === t.type && (c = Sy.EMERGENCY);
+var c = wy.NORMAL;
+"siege" === t.type ? c = wy.HIGH : "defense" === t.type && (c = wy.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = Kg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Fg[t];
-}, 0), m = i ? Yg(r) : [], d = {
+var u = Hg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Bg[t];
+}, 0), m = i ? Vg(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39941,7 +39943,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Dy.addRequest(d), o.spawnRequests.add(d.id);
+Fy.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -39955,42 +39957,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function Kg(e, t, r) {
+function Hg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Hg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return Yg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Hg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Yg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Hg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Yg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Hg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return Yg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Hg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return Yg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Hg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return Yg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Hg(e, t, r) {
+function Yg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Fg[t];
+return e + Bg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Fg[t];
+return e + Bg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Yg(e) {
+function Vg(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40021,45 +40023,45 @@ return [];
 }
 }
 
-function Vg(e) {
-return Bg.has(e);
-}
-
 function qg(e) {
-return Og(e) || Ag(e);
+return Wg.has(e);
 }
 
-(Gg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Gg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Gg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Lg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Lg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Lg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Lg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Dg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Dg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Dg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Dg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Dg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+function jg(e) {
+return Ag(e) || kg(e);
+}
 
-var jg = {
+(Lg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Lg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Lg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Dg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Dg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Dg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Dg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Fg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Fg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Fg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Fg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Fg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+
+var zg = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function zg(e, t) {
-var r = jg[t], o = vg.getClusters();
+function Qg(e, t) {
+var r = zg[t], o = gg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function Qg(e, t, r) {
+function Xg(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = vg.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = gg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: zg(e, i.danger),
+reservedEnergy: Qg(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40149,7 +40151,7 @@ success: !1
 });
 }
 
-var Xg = {
+var Zg = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40159,7 +40161,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Zg(e, t, r) {
+function Jg(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40190,7 +40192,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function Jg(e, t, r, o) {
+function $g(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40200,7 +40202,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function $g(e, t) {
+function eh(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40221,19 +40223,19 @@ if (r) throw r.error;
 return n;
 }
 
-function eh() {
-var e = vg.getEmpire();
+function th() {
+var e = gg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function th(e) {
-eh()[e.id] = e;
+function rh(e) {
+th()[e.id] = e;
 }
 
-function rh(e) {
+function oh(e) {
 e.lastUpdate = Game.time;
-var t = vg.getCluster(e.clusterId);
-if (!t) return e.state = "failed", th(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = gg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", rh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40243,12 +40245,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (qg(r) || Vg(e) || Wg(0, r), qg(r));
+return !!r && (jg(r) || qg(e) || Kg(0, r), jg(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), th(e);
+})), rh(e);
 }(e, t);
 break;
 
@@ -40259,7 +40261,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (_g(o), Ug(o)) {
+if (Ng(o), _g(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40288,7 +40290,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = vg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = gg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40315,14 +40317,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), th(e);
+})), rh(e);
 }(e, t);
 }
 }
 
-var oh = "defenseAssist";
+var nh = "defenseAssist";
 
-function nh(e, t, r) {
+function ah(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40341,11 +40343,11 @@ score: n.score + o.score
 }
 }
 
-function ah(e, t, r) {
+function ih(e, t, r) {
 return Gr(e, t, r);
 }
 
-function ih(e, t) {
+function sh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40358,11 +40360,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function sh(e) {
+function ch(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function ch(e, t, r) {
+function uh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40375,8 +40377,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function uh(e, t, r) {
-var o = ah(t, e.energyCapacityAvailable, r);
+function lh(e, t, r) {
+var o = ih(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40384,16 +40386,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function lh(e, t, r, o) {
+function mh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = uh(e, t, o);
-if (s !== uh(n, t, o)) return s ? -1 : 1;
+var a, i, s = lh(e, t, o);
+if (s !== lh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function mh(e, t) {
+function dh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40477,25 +40479,25 @@ if (r) throw r.error;
 return u;
 }
 
-function dh(e, t) {
+function ph(e, t) {
 return {
-guard: Math.max(0, ih(e, "guard") - t.counts.guard),
-ranger: Math.max(0, ih(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, ih(e, "healer") - t.counts.healer)
+guard: Math.max(0, sh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, sh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, sh(e, "healer") - t.counts.healer)
 };
 }
 
-function ph(e, t, r) {
+function fh(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function fh(e) {
+function yh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function yh(e, t) {
+function vh(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return fh(e.role);
+return yh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40508,12 +40510,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function vh(e) {
+function gh(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === oh ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === nh ? e.targetRoom : void 0;
 }
 
-function gh(e) {
+function hh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40525,7 +40527,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-fh(m) && vh(l) === e && !u.spawning && nh(i, m, u.body.filter(function(e) {
+yh(m) && gh(l) === e && !u.spawning && ah(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40543,7 +40545,7 @@ if (t) throw t.error;
 return i;
 }
 
-function hh(e, t, r) {
+function Rh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40573,16 +40575,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: yh(e, r)
+pendingAssist: vh(e, r)
 };
 }
 }
 
-function Rh(e, t) {
+function Eh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = ah(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = ih(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40603,7 +40605,7 @@ subsystem: "Cluster"
 }
 }
 
-function Eh(e, t, r) {
+function Th(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40645,20 +40647,20 @@ exitAccess: a
 };
 }
 
-function Th(e, t) {
+function Ch(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function Ch(e, t, r) {
+function Sh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function Sh(e) {
+function wh(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function wh(e, t) {
+function xh(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40669,7 +40671,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function xh(e, t, r) {
+function bh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40680,8 +40682,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = Sh(g);
-h && (g.assistTarget || wh(v, h) && (t.assignedCreeps.includes(v.name) || Th(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = wh(g);
+h && (g.assistTarget || xh(v, h) && (t.assignedCreeps.includes(v.name) || Ch(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40718,7 +40720,7 @@ return e.distance - t.distance;
 });
 }
 
-function bh(e, t) {
+function Oh(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40743,21 +40745,21 @@ if (r) throw r.error;
 return i;
 }
 
-function Oh(e) {
+function Ah(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var Ah = {
+var kh = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, kh = function() {
+}, Mh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Ah), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, kh), e);
 }
 return e.prototype.run = function() {
-var e = vg.getClusters();
+var e = gg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40776,7 +40778,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: fg.map(function(t) {
+steps: yg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40837,7 +40839,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-Cg.processCluster(t);
+Sg.processCluster(t);
 break;
 
 case "squads":
@@ -40869,7 +40871,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = Eh(e, new RoomPosition(s, c, e.name), "defense");
+var u = Th(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40918,9 +40920,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = vg.getSwarmState(i);
+var i = n.value, s = gg.getSwarmState(i);
 if (s) {
-var c = zg(i, s.danger);
+var c = Qg(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40951,7 +40953,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = vg.getSwarmState(m);
+var m = l.value, d = gg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -40983,7 +40985,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += Oh(l.controller.level));
+}).length, i += Ah(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41100,7 +41102,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-_g(i), "gathering" !== i.state || qg(i) || Vg(i.id) || Wg(0, i), Ug(i) && (i.state = "dissolving");
+Ng(i), "gathering" !== i.state || jg(i) || qg(i.id) || Kg(0, i), _g(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41125,7 +41127,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Mg(e, s);
+var s = i.value, c = Ug(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41142,7 +41144,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(eh()).filter(function(e) {
+var t = (a = e.id, Object.values(th()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41153,22 +41155,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Xg), n), m = [], d = vg.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, Zg), n), m = [], d = gg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = Zg(f, y, d);
+var g = Jg(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = $g(e, f);
+var h = eh(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = Jg(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = $g(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Pg(f, {
+var C = Ig(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41203,29 +41205,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Ig(e, n.doctrine) ? function(e, t, r) {
+Gg(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = vg.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = gg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = Zg(e, o, r);
+var n = Jg(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (vg.getEmpire().knownRooms || {})[t], n = null != r ? r : Pg(t, {
+var o = (gg.getEmpire().knownRooms || {})[t], n = null != r ? r : Ig(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Ig(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Gg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41238,7 +41240,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-th(i);
+rh(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41252,13 +41254,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = kg(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Mg(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: wg(n),
+targetComposition: xg(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41273,8 +41275,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), th(i), Wg(0, c), i.state = "forming", i.lastUpdate = Game.time,
-th(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), rh(i), Kg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+rh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41293,11 +41295,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Bg.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Wg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Bg.delete(c));
+}), Wg.delete(c));
 }
 } catch (t) {
 e = {
@@ -41311,10 +41313,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = eh();
-for (var t in e) rh(e[t]);
+var e = th();
+for (var t in e) oh(e[t]);
 !function() {
-var e = eh();
+var e = th();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41392,14 +41394,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = vg.getCluster(t, e);
+var t = "cluster_".concat(e), r = gg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = vg.getCluster(e);
+var o = gg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41428,7 +41430,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Qg(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Xg(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41445,7 +41447,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = vg.getSwarmState(t);
+var n, a, i = gg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41486,7 +41488,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mr(g), f[g] = gh(g);
+p[g] = Mr(g), f[g] = hh(g);
 }
 } catch (e) {
 r = {
@@ -41502,7 +41504,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = hh(E, m, t);
+d[E] = Rh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41521,13 +41523,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = ch(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = uh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = mh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = dh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, dh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, ph(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = lh(h, b, g.roomName, R), k = 0; k < O; k++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = mh(h, b, g.roomName, R), k = 0; k < O; k++) {
 var M = A.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41539,13 +41541,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").con
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: sh(g.urgency),
+priority: ch(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: oh,
-defenseSquadId: ph(M.roomName, g.roomName, e.now),
+task: nh,
+defenseSquadId: fh(M.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41585,7 +41587,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) Rh(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) Eh(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41600,7 +41602,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Dy);
+}(e, Fy);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41612,7 +41614,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = bh(f, xh(e, f, t)), v = y.reduce(function(e, t) {
+var y = Oh(f, bh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41623,7 +41625,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-Ch(f, R.role, Th(f, R.role) - 1), l.push({
+Sh(f, R.role, Ch(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41690,19 +41692,19 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Mh = new kh, Uh = /^([WE])(\d+)([NS])(\d+)$/;
+}(), Uh = new Mh, _h = /^([WE])(\d+)([NS])(\d+)$/;
 
-function _h(e) {
-return Uh.test(e);
+function Nh(e) {
+return _h.test(e);
 }
 
-var Nh = {
+var Ph = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Ph = function() {
+}, Ih = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Nh), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ph), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
@@ -41777,7 +41779,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (_h(x)) {
+if (e.isAlly(x)) f.add(x); else if (Nh(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41853,7 +41855,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Ih = new Ph, Gh = function() {
+}(), Gh = new Ih, Lh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41930,9 +41932,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), Lh = new Gh, Dh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), Dh = new Lh, Fh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Fh(e, t) {
+function Bh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41955,13 +41957,13 @@ if (r) throw r.error;
 return n;
 }
 
-function Bh(e) {
+function Wh(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function Wh(e, t, r) {
-if (!Bh(e)) return 0;
-var o = Fh(e.name, t);
+function Kh(e, t, r) {
+if (!Wh(e)) return 0;
+var o = Bh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += oc(e.mineralType),
@@ -41970,7 +41972,7 @@ n += sc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += uc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function Kh(e, t) {
+function Hh(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -41980,13 +41982,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Dh.has(e.type);
+return e.hits > 0 && Fh.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function Hh(e, t, r) {
+function Yh(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -41996,7 +41998,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function Yh(e) {
+function Vh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42007,8 +42009,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function Vh(e) {
-var t = Yh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function qh(e) {
+var t = Vh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42027,14 +42029,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var qh = {
+var jh = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, jh = function() {
+}, zh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, qh), e);
+void 0 === e && (e = {}), this.config = o(o({}, jh), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42125,7 +42127,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = Yh(e);
+var t = Vh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42137,14 +42139,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return Vh(zh(e));
+return qh(Qh(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = Vh(zh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = qh(Qh(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function zh(e) {
+function Qh(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42176,11 +42178,11 @@ swamps: d
 };
 }
 
-var Qh = new jh, Xh = /^([WE])(\d+)([NS])(\d+)$/, Zh = {
+var Xh = new zh, Zh = /^([WE])(\d+)([NS])(\d+)$/, Jh = {
 allies: []
-}, Jh = function() {
+}, $h = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Zh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Jh), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42200,7 +42202,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!Xh.test(e)) return !1;
+if (!Zh.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42308,7 +42310,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return Xh.test(e);
+return Zh.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42335,7 +42337,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), $h = new Jh, eR = {
+}(), eR = new $h, tR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42348,9 +42350,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, tR = function() {
+}, rR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, eR), e);
+void 0 === e && (e = {}), this.config = o(o({}, tR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42363,7 +42365,7 @@ t.updateExpansionQueue(o);
 }), Ji.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Ji.measureSubsystem("empire:warTargets", function() {
-$h.updateWarTargets(o);
+eR.updateWarTargets(o);
 }), Ji.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Ji.measureSubsystem("empire:gclTracking", function() {
@@ -42371,13 +42373,13 @@ t.trackGCLProgress(o);
 }), s && Ji.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Ji.measureSubsystem("empire:intelRefresh", function() {
-Qh.refreshRoomIntel(o);
+Xh.refreshRoomIntel(o);
 }), Ji.measureSubsystem("empire:roomDiscovery", function() {
-Qh.discoverNearbyRooms(o);
+Xh.discoverNearbyRooms(o);
 })), s && Ji.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Ji.measureSubsystem("empire:clusterHealth", function() {
-Lh.monitorClusterHealth();
+Dh.monitorClusterHealth();
 }), Ji.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42460,22 +42462,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = Kh(f, u);
+var y = Boolean(Game.rooms[f]), v = Hh(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = Fh(f, t);
+var g = Bh(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = Hh(h, u, y);
+var h = e.knownRooms[f], R = Yh(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? Wh(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? Kh(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42519,10 +42521,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && Bh(a)) {
-var i = Fh(a.name, t);
+if (a && Wh(a)) {
+var i = Bh(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = Wh(a, t, r);
+var s = Kh(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -42842,13 +42844,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), rR = new tR;
+}(), oR = new rR;
 
-function oR(e) {
+function nR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var nR = {
+var aR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42856,10 +42858,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, aR = function() {
+}, iR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, nR), e);
+this.config = o(o({}, aR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -43003,7 +43005,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, oR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, nR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43178,7 +43180,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), iR = new aR, sR = function() {
+}(), sR = new iR, cR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new ec(o(o({}, Bs), e), {
 getEmpire: function() {
@@ -43214,7 +43216,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), cR = new sR, uR = function() {
+}(), uR = new cR, lR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -43232,9 +43234,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), lR = new (function(e) {
+}(), mR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new uR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new lR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43246,22 +43248,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
 }(Ii));
 
-function mR() {
+function dR() {
 return global;
 }
 
-function dR(e) {
+function pR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function pR(e) {
+function fR(e) {
 return Number(null != e ? e : 0);
 }
 
-var fR = function() {
+var yR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = mR();
+var e = dR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43269,12 +43271,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return mR()._pixelGenerationMemory;
+return dR()._pixelGenerationMemory;
 }, e;
-}(), yR = function(e) {
+}(), vR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new fR) || this;
+var r = e.call(this, t, new yR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43291,7 +43293,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(dR).length : Object.values(null != t ? t : {}).filter(dR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(pR).length : Object.values(null != t ? t : {}).filter(pR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43302,9 +43304,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (pR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (pR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = pR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = pR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (fR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (fR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = fR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = fR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43326,9 +43328,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Li), vR = new yR;
+}(Li), gR = new vR;
 
-function gR(e, t) {
+function hR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -43350,7 +43352,7 @@ lost: !1
 };
 }
 
-function hR(e, t, r) {
+function RR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43364,20 +43366,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var RR = Ue().cpu.bucketThresholds.highMode + 1800, ER = {
+var ER = Ue().cpu.bucketThresholds.highMode + 1800, TR = {
 updateInterval: 250,
-minBucket: RR,
+minBucket: ER,
 maxSitesPerRemotePerTick: 2
 };
 
-function TR(e, t) {
+function CR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var CR = function() {
+var SR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, ER), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, TR), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43394,8 +43396,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = gR(l);
-m.lost && m.reason && hR(e, u, m.reason);
+var m = hR(l);
+m.lost && m.reason && RR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43413,10 +43415,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = TR("remoteInfrastructure.intent", function() {
+var i = CR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-TR("remoteInfrastructure.execute", function() {
+CR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43582,13 +43584,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = TR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = CR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = TR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = CR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43621,7 +43623,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = TR("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = CR("remoteInfrastructure.calculateRemoteRoads", function() {
 return xn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43650,14 +43652,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = TR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = CR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? TR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? CR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43674,7 +43676,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? TR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? CR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43692,7 +43694,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return TR("remoteInfrastructure.findSources", function() {
+return CR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43789,10 +43791,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: ha.LOW,
 interval: 1e3,
-minBucket: RR,
+minBucket: ER,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), SR = new CR, wR = new (function(e) {
+}(), wR = new SR, xR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43804,7 +43806,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Pp)), xR = function() {
+}(Pp)), bR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43894,7 +43896,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ki() ], e);
-}(), bR = new xR, OR = new (function() {
+}(), OR = new bR, AR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43941,7 +43943,7 @@ if (e) throw e.error;
 Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(bR, Ns, Ds, ls, rR, vc, iR, SR, As, lR, vR, cR, qc, Zc, wR, Ih, Bc, Mh, za, Pa),
+}(OR, Ns, Ds, ls, oR, vc, sR, wR, As, mR, gR, uR, qc, Zc, xR, Gh, Bc, Uh, za, Pa),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -44008,9 +44010,9 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), AR = "_ownedRooms", kR = "_ownedRoomsTick";
+}), kR = "_ownedRooms", MR = "_ownedRoomsTick";
 
-function MR(e) {
+function UR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44020,13 +44022,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var UR = Ei("NativeCallsTracker");
+var _R = Ei("NativeCallsTracker");
 
-function _R(e, t, r) {
+function NR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) UR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) _R.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44042,7 +44044,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-UR.warn("Failed to wrap method", {
+_R.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44052,30 +44054,30 @@ error: String(e)
 }
 }
 
-var NR, PR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], IR = "shard1", GR = {
+var PR, IR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], GR = "shard1", LR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, LR = {
+}, DR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, DR = {
+}, FR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function FR() {
+function BR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function BR() {
+function WR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: PR,
+targetShards: IR,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44085,11 +44087,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = PR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = IR),
 Memory.interShardOperation;
 }
 
-function WR() {
+function KR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -44130,33 +44132,33 @@ checksum: 0
 }
 }
 
-function KR(e) {
+function HR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
 InterShardMemory.setLocal(bp(e));
 } catch (e) {}
 }
 
-function HR() {
-var e, t, r, o, n, i, s, c = WR(), u = FR();
+function YR() {
+var e, t, r, o, n, i, s, c = KR(), u = BR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: PR,
+targetShards: IR,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : PR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : IR,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && YR() ? "established" : "unreached",
+status: p === u && VR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44174,7 +44176,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === IR ? "core" : "frontier",
+role: u === GR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44191,24 +44193,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), KR(c), c.footprintOperation;
+}), HR(c), c.footprintOperation;
 }
 
-function YR() {
+function VR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function VR() {
+function qR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function qR(e, t) {
+function jR(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44227,9 +44229,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(VR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(qR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Dy.getPendingRequests(p.name).filter(function(r) {
+s += Fy.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44248,7 +44250,7 @@ if (n) throw n.error;
 return s;
 }
 
-function jR(e) {
+function zR(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44292,7 +44294,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = WR().shards[FR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = KR().shards[BR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44302,8 +44304,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function zR(e, t) {
-if (!(qR("scout", t) >= 1)) {
+function QR(e, t) {
+if (!(jR("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44341,13 +44343,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Dy.addRequest({
+r && Fy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: DR,
-priority: Sy.LOW + 5,
+body: FR,
+priority: wy.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44358,14 +44360,14 @@ task: "interShardPortalScout"
 }
 }
 
-function QR(e, t, r) {
-qR("interShardClaimer", t) >= 1 || Dy.addRequest({
+function XR(e, t, r) {
+jR("interShardClaimer", t) >= 1 || Fy.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: GR,
-priority: Sy.NORMAL + 50,
+body: LR,
+priority: wy.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44378,14 +44380,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function XR(e, t, r) {
-qR("interShardScout", t) >= 1 || Dy.addRequest({
+function ZR(e, t, r) {
+jR("interShardScout", t) >= 1 || Fy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: DR,
-priority: Sy.NORMAL,
+body: FR,
+priority: wy.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44398,15 +44400,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function ZR(e, t, r) {
+function JR(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (qR("interShardPioneer", t.shard) >= 3 || Dy.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (jR("interShardPioneer", t.shard) >= 3 || Fy.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: LR,
-priority: Sy.NORMAL + 25,
+body: DR,
+priority: wy.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44419,16 +44421,16 @@ workflowState: "movingToPortal"
 }));
 }
 
-function JR(e) {
+function $R(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = FR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = BR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : PR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : IR), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
 var f = InterShardMemory.getRemote(p), y = f ? Op(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
@@ -44463,9 +44465,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(VR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(qR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Dy.getPendingRequests(l.name).filter(function(e) {
+n += Fy.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44484,22 +44486,22 @@ return n;
 }() < o;
 }
 
-(NR = {
-optimizeBody: Py,
+(PR = {
+optimizeBody: Iy,
 spawnQueue: {
 addRequest: function(e) {
-return Dy.addRequest(e);
+return Fy.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Sy.LOW,
-NORMAL: Sy.NORMAL,
-HIGH: Sy.HIGH
+LOW: wy.LOW,
+NORMAL: wy.NORMAL,
+HIGH: wy.HIGH
 }
-}).optimizeBody && (Gp.optimizeBody = NR.optimizeBody), NR.spawnQueue && (Gp.spawnQueue = NR.spawnQueue),
-NR.spawnPriorities && (Gp.spawnPriorities = o(o({}, Gp.spawnPriorities), NR.spawnPriorities));
+}).optimizeBody && (Gp.optimizeBody = PR.optimizeBody), PR.spawnQueue && (Gp.spawnQueue = PR.spawnQueue),
+PR.spawnPriorities && (Gp.spawnPriorities = o(o({}, Gp.spawnPriorities), PR.spawnPriorities));
 
-var $R, eE = function() {
+var eE, tE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44543,7 +44545,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function tE(e) {
+function rE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44564,7 +44566,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function rE(e, t, r) {
+function oE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44630,16 +44632,16 @@ return u;
 });
 }
 
-function oE(e) {
+function nE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}($R || ($R = {}));
+}(eE || (eE = {}));
 
-var nE = function() {
+var aE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44677,8 +44679,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = rE(h.pos, T.pos, this.logger);
-if (oE(C)) {
+var T = E.value, C = oE(h.pos, T.pos, this.logger);
+if (nE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44705,8 +44707,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, k = rE(A, u.pos, this.logger);
-oE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
+var A = O.value, k = oE(A, u.pos, this.logger);
+nE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44745,8 +44747,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = rE(e, t, this.logger);
-if (oE(n)) {
+var n = oE(e, t, this.logger);
+if (nE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44756,7 +44758,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), aE = function() {
+}(), iE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44766,7 +44768,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = tE(s);
+var c = rE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44792,7 +44794,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), iE = function() {
+}(), sE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44841,7 +44843,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), sE = {
+}(), cE = {
 debug: function(e, t) {
 return k("RemoteMining").debug(e, t);
 },
@@ -44854,7 +44856,7 @@ return k("RemoteMining").warn(e, t);
 error: function(e, t) {
 return k("RemoteMining").error(e, t);
 }
-}, cE = {
+}, uE = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44881,7 +44883,7 @@ direction: a
 }
 return t;
 }
-}, uE = {
+}, lE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
 void 0 === o && (o = vm.MEDIUM), Om.register({
@@ -44894,13 +44896,13 @@ skippable: o !== vm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, lE = new nE(cE, sE), mE = new aE(sE, uE, lE), dE = new iE(sE, cE, lE, Gu.moveTo);
+}, mE = new aE(uE, cE), dE = new iE(cE, lE, mE), pE = new sE(cE, uE, mE, Gu.moveTo);
 
-function pE(e, t, r, o) {
-return dE.moveToWithRemoteCache(e, t, r, o);
+function fE(e, t, r, o) {
+return pE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var fE, yE = function() {
+var yE, vE = function() {
 function e() {
 this.logger = k("Pathfinding");
 }
@@ -44913,12 +44915,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), vE = function() {
+}(), gE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), gE = function() {
+}(), hE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44963,28 +44965,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), hE = function() {
+}(), RE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return tE(e);
+return rE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-lE.precacheRemoteRoutes(e, t);
+mE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), RE = new eE(new yE, new vE, new gE, new hE), EE = {
+}(), EE = new tE(new vE, new gE, new hE, new RE), TE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, TE = function() {
+}, CE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, EE), e);
+this.config = o(o({}, TE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45078,123 +45080,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new TE, (fE = {})[FIND_STRUCTURES] = {
+new CE, (yE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, fE[FIND_MY_STRUCTURES] = {
+}, yE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, fE[FIND_HOSTILE_STRUCTURES] = {
+}, yE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, fE[FIND_SOURCES_ACTIVE] = {
+}, yE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, fE[FIND_SOURCES] = {
+}, yE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, fE[FIND_MINERALS] = {
+}, yE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, fE[FIND_DEPOSITS] = {
+}, yE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, fE[FIND_MY_CONSTRUCTION_SITES] = {
+}, yE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, fE[FIND_CONSTRUCTION_SITES] = {
+}, yE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, fE[FIND_CREEPS] = {
+}, yE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, fE[FIND_MY_CREEPS] = {
+}, yE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, fE[FIND_HOSTILE_CREEPS] = {
+}, yE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, fE[FIND_DROPPED_RESOURCES] = {
+}, yE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, fE[FIND_TOMBSTONES] = {
+}, yE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, fE[FIND_RUINS] = {
+}, yE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, fE[FIND_FLAGS] = {
+}, yE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, fE[FIND_MY_SPAWNS] = {
+}, yE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, fE[FIND_HOSTILE_SPAWNS] = {
+}, yE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, fE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, yE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, fE[FIND_NUKES] = {
+}, yE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, fE[FIND_POWER_CREEPS] = {
+}, yE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, fE[FIND_MY_POWER_CREEPS] = {
+}, yE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, fE[FIND_HOSTILE_POWER_CREEPS] = {
+}, yE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, fE[FIND_EXIT_TOP] = {
+}, yE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, fE[FIND_EXIT_RIGHT] = {
+}, yE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, fE[FIND_EXIT_BOTTOM] = {
+}, yE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, fE[FIND_EXIT_LEFT] = {
+}, yE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, fE[FIND_EXIT] = {
+}, yE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var CE = new le({}, mr), SE = new Ee({}, mr);
+var SE = new le({}, mr), wE = new Ee({}, mr);
 
-function wE(e) {
+function xE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45202,11 +45204,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var xE = !1;
+var bE = !1;
 
-function bE() {
+function OE() {
 var e, t;
-xE || (ii({
+bE || (ii({
 level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45221,11 +45223,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Fy.getPendingTransfers = function(e) {
+r.getPendingTransfers && (By.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Fy.needsCarrier = function(e) {
+}), r.needsCarrier && (By.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Fy.getActiveRequests = function() {
+}), r.getActiveRequests && (By.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45239,31 +45241,31 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (By.predictConsumption = function(e) {
+a.predictConsumption && (Wy.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (By.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Wy.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (By.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Wy.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (By.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Wy.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Wy.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Ky.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Wy.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Ky.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Wy.needsCarriers = function(e) {
+}), i.needsCarriers && (Ky.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Wy.requestSpawns = function(e) {
+}), i.requestSpawns && (Ky.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-Ky.getEmergencyState = function(e) {
+Hy.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
@@ -45293,7 +45295,7 @@ return Ru.getLabOverflow(e);
 }), Ji.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) UR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) _R.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45307,7 +45309,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-UR.warn("Failed to wrap PathFinder.search", {
+_R.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45315,11 +45317,11 @@ error: String(e)
 }
 }
 }
-}(), _R(e = Creep.prototype, "moveTo", "moveTo"), _R(e, "move", "move"), _R(e, "harvest", "harvest"),
-_R(e, "transfer", "transfer"), _R(e, "withdraw", "withdraw"), _R(e, "build", "build"),
-_R(e, "repair", "repair"), _R(e, "upgradeController", "upgradeController"), _R(e, "attack", "attack"),
-_R(e, "rangedAttack", "rangedAttack"), _R(e, "heal", "heal"), _R(e, "dismantle", "dismantle"),
-_R(e, "say", "say")), function(e, t, r) {
+}(), NR(e = Creep.prototype, "moveTo", "moveTo"), NR(e, "move", "move"), NR(e, "harvest", "harvest"),
+NR(e, "transfer", "transfer"), NR(e, "withdraw", "withdraw"), NR(e, "build", "build"),
+NR(e, "repair", "repair"), NR(e, "upgradeController", "upgradeController"), NR(e, "attack", "attack"),
+NR(e, "rangedAttack", "rangedAttack"), NR(e, "heal", "heal"), NR(e, "dismantle", "dismantle"),
+NR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -45335,15 +45337,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, wf), RE.initializePathCacheEvents(), mE.initialize(vm.MEDIUM), Tl = pE,
-Ft.initialize(), wR.initialize(), xE = !0), mr.initialize();
-var r = OR.configureForCurrentTick();
+}(Ja, mr, wf), EE.initializePathCacheEvents(), dE.initialize(vm.MEDIUM), Tl = fE,
+Ft.initialize(), xR.initialize(), bE = !0), mr.initialize();
+var r = AR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = BR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, HR(), function() {
-var e, t, r, o, n = WR(), a = n.footprintOperation, i = FR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = WR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, YR(), function() {
+var e, t, r, o, n = KR(), a = n.footprintOperation, i = BR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45356,15 +45358,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, KR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, HR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = BR();
+var e, t, r, n, i, s, c = WR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : PR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === IR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : IR), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === GR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45382,7 +45384,7 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !YR())) try {
+}(), !VR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
 "interShardClaimer" !== c && "interShardScout" !== c || $p(s), "interShardPioneer" === c && Jp(s);
@@ -45409,17 +45411,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: xE
+systemsInitialized: bE
 }
-}), OR.ensureProcessesRegistered(), Ji.startTick(), ku.clear(), OR.startEventTick();
+}), AR.ensureProcessesRegistered(), Ji.startTick(), ku.clear(), AR.startEventTick();
 var i = function(e) {
-var t = e.cache[AR], r = e.cache[kR];
+var t = e.cache[kR], r = e.cache[MR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[AR] = o, e.cache[kR] = e.tick, o;
+return e.cache[kR] = o, e.cache[MR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45456,15 +45458,15 @@ if (e) throw e.error;
 }
 }), Ji.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = BR();
+var e, t, r, o = WR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = HR();
+var n = YR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : PR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : IR), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== FR()) try {
+if (d !== BR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
 var f = Op(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
@@ -45485,20 +45487,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = VR().sort(function(e, t) {
+var i = qR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : PR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : IR), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== FR()) {
+if (u !== BR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = jR(u);
+var m = zR(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? ZR(i, l, m) : JR() ? QR(i, u, m) : (XR(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (zR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? JR(i, l, m) : $R() ? XR(i, u, m) : (ZR(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (QR(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45515,8 +45517,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = WR();
-d.footprintOperation = n, KR(d);
+var d = KR();
+d.footprintOperation = n, HR(d);
 }
 }
 })(), function() {
@@ -45524,8 +45526,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || wE(s))) {
-var c = ug(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || xE(s))) {
+var c = lg(s, mr.getOrInitSwarmState(s.name));
 Ji.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45542,13 +45544,13 @@ if (e) throw e.error;
 }
 }();
 }), Gu.preTick(), Ji.measureSubsystem("processSync", function() {
-mf.syncCreepProcesses(), my.syncRoomProcesses();
+mf.syncCreepProcesses(), dy.syncRoomProcesses();
 }), Ji.measureSubsystem("kernel", function() {
-OR.runProcesses();
+AR.runProcesses();
 }), Ji.measureSubsystem("eventQueue", function() {
-OR.processQueuedEvents();
+AR.processQueuedEvents();
 }), Ji.measureSubsystem("ss2PacketQueue", function() {
-pg.processQueue();
+fg.processQueue();
 }), Ja.hasCpuBudget() && Ji.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
@@ -45569,7 +45571,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), MR({
+}), UR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("visualizations", function() {
@@ -45579,8 +45581,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = CE.getConfig(), s = SE.getConfig();
-CE.setConfig(n.roomVisualizerConfig), n.renderMap && SE.setConfig(n.mapVisualizerConfig);
+var i = SE.getConfig(), s = wE.getConfig();
+SE.setConfig(n.roomVisualizerConfig), n.renderMap && wE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45591,7 +45593,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-CE.draw(m);
+SE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45613,14 +45615,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-SE.draw();
+wE.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-CE.setConfig(i), SE.setConfig(s);
+SE.setConfig(i), wE.setConfig(s);
 }
 }
 }
@@ -45705,7 +45707,7 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Gu.reconcileTraffic(), MR({
+}), Gu.reconcileTraffic(), UR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("scheduledTasks", function() {
@@ -45717,7 +45719,7 @@ return e.set(t.id, t), e;
 Ji.finalizeTick(), Ci.flush();
 }
 
-var OE = function() {
+var AE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45725,15 +45727,6 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = CE.getConfig(), r = Object.keys(t).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof t[e];
-});
-if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
-var o = e;
-CE.toggle(o);
-var n = CE.getConfig()[o];
-return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t = SE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
@@ -45741,9 +45734,18 @@ if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.
 var o = e;
 SE.toggle(o);
 var n = SE.getConfig()[o];
+return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t = wE.getConfig(), r = Object.keys(t).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof t[e];
+});
+if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
+var o = e;
+wE.toggle(o);
+var n = wE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = SE.getConfig();
+var e = wE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45866,15 +45868,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), AE = function() {
+}(), kE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = wR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = xR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = wR.getAllShards();
+var e, t, r = xR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45896,9 +45898,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (wR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (xR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = wR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = xR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45923,16 +45925,16 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = wR.getOptimalPortalRoute(e, t);
+var r, o = xR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (wR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (xR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (wR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (xR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
 var e, t, r = Dp.getActiveRequests();
@@ -45956,7 +45958,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = wR.getCurrentShardState();
+var e, t, r = xR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45977,7 +45979,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = wR.getActiveTransferTasks();
+var e, t, r, o = xR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -45998,16 +46000,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = wR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+var e = xR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
 return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Mp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = wR.getMemoryStats();
+var e = xR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return wR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return xR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = WR().footprintOperation;
+var e, t, r, o = KR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46113,9 +46115,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), kE = new AE;
+}(), ME = new kE;
 
-function ME(e) {
+function UE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46145,7 +46147,7 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? ME(e.metadata.usage) : void 0
+params: e.metadata.usage ? UE(e.metadata.usage) : void 0
 };
 });
 return Gm({
@@ -46360,39 +46362,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var UE = new py, _E = new OE, NE = new fy, PE = new bu, IE = new dy, GE = new yy, LE = new vy, DE = "__screepsGlobalRuntimeDiagnostics";
+var _E = new fy, NE = new AE, PE = new yy, IE = new bu, GE = new py, LE = new vy, DE = new gy, FE = "__screepsGlobalRuntimeDiagnostics";
 
-function FE() {
+function BE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function BE(e, t) {
+function WE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function WE(e, t) {
+function KE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function KE(e) {
+function HE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function HE(e) {
+function YE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: BE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: BE(n.switchCount, 0),
-lastTick: WE(n.lastTick, Game.time),
-lastResetTick: WE(n.lastResetTick, Game.time),
-lastSwitchTick: KE(n.lastSwitchTick),
-lastSwitchPreviousTick: KE(n.lastSwitchPreviousTick),
-lastWarningTick: KE(n.lastWarningTick)
+resetCount: WE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: WE(n.switchCount, 0),
+lastTick: KE(n.lastTick, Game.time),
+lastResetTick: KE(n.lastResetTick, Game.time),
+lastSwitchTick: HE(n.lastSwitchTick),
+lastSwitchPreviousTick: HE(n.lastSwitchPreviousTick),
+lastWarningTick: HE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46406,13 +46408,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var YE = Ei("Main");
+var VE = Ei("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(UE), Ct(_E), Ct(NE), Ct(PE), Ct(IE), Ct(GE), Ct(LE), Ct(Su),
-Ct(wu), Ct(xu), Ct(kE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
+Et.initialize(), Ct(_E), Ct(NE), Ct(PE), Ct(IE), Ct(GE), Ct(LE), Ct(DE), Ct(Su),
+Ct(wu), Ct(xu), Ct(ME), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -46427,12 +46429,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : FE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[DE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : BE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[FE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[DE] = s, function(e, t) {
-var r, o = HE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[FE] = s, function(e, t) {
+var r, o = YE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46450,7 +46452,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = HE(e.heapId);
+var n, a = YE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46471,14 +46473,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = HE(s.heapId);
+var u = YE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: YE
-}), bE();
+logger: VE
+}), OE();
 } catch (e) {
-throw YE.error("Critical error in main loop: ".concat(String(e)), {
+throw VE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-bot/src/core/managers/RoomConstructionManager.ts
+++ b/packages/screeps-bot/src/core/managers/RoomConstructionManager.ts
@@ -137,10 +137,6 @@ function isEarlyGameDefense(rcl: number): boolean {
   return rcl >= EARLY_GAME_RCL_MIN && rcl <= EARLY_GAME_RCL_MAX;
 }
 
-function countOwnedStructures(room: Room, structureType: StructureConstant): number {
-  return room.find(FIND_MY_STRUCTURES, { filter: structure => structure.structureType === structureType }).length;
-}
-
 function countBuildsForType(room: Room, structureType: BuildableStructureConstant): number {
   const ownedStructures = room.find(FIND_MY_STRUCTURES, {
     filter: structure => structure.structureType === structureType
@@ -150,6 +146,19 @@ function countBuildsForType(room: Room, structureType: BuildableStructureConstan
   });
 
   return ownedStructures.length + ownedSites.length;
+}
+
+function getControllerStructureLimit(structureType: StructureConstant, rcl: number): number {
+  const controllerStructures = (typeof CONTROLLER_STRUCTURES === "undefined"
+    ? { [STRUCTURE_TOWER]: { 1: 0, 2: 0, 3: 1, 4: 1, 5: 2, 6: 2, 7: 3, 8: 6 } }
+    : CONTROLLER_STRUCTURES) as Record<string, Record<number, number>>;
+
+  return controllerStructures[structureType]?.[rcl] ?? 0;
+}
+
+function hasOutstandingTowerDemand(room: Room, rcl: number): boolean {
+  const towerLimit = getControllerStructureLimit(STRUCTURE_TOWER, rcl);
+  return towerLimit > 0 && countBuildsForType(room, STRUCTURE_TOWER) < towerLimit;
 }
 
 function hasOutstandingMandatoryBlueprintDemand(room: Room, rcl: number): boolean {
@@ -173,11 +182,8 @@ function placeCriticalDefenseConstructionSites(room: Room, stampPlan: ReturnType
   if (globalExistingSites >= globalSiteCap) return 0;
 
   const rcl = room.controller?.level ?? stampPlan.rcl;
-  const controllerStructures = (typeof CONTROLLER_STRUCTURES === "undefined"
-    ? { [STRUCTURE_TOWER]: { 1: 0, 2: 0, 3: 1, 4: 1, 5: 2, 6: 2, 7: 3, 8: 6 } }
-    : CONTROLLER_STRUCTURES) as Record<string, Record<number, number>>;
-  const towerLimit = controllerStructures[STRUCTURE_TOWER]?.[rcl] ?? 0;
-  const towerCount = countOwnedStructures(room, STRUCTURE_TOWER);
+  const towerLimit = getControllerStructureLimit(STRUCTURE_TOWER, rcl);
+  const towerBuildCount = countBuildsForType(room, STRUCTURE_TOWER);
   const existingStructureKeys = new Set<string>();
   const existingSiteKeys = new Set<string>();
   for (const structure of room.find(FIND_STRUCTURES)) {
@@ -189,7 +195,7 @@ function placeCriticalDefenseConstructionSites(room: Room, stampPlan: ReturnType
   const queue = buildConstructionQueue(stampPlan, { existingStructureKeys, existingSiteKeys, currentRcl: rcl })
     .filter(item =>
       item.structureType === STRUCTURE_TOWER ||
-      (item.structureType === STRUCTURE_RAMPART && (towerCount < towerLimit || rcl >= 3))
+      (item.structureType === STRUCTURE_RAMPART && (towerBuildCount < towerLimit || rcl >= 3))
     )
     .sort((a, b) => {
       if (a.structureType === STRUCTURE_TOWER && b.structureType !== STRUCTURE_TOWER) return -1;
@@ -197,7 +203,7 @@ function placeCriticalDefenseConstructionSites(room: Room, stampPlan: ReturnType
       return b.score - a.score;
     });
 
-  if (towerCount < towerLimit && !queue.some(item => item.structureType === STRUCTURE_TOWER)) {
+  if (towerBuildCount < towerLimit && !queue.some(item => item.structureType === STRUCTURE_TOWER)) {
     const spawn = room.find(FIND_MY_SPAWNS)[0];
     const anchor = spawn?.pos ?? room.controller?.pos;
     if (anchor) {
@@ -273,18 +279,6 @@ export class RoomConstructionManager {
       return;
     }
 
-    // Priority 0: place critical dynamic link/lab sites before static blueprint
-    // work can consume the room's local construction throttle.
-    let linkSitesPlaced = 0;
-    if (rcl >= 5) {
-      linkSitesPlaced = placeLinkConstructionSites(room, 2);
-    }
-
-    let labSitesPlaced = 0;
-    if (rcl >= 6) {
-      labSitesPlaced = placeLabClusterConstructionSites(room, 3);
-    }
-
     // Use the canonical framework stamp planner as the single layout authority.
     // A remembered anchor keeps cleanup/perimeter stable; without one the planner
     // derives an anchor from fixed structures and room facts.
@@ -298,13 +292,28 @@ export class RoomConstructionManager {
     const finalBlueprint = blueprintFromPlan(stampPlan);
     rememberLayoutAnchor(swarm, anchor, finalBlueprint.name, rcl);
 
-    const criticalDefenseSitesPlaced = swarm.danger >= 1 && rcl >= 3
+    // Priority 0: missing towers are survival-critical even in peaceful recovery.
+    // Place them before dynamic links/labs can consume the final global site slot.
+    const shouldPlaceCriticalDefenseSites = rcl >= 3 && (swarm.danger >= 1 || hasOutstandingTowerDemand(room, rcl));
+    const criticalDefenseSitesPlaced = shouldPlaceCriticalDefenseSites
       ? placeCriticalDefenseConstructionSites(room, stampPlan, swarm.danger >= 2 ? 3 : 1)
       : 0;
 
     if (options.criticalOnly) {
       swarm.metrics.constructionSites = existingSites.length + criticalDefenseSitesPlaced;
       return;
+    }
+
+    // Priority 1: place dynamic link/lab sites before lower-priority blueprint
+    // and road work, but after missing tower recovery preserves room safety.
+    let linkSitesPlaced = 0;
+    if (rcl >= 5) {
+      linkSitesPlaced = placeLinkConstructionSites(room, 2);
+    }
+
+    let labSitesPlaced = 0;
+    if (rcl >= 6) {
+      labSitesPlaced = placeLabClusterConstructionSites(room, 3);
     }
 
     // Check per-room construction site throttle after first-spawn/bootstrap, priority economy sites,

--- a/packages/screeps-bot/test/unit/roomConstructionManager.test.ts
+++ b/packages/screeps-bot/test/unit/roomConstructionManager.test.ts
@@ -169,8 +169,10 @@ describe("RoomConstructionManager", () => {
       );
     });
 
-    it("should place missing RCL5 tower sites before local construction cap during danger", () => {
-      const record: { calls: { x: number; y: number; structureType: BuildableStructureConstant }[] } = { calls: [] };
+    function createRcl5RoomWithBacklog(
+      record: { calls: { x: number; y: number; structureType: BuildableStructureConstant }[] },
+      existingSites: ConstructionSite[]
+    ): { room: Room; spawn: StructureSpawn; structures: Structure[] } {
       const spawn = {
         id: "spawn1" as Id<StructureSpawn>,
         structureType: STRUCTURE_SPAWN,
@@ -182,19 +184,15 @@ describe("RoomConstructionManager", () => {
         pos: new RoomPosition(25, 8, "W2N1")
       } as unknown as StructureController;
       const source = { pos: new RoomPosition(10, 25, "W2N1") } as Source;
-      const sites = Array.from({ length: 10 }, (_, index) => ({
-        structureType: STRUCTURE_ROAD,
-        pos: new RoomPosition(10 + index, 10, "W2N1")
-      }) as ConstructionSite);
       const structures = [spawn] as Structure[];
       const room = {
         name: "W2N1",
         controller,
         getTerrain: () => ({ get: () => 0 }),
-        find: (type: FindConstant, options?: { filter?: (structure: Structure) => boolean }) => {
+        find: (type: FindConstant, options?: { filter?: (structure: Structure | ConstructionSite) => boolean }) => {
           if (type === FIND_STRUCTURES) return structures;
           if (type === FIND_MY_STRUCTURES) return options?.filter ? structures.filter(options.filter) : structures;
-          if (type === FIND_MY_CONSTRUCTION_SITES) return sites;
+          if (type === FIND_MY_CONSTRUCTION_SITES) return options?.filter ? existingSites.filter(options.filter) : existingSites;
           if (type === FIND_MY_SPAWNS) return [spawn];
           if (type === FIND_SOURCES) return [source];
           if (type === FIND_MINERALS) return [];
@@ -205,6 +203,17 @@ describe("RoomConstructionManager", () => {
           return OK;
         }
       } as unknown as Room;
+
+      return { room, spawn, structures };
+    }
+
+    it("should place missing RCL5 tower sites before local construction cap during danger", () => {
+      const record: { calls: { x: number; y: number; structureType: BuildableStructureConstant }[] } = { calls: [] };
+      const sites = Array.from({ length: 10 }, (_, index) => ({
+        structureType: STRUCTURE_ROAD,
+        pos: new RoomPosition(10 + index, 10, "W2N1")
+      }) as ConstructionSite);
+      const { room, spawn } = createRcl5RoomWithBacklog(record, sites);
       const swarm = { danger: 3, remoteAssignments: [], metrics: {}, posture: "siege" } as any;
       const oldGame = (globalThis as { Game?: unknown }).Game;
       (globalThis as { Game?: unknown }).Game = { time: 100, constructionSites: {} };
@@ -218,6 +227,42 @@ describe("RoomConstructionManager", () => {
       assert.isTrue(
         record.calls.some(call => call.structureType === STRUCTURE_TOWER),
         "critical defense construction should bypass the local site cap to place a missing tower"
+      );
+    });
+
+    it("should reserve the last global construction slot for a missing RCL5 tower in peaceful recovery rooms", () => {
+      const record: { calls: { x: number; y: number; structureType: BuildableStructureConstant }[] } = { calls: [] };
+      const sites = Array.from({ length: 10 }, (_, index) => ({
+        structureType: STRUCTURE_ROAD,
+        pos: new RoomPosition(10 + index, 10, "W2N1")
+      }) as ConstructionSite);
+      const { room, spawn, structures } = createRcl5RoomWithBacklog(record, sites);
+      const swarm = { danger: 0, remoteAssignments: [], metrics: {}, posture: "eco" } as any;
+      const oldGame = (globalThis as { Game?: unknown }).Game;
+      (globalThis as { Game?: unknown }).Game = {
+        time: 100,
+        constructionSites: Object.fromEntries(Array.from({ length: 99 }, (_, index) => [`site${index}`, {}]))
+      };
+
+      try {
+        manager.runConstruction(room, swarm, sites, [spawn]);
+      } finally {
+        (globalThis as { Game?: unknown }).Game = oldGame;
+      }
+
+      assert.equal(
+        record.calls[0]?.structureType,
+        STRUCTURE_TOWER,
+        "peaceful RCL5 recovery should use the final global construction slot for missing tower defense before lower-priority backlog work"
+      );
+      assert.equal(
+        record.calls.filter(call => call.structureType === STRUCTURE_TOWER).length,
+        1,
+        "one missing tower site should be enough for the final global construction slot"
+      );
+      assert.isTrue(
+        structures.every(structure => structure.structureType !== STRUCTURE_TOWER),
+        "fixture should reproduce a room with no completed towers"
       );
     });
 


### PR DESCRIPTION
## Summary

Prioritizes peaceful RCL5 tower recovery when a room is underbuilt and the global construction-site cap has only a final slot available.

## Linked issue

Refs #3242

## Changes

### Code changes
- Treat missing RCL3+ tower demand as recovery-critical even when `swarm.danger === 0`.
- Move tower recovery site placement ahead of dynamic link/lab site placement so links cannot consume the last global site slot.
- Count existing tower construction sites toward tower demand to avoid duplicate tower placement attempts.

### Test changes
- Adds a regression test for a peaceful RCL5 recovery room with local construction backlog and 99/100 global construction sites.
- Refactors the RCL5 construction test fixture used by danger and peaceful recovery cases.

### Docs changes
- None; runtime construction prioritization only.

## Validation

- PASS: `npm run test:unit -w screeps-typescript-starter -- --grep "reserve the last"`
- PASS: `npm run test:unit -w screeps-typescript-starter -- --grep "RoomConstructionManager"`
- PASS: `npm run lint -w screeps-typescript-starter -- --max-warnings=0`
- PASS: `npm run build:bot && npm run test:unit -w screeps-typescript-starter && npm run check:alliance-safety`
- PASS: reviewer subagent found no must-fix issues.

## Deployment impact

Affects `screeps.com` runtime construction ordering. Includes updated `packages/screeps-bot/dist/main.js` for deploy path.

## Live bot evidence

Current live W18S28 evidence from read-only Screeps API:
- `W18S28` is RCL5 with one spawn, no built towers/storage in latest sampled summary.
- Current live artifacts: `artifacts/live-analysis-20260705T0153-current/summary.md`, `artifacts/live-analysis-20260705T015100Z/cpu-profile/live-cpu-profile-2026-07-05T01-51-07-778Z.json`.

## Follow-up issues

No new issues created per operator constraint. Existing related work remains tracked by #3119, #3105, #3104, and #3184.
