### PR TITLE
[codex] Interrupt economy refill backlog

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/index.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/index.ts
@@ -26,12 +26,14 @@
  */
 
 import type { CreepAction, CreepContext } from "../types";
+import type { CreepState } from "../../memory/schemas";
+import { findAssignedCriticalEnergyDelivery } from "./common/energyManagement";
 import { larvaWorker } from "./larvaWorker";
 import { pioneer } from "./pioneer";
 import { interShardPioneer } from "./interShardPioneer";
 import { harvester } from "./harvester";
 import { hauler } from "./hauler";
-import { upgrader } from "./upgrader";
+import { shouldUpgraderRefillCriticalStructures, upgrader } from "./upgrader";
 import { builder } from "./builder";
 import { mineralHarvester, depositHarvester } from "./mining";
 import { remoteHarvester, remoteHauler } from "./remote";
@@ -64,6 +66,20 @@ const economyBehaviors: Record<string, (ctx: CreepContext) => CreepAction> = {
 export function evaluateEconomyBehavior(ctx: CreepContext): CreepAction {
   const behavior = economyBehaviors[ctx.memory.role] ?? larvaWorker;
   return behavior(ctx);
+}
+
+const INTERRUPTIBLE_ECONOMY_DELIVERY_STATES = new Set(["build", "repair", "upgrade"]);
+
+/**
+ * Preempt long-running economy work when carried energy can immediately satisfy
+ * task-board critical room refill demand. This keeps refill reservations visible
+ * instead of letting builders/upgraders stay committed until empty.
+ */
+export function getEconomyStateInterrupt(ctx: CreepContext, currentState: CreepState): CreepAction | null {
+  if (!INTERRUPTIBLE_ECONOMY_DELIVERY_STATES.has(currentState.action)) return null;
+  if (ctx.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) return null;
+  if (ctx.memory.role === "upgrader" && !shouldUpgraderRefillCriticalStructures(ctx)) return null;
+  return findAssignedCriticalEnergyDelivery(ctx);
 }
 
 // Export individual behaviors with backward-compatible names

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/upgrader.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/upgrader.ts
@@ -29,7 +29,7 @@ function hasCriticallyEmptySpawn(ctx: CreepContext): boolean {
   );
 }
 
-function shouldUpgraderRefillCriticalStructures(ctx: CreepContext): boolean {
+export function shouldUpgraderRefillCriticalStructures(ctx: CreepContext): boolean {
   if (!hasActiveLocalHauler(ctx)) return true;
   return hasCriticallyEmptySpawn(ctx);
 }

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/index.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/index.ts
@@ -24,7 +24,7 @@ export { createContext } from "./context";
 export { executeAction } from "./executor";
 
 // Behavior evaluators by role family
-export { evaluateEconomyBehavior } from "./economy/index";
+export { evaluateEconomyBehavior, getEconomyStateInterrupt } from "./economy/index";
 export { evaluateMilitaryBehavior } from "./military";
 export { evaluateUtilityBehavior, getUtilityStateInterrupt } from "./utility";
 export {

--- a/packages/@ralphschuler/screeps-roles/src/index.ts
+++ b/packages/@ralphschuler/screeps-roles/src/index.ts
@@ -67,7 +67,8 @@ export {
   haulBehavior,
   buildBehavior,
   upgradeBehavior,
-  evaluateEconomyBehavior
+  evaluateEconomyBehavior,
+  getEconomyStateInterrupt
 } from "./behaviors/economy";
 
 // Export individual economy behavior functions

--- a/packages/@ralphschuler/screeps-roles/src/roles/economy.ts
+++ b/packages/@ralphschuler/screeps-roles/src/roles/economy.ts
@@ -14,7 +14,7 @@
  * - FactoryWorker
  */
 
-import { createContext, evaluateEconomyBehavior, executeAction } from "../behaviors";
+import { createContext, evaluateEconomyBehavior, executeAction, getEconomyStateInterrupt } from "../behaviors";
 import { evaluateWithStateMachine } from "../behaviors/stateMachine";
 
 /**
@@ -23,6 +23,6 @@ import { evaluateWithStateMachine } from "../behaviors/stateMachine";
  */
 export function runEconomyRole(creep: Creep): void {
   const ctx = createContext(creep);
-  const action = evaluateWithStateMachine(ctx, evaluateEconomyBehavior);
+  const action = evaluateWithStateMachine(ctx, evaluateEconomyBehavior, { interrupt: getEconomyStateInterrupt });
   executeAction(creep, action, ctx);
 }

--- a/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
+++ b/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
@@ -430,6 +430,11 @@ function isAllowedTaskType(task: CreepTask, options: TaskAssignmentOptions): boo
 
 function assignTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: TaskAssignmentOptions = {}): CreepTask | null {
   const current = getCurrentAssignedTask(board, ctx.creep.name, ctx.memory.assignedTaskId);
+  if (current && ctx.memory.assignedTaskId !== current.id) {
+    ctx.memory.assignedTaskId = current.id;
+  } else if (!current && ctx.memory.assignedTaskId) {
+    delete ctx.memory.assignedTaskId;
+  }
   if (current && isAllowedTaskType(current, options) && isTargetStillValid(current) && canPerformTask(ctx, current)) {
     if (!shouldCheckForPreemption(ctx, current)) {
       return current;

--- a/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { TaskPriority, taskBoard } from "../src/tasks";
-import { evaluateEconomyBehavior } from "../src/behaviors/economy";
+import { evaluateEconomyBehavior, getEconomyStateInterrupt } from "../src/behaviors/economy";
+import { evaluateWithStateMachine } from "../src/behaviors/stateMachine";
 import { createMockCreep, createMockRoom, resetMockGame, MockGame } from "./setup";
 import type { CreepAction, CreepContext } from "../src";
 
@@ -711,6 +712,128 @@ describe("TaskBoard", () => {
     expect(Object.values(board.tasks).map((task: any) => task.type)).to.deep.equal(["refillExtension"]);
     expect(board.stats.invalidated).to.equal(3);
     expect((builder.memory as any).assignedTaskId).to.equal(undefined);
+  });
+
+  it("interrupts a committed builder upgrade state for critical refill task-board work", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const controller = makeController("controller1" as Id<StructureController>);
+    const room = createMockRoom("W1N1", { controller });
+    (room as any).find = (type: number) => {
+      if (type === FIND_MY_STRUCTURES) return [extension];
+      if (type === FIND_MY_CONSTRUCTION_SITES) return [];
+      if (type === FIND_STRUCTURES) return [];
+      if (type === FIND_MY_CREEPS) return [];
+      return [];
+    };
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : id === controller.id ? controller : null;
+
+    const creep = createMockCreep("builder1", {
+      room,
+      memory: {
+        role: "builder",
+        family: "economy",
+        homeRoom: room.name,
+        version: 1,
+        working: true,
+        state: { action: "upgrade", targetId: controller.id, startTick: Game.time - 1, timeout: 25 }
+      },
+      store: makeStore(50, 50),
+      pos: { x: 25, y: 25, roomName: room.name, getRangeTo: () => 10, isNearTo: () => false, findInRange: () => [] }
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    expect(getEconomyStateInterrupt).to.be.a("function");
+    const action = evaluateWithStateMachine(makeContext(creep, room), evaluateEconomyBehavior, {
+      interrupt: getEconomyStateInterrupt
+    });
+
+    expect(action.type).to.equal("transfer");
+    expect((action as Extract<CreepAction, { type: "transfer" }>).target).to.equal(extension);
+    expect((creep.memory as any).state.action).to.equal("transfer");
+    expect(taskBoard.describeAssignments(room.name)).to.contain("builder1 -> refillExtension");
+  });
+
+  it("clears stale creep assignment memory when no matching reservation exists", () => {
+    const room = createMockRoom("W1N1");
+    (room as any).find = () => [];
+    MockGame.rooms[room.name] = room;
+
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: {
+        role: "hauler",
+        family: "economy",
+        homeRoom: room.name,
+        version: 1,
+        working: true,
+        assignedTaskId: "W1N1:refillExtension:missing"
+      },
+      store: makeStore(50, 50)
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const action = taskBoard.getAssignedDeliveryAction(makeContext(creep, room));
+
+    expect(action).to.equal(null);
+    expect((creep.memory as any).assignedTaskId).to.equal(undefined);
+  });
+
+  it("repairs stale assignment memory when an active reservation exists", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const room = createMockRoom("W1N1");
+    (room as any).find = (type: number) => type === FIND_MY_STRUCTURES ? [extension] : [];
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : null;
+
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1, working: true },
+      store: makeStore(50, 50)
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const firstAction = taskBoard.getAssignedDeliveryAction(makeContext(creep, room));
+    expect(firstAction?.type).to.equal("transfer");
+    const assignedTaskId = (creep.memory as any).assignedTaskId;
+    (creep.memory as any).assignedTaskId = "W1N1:refillExtension:stale";
+
+    const continuedAction = taskBoard.getAssignedDeliveryAction(makeContext(creep, room));
+
+    expect(continuedAction?.type).to.equal("transfer");
+    expect((creep.memory as any).assignedTaskId).to.equal(assignedTaskId);
+  });
+
+  it("does not interrupt active-hauler upgraders for extension refill", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const controller = makeController("controller1" as Id<StructureController>);
+    const room = createMockRoom("W1N1", { controller });
+    (room as any).find = (type: number) => type === FIND_MY_STRUCTURES ? [extension] : [];
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : id === controller.id ? controller : null;
+
+    const hauler = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1 },
+      store: makeStore(0, 50)
+    });
+    const upgrader = createMockCreep("upgrader1", {
+      room,
+      memory: { role: "upgrader", family: "economy", homeRoom: room.name, version: 1, working: true },
+      store: makeStore(50, 50)
+    });
+    MockGame.creeps[hauler.name] = hauler;
+    MockGame.creeps[upgrader.name] = upgrader;
+
+    const interrupt = getEconomyStateInterrupt(makeContext(upgrader, room), {
+      action: "upgrade",
+      targetId: controller.id,
+      startTick: Game.time - 1,
+      timeout: 25
+    });
+
+    expect(interrupt).to.equal(null);
+    expect(taskBoard.describeAssignments(room.name)).to.not.contain("upgrader1 -> refillExtension");
   });
 
   it("assigns builder critical extension refill through the task board before direct build fallback", () => {

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -24648,7 +24648,8 @@ return Object.values(e.tasks).find(function(e) {
 return e.reservations[t];
 });
 }(e, t.creep.name, t.memory.assignedTaskId);
-if (s && dl(s, r) && cl(s) && tl(t, s)) {
+if (s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId,
+s && dl(s, r) && cl(s) && tl(t, s)) {
 if (!function(e, t) {
 var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Du.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
@@ -25665,19 +25666,6 @@ invalidReason: s.reason
 return Ml(e, t(e), "Committed new state action");
 }
 
-function _l(e) {
-var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
-void 0 === e.memory.working && (e.memory.working = !t);
-var o = e.memory.working;
-t ? e.memory.working = !1 : r && (e.memory.working = !0);
-var n = e.memory.working;
-return o !== n && et(e.creep), n;
-}
-
-function Nl(e) {
-e.memory.working = !1, et(e.creep);
-}
-
 (Ol = {})[FIND_SOURCES] = 5e3, Ol[FIND_MINERALS] = 5e3, Ol[FIND_DEPOSITS] = 100,
 Ol[FIND_STRUCTURES] = 50, Ol[FIND_MY_STRUCTURES] = 50, Ol[FIND_HOSTILE_STRUCTURES] = 20,
 Ol[FIND_MY_SPAWNS] = 100, Ol[FIND_MY_CONSTRUCTION_SITES] = 20, Ol[FIND_CONSTRUCTION_SITES] = 20,
@@ -25685,23 +25673,23 @@ Ol[FIND_CREEPS] = 5, Ol[FIND_MY_CREEPS] = 5, Ol[FIND_HOSTILE_CREEPS] = 3, Ol[FIN
 Ol[FIND_TOMBSTONES] = 10, Ol[FIND_RUINS] = 10, Ol[FIND_FLAGS] = 50, Ol[FIND_NUKES] = 20,
 Ol[FIND_POWER_CREEPS] = 10, Ol[FIND_MY_POWER_CREEPS] = 10;
 
-var Pl, Il, Gl = {}, Ll = {}, Dl = {}, Fl = {};
+var _l, Nl, Pl = {}, Il = {}, Gl = {}, Ll = {};
 
-function Bl() {
-if (Pl) return Fl;
-Pl = 1;
+function Dl() {
+if (_l) return Ll;
+_l = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Fl.encode = function(t) {
+return Ll.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, Fl;
+}, Ll;
 }
 
-function Wl() {
-if (Il) return Dl;
-Il = 1;
-const e = Bl();
-return Dl.encode = function(t) {
+function Fl() {
+if (Nl) return Gl;
+Nl = 1;
+const e = Dl();
+return Gl.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25709,23 +25697,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Dl;
+}, Gl;
 }
 
-var Kl, Hl, Yl, Vl = {}, ql = jt(Object.freeze({
+var Bl, Wl, Kl, Hl = {}, Yl = jt(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function jl() {
-return Hl ? Kl : (Hl = 1, Kl = "function" == typeof URL ? URL : ql.URL);
+function Vl() {
+return Wl ? Bl : (Wl = 1, Bl = "function" == typeof URL ? URL : Yl.URL);
 }
 
-function zl() {
-if (Yl) return Vl;
-Yl = 1;
-const e = jl();
-Vl.getArg = function(e, t, r) {
+function ql() {
+if (Kl) return Hl;
+Kl = 1;
+const e = Vl();
+Hl.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25745,16 +25733,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Vl.toSetString = t ? r : function(e) {
+Hl.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Vl.fromSetString = t ? r : function(e) {
+}, Hl.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Vl.compareByGeneratedPositionsInflated = function(e, t) {
+}, Hl.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Vl.parseSourceMapInput = function(e) {
+}, Hl.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25808,7 +25796,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Vl.normalize = f, Vl.join = y, Vl.relative = function(t, r) {
+return Hl.normalize = f, Hl.join = y, Hl.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25820,18 +25808,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Vl.computeSourceURL = function(e, t, r) {
+}, Hl.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Vl;
+}, Hl;
 }
 
-var Ql, Xl = {};
+var jl, zl = {};
 
-function Zl() {
-if (Ql) return Xl;
-Ql = 1;
+function Ql() {
+if (jl) return zl;
+jl = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -25864,19 +25852,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Xl.ArraySet = e, Xl;
+return zl.ArraySet = e, zl;
 }
 
-var Jl, $l, em = {};
+var Xl, Zl, Jl = {};
 
-function tm() {
-if ($l) return Ll;
-$l = 1;
-const e = Wl(), t = zl(), r = Zl().ArraySet, o = function() {
-if (Jl) return em;
-Jl = 1;
-const e = zl();
-return em.MappingList = class {
+function $l() {
+if (Zl) return Il;
+Zl = 1;
+const e = Fl(), t = ql(), r = Ql().ArraySet, o = function() {
+if (Xl) return Jl;
+Xl = 1;
+const e = ql();
+return Jl.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -25896,7 +25884,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, em;
+}, Jl;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26025,13 +26013,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Ll.SourceMapGenerator = n, Ll;
+return n.prototype._version = 3, Il.SourceMapGenerator = n, Il;
 }
 
-var rm, om = {}, nm = {};
+var em, tm = {}, rm = {};
 
-function am() {
-return rm || (rm = 1, function(e) {
+function om() {
+return em || (em = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26043,36 +26031,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(nm)), nm;
+}(rm)), rm;
 }
 
-var im, sm, cm, um, lm = {
+var nm, am, im, sm, cm = {
 exports: {}
 };
 
-function mm() {
-if (im) return lm.exports;
-im = 1;
+function um() {
+if (nm) return cm.exports;
+nm = 1;
 let e = null;
-return lm.exports = function() {
+return cm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, lm.exports.initialize = t => {
+}, cm.exports.initialize = t => {
 e = t;
-}, lm.exports;
+}, cm.exports;
 }
 
-function dm() {
-if (cm) return sm;
-cm = 1;
-const e = mm();
+function lm() {
+if (im) return am;
+im = 1;
+const e = um();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return sm = function() {
+return am = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26139,28 +26127,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, sm;
+}, am;
 }
 
-var pm, fm, ym, vm, gm = {};
+var mm, dm, pm, fm, ym = {};
 
-function hm(e, t, r) {
+function vm(e, t, r) {
 return e - t >= r;
 }
 
-function Rm(e, t) {
+function gm(e, t) {
 return e.priority - t.priority;
 }
 
-function Em(e, t, r, o) {
+function hm(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function Tm(e, t, r, o) {
+function Rm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Cm(e) {
+function Em(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26178,12 +26166,12 @@ if (t) throw t.error;
 return o;
 }
 
-fm || (fm = 1, Gl.SourceMapGenerator = tm().SourceMapGenerator, Gl.SourceMapConsumer = function() {
-if (um) return om;
-um = 1;
-const e = zl(), t = am(), r = Zl().ArraySet;
-Wl();
-const o = mm(), n = dm(), a = Symbol("smcInternal");
+dm || (dm = 1, Pl.SourceMapGenerator = $l().SourceMapGenerator, Pl.SourceMapConsumer = function() {
+if (sm) return tm;
+sm = 1;
+const e = ql(), t = om(), r = Ql().ArraySet;
+Fl();
+const o = um(), n = lm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26220,7 +26208,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, om.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, tm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26410,7 +26398,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, om.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, tm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26519,11 +26507,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return om.IndexedSourceMapConsumer = c, om;
-}().SourceMapConsumer, Gl.SourceNode = function() {
-if (pm) return gm;
-pm = 1;
-const e = tm().SourceMapGenerator, t = zl(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return tm.IndexedSourceMapConsumer = c, tm;
+}().SourceMapConsumer, Pl.SourceNode = function() {
+if (mm) return ym;
+mm = 1;
+const e = $l().SourceMapGenerator, t = ql(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26662,27 +26650,27 @@ map: o
 };
 }
 }
-return gm.SourceNode = n, gm;
+return ym.SourceNode = n, ym;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(vm || (vm = {}));
+}(fm || (fm = {}));
 
-var Sm, wm = [ vm.CRITICAL, vm.HIGH, vm.MEDIUM, vm.LOW ], xm = {
-bucketThresholds: (ym = {}, ym[vm.CRITICAL] = 0, ym[vm.HIGH] = 2e3, ym[vm.MEDIUM] = 5e3,
-ym[vm.LOW] = 8e3, ym),
+var Tm, Cm = [ fm.CRITICAL, fm.HIGH, fm.MEDIUM, fm.LOW ], Sm = {
+bucketThresholds: (pm = {}, pm[fm.CRITICAL] = 0, pm[fm.HIGH] = 2e3, pm[fm.MEDIUM] = 5e3,
+pm[fm.LOW] = 8e3, pm),
 defaultMaxCpu: 5,
 logExecution: !1
-}, bm = function() {
+}, wm = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Cm(wm),
+tasksByPriority: Em(Cm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, xm), e);
+}, this.config = o(o({}, Sm), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26696,13 +26684,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(Rm), l = 0;
+var u = Array.from(this.tasks.values()).sort(gm), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (hm(Game.time, p.lastRun, p.interval)) if (Em(p.priority, s, this.config.bucketThresholds, vm.CRITICAL)) this.stats.skippedThisTick++; else {
+if (vm(Game.time, p.lastRun, p.interval)) if (hm(p.priority, s, this.config.bucketThresholds, fm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (Tm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Rm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26750,7 +26738,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Cm(wm);
+var t, r, o = Em(Cm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26767,22 +26755,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), Om = ((Sm = global)._computationScheduler || (Sm._computationScheduler = new bm),
-Sm._computationScheduler), Am = new Map;
+}(), xm = ((Tm = global)._computationScheduler || (Tm._computationScheduler = new wm),
+Tm._computationScheduler), bm = new Map;
 
-function km(e) {
-var t = Am.get(e);
+function Om(e) {
+var t = bm.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Am.set(e, t)), t;
+}, bm.set(e, t)), t;
 }
 
-function Mm(e, t, r) {
+function Am(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return Um(e, t[0], r), t[0];
-var i = km(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return km(e, t[0], r), t[0];
+var i = Om(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26799,32 +26787,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && Um(e, s, r), s;
+return s && km(e, s, r), s;
 }
 
-function Um(e, t, r) {
-var o = km(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function km(e, t, r) {
+var o = Om(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var _m = {
+var Mm = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function Nm(e, t, r) {
+function Um(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(_m[t], ";") : "";
+var o = t ? "color: ".concat(Mm[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function Pm(e) {
+function _m(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Im = {
+var Nm = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26838,7 +26826,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(Pm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(_m((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -26855,44 +26843,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(Pm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(_m(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Gm() {
+function Pm() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Fm() + Bm() + '<div class="module-help">'.concat(e.map(Lm).join(""), "</div>");
+return Lm() + Dm() + '<div class="module-help">'.concat(e.map(Im).join(""), "</div>");
 }
 
-var Lm = function(e) {
-var t = e.api.map(Dm).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Nm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Nm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Dm = function(e) {
+var Im = function(e) {
+var t = e.api.map(Gm).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Um(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Um(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Gm = function(e) {
 var t = [];
-e.describe && t.push(Nm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(Nm(e.name, "blue"), ": ").concat(Nm(e.desc, "green"));
+e.describe && t.push(Um(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Um(e.name, "blue"), ": ").concat(Um(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return Nm(e.name, "blue");
-}).join(", ") : "", o = Nm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Um(e.name, "blue");
+}).join(", ") : "", o = Um(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Nm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Fm = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Um(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, Lm = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, Bm = function() {
+}, Dm = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Wm = k("EnergyCollection"), Km = [ "refillSpawn", "refillExtension", "refillTower" ];
+}, Fm = k("EnergyCollection"), Bm = [ "refillSpawn", "refillExtension", "refillTower" ];
 
-function Hm(e) {
+function Wm(e) {
 if (e.droppedResources.length > 0) {
 var t = Je(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -26902,22 +26890,22 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Mm(e.creep, r, "energy_container");
-if (o) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Am(e.creep, r, "energy_container");
+if (o) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(r)) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
+if (Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(r)) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "withdraw",
 target: a,
 resourceType: RESOURCE_ENERGY
 };
 }
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -26927,35 +26915,35 @@ var n = ze(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (n.length > 0) {
-var a, i = Mm(e.creep, n, "energy_source");
-if (i) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
+var a, i = Am(e.creep, n, "energy_source");
+if (i) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
-if (Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(n)) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
+if (Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(n)) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "harvest",
 target: a
 };
 }
-return Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Ym(e) {
-var t = hl.getAssignedAction(e, Km);
+function Km(e) {
+var t = hl.getAssignedAction(e, Bm);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Vm(e) {
-return hl.hasActiveTask(e.room.name, Km);
+function Hm(e) {
+return hl.hasActiveTask(e.room.name, Bm);
 }
 
-function qm(e, t) {
+function Ym(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -26982,11 +26970,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function jm(e) {
+function Vm(e) {
 var t = hl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Vm(e)) {
-var r = qm(e, "deliver");
+if (!Hm(e)) {
+var r = Ym(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27006,6 +26994,19 @@ resourceType: RESOURCE_ENERGY
 };
 }
 return null;
+}
+
+function qm(e) {
+var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
+void 0 === e.memory.working && (e.memory.working = !t);
+var o = e.memory.working;
+t ? e.memory.working = !1 : r && (e.memory.working = !0);
+var n = e.memory.working;
+return o !== n && et(e.creep), n;
+}
+
+function jm(e) {
+e.memory.working = !1, et(e.creep);
 }
 
 var zm = function() {
@@ -27106,9 +27107,9 @@ lastUpdate: Game.time
 }(), Qm = new zm, Xm = k("LarvaWorkerBehavior");
 
 function Zm(e) {
-if (_l(e)) {
+if (qm(e)) {
 Xm.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var t = jm(e);
+var t = Vm(e);
 if (t) return Xm.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
 t;
 var r = function(e) {
@@ -27143,9 +27144,9 @@ if (e.isEmpty) return Xm.warn("".concat(e.creep.name, " larvaWorker idle (empty,
 type: "idle"
 };
 Xm.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-Nl(e);
+jm(e);
 }
-return Hm(e);
+return Wm(e);
 }
 
 function Jm(e) {
@@ -27174,16 +27175,30 @@ if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return Um(e, c, r), c;
+if (c) return km(e, c, r), c;
 }
-var u = Mm(e, t, r);
+var u = Am(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-var ad = {
+function ad(e) {
+return !function(e) {
+var t = globalThis.Game;
+return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
+var r = t.memory;
+return "hauler" === r.role && r.homeRoom === e.homeRoom && !t.spawning;
+});
+}(e) || function(e) {
+return e.spawnStructures.some(function(e) {
+return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) >= 250;
+});
+}(e);
+}
+
+var id = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27193,11 +27208,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, id = ad, sd = function(e) {
-return id.getLabResourceNeeds(e);
+}, sd = id, cd = function(e) {
+return sd.getLabResourceNeeds(e);
 };
 
-function cd(e) {
+function ud(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27219,7 +27234,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = sd(e.room.name);
+var n = cd(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27247,7 +27262,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, id.getLabOverflow(r));
+var t, r, o = (r = e.room.name, sd.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27262,7 +27277,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = sd(e.room.name);
+var i = cd(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27281,7 +27296,7 @@ type: "idle"
 }(e);
 }
 
-var ud = {
+var ld = {
 larvaWorker: Zm,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
@@ -27298,7 +27313,7 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (_l(e)) {
+if (qm(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27317,7 +27332,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Hm(e);
+return Wm(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27354,7 +27369,7 @@ roomName: o.targetRoom
 if (e.hostiles.some($m)) return {
 type: "idle"
 };
-if (_l(e)) {
+if (qm(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27373,7 +27388,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Hm(e);
+return Wm(e);
 },
 harvester: function(e) {
 var t, r = (t = ed(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
@@ -27487,7 +27502,7 @@ resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = _l(e), o = "defenseRefuel" === e.memory.task;
+var t, r = qm(e), o = "defenseRefuel" === e.memory.task;
 if (rd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
@@ -27525,7 +27540,7 @@ if (s) return s;
 }
 var c = hl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Vm(e)) {
+if (!Hm(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27587,7 +27602,7 @@ if (e.isEmpty) return rd.warn("".concat(e.creep.name, " hauler idle (empty, work
 type: "idle"
 };
 rd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-Nl(e);
+jm(e);
 }
 if (o) {
 var y = function(e) {
@@ -27726,11 +27741,11 @@ type: "idle"
 }));
 },
 builder: function(e) {
-if (_l(e)) {
-var t = Ym(e);
+if (qm(e)) {
+var t = Km(e);
 if (t) return t;
-if (!Vm(e)) {
-var r = qm(e, "builder");
+if (!Hm(e)) {
+var r = Ym(e, "builder");
 if (r) return r;
 }
 var o = function(e) {
@@ -27758,27 +27773,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Hm(e);
+return Wm(e);
 },
 upgrader: function(e) {
-if (_l(e)) {
-if (function(e) {
-return !function(e) {
-var t = globalThis.Game;
-return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
-var r = t.memory;
-return "hauler" === r.role && r.homeRoom === e.homeRoom && !t.spawning;
-});
-}(e) || function(e) {
-return e.spawnStructures.some(function(e) {
-return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) >= 250;
-});
-}(e);
-}(e)) {
-var t = Ym(e);
+if (qm(e)) {
+if (ad(e)) {
+var t = Km(e);
 if (t) return t;
-if (!Vm(e)) {
-var r = qm(e, "upgrader");
+if (!Hm(e)) {
+var r = Ym(e, "upgrader");
 if (r) return r;
 }
 }
@@ -27851,7 +27854,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (_l(e)) {
+if (qm(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -27875,7 +27878,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : jm(e) || (e.storage ? {
+} : Vm(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -27995,15 +27998,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : cd(e);
+} : ud(e);
 },
-labSupply: cd,
+labSupply: ud,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (_l(e)) {
+if (qm(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28183,7 +28186,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = _l(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = qm(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28206,9 +28209,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : jm(e) || (e.isEmpty || e.room.name !== o ? {
+} : Vm(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (Nl(e), {
+} : (jm(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28307,12 +28310,18 @@ roomName: o
 }
 };
 
-function ld(e) {
+function md(e) {
 var t;
-return (null !== (t = ud[e.memory.role]) && void 0 !== t ? t : Zm)(e);
+return (null !== (t = ld[e.memory.role]) && void 0 !== t ? t : Zm)(e);
 }
 
-var md = "patrol", dd = [ {
+var dd = new Set([ "build", "repair", "upgrade" ]);
+
+function pd(e, t) {
+return dd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || ad(e) ? Km(e) : null : null;
+}
+
+var fd = "patrol", yd = [ {
 x: 10,
 y: 5
 }, {
@@ -28348,7 +28357,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], pd = [ {
+} ], vd = [ {
 x: 10,
 y: 10
 }, {
@@ -28365,7 +28374,7 @@ x: 25,
 y: 25
 } ];
 
-function fd(e) {
+function gd(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28373,7 +28382,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function yd(e) {
+function hd(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28383,9 +28392,9 @@ roomName: e.roomName
 });
 }
 
-function vd(e) {
+function Rd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Fe.get(e.name, {
-namespace: md
+namespace: fd
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28405,25 +28414,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(dd), !1), i(pd), !1);
-}(t).map(fd).filter(function(e) {
+}(e)), !1), i(yd), !1), i(vd), !1);
+}(t).map(gd).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Fe.set(e.name, {
-waypoints: yd(n),
+waypoints: hd(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: md,
+namespace: fd,
 ttl: 1e3
 }), n;
 }
 
-function gd(e, t) {
+function Ed(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28433,87 +28442,87 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var hd = k("MilitaryBehaviors"), Rd = "defenseAssist";
+var Td = k("MilitaryBehaviors"), Cd = "defenseAssist";
 
-function Ed(e) {
+function Sd(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Rd ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Cd ? e.targetRoom : void 0;
 }
 
-function Td(e) {
+function wd(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === Rd && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === Cd && (delete e.task,
 delete e.targetRoom);
 }
 
-function Cd(e, t) {
+function xd(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function Sd(e) {
+function bd(e) {
 return Ir(Mr(e));
 }
 
-function wd(e) {
+function Od(e) {
 return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
 }
 
-function xd(e) {
+function Ad(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function bd(e, t) {
+function kd(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Od(e) {
-return bd(e, "guard") + bd(e, "ranger") + bd(e, "healer");
-}
-
-function Ad(e, t, r) {
-var o = e.memory;
-return Ed(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
-}
-
-function kd(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-return Ad(r, e, t);
-});
-}
-
-function Md(e, t) {
-return "defenseAssist:".concat(e, ":").concat(t, ":active");
+function Md(e) {
+return kd(e, "guard") + kd(e, "ranger") + kd(e, "healer");
 }
 
 function Ud(e, t, r) {
-return bd(e, t) > function(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-var o = r.memory;
-return !r.spawning && o.role === t && Ed(o) === e;
-}).length;
-}(e.roomName, t) || Od(e) > 0 && Sd(e.roomName) && function(e, t) {
-return kd(e, t).length;
-}(e.roomName, r) < 5;
+var o = e.memory;
+return Sd(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
 function _d(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+return Ud(r, e, t);
+});
+}
+
+function Nd(e, t) {
+return "defenseAssist:".concat(e, ":").concat(t, ":active");
+}
+
+function Pd(e, t, r) {
+return kd(e, t) > function(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+var o = r.memory;
+return !r.spawning && o.role === t && Sd(o) === e;
+}).length;
+}(e.roomName, t) || Md(e) > 0 && bd(e.roomName) && function(e, t) {
+return _d(e, t).length;
+}(e.roomName, r) < 5;
+}
+
+function Id(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== Rd) return null;
-if (wd(e)) return null;
+if (t.task && t.task !== Cd) return null;
+if (Od(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(xd).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ad).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== j(l).length && Ud(u, t.role, e.homeRoom)) return t.task = Rd, t.targetRoom = u.roomName,
-t.assistTarget = u.roomName, t.defenseSquadId = Md(e.homeRoom, u.roomName), t.defenseSquadSize = Sd(u.roomName) ? Math.max(5, Od(u)) : Math.max(1, Od(u)),
+if (l && 0 !== j(l).length && Pd(u, t.role, e.homeRoom)) return t.task = Cd, t.targetRoom = u.roomName,
+t.assistTarget = u.roomName, t.defenseSquadId = Nd(e.homeRoom, u.roomName), t.defenseSquadSize = bd(u.roomName) ? Math.max(5, Md(u)) : Math.max(1, Md(u)),
 t.defenseSquadCreatedAt = Game.time, u.roomName;
 }
 } catch (e) {
@@ -28530,7 +28539,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Nd(e) {
+function Gd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28538,19 +28547,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Pd(e, t) {
+function Ld(e, t) {
 if (!function(e) {
-return Boolean(Ed(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(Sd(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = Ed(t);
+var r = Sd(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = Mr(r), n = Ir(o), a = n ? kd(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = Ed(e);
+var o = Mr(r), n = Ir(o), a = n ? _d(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = Sd(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Ad(e, r, o);
+return e.memory.defenseSquadId === t && Ud(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28564,7 +28573,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return kd(e, t).reduce(function(e, t) {
+return _d(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = br(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28586,16 +28595,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return Cd(t, "parity-ready"), null;
-if (c >= u) return Cd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return xd(t, "parity-ready"), null;
+if (c >= u) return xd(t, "squad-quorum"), null;
 if (l) {
-if (!n) return Cd(t, "expired-staging"), null;
+if (!n) return xd(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Nd(e) - Nd(t);
+var r = Gd(e) - Gd(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28603,11 +28612,11 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return Cd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return xd(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return Cd(t, "squad-quorum"), null;
-if (l) return Cd(t, "expired-staging"), null;
+if (c >= u) return xd(t, "squad-quorum"), null;
+if (l) return xd(t, "expired-staging"), null;
 }
 var m = Lu(e.room.name);
 return {
@@ -28616,7 +28625,7 @@ position: null != m ? m : e.creep.pos
 };
 }
 
-function Id(e) {
+function Dd(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28648,21 +28657,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Gd(e, t) {
+function Fd(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Ld(e, t) {
+function Bd(e, t) {
 if (!e.swarmState) return null;
 var r = Lu(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (hd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+return r && e.creep.pos.getRangeTo(r) > 2 ? (Td.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Dd(e) {
+function Wd(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28686,7 +28695,7 @@ if (t) throw t.error;
 }
 }
 
-function Fd(e) {
+function Kd(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28694,23 +28703,23 @@ return Boolean(e);
 });
 }
 
-function Bd(e) {
+function Hd(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Wd(e) {
+function Yd(e) {
 var t, r = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Dd(e.memory.squadId);
-if (o) return Kd(e, o);
+var o = Wd(e.memory.squadId);
+if (o) return Vd(e, o);
 }
-var n = null !== (t = _d(e, r)) && void 0 !== t ? t : Ed(r);
-if (n && !wd(e)) {
-var a = Pd(e, r);
+var n = null !== (t = Id(e, r)) && void 0 !== t ? t : Sd(r);
+if (n && !Od(e)) {
+var a = Ld(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28723,9 +28732,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Id(e);
+var s = Dd(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Gd(e.creep, RANGED_ATTACK), l = Gd(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Fd(e.creep, RANGED_ATTACK), l = Fd(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28737,7 +28746,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Gd(e.creep, RANGED_ATTACK), l = Gd(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Fd(e.creep, RANGED_ATTACK), l = Fd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28748,7 +28757,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (Td(r), e.creep.room.name !== e.homeRoom) return {
+} else if (wd(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28757,8 +28766,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Id(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Gd(e.creep, RANGED_ATTACK), l = Gd(e.creep, ATTACK),
+var m = Dd(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Fd(e.creep, RANGED_ATTACK), l = Fd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28769,7 +28778,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = vd(e.room), p = gd(e.creep, d);
+var d = Rd(e.room), p = Ed(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28783,7 +28792,7 @@ type: "idle"
 };
 }
 
-function Kd(e, t) {
+function Vd(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28791,7 +28800,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Bd(t);
+var n = Hd(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28799,7 +28808,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Fd(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Kd(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -28822,7 +28831,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Fd(e).filter(function(t) {
+var t, r, o = Kd(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -28851,7 +28860,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Fd(t).filter(function(t) {
+var r = Kd(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -28867,7 +28876,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Fd(t).sort(function(e, t) {
+var a = Kd(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -28904,7 +28913,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Fd(t).filter(function(e) {
+var l = Kd(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -28921,7 +28930,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Fd(e).find(function(e) {
+return null !== (t = Kd(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -28932,7 +28941,7 @@ target: m
 type: "idle"
 };
 }
-var d = Id(e);
+var d = Dd(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -28944,10 +28953,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Gd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Fd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Gd(e.creep, ATTACK) && p <= 1 ? {
+} : Fd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -28963,10 +28972,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Gd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Fd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Gd(e.creep, ATTACK) && p <= 1 ? {
+} : Fd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -28982,7 +28991,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Bd(t)
+target: Hd(t)
 };
 
 case "dissolving":
@@ -29000,8 +29009,8 @@ type: "idle"
 }
 }
 
-var Hd = {
-guard: Wd,
+var qd = {
+guard: Yd,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29010,8 +29019,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = vd(e.room);
-return (o = gd(e.creep, r)) ? {
+var r = Rd(e.room);
+return (o = Ed(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29032,7 +29041,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = vd(e.room), (o = gd(e.creep, r)) ? {
+} : (r = Rd(e.room), (o = Ed(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29046,11 +29055,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Gd(e, HEAL);
+return Fd(e, HEAL);
 }), t.filter(function(e) {
-return Gd(e, RANGED_ATTACK);
+return Fd(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Gd(e, ATTACK);
+return Fd(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29071,7 +29080,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Gd(e.creep, RANGED_ATTACK), u = Gd(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Fd(e.creep, RANGED_ATTACK), u = Fd(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29102,19 +29111,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Dd(e.memory.squadId);
-if (o) return Kd(e, o);
+var o = Wd(e.memory.squadId);
+if (o) return Vd(e, o);
 }
-var n = null !== (t = _d(e, r)) && void 0 !== t ? t : Ed(r);
-if (n && !wd(e)) {
-var a = Pd(e, r);
+var n = null !== (t = Id(e, r)) && void 0 !== t ? t : Sd(r);
+if (n && !Od(e)) {
+var a = Ld(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === j(i).length) return Td(r), {
+if (0 === j(i).length) return wd(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29122,7 +29131,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== Rd && !r.assistTarget) {
+if (r.targetRoom && r.task !== Cd && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -29182,7 +29191,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || Ed(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || Sd(r) === t);
 }(e, t);
 }
 });
@@ -29208,7 +29217,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = vd(e.room), v = gd(e.creep, y);
+var y = Rd(e.room), v = Ed(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29219,8 +29228,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Dd(e.memory.squadId);
-if (r) return Kd(e, r);
+var r = Wd(e.memory.squadId);
+if (r) return Vd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29242,9 +29251,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Id(e);
+var a = Dd(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Gd(e.creep, RANGED_ATTACK), c = Gd(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Fd(e.creep, RANGED_ATTACK), c = Fd(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29263,7 +29272,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = vd(e.room), m = gd(e.creep, l);
+var l = Rd(e.room), m = Ed(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29285,8 +29294,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Dd(e.memory.squadId);
-if (r) return Kd(e, r);
+var r = Wd(e.memory.squadId);
+if (r) return Vd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29347,9 +29356,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Ld(e, "siegeUnit");
+var p = Bd(e, "siegeUnit");
 if (p) return p;
-var f = vd(e.room), y = gd(e.creep, f);
+var f = Rd(e.room), y = Ed(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29360,8 +29369,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Dd(e.memory.squadId);
-if (r) return Kd(e, r);
+var r = Wd(e.memory.squadId);
+if (r) return Vd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29378,7 +29387,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Ld(e, "harasser (no target)") || {
+if (!t) return Bd(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29420,9 +29429,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Ld(e, "harasser (no targets)");
+var c = Bd(e, "harasser (no targets)");
 if (c) return c;
-var u = vd(e.room), l = gd(e.creep, u);
+var u = Rd(e.room), l = Ed(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29435,9 +29444,9 @@ var t, r, o = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Dd(e.memory.squadId))) return Kd(e, a);
+if (e.memory.squadId && (a = Wd(e.memory.squadId))) return Vd(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (Ed(o) && Td(o), e.room.name !== e.homeRoom) return {
+if (Sd(o) && wd(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29451,9 +29460,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = _d(e, o)) && void 0 !== t ? t : Ed(o);
-if (i && !wd(e)) {
-var s = Pd(e, o);
+var a, i = null !== (t = Id(e, o)) && void 0 !== t ? t : Sd(o);
+if (i && !Od(e)) {
+var s = Ld(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29463,14 +29472,14 @@ roomName: i
 var u = j(c), l = z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return Td(o), {
+if (0 === u.length && 0 === l.length) return wd(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Id(e);
+var m = Dd(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29490,8 +29499,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Dd(e.memory.squadId))) return Kd(e, a);
-var p, f = Id(e);
+if (e.memory.squadId && (a = Wd(e.memory.squadId))) return Vd(e, a);
+var p, f = Dd(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29502,7 +29511,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = vd(e.room), v = gd(e.creep, y);
+var y = Rd(e.room), v = Ed(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29523,21 +29532,21 @@ type: "idle"
 }
 };
 
-function Yd(e) {
+function jd(e) {
 var t;
-return hl.getAssignedAction(e) || (null !== (t = Hd[e.memory.role]) && void 0 !== t ? t : Wd)(e);
+return hl.getAssignedAction(e) || (null !== (t = qd[e.memory.role]) && void 0 !== t ? t : Yd)(e);
 }
 
-var Vd = k("PowerExecutor");
+var zd = k("PowerExecutor");
 
-function qd(e, t) {
+function Qd(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function jd(e) {
+function Xd(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29579,8 +29588,8 @@ type: "idle"
 };
 }
 
-var zd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Qd = {
-powerHarvester: jd,
+var Zd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Jd = {
+powerHarvester: Xd,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29652,65 +29661,65 @@ roomName: e.homeRoom
 }
 };
 
-function Xd(e) {
+function $d(e) {
 var t;
-return (null !== (t = Qd[e.memory.role]) && void 0 !== t ? t : jd)(e);
+return (null !== (t = Jd[e.memory.role]) && void 0 !== t ? t : Xd)(e);
 }
 
-function Zd(e) {
+function ep(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var Jd = {
+var tp = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, $d = {
+}, rp = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, ep = {
+}, op = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, tp = {
+}, np = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, rp = {
+}, ap = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, op = {
+}, ip = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, np = {
+}, sp = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, ap = {
+}, cp = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function ip(e) {
+function up(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function sp(e) {
+function lp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29718,7 +29727,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function cp(e) {
+function mp(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29726,12 +29735,12 @@ y: parseInt(n, 10)
 };
 }
 
-function up(e) {
+function dp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = lp(s);
+o[s.n] = pp(s);
 }
 } catch (e) {
 t = {
@@ -29747,23 +29756,23 @@ if (t) throw t.error;
 return o;
 }
 
-function lp(e) {
+function pp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = $d[e.r]) && void 0 !== t ? t : "core",
-health: mp(e.h),
+role: null !== (t = rp[e.r]) && void 0 !== t ? t : "core",
+health: fp(e.h),
 activeTasks: e.t,
-portals: e.p.map(dp),
+portals: e.p.map(yp),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(pp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(vp)
 };
 }
 
-function mp(e) {
+function fp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = tp[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = np[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29776,11 +29785,11 @@ lastUpdate: e.u
 };
 }
 
-function dp(e) {
+function yp(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: sp(e.sp),
+sourcePos: lp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29790,7 +29799,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function pp(e) {
+function vp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29799,7 +29808,7 @@ bucketLevel: e.b
 };
 }
 
-function fp(e) {
+function gp(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -29809,12 +29818,12 @@ isAlly: 1 === e.a
 };
 }
 
-function yp(e) {
+function hp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = vp(u);
+i[u.n] = Rp(u);
 }
 } catch (e) {
 t = {
@@ -29837,13 +29846,13 @@ updatedAt: e.u
 };
 }
 
-function vp(e) {
+function Rp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: cp(e.pp),
+portalPos: mp(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -29854,46 +29863,46 @@ lastUpdate: e.u
 };
 }
 
-function gp(e) {
+function Ep(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = op[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = ip[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = ap[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = cp[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function hp(e, t) {
+function Tp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function Rp(e) {
+function Cp(e) {
 var t;
 return {
-c: null !== (t = ep[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: hp(e.cpuUsage, 2),
+c: null !== (t = op[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: Tp(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: hp(e.avgRCL, 1),
+rl: Tp(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function Ep(e) {
+function Sp(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: ip(e.sourcePos),
+sp: up(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -29902,27 +29911,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function Tp(e) {
+function wp(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: hp(e.cpuUsed, 2),
+u: Tp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function Cp(e) {
+function xp(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Sp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(bp)
 };
 }
 
-function Sp(e) {
+function bp(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -29932,23 +29941,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function wp(e) {
+function Op(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = rp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = ap[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = np[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = sp[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function xp(e) {
+function Ap(e) {
 return {
 name: e,
 role: "core",
@@ -29971,7 +29980,7 @@ cpuLimit: 0
 };
 }
 
-function bp(e) {
+function kp(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -29981,16 +29990,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = Jd[t.role]) && void 0 !== r ? r : t.role[0],
-h: Rp(t.health),
+r: null !== (r = tp[t.role]) && void 0 !== r ? r : t.role[0],
+h: Cp(t.health),
 t: t.activeTasks,
-p: t.portals.map(Ep),
+p: t.portals.map(Sp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Tp)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(wp)
 };
 }(t[0], t[1]);
 }),
-g: Cp(e.globalTargets),
+g: xp(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30004,7 +30013,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? ip(t.portalPos) : void 0,
+pp: t.portalPos ? up(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30016,20 +30025,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(wp),
+k: e.tasks.map(Op),
 ls: e.lastSync
 };
 var t;
-}(e), r = Zd(JSON.stringify(t));
+}(e), r = ep(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Op(e) {
+function Mp(e) {
 try {
-var t = JSON.parse(e), r = Zd(JSON.stringify(t.d));
+var t = JSON.parse(e), r = ep(JSON.stringify(t.d));
 return t.c !== r ? (va.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30038,13 +30047,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: up(a.s),
+shards: dp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(fp)), n),
-footprintOperation: a.o ? yp(a.o) : void 0,
-tasks: a.k.map(gp),
+o.en && (n.enemies = o.en.map(gp)), n),
+footprintOperation: a.o ? hp(a.o) : void 0,
+tasks: a.k.map(Ep),
 lastSync: a.ls,
 checksum: i
 });
@@ -30056,34 +30065,34 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Ap, kp, Mp = 102400;
+var Up, _p, Np = 102400;
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Ap || (Ap = {})), function(e) {
+}(Up || (Up = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(kp || (kp = {}));
+}(_p || (_p = {}));
 
-var Up = null != va ? va : {
+var Pp = null != va ? va : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, _p = {
+}, Ip = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Np = {
+}, Gp = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Pp = function() {
+}, Lp = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, _p), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ip), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30100,19 +30109,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Op(r);
-o && (this.interShardMemory = o, Up.debug("Loaded InterShardMemory", {
+var o = Mp(r);
+o && (this.interShardMemory = o, Pp.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Up.error("Failed to load InterShardMemory: ".concat(n), {
+Pp.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = xp(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Ap(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30273,25 +30282,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Up.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Pp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Up.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Pp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Up.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Pp.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Up.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Pp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30324,7 +30333,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Up.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Pp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30354,12 +30363,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Up.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Pp.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Up.info("War ended, transitioning to ".concat(i), {
+Pp.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Up.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Pp.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30385,7 +30394,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Np[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Gp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30437,13 +30446,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Up.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Pp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Up.debug("Could not set shard limits: ".concat(S), {
+Pp.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30451,27 +30460,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Up.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Pp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
 try {
-var t = InterShardMemory.getLocal(), r = t ? Op(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
+var t = InterShardMemory.getLocal(), r = t ? Mp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
 o && (!n || o.updatedAt >= n.updatedAt) && (this.interShardMemory.footprintOperation = o);
 } catch (e) {}
-var a = bp(this.interShardMemory);
-if (a.length > Mp) {
-Up.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Mp), {
+var a = kp(this.interShardMemory);
+if (a.length > Np) {
+Pp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Np), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var i = bp(this.interShardMemory);
-return i.length > Mp ? (Up.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Mp), {
+var i = kp(this.interShardMemory);
+return i.length > Np ? (Pp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Np), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(i);
 }
 InterShardMemory.setLocal(a), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var s = e instanceof Error ? e.message : String(e);
-Up.error("Failed to sync InterShardMemory: ".concat(s), {
+Pp.error("Failed to sync InterShardMemory: ".concat(s), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30509,7 +30518,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = xp(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Ap(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30527,40 +30536,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Up.info("Repaired InterShardMemory structure", {
+Pp.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Up.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Pp.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Op(r);
-if (!o) return void Up.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Mp(r);
+if (!o) return void Pp.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Up.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Pp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Up.warn("InterShardMemory verification failed: ".concat(a), {
+Pp.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Up.info("Attempting InterShardMemory recovery", {
+Pp.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Op(r);
-if (o) return this.interShardMemory = o, void Up.info("Recovered InterShardMemory from storage", {
+var o = Mp(r);
+if (o) return this.interShardMemory = o, void Pp.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30575,12 +30584,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = xp(n), Up.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Ap(n), Pp.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Up.error("InterShardMemory recovery failed: ".concat(a), {
+Pp.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30590,7 +30599,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Up.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Pp.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30606,7 +30615,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Up.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Pp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30622,7 +30631,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Up.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Pp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30637,7 +30646,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Up.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Pp.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30656,7 +30665,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Up.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Pp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30702,11 +30711,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Up.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Pp.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = bp(this.interShardMemory).length, o = r / Mp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = kp(this.interShardMemory).length, o = r / Np * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30733,11 +30742,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Up.info("Forcing InterShardMemory sync with validation", {
+Pp.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = bp(this.interShardMemory).length, n = bp(o(o({}, this.interShardMemory), {
+var e, t, r = kp(this.interShardMemory).length, n = kp(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -30761,8 +30770,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: Mp,
-percent: Math.round(r / Mp * 1e4) / 100,
+limit: Np,
+percent: Math.round(r / Np * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -30770,10 +30779,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Ap.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Up.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), Ip = new Pp, Gp = {
+}(), Dp = new Lp, Fp = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -30784,11 +30793,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: kp.LOW,
-NORMAL: kp.NORMAL,
-HIGH: kp.HIGH
+LOW: _p.LOW,
+NORMAL: _p.NORMAL,
+HIGH: _p.HIGH
 }
-}, Lp = function() {
+}, Bp = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -30798,7 +30807,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = Ip.getActiveTransferTasks();
+var n = Dp.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -30825,7 +30834,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = Ip.getOptimalPortalRoute(e.targetShard);
+var t = Dp.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -30893,7 +30902,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-Ip.updateTaskProgress(e.taskId, t);
+Dp.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -30909,7 +30918,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = Gp.optimizeBody({
+i = Fp.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -30920,8 +30929,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Gp.spawnPriorities.LOW;
-e.priority >= 80 ? d = Gp.spawnPriorities.HIGH : e.priority >= 50 && (d = Gp.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Fp.spawnPriorities.LOW;
+e.priority >= 80 ? d = Fp.spawnPriorities.HIGH : e.priority >= 50 && (d = Fp.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -30939,7 +30948,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-Gp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Fp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -30966,7 +30975,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void Ip.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Dp.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", va.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -30978,8 +30987,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, Ip.updateTaskProgress(e.taskId, 100, "complete"),
-Ip.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Dp.updateTaskProgress(e.taskId, 100, "complete"),
+Dp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31009,12 +31018,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Dp = new Lp;
+}(), Wp = new Bp;
 
-function Fp(e, t, r) {
+function Kp(e, t, r) {
 var o, n, a, i;
 try {
-var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Op(c)) && void 0 !== a ? a : {
+var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Mp(c)) && void 0 !== a ? a : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -31029,11 +31038,11 @@ if (!(null == l ? void 0 : l.targets[s])) return;
 var m = l.targets[s];
 m.status = e, null !== (i = m.arrivedAt) && void 0 !== i || (m.arrivedAt = Game.time),
 m.claimTargetRoom = null != t ? t : m.claimTargetRoom, m.blockedReason = r, m.lastUpdate = Game.time,
-"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(bp(u));
+"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(kp(u));
 } catch (e) {}
 }
 
-function Bp(e) {
+function Hp(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31061,15 +31070,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Fp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Kp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || j(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Fp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Kp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Fp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Kp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31086,24 +31095,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Fp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Kp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Fp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Kp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Wp(e) {
+function Yp(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Kp(e, t) {
+function Vp(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31137,14 +31146,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (A.mineralType = y.mineralType), u[e.name] = A;
 }
 
-function Hp(e, t) {
+function qp(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function Yp(e) {
+function jp(e) {
 var t = Qm.getEmpire();
-if (Gu.isExit(e.creep.pos)) return Wp(e.room.name);
+if (Gu.isExit(e.creep.pos)) return Yp(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31159,7 +31168,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Hp(t.x, t.y - 1), Hp(t.x + 1, t.y), Hp(t.x, t.y + 1), Hp(t.x - 1, t.y) ] : [];
+return t ? [ qp(t.x, t.y - 1), qp(t.x + 1, t.y), qp(t.x, t.y + 1), qp(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31222,13 +31231,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Kp(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Vp(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Kp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Vp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31238,19 +31247,19 @@ type: "idle"
 };
 }
 
-function Vp(e) {
+function zp(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function qp(e) {
-return e.hostiles.some(Vp);
+function Qp(e) {
+return e.hostiles.some(zp);
 }
 
-function jp(e) {
+function Xp(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function zp(e) {
+function Zp(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31273,8 +31282,8 @@ type: "idle"
 };
 }
 
-var Qp = {
-scout: Yp,
+var Jp = {
+scout: jp,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31308,7 +31317,7 @@ return {
 type: "idle"
 };
 }
-if (Gu.isExit(e.creep.pos)) return Wp(e.room.name);
+if (Gu.isExit(e.creep.pos)) return Yp(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31330,8 +31339,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Bp,
-interShardScout: Bp,
+interShardClaimer: Hp,
+interShardScout: Hp,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31407,8 +31416,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return zp(e);
-if (qp(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return Zp(e);
+if (Qp(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31449,7 +31458,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return jp(t) - jp(e);
+return Xp(t) - Xp(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31469,7 +31478,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : zp(e);
+} : Zp(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31558,9 +31567,9 @@ type: "idle"
 }
 };
 
-function Xp(e, t) {
+function $p(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : qp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Qp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31568,24 +31577,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function Zp(e) {
+function ef(e) {
 var t;
-return (null !== (t = Qp[e.memory.role]) && void 0 !== t ? t : Yp)(e);
+return (null !== (t = Jp[e.memory.role]) && void 0 !== t ? t : jp)(e);
 }
 
-function Jp(e) {
+function tf(e) {
 var t = Nu(e);
-wl(e, Ul(t, ld), t);
-}
-
-function $p(e) {
-var t = Nu(e);
-wl(e, Ul(t, Zp, {
-interrupt: Xp
+wl(e, Ul(t, md, {
+interrupt: pd
 }), t);
 }
 
-function ef(e) {
+function rf(e) {
+var t = Nu(e);
+wl(e, Ul(t, ef, {
+interrupt: $p
+}), t);
+}
+
+function of(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31626,8 +31637,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && zd.has(i) && V(s))) {
-Vd.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && Zd.has(i) && V(s))) {
+zd.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31692,7 +31703,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !qd(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Qd(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31702,7 +31713,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !qd(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Qd(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31713,7 +31724,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !qd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Qd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -31766,7 +31777,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !qd(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Qd(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -31808,7 +31819,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !qd(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Qd(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -31818,7 +31829,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !qd(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Qd(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -31826,7 +31837,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && j(e.room).length > 0) {
 var o = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !qd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Qd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -31838,7 +31849,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !qd(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Qd(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -31846,12 +31857,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !qd(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Qd(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !qd(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Qd(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -31885,18 +31896,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function tf(e) {
+function nf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var rf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), of = -1, nf = Object.create(null);
+var af = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), sf = -1, cf = Object.create(null);
 
-function af(e) {
+function uf(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var sf = {
+var lf = {
 harvester: ha.CRITICAL,
 queenCarrier: ha.CRITICAL,
 hauler: ha.HIGH,
@@ -31931,12 +31942,12 @@ labTech: ha.IDLE,
 factoryWorker: ha.IDLE
 };
 
-function cf(e) {
+function mf(e) {
 var t;
-return null !== (t = sf[e]) && void 0 !== t ? t : ha.MEDIUM;
+return null !== (t = lf[e]) && void 0 !== t ? t : ha.MEDIUM;
 }
 
-function uf(e) {
+function df(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -31952,20 +31963,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && af(o) === e && t++;
+o && uf(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (of !== Game.time && (of = Game.time, nf = function() {
+}(e) : null !== (r = (sf !== Game.time && (sf = Game.time, cf = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = af(o);
+var n = uf(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), nf)[e]) && void 0 !== r ? r : 0;
+}()), cf)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Ue().cpu.disableCreepBootstrapCountCache
@@ -31975,7 +31986,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!rf.has(t.role)) return !1;
+if (!af.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -31985,7 +31996,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !tf(r)) return !1;
+if (!r || !nf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -31999,7 +32010,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !tf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !nf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32007,7 +32018,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !tf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !nf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32015,7 +32026,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !tf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !nf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32023,7 +32034,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && tf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && nf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32039,7 +32050,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !tf(r)) return !1;
+if (!r || !nf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32080,28 +32091,30 @@ case "economy":
 default:
 !function(e) {
 var t = Nu(e);
-wl(e, Ul(t, ld), t);
+wl(e, Ul(t, md, {
+interrupt: pd
+}), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
 var t = Nu(e);
-wl(e, Ul(t, Yd), t);
+wl(e, Ul(t, jd), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
 var t = Nu(e);
-wl(e, Ul(t, Zp), t);
+wl(e, Ul(t, ef), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
 var t = Nu(e);
-wl(e, Ul(t, Xd), t);
+wl(e, Ul(t, $d), t);
 }(e);
 }
 });
@@ -32122,7 +32135,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var lf = function() {
+var pf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32163,7 +32176,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = cf(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = mf(r), n = "creep:".concat(e.name);
 Ja.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -32179,7 +32192,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && uf(t);
+t && !t.spawning && df(t);
 }
 }), this.registeredCreeps.add(e.name), Ci.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32204,7 +32217,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = cf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = mf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32229,20 +32242,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), mf = new lf;
+}(), ff = new pf;
 
-function df(e) {
+function yf(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, pf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, vf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function pf(e) {
+function vf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function ff(e) {
+function gf(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32255,14 +32268,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function yf(e, t) {
+function hf(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var vf = {
+var Rf = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32290,11 +32303,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function gf(e, t) {
+function Ef(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function hf(e) {
+function Tf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32304,9 +32317,9 @@ tick: Game.time
 }, a;
 }
 
-var Rf = [ "defense", "war", "expand", "siege" ];
+var Cf = [ "defense", "war", "expand", "siege" ];
 
-function Ef(e) {
+function Sf(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32319,11 +32332,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function Tf(e, t, r) {
-t >= 2 && (e.pheromones.war = gf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = gf(e.pheromones.siege + 20, r));
+function wf(e, t, r) {
+t >= 2 && (e.pheromones.war = Ef(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ef(e.pheromones.siege + 20, r));
 }
 
-var Cf = function() {
+var xf = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32338,27 +32351,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), Sf = function() {
+}(), bf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, vf), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Rf), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new Cf(10),
-energySpawning: new Cf(10),
-energyConstruction: new Cf(10),
-energyRepair: new Cf(10),
-energyTower: new Cf(10),
-controllerProgress: new Cf(10),
-hostileCount: new Cf(5),
-damageReceived: new Cf(5),
-idleWorkers: new Cf(10),
+energyHarvested: new xf(10),
+energySpawning: new xf(10),
+energyConstruction: new xf(10),
+energyRepair: new xf(10),
+energyTower: new xf(10),
+controllerProgress: new xf(10),
+hostileCount: new xf(5),
+damageReceived: new xf(5),
+idleWorkers: new xf(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = hf(e);
+var o = Tf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32431,7 +32444,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = gf(e[s] * c, t);
+e[s] = Ef(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32447,43 +32460,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = hf(t);
+var o = Tf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = gf(e.harvest + n / 3e3 * 10, r);
+e.harvest = Ef(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = gf(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = Ef(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = gf(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = Ef(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = gf(e.defense + 10 * o, r));
+o > 0 && (e.defense = Ef(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = gf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = gf(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = Ef(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ef(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = gf(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = Ef(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = gf(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = Ef(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = gf(e.pheromones.defense + 5 * t, o), Tf(e, r, o),
+e.danger = r, e.pheromones.defense = Ef(e.pheromones.defense + 5 * t, o), wf(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32491,7 +32504,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = gf(t / 10, o), Tf(e, r, o);
+e.danger = r, e.pheromones.defense = Ef(t / 10, o), wf(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32504,8 +32517,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = gf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = gf(f + y, o);
+var p = Ef(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = Ef(f + y, o);
 }
 }
 }
@@ -32524,18 +32537,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = gf(e.pheromones.defense + 5, r), e.pheromones.build = gf(e.pheromones.build + 10, r),
+e.pheromones.defense = Ef(e.pheromones.defense + 5, r), e.pheromones.build = Ef(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = gf(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ef(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = gf(e.pheromones.siege + 50, t), e.pheromones.defense = gf(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = Ef(e.pheromones.siege + 50, t), e.pheromones.defense = Ef(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = gf(e.pheromones.expand - 10, t), e.pheromones.defense = gf(e.pheromones.defense + 5, t);
+e.pheromones.expand = Ef(e.pheromones.expand - 10, t), e.pheromones.defense = Ef(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32545,10 +32558,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Ef(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(Sf(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Rf)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(Cf)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32602,7 +32615,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = gf(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = Ef(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32637,7 +32650,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), wf = new Sf, xf = {
+}(), Of = new bf, Af = {
 seedNest: {
 rcl: 1
 },
@@ -32678,7 +32691,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, bf = {
+}, kf = {
 eco: {
 economy: .75,
 military: .05,
@@ -32721,7 +32734,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Of = {
+}, Mf = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -32778,13 +32791,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Af = function() {
+}, Uf = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = xf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = xf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= xf.fortifiedHive.rcl ? "fortifiedHive" : s >= xf.matureColony.rcl ? "matureColony" : s >= xf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Af.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Af.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Af.fortifiedHive.rcl ? "fortifiedHive" : s >= Af.matureColony.rcl ? "matureColony" : s >= Af.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Fe.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -32819,7 +32832,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = xf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Af[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -32832,7 +32845,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), kf = function() {
+}(), _f = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -32854,9 +32867,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return bf[e];
+return kf[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return Of[e];
+return Mf[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -32866,15 +32879,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Mf = new Af, Uf = new kf;
+}(), Nf = new Uf, Pf = new _f;
 
-function _f(e) {
+function If(e) {
 return !Y(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Nf(e, t, r) {
+function Gf(e, t, r) {
 if (!e) return null;
 var o = mr.getEmpire();
 if (Y(e, {
@@ -32913,11 +32926,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Pf() {
+function Lf() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var If = new Map, Gf = function() {
+var Df = new Map, Ff = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = j(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33061,7 +33074,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: If.get(e.name),
+previousStructures: Df.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33091,7 +33104,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && If.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Df.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33100,7 +33113,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-_f(u) && o.add(u.owner.username);
+If(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33114,7 +33127,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Nf(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Gf(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33130,7 +33143,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? wf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? wf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && wf.onNukeDetected(t);
+"danger" === y.type ? Of.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Of.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Of.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33190,10 +33203,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Pf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = Lf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Pf()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = Lf()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33236,7 +33249,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Uf.isCombatPosture(t.posture),
+isCombatPosture: Pf.isCombatPosture(t.posture),
 wallRepairTarget: so(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33260,27 +33273,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Lf = new Gf, Df = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Bf = new Ff, Wf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Ff() {
+function Kf() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Bf(e, t, r, o) {
+function Hf(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Ff()
+selectedAt: Kf()
 });
 }
 
-function Wf(e) {
+function Yf(e) {
 return e >= 2 && e <= 3;
 }
 
-function Kf(e, t) {
+function Vf(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33293,7 +33306,7 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-function Hf(e, t) {
+function qf(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -33307,10 +33320,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var Yf = function() {
+var jf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Wf(e) ? 5 : 10;
+return Yf(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33708,16 +33721,16 @@ y: e.y - R.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Bf(t, v, E.name, f);
+Hf(t, v, E.name, f);
 var T = f >= 3 && (t.danger >= 1 || function(e, t) {
-var r = Hf(STRUCTURE_TOWER, t);
-return r > 0 && Kf(e, STRUCTURE_TOWER) < r;
+var r = qf(STRUCTURE_TOWER, t);
+return r > 0 && Vf(e, STRUCTURE_TOWER) < r;
 }(e, f)), C = T ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Hf(STRUCTURE_TOWER, g), R = Kf(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = qf(STRUCTURE_TOWER, g), R = Vf(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34114,7 +34127,7 @@ var r, o, n, i = Vo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && Kf(e, u) < l) return !0;
+if (!(l <= 0) && Vf(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34130,8 +34143,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + S + w + C >= 10 && !x) t.metrics.constructionSites = p.length + S + w + C; else {
-if (!Uf.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Ff());
+if (!Pf.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Kf());
 }(t, v)) {
 var b = function(e, t, r, o, n) {
 var i, s;
@@ -34289,7 +34302,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Df.has(e.structureType);
+return Wf.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34298,7 +34311,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = Wf(f) ? 2 : 3;
+var M = Yf(f) ? 2 : 3;
 (k = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -34974,13 +34987,13 @@ anchor: l
 }
 return null;
 }(e, f);
-L && (Bf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
+L && (Hf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), Vf = new Yf;
+}(), zf = new jf;
 
-function qf(e) {
+function Qf(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35002,7 +35015,7 @@ siege: e.pheromones.siege
 };
 }
 
-var jf = {
+var Xf = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35015,10 +35028,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, zf = new (function() {
+}, Zf = new (function() {
 function e() {
 this.manager = new ou({
-logger: jf
+logger: Xf
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35028,23 +35041,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = qf(t);
+var r = Qf(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = qf(t);
+var r = Qf(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), Qf = {
+}()), Jf = {
 labManager: Ru,
 boostManager: fu,
-chemistryPlanner: zf,
+chemistryPlanner: Zf,
 labConfigManager: gu,
 logger: Ci
-}, Xf = function() {
+}, $f = function() {
 function e(e) {
-void 0 === e && (e = Qf), this.deps = e;
+void 0 === e && (e = Jf), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35083,9 +35096,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), Zf = new Xf, Jf = function() {
+}(), ey = new $f, ty = function() {
 function e(e) {
-void 0 === e && (e = Zf), this.labWorkflow = e;
+void 0 === e && (e = ey), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35130,27 +35143,27 @@ if (r) throw r.error;
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), $f = new Jf, ey = {
+}(), ry = new ty, oy = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, ty = new Map;
+}, ny = new Map;
 
-function ry(e) {
+function ay(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function oy(e) {
+function iy(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var ny = function() {
+var sy = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, ey), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, oy), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35192,7 +35205,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = ty.get(e.name);
+var t = ny.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35214,28 +35227,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return ty.set(e.name, o), o;
+return ny.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && wf.updateMetrics(i, c),
-Lf.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Of.updateMetrics(i, c),
+Bf.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Mf.updateEvolutionStage(c, i, e),
-s || Mf.updateMissingStructures(c, i)), Uf.updatePosture(c), this.config.enablePheromones && !s && wf.updatePheromones(c, i),
-this.config.enableTowers && Lf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Vf.getConstructionInterval(l), d = Uf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Nf.updateEvolutionStage(c, i, e),
+s || Nf.updateMissingStructures(c, i)), Pf.updatePosture(c), this.config.enablePheromones && !s && Of.updatePheromones(c, i),
+this.config.enableTowers && Bf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = zf.getConstructionInterval(l), d = Pf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = ry(r), n = oy(e);
+var o = ay(r), n = iy(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Vf.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (zf.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = ry(r), n = oy(e);
+var o = ay(r), n = iy(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && $f.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && ry.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35245,7 +35258,7 @@ var f = Game.cpu.getUsed() - n;
 Ji.recordRoom(i, f), Ji.endRoom(this.roomName, n);
 } else Ji.endRoom(this.roomName, n);
 }, e;
-}(), ay = function() {
+}(), cy = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35259,7 +35272,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new ny(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new sy(v.name));
 }
 } catch (t) {
 e = {
@@ -35322,7 +35335,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new ny(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new sy(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35343,9 +35356,9 @@ stack: c
 }
 }
 }, e;
-}(), iy = new ay;
+}(), uy = new cy;
 
-function sy(e) {
+function ly(e) {
 var t, r, o;
 if (j(e).length > 0) return ha.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
@@ -35356,14 +35369,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
 }
 
-function cy(e) {
+function my(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function uy(e, t, r) {
+function dy(e, t, r) {
 var o;
 return t === ha.CRITICAL ? {
 tickModulo: void 0,
@@ -35383,7 +35396,7 @@ tickOffset: void 0
 };
 }
 
-var ly, my = function() {
+var py, fy = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35399,7 +35412,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = sy(n), u = cy(n);
+var i = "room:".concat(o), s = Ja.getProcess(i), c = ly(n), u = my(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35418,7 +35431,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = sy(e), o = cy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = uy(e, r, a);
+var t, r = ly(e), o = my(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = dy(e, r, a);
 Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35435,7 +35448,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && iy.runRoom(t);
+t && uy.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35443,7 +35456,7 @@ Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = uy(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = dy(e, t, a);
 Ja.unregisterProcess(n), Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35460,7 +35473,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && iy.runRoom(t);
+t && uy.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35482,7 +35495,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = sy(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = ly(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35509,7 +35522,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), dy = new my, py = function() {
+}(), yy = new fy, vy = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Ja.getStatsSummary(), t = Ja.getConfig();
@@ -35586,11 +35599,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(ff(e.summary.byLayer)), "Groups: ".concat(ff(e.summary.byGroup)), "States: ".concat(ff(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(gf(e.summary.byLayer)), "Groups: ".concat(gf(e.summary.byGroup)), "States: ".concat(gf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(yf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(hf)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(df(m));
+c.push(yf(m));
 }
 } catch (e) {
 t = {
@@ -35689,7 +35702,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = mf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = ff.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35708,7 +35721,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = dy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = yy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35855,7 +35868,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), fy = function() {
+}(), gy = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -35888,7 +35901,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), yy = function() {
+}(), hy = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36413,7 +36426,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), vy = function() {
+}(), Ry = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36432,7 +36445,7 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), gy = function() {
+}(), Ey = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
@@ -36467,21 +36480,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), hy = ((ly = {})[MOVE] = 50, ly[WORK] = 100, ly[CARRY] = 50, ly[ATTACK] = 80,
-ly[RANGED_ATTACK] = 150, ly[HEAL] = 250, ly[CLAIM] = 600, ly[TOUGH] = 10, ly);
+}(), Ty = ((py = {})[MOVE] = 50, py[WORK] = 100, py[CARRY] = 50, py[ATTACK] = 80,
+py[RANGED_ATTACK] = 150, py[HEAL] = 250, py[CLAIM] = 600, py[TOUGH] = 10, py);
 
-function Ry(e, t) {
+function Cy(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, hy), t);
+var r = o(o({}, Ty), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : hy[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : Ty[t]);
 }, 0);
 }
 
-function Ey(e, t) {
+function Sy(e, t) {
 void 0 === t && (t = 0);
-var r = Ry(e);
+var r = Cy(e);
 return {
 parts: e,
 cost: r,
@@ -36489,7 +36502,7 @@ minCapacity: t || r
 };
 }
 
-function Ty() {
+function wy() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36497,11 +36510,11 @@ return Array(o).fill(r);
 });
 }
 
-var Cy, Sy, wy, xy = {
+var xy, by, Oy, Ay = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Ey([ WORK, CARRY ], 150), Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ey([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Ey([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Sy([ WORK, CARRY ], 150), Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Sy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Sy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36509,7 +36522,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Ey([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Ey([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Sy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Sy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36517,7 +36530,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Ey([ WORK, CARRY, MOVE, MOVE ], 250), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Sy([ WORK, CARRY, MOVE, MOVE ], 250), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36525,7 +36538,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Ey([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ey([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Sy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Sy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36533,7 +36546,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Ey([ CARRY, CARRY, MOVE, MOVE ], 200), Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ey(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Sy([ CARRY, CARRY, MOVE, MOVE ], 200), Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Sy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36541,7 +36554,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Ey([ WORK, CARRY, MOVE ], 200), Ey([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36549,7 +36562,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Ey([ WORK, CARRY, MOVE, MOVE ], 250), Ey([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ Sy([ WORK, CARRY, MOVE, MOVE ], 250), Sy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36557,7 +36570,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36565,7 +36578,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Ey([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ Sy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36573,7 +36586,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36581,7 +36594,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36589,7 +36602,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Ey([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Ey([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Ey([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ Sy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Sy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36597,7 +36610,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Ey(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Sy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36605,7 +36618,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Ey([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Ey([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36613,16 +36626,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Ey(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Ey(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Ey(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Ey(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Sy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Sy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Sy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Sy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, by = {
+}, ky = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Ey([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Ey([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ Sy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Sy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36630,7 +36643,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Ey([ TOUGH, ATTACK, MOVE, MOVE ], 190), Ey([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Ey([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ Sy([ TOUGH, ATTACK, MOVE, MOVE ], 190), Sy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Sy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36638,7 +36651,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Ey([ HEAL, MOVE, MOVE ], 350), Ey([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Ey([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ Sy([ HEAL, MOVE, MOVE ], 350), Sy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Sy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36646,7 +36659,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Ey([ ATTACK, ATTACK, MOVE, MOVE ], 260), Ey([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ Sy([ ATTACK, ATTACK, MOVE, MOVE ], 260), Sy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36654,7 +36667,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Ey([ WORK, WORK, MOVE, MOVE ], 300), Ey([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ Sy([ WORK, WORK, MOVE, MOVE ], 300), Sy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36662,7 +36675,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Ey([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Ey([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Ey([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Ey([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ Sy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Sy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Sy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36670,16 +36683,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Ey([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Ey([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Ey([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ Sy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Sy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Sy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Oy = {
+}, My = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Ey(Ty([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Ey(Ty([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ Sy(wy([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Sy(wy([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36687,16 +36700,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Ey(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Ey(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ Sy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Sy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Ay = {
+}, Uy = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Ey([ MOVE ], 50) ],
+bodies: [ Sy([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36704,7 +36717,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Ey([ MOVE ], 50) ],
+bodies: [ Sy([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36712,7 +36725,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Ey([ CLAIM, MOVE ], 650) ],
+bodies: [ Sy([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36720,7 +36733,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Ey([ CLAIM, MOVE ], 650), Ey([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ Sy([ CLAIM, MOVE ], 650), Sy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36728,7 +36741,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Ey([ WORK, CARRY, MOVE, MOVE ], 250), Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Sy([ WORK, CARRY, MOVE, MOVE ], 250), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36736,30 +36749,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Ey([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Ey([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Sy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, ky = o(o(o(o({}, xy), by), Ay), Oy);
+}, _y = o(o(o(o({}, Ay), ky), Uy), My);
 
 try {
-for (var My = a(Object.values(ky)), Uy = My.next(); !Uy.done; Uy = My.next()) Uy.value.bodies.sort(function(e, t) {
+for (var Ny = a(Object.values(_y)), Py = Ny.next(); !Py.done; Py = Ny.next()) Py.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Cy = {
+xy = {
 error: e
 };
 } finally {
 try {
-Uy && !Uy.done && (Sy = My.return) && Sy.call(My);
+Py && !Py.done && (by = Ny.return) && by.call(Ny);
 } finally {
-if (Cy) throw Cy.error;
+if (xy) throw xy.error;
 }
 }
 
-function _y(e) {
+function Iy(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36774,11 +36787,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Ny(o);
+return Gy(o);
 }
 
-function Ny(e) {
-var t = Ry(e);
+function Gy(e) {
+var t = Cy(e);
 return {
 parts: e,
 cost: t,
@@ -36786,16 +36799,16 @@ minCapacity: t
 };
 }
 
-function Py(e, t) {
+function Ly(e, t) {
 var r;
-return null !== (r = e.map(Ny).filter(function(e) {
+return null !== (r = e.map(Gy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Iy(e) {
+function Dy(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36809,7 +36822,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = Ry(a);
+var s = Cy(a);
 return {
 parts: a,
 cost: s,
@@ -36834,8 +36847,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: Ry(p),
-minCapacity: Ry(p)
+cost: Cy(p),
+minCapacity: Cy(p)
 };
 }(e);
 
@@ -36846,7 +36859,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return _y([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Iy([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -36867,7 +36880,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return _y([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Iy([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -36876,13 +36889,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Ny).filter(function(e) {
+var u = n.map(Gy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Py(n, t);
+var l = Ly(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -36892,7 +36905,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Py(n, t);
+var u = Ly(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -36901,14 +36914,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Py(r, t);
+var a = Ly(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Gy(e) {
+function Fy(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -36919,9 +36932,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Ly(e, t) {
+function By(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Gy(t)
+memory: Fy(t)
 });
 var r;
 }
@@ -36929,9 +36942,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(wy || (wy = {}));
+}(Oy || (Oy = {}));
 
-var Dy = function() {
+var Wy = function() {
 function e() {
 this.queues = new Map;
 }
@@ -37026,7 +37039,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Ly(m, d);
+var p = By(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37046,7 +37059,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= wy.EMERGENCY;
+return e.priority >= Oy.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37064,7 +37077,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= wy.EMERGENCY ? n.emergency++ : c.priority >= wy.HIGH ? n.high++ : c.priority >= wy.NORMAL ? n.normal++ : n.low++;
+c.priority >= Oy.EMERGENCY ? n.emergency++ : c.priority >= Oy.HIGH ? n.high++ : c.priority >= Oy.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37079,14 +37092,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Fy = new Dy, By = {
+}(), Ky = new Wy, Hy = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Wy = {
+}, Yy = {
 predictConsumption: function() {
 return 0;
 },
@@ -37105,7 +37118,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Ky = {
+}, Vy = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37122,44 +37135,44 @@ healers: 0,
 powerCarriers: 0
 };
 }
-}, Hy = {
+}, qy = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Yy(e, t, r, o, n) {
+function jy(e, t, r, o, n) {
 return rc(e, t, r, o, n);
 }
 
-var Vy = new Map, qy = -1, jy = null;
+var zy = new Map, Qy = -1, Xy = null;
 
-function zy() {
-qy === Game.time && jy === Game.creeps || (Vy.clear(), qy = Game.time, jy = Game.creeps);
+function Zy() {
+Qy === Game.time && Xy === Game.creeps || (zy.clear(), Qy = Game.time, Xy = Game.creeps);
 }
 
-function Qy(e) {
+function Jy(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Xy(e, t) {
+function $y(e, t) {
 var r;
-void 0 === t && (t = !1), zy();
-var o = t ? "".concat(e, "_active") : e, n = Vy.get(o);
+void 0 === t && (t = !1), Zy();
+var o = t ? "".concat(e, "_active") : e, n = zy.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Qy(c);
+var u = Jy(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Vy.set(o, a), a;
+return zy.set(o, a), a;
 }
 
-function Zy(e, t, r) {
+function ev(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37180,22 +37193,22 @@ if (o) throw o.error;
 return i;
 }
 
-function Jy(e) {
+function tv(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var $y = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var rv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function ev(e) {
-return $y.includes(e);
+function ov(e) {
+return rv.includes(e);
 }
 
-function tv(e) {
+function nv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function rv(e, t, r, o) {
+function av(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37208,10 +37221,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Yy(e, t, ze(r).length, o, {
-reserved: tv(r)
+if (r) return jy(e, t, ze(r).length, o, {
+reserved: nv(r)
 }).recommendedHaulers;
-var n = Yy(e, t, 2, o, {
+var n = jy(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37222,7 +37235,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: Jy
+filter: tv
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37233,7 +37246,7 @@ return 2;
 }
 }
 
-function ov(e, t) {
+function iv(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37243,13 +37256,13 @@ return null;
 }
 }
 
-function nv() {
+function sv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function av(e) {
-var t = nv(), r = function(e) {
+function cv(e) {
+var t = sv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37261,14 +37274,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function iv(e) {
+function uv(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = nv();
+var r = sv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function sv(e) {
+function lv(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37276,11 +37289,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function cv(e) {
+function mv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function uv() {
+function dv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37290,7 +37303,7 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-function lv(e, t) {
+function pv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37302,8 +37315,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(uv()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Fy.getPendingRequests(c).some(function(r) {
+for (var i = a(dv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Ky.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37323,7 +37336,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function mv(e, t) {
+function fv(e, t) {
 var r, o, n, c = mr.getEmpire(), u = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37333,15 +37346,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !lv(e.roomName, "claim");
+return !pv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || sv(t));
+return !(!r || r.my || r.owner || r.reservation || lv(t));
 }
-return !iv(e);
+return !uv(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37360,7 +37373,7 @@ return e.roomName;
 })), !1)) : new Set;
 if (l) {
 var p = c.claimQueue.find(function(e) {
-return !e.claimed && !lv(e.roomName, "claim");
+return !e.claimed && !pv(e.roomName, "claim");
 });
 if (p) return {
 targetRoom: p.roomName,
@@ -37372,20 +37385,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = nv();
+var l = sv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !lv(p, "claim")) {
+if (!t.has(p) && !pv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || av(y)) continue;
-if (sv(f)) continue;
+if (y.owner || cv(y)) continue;
+if (lv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !lv(p, "reserve")) return p;
-} else if (!iv(p) && !lv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !pv(p, "reserve")) return p;
+} else if (!uv(p) && !pv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37407,34 +37420,34 @@ task: "reserve"
 } : null;
 }
 
-function dv(e) {
+function yv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function pv(e) {
-return dv(e) ? wy.EMERGENCY : wy.HIGH;
+function vv(e) {
+return yv(e) ? Oy.EMERGENCY : Oy.HIGH;
 }
 
-function fv(e, t, r) {
+function gv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!cv(e)) return !1;
+if (!mv(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function yv(e, t, r) {
+function hv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return fv(e, t, r);
+return gv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = ov(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = iv(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37442,18 +37455,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function vv(e, t) {
+function Rv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !fv(n, e, t)) return null;
+if (!n || !gv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !cv(e);
+return !mv(e);
 }).filter(function(e) {
-return !sv(e);
+return !lv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37474,9 +37487,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(uv()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(dv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Fy.getPendingRequests(d).filter(function(t) {
+i += Ky.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37493,12 +37506,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (dv(e) ? 3 : 1);
+}(e.name) < (yv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = ov(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = iv(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37506,10 +37519,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (yv(u.room, e, t) === e) return {
+if (hv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: pv(u.room)
+priority: vv(u.room)
 };
 }
 } catch (e) {
@@ -37526,10 +37539,10 @@ if (r) throw r.error;
 return null;
 }
 
-function gv(e, t) {
+function Ev(e, t) {
 if (t <= 0) return null;
 try {
-var r = Iy({
+var r = Dy({
 maxEnergy: t,
 role: e
 });
@@ -37539,18 +37552,18 @@ return null;
 }
 }
 
-function hv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : gv(e, t);
+function Tv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : Ev(e, t);
 }
 
-function Rv(e) {
+function Cv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Ev(e) {
+function Sv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37564,7 +37577,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Rv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Cv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37585,7 +37598,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Rv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Cv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37601,23 +37614,23 @@ return i;
 }(e)) : r;
 }
 
-var Tv = "defenseAssist", Cv = [ "guard", "ranger", "healer" ];
+var wv = "defenseAssist", xv = [ "guard", "ranger", "healer" ];
 
-function Sv(e, t) {
+function bv(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function wv(e, t, r, o) {
+function Ov(e, t, r, o) {
 void 0 === o && (o = Mr(e.roomName));
-var n = Sv(e, t);
+var n = bv(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = Av(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, Sv(e, "guard") - i.guard),
-ranger: Math.max(0, Sv(e, "ranger") - i.ranger),
-healer: Math.max(0, Sv(e, "healer") - i.healer)
-}, Mv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = Uv(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, bv(e, "guard") - i.guard),
+ranger: Math.max(0, bv(e, "ranger") - i.ranger),
+healer: Math.max(0, bv(e, "healer") - i.healer)
+}, Nv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37632,7 +37645,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && Uv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Pv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37650,30 +37663,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function xv(e) {
+function Av(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function bv(e) {
+function kv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Tv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === wv ? e.targetRoom : void 0;
 }
 
-function Ov(e, t) {
-var r = Mr(e.roomName), o = Av(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, Sv(e, "guard") - o.guard),
-ranger: Math.max(0, Sv(e, "ranger") - o.ranger),
-healer: Math.max(0, Sv(e, "healer") - o.healer)
-}, Mv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function Mv(e, t) {
+var r = Mr(e.roomName), o = Uv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, bv(e, "guard") - o.guard),
+ranger: Math.max(0, bv(e, "ranger") - o.ranger),
+healer: Math.max(0, bv(e, "healer") - o.healer)
+}, Nv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = Cv.filter(function(o) {
-return !(wv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = xv.filter(function(o) {
+return !(Ov(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function Av(e) {
+function Uv(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37682,7 +37695,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && bv(d) === e && u[p]++;
+Br(p) && kv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37696,9 +37709,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Fy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Ky.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Tv && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === wv && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37714,21 +37727,21 @@ if (o) throw o.error;
 return u;
 }
 
-function kv(e, t, r) {
+function _v(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function Mv(e) {
+function Nv(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && bv(f) === e) {
+if (Br(y) && kv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && kv(l, y, v);
+v.length > 0 && _v(l, y, v);
 }
 }
 } catch (e) {
@@ -37743,9 +37756,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Fy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Ky.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Tv && E.targetRoom === e) && kv(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === wv && E.targetRoom === e) && _v(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37761,27 +37774,27 @@ if (o) throw o.error;
 return l;
 }
 
-function Uv(e) {
+function Pv(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function _v(e, t, r) {
+function Iv(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function Nv(e, t, r, o) {
+function Gv(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && hv("guard", Ev(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && Tv("guard", Sv(r), o) ? 1 : 0;
 }
 
-function Pv(e, t) {
+function Lv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !Uv(o)) return null;
+if (!o || !Pv(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -37806,7 +37819,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(xv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Av);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -37814,15 +37827,15 @@ return t.roomName !== e;
 var r = Mr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(wv(e, t, n, r), Nv(e, t, o, r))
+helperNeed: Math.max(Ov(e, t, n, r), Gv(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return xv(e.request);
+return Av(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? Av(e)[t] : 0;
+return Br(t) ? Uv(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37847,28 +37860,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: Tv,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? wy.EMERGENCY : wy.HIGH,
-defenseSquadId: _v(e, r, n.createdAt),
-defenseSquadSize: Ov(r, t),
+task: wv,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Oy.EMERGENCY : Oy.HIGH,
+defenseSquadId: Iv(e, r, n.createdAt),
+defenseSquadSize: Mv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var Iv = "defenseRefuel", Gv = {
+var Dv = "defenseRefuel", Fv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Lv(e, t) {
+function Bv(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Gv.cost);
-}(n) ? Ev(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Fv.cost);
+}(n) ? Sv(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -37905,9 +37918,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Fy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Ky.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Iv && s++;
+"hauler" === p.role && f === Dv && s++;
 }
 } catch (e) {
 o = {
@@ -37922,24 +37935,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Iv,
-priority: wy.EMERGENCY,
-body: Gv
+task: Dv,
+priority: Oy.EMERGENCY,
+body: Fv
 } : null : null;
 }
 
-function Dv(e) {
+function Wv(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !av(t.controller) && !sv(t) : !iv(e);
+return t ? !!t.controller && !cv(t.controller) && !lv(t) : !uv(e);
 }
 
-function Fv(e) {
+function Kv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !av(t.controller) : !iv(e);
+return (null == t ? void 0 : t.controller) ? !cv(t.controller) : !uv(e);
 }
 
-function Bv(e, t, r) {
-var o = ky[t];
+function Hv(e, t, r) {
+var o = _y[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -37951,13 +37964,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Wv(e, t, r) {
+function Yv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Dv(l) && Zy(e, t, l) < rv(e, l, t, Game.rooms[l])) return l;
+if (Wv(l) && ev(e, t, l) < av(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37973,10 +37986,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Kv(e, t, r, o) {
+function Vv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = ky[t];
+var p = _y[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -37990,32 +38003,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = ky[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = ky[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = _y[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = _y[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Xy(e), y)) return !1;
+}(t, $y(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (ev(t)) return !("remoteWorker" === t && function(e, t) {
-zy();
-var r = "".concat(e, ":").concat(t), o = Vy.get(r);
+if (ov(t)) return !("remoteWorker" === t && function(e, t) {
+Zy();
+var r = "".concat(e, ":").concat(t), o = zy.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Vy.set(r, n), n;
-}(e, t) >= Bv(e, t, r)) && null !== Wv(e, t, r);
+return zy.set(r, n), n;
+}(e, t) >= Hv(e, t, r)) && null !== Yv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Fv(R)) {
+if (Kv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -38023,7 +38036,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && Zy(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && ev(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38040,9 +38053,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Xy(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== vv(e, r);
-if (C >= Bv(e, t, r)) return !1;
+var C = null !== (u = $y(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== Rv(e, r);
+if (C >= Hv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38054,14 +38067,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = ov(e, o);
+var a = iv(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== mv(0, r);
+if ("claimer" === t) return null !== fv(0, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38097,7 +38110,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = By.getActiveRequests) || void 0 === m ? void 0 : m.call(By)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = Hy.getActiveRequests) || void 0 === m ? void 0 : m.call(Hy)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38125,16 +38138,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Hv(e) {
+function qv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Yv(e) {
-return 0 === Hv(Xy(e, !0));
+function jv(e) {
+return 0 === qv($y(e, !0));
 }
 
-function Vv(e) {
+function zv(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -38157,14 +38170,14 @@ minCount: 1
 } ];
 }
 
-function qv(e, t) {
-var r, o, n, i, s = Xy(e, !0);
-if (0 === Hv(s)) return !0;
+function Qv(e, t) {
+var r, o, n, i, s = $y(e, !0);
+if (0 === qv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Xy(e, !1), u = Vv(t);
+var c = $y(e, !1), u = zv(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38184,57 +38197,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function jv(e) {
+function Xv(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function zv(e, t, r) {
-var n = Bv(e.name, r.roleName, t);
+function Zv(e, t, r) {
+var n = Hv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Qv(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return wy.EMERGENCY;
+function Jv(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Oy.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return wy.HIGH;
-if (Hy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Oy.HIGH;
+if (qy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return wy.EMERGENCY;
-if (a > 0) return wy.HIGH;
+if (a >= 100) return Oy.EMERGENCY;
+if (a > 0) return Oy.HIGH;
 }
 return function(e) {
-return e >= 90 ? wy.HIGH : e >= 60 ? wy.NORMAL : wy.LOW;
+return e >= 90 ? Oy.HIGH : e >= 60 ? Oy.NORMAL : Oy.LOW;
 }(o);
 }
 
-function Xv(e, t) {
+function $v(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-jv(e);
-var l = Xy(e.name), m = Yv(e.name), d = [];
-if (qv(e.name, e)) {
+Xv(e);
+var l = $y(e.name), m = jv(e.name), d = [];
+if (Qv(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Hv(Xy(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === qv($y(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Xy(e, !1), c = Vv(t);
+var s = $y(e, !1), c = zv(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38249,7 +38262,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Kv(e, m.role, r, !0);
+var p = Vv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38280,17 +38293,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = ky[p]) && Kv(e.name, p, t, !0) ? (d.push(zv(e, t, {
+return p && (g = _y[p]) && Vv(e.name, p, t, !0) ? (d.push(Zv(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: Qv(e, 0, p, g.priority, m),
+priority: Jv(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(ky)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Lv(e.name, p);
+for (var f = a(Object.entries(_y)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Bv(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38301,7 +38314,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Pv(e.name, p);
+var E = Lv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38315,8 +38328,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Kv(e.name, p, t, m)) {
-var T = ev(p), C = T ? Wv(e.name, p, t) : null, S = "claimer" === p ? mv(e.name, t) : null, w = "pioneer" === p ? vv(e.name, t) : null;
+}); else if (Vv(e.name, p, t, m)) {
+var T = ov(p), C = T ? Yv(e.name, p, t) : null, S = "claimer" === p ? fv(e.name, t) : null, w = "pioneer" === p ? Rv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38326,11 +38339,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(zv(e, t, {
+}) : d.push(Zv(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: Qv(e, 0, p, g.priority, m),
+priority: Jv(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38352,7 +38365,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Zv(e, l.value);
+var m = eg(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38373,10 +38386,10 @@ requests: c
 };
 }
 
-function Zv(e, t) {
+function eg(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Wy.getMaxAffordableInTicks(e, l), d = Ev(e), p = t.priority >= wy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= wy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : hv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Yy.getMaxAffordableInTicks(e, l), d = Sv(e), p = t.priority >= Oy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Oy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : Tv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38397,7 +38410,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : Iy({
+}(t.def, p)) && void 0 !== c ? c : Dy({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38433,44 +38446,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Jv = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), $v = new Set([ "guard", "ranger", "healer" ]);
+var tg = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), rg = new Set([ "guard", "ranger", "healer" ]);
 
-function eg() {
+function og() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function tg(e) {
+function ng(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function rg(e) {
+function ag(e) {
 var t;
-return e.priority >= wy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Oy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function og(e) {
+function ig(e) {
 var t;
-return e.priority >= wy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Oy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function ng(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Ev(e), m = r.urgency >= 2 || t.danger >= 3 ? wy.EMERGENCY : wy.HIGH, d = kr(j(e)), p = function(e) {
+function sg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Sv(e), m = r.urgency >= 2 || t.danger >= 3 ? Oy.EMERGENCY : Oy.HIGH, d = kr(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === wy.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === Oy.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Fy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Ky.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || ag(u, e) && ("guard" === u.role && (n.guards++,
-sg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, sg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, sg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || cg(u, e) && ("guard" === u.role && (n.guards++,
+lg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, lg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, lg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38498,7 +38511,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && sg(n, u, l);
+0 !== l.length && lg(n, u, l);
 }
 }
 }
@@ -38537,26 +38550,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ig("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) cg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ig("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) cg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ig("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) cg(e, "healer", "military", wy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ug("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) mg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ug("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) mg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ug("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) mg(e, "healer", "military", Oy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < wy.EMERGENCY || function(e, t) {
+if (!(t < Oy.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !$v.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !rg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Fy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Ky.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < wy.EMERGENCY || $v.has(c.role) && ag(c, e.name) && c.body.cost <= t && n++;
+c.priority < Oy.EMERGENCY || rg.has(c.role) && cg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38573,7 +38586,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = gv(t, e);
+var r = Ev(t, e);
 return r ? {
 role: t,
 body: r
@@ -38588,38 +38601,38 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && cg(e, n.role, "military", wy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && mg(e, n.role, "military", Oy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function ag(e, t) {
+function cg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function ig(e, t, r) {
+function ug(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function sg(e, t, r) {
+function lg(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function cg(e, t, r, o, n, a, i) {
+function mg(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
-var s = null != i ? i : Iy({
+var s = null != i ? i : Dy({
 maxEnergy: n,
 role: t
 });
 if (s.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(s.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Fy.addRequest({
+Ky.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38635,34 +38648,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function ug(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= wy.HIGH) return !1;
+function dg(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Oy.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < wy.NORMAL) {
-if (Wy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Oy.NORMAL) {
+if (Yy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === wy.NORMAL && o / e.energyCapacityAvailable < .3 && Wy.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Oy.NORMAL && o / e.energyCapacityAvailable < .3 && Yy.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function lg(e, t) {
+function pg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-jv(e);
-var s = Fy.getQueueSize(e.name);
+Xv(e);
+var s = Ky.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = qv(e.name, e), u = Yv(e.name) && !Fy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = Qv(e.name, e), u = jv(e.name) && !Ky.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && Fy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && ng(e, t, l, m);
+s > 0 && Ky.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && sg(e, t, l, m);
 try {
-for (var d = a(Xv(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a($v(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Fy.addRequest(f);
+Ky.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38675,7 +38688,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && ng(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && sg(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38684,13 +38697,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Fy.getPendingRequests(e.name).map(tg));
+var c = new Set(Ky.getPendingRequests(e.name).map(ng));
 try {
-for (var u = a(Xv(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= wy.HIGH, p = "claimer" === m.role && eg(), f = rg(m), y = og(m);
-if (Jv.has(m.role) || d || p || f || y) {
-var v = tg(m);
-c.has(v) || (Fy.addRequest(m), c.add(v));
+for (var u = a($v(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Oy.HIGH, p = "claimer" === m.role && og(), f = ag(m), y = ig(m);
+if (tg.has(m.role) || d || p || f || y) {
+var v = ng(m);
+c.has(v) || (Ky.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38707,19 +38720,19 @@ if (r) throw r.error;
 }
 }(e, t); else {
 !function(e) {
-var t = Ky.requestSpawns(e.name);
+var t = Vy.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = wy.NORMAL, n = 0; n < t.powerHarvesters; n++) cg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) cg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) cg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = Oy.NORMAL, n = 0; n < t.powerHarvesters; n++) mg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) mg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) mg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a(Xv(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Fy.addRequest(f);
+for (var y = a($v(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Ky.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38731,32 +38744,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Fy.getQueueStats(e.name);
+var g = Ky.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Fy.clearQueue(e.name);
+} else s > 0 && Ky.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Fy.getAvailableSpawns(e.name);
+var t, r, o = Ky.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Ev(e);
+var n = 0, i = Sv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Fy.getNextRequest(e.name, i);
+var u = c.value, l = Ky.getNextRequest(e.name, i);
 if (!l) break;
-if (ug(e, l, i)) {
+if (dg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Ly(u, l);
-m === OK ? (n++, i -= l.body.cost, Fy.markInProgress(e.name, l.id, u.id), Fy.removeRequest(e.name, l.id),
+var m = By(u, l);
+m === OK ? (n++, i -= l.body.cost, Ky.markInProgress(e.name, l.id, u.id), Ky.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Fy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Ky.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -38772,7 +38785,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Fy.getQueueStats(e.name);
+}(e), o = Ky.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -38786,7 +38799,7 @@ stats: o
 }(e, t);
 }
 
-var mg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, dg = /^(\d{1,2})\|(.+)$/, pg = k("SS2TerminalComms"), fg = function() {
+var fg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, yg = /^(\d{1,2})\|(.+)$/, vg = k("SS2TerminalComms"), gg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38846,11 +38859,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(mg);
+var t = e.match(fg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(dg);
+var i = a.match(yg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38885,7 +38898,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-pg.warn("Missing packet in multi-packet message", {
+vg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38901,7 +38914,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), pg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), vg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38925,7 +38938,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && pg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && vg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38937,7 +38950,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return pg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return vg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38945,14 +38958,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), pg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), vg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (pg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (vg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38977,7 +38990,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-pg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+vg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -38989,7 +39002,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-pg.info("Completed sending multi-packet message", {
+vg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -38997,25 +39010,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? pg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? vg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (pg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (vg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else pg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else vg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else pg.warn("Terminal not found for queue item, removing from queue", {
+} else vg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39049,7 +39062,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && pg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && vg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39059,7 +39072,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-pg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+vg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39150,7 +39163,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (pg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (vg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39172,7 +39185,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return pg.error("Error parsing JSON", {
+return vg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39183,7 +39196,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), yg = [ {
+}(), hg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39203,7 +39216,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], vg = function() {
+} ], Rg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39250,9 +39263,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), gg = new vg;
+}(), Eg = new Rg;
 
-function hg(e) {
+function Tg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39260,19 +39273,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function Rg(e, t) {
+function Cg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Eg(e, t) {
+function Sg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var Tg = {
+var wg = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39283,9 +39296,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, Cg = function() {
+}, xg = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Tg), e);
+void 0 === e && (e = {}), this.config = o(o({}, wg), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39306,7 +39319,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = gg.getSwarmState(r.toRoom);
+var o = Eg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39319,7 +39332,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = gg.getSwarmState(c);
+var l = Eg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39389,9 +39402,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(Rg), u = n.filter(function(e) {
+}).sort(Cg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Eg), l = [], m = [], d = function(t) {
+}).sort(Sg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39413,11 +39426,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return hg({
+return Tg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + hg({
+}) + Tg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39516,7 +39529,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), Sg = new Cg, wg = {
+}(), bg = new xg, Og = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39537,14 +39550,14 @@ siegeUnits: 1
 }
 };
 
-function xg(e) {
+function Ag(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function bg(e) {
+function kg(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39567,9 +39580,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function Og(e) {
+function Mg(e) {
 var t, r, o;
-bg(e);
+kg(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39593,20 +39606,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Ag(e) {
+function Ug(e) {
 var t;
-bg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Og(e);
+kg(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Mg(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function kg(e) {
-return !!Ag(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function _g(e) {
+return !!Ug(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-bg(e);
+kg(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39617,12 +39630,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = Og(e);
+var d = Mg(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function Mg(e, t) {
+function Ng(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39643,20 +39656,20 @@ if (r) throw r.error;
 return n;
 }
 
-function Ug(e, t) {
+function Pg(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = wg[r]) && void 0 !== t ? t : wg[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Og[r]) && void 0 !== t ? t : Og[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Mg(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Ng(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: xg(r),
+targetComposition: Ag(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39668,7 +39681,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function _g(e) {
+function Ig(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39688,9 +39701,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function Ng(e) {
+function Gg(e) {
 var t = e.members.length;
-bg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+kg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39704,7 +39717,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && kg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && _g(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39733,7 +39746,7 @@ subsystem: "Squad"
 }
 }
 
-var Pg = {
+var Lg = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39820,7 +39833,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Ig(e, t) {
+function Dg(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39835,8 +39848,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Gg(e, t) {
-var r, o, n, i = Pg[t], s = 0;
+function Fg(e, t) {
+var r, o, n, i = Lg[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39862,7 +39875,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Lg, Dg, Fg, Bg = {
+var Bg, Wg, Kg, Hg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39871,11 +39884,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Wg = new Map;
+}, Yg = new Map;
 
-function Kg(e, t) {
+function Vg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Wg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Yg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39887,7 +39900,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Pg[p].composition;
+d = Lg[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39902,19 +39915,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Wg.set(m, y), function(e, t, r, o) {
+v ? (Yg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Pg[s].useBoosts;
+i = Lg[s].useBoosts;
 }
-var c = wy.NORMAL;
-"siege" === t.type ? c = wy.HIGH : "defense" === t.type && (c = wy.EMERGENCY);
+var c = Oy.NORMAL;
+"siege" === t.type ? c = Oy.HIGH : "defense" === t.type && (c = Oy.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = Hg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Bg[t];
-}, 0), m = i ? Vg(r) : [], d = {
+var u = qg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Hg[t];
+}, 0), m = i ? zg(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39943,7 +39956,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Fy.addRequest(d), o.spawnRequests.add(d.id);
+Ky.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -39957,42 +39970,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function Hg(e, t, r) {
+function qg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Yg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return jg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Yg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return jg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Yg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return jg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Yg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return jg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Yg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return jg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Yg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return jg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Yg(e, t, r) {
+function jg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Bg[t];
+return e + Hg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Bg[t];
+return e + Hg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Vg(e) {
+function zg(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40023,45 +40036,45 @@ return [];
 }
 }
 
-function qg(e) {
-return Wg.has(e);
+function Qg(e) {
+return Yg.has(e);
 }
 
-function jg(e) {
-return Ag(e) || kg(e);
+function Xg(e) {
+return Ug(e) || _g(e);
 }
 
-(Lg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Lg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Lg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Dg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Dg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Dg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Dg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Fg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Fg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Fg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Fg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Fg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(Bg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Bg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Bg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Wg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Wg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Wg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Wg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Kg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Kg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Kg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Kg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Kg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var zg = {
+var Zg = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Qg(e, t) {
-var r = zg[t], o = gg.getClusters();
+function Jg(e, t) {
+var r = Zg[t], o = Eg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function Xg(e, t, r) {
+function $g(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = gg.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = Eg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Qg(e, i.danger),
+reservedEnergy: Jg(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40151,7 +40164,7 @@ success: !1
 });
 }
 
-var Zg = {
+var eh = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40161,7 +40174,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Jg(e, t, r) {
+function th(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40192,7 +40205,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function $g(e, t, r, o) {
+function rh(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40202,7 +40215,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function eh(e, t) {
+function oh(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40223,19 +40236,19 @@ if (r) throw r.error;
 return n;
 }
 
-function th() {
-var e = gg.getEmpire();
+function nh() {
+var e = Eg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function rh(e) {
-th()[e.id] = e;
+function ah(e) {
+nh()[e.id] = e;
 }
 
-function oh(e) {
+function ih(e) {
 e.lastUpdate = Game.time;
-var t = gg.getCluster(e.clusterId);
-if (!t) return e.state = "failed", rh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = Eg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", ah(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40245,12 +40258,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (jg(r) || qg(e) || Kg(0, r), jg(r));
+return !!r && (Xg(r) || Qg(e) || Vg(0, r), Xg(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), rh(e);
+})), ah(e);
 }(e, t);
 break;
 
@@ -40261,7 +40274,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (Ng(o), _g(o)) {
+if (Gg(o), Ig(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40290,7 +40303,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = gg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = Eg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40317,14 +40330,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), rh(e);
+})), ah(e);
 }(e, t);
 }
 }
 
-var nh = "defenseAssist";
+var sh = "defenseAssist";
 
-function ah(e, t, r) {
+function ch(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40343,11 +40356,11 @@ score: n.score + o.score
 }
 }
 
-function ih(e, t, r) {
+function uh(e, t, r) {
 return Gr(e, t, r);
 }
 
-function sh(e, t) {
+function lh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40360,11 +40373,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function ch(e) {
+function mh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function uh(e, t, r) {
+function dh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40377,8 +40390,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function lh(e, t, r) {
-var o = ih(t, e.energyCapacityAvailable, r);
+function ph(e, t, r) {
+var o = uh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40386,16 +40399,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function mh(e, t, r, o) {
+function fh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = lh(e, t, o);
-if (s !== lh(n, t, o)) return s ? -1 : 1;
+var a, i, s = ph(e, t, o);
+if (s !== ph(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function dh(e, t) {
+function yh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40479,25 +40492,25 @@ if (r) throw r.error;
 return u;
 }
 
-function ph(e, t) {
+function vh(e, t) {
 return {
-guard: Math.max(0, sh(e, "guard") - t.counts.guard),
-ranger: Math.max(0, sh(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, sh(e, "healer") - t.counts.healer)
+guard: Math.max(0, lh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, lh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, lh(e, "healer") - t.counts.healer)
 };
 }
 
-function fh(e, t, r) {
+function gh(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function yh(e) {
+function hh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function vh(e, t) {
+function Rh(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return yh(e.role);
+return hh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40510,12 +40523,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function gh(e) {
+function Eh(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === nh ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === sh ? e.targetRoom : void 0;
 }
 
-function hh(e) {
+function Th(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40527,7 +40540,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-yh(m) && gh(l) === e && !u.spawning && ah(i, m, u.body.filter(function(e) {
+hh(m) && Eh(l) === e && !u.spawning && ch(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40545,7 +40558,7 @@ if (t) throw t.error;
 return i;
 }
 
-function Rh(e, t, r) {
+function Ch(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40575,16 +40588,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: vh(e, r)
+pendingAssist: Rh(e, r)
 };
 }
 }
 
-function Eh(e, t) {
+function Sh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = ih(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = uh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40605,7 +40618,7 @@ subsystem: "Cluster"
 }
 }
 
-function Th(e, t, r) {
+function wh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40647,20 +40660,20 @@ exitAccess: a
 };
 }
 
-function Ch(e, t) {
+function xh(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function Sh(e, t, r) {
+function bh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function wh(e) {
+function Oh(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function xh(e, t) {
+function Ah(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40671,7 +40684,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function bh(e, t, r) {
+function kh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40682,8 +40695,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = wh(g);
-h && (g.assistTarget || xh(v, h) && (t.assignedCreeps.includes(v.name) || Ch(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = Oh(g);
+h && (g.assistTarget || Ah(v, h) && (t.assignedCreeps.includes(v.name) || xh(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40720,7 +40733,7 @@ return e.distance - t.distance;
 });
 }
 
-function Oh(e, t) {
+function Mh(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40745,21 +40758,21 @@ if (r) throw r.error;
 return i;
 }
 
-function Ah(e) {
+function Uh(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var kh = {
+var _h = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, Mh = function() {
+}, Nh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, kh), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, _h), e);
 }
 return e.prototype.run = function() {
-var e = gg.getClusters();
+var e = Eg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40778,7 +40791,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: yg.map(function(t) {
+steps: hg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40839,7 +40852,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-Sg.processCluster(t);
+bg.processCluster(t);
 break;
 
 case "squads":
@@ -40871,7 +40884,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = Th(e, new RoomPosition(s, c, e.name), "defense");
+var u = wh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40920,9 +40933,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = gg.getSwarmState(i);
+var i = n.value, s = Eg.getSwarmState(i);
 if (s) {
-var c = Qg(i, s.danger);
+var c = Jg(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40953,7 +40966,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = gg.getSwarmState(m);
+var m = l.value, d = Eg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -40985,7 +40998,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += Ah(l.controller.level));
+}).length, i += Uh(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41102,7 +41115,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Ng(i), "gathering" !== i.state || jg(i) || qg(i.id) || Kg(0, i), _g(i) && (i.state = "dissolving");
+Gg(i), "gathering" !== i.state || Xg(i) || Qg(i.id) || Vg(0, i), Ig(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41127,7 +41140,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Ug(e, s);
+var s = i.value, c = Pg(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41144,7 +41157,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(th()).filter(function(e) {
+var t = (a = e.id, Object.values(nh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41155,22 +41168,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Zg), n), m = [], d = gg.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, eh), n), m = [], d = Eg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = Jg(f, y, d);
+var g = th(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = eh(e, f);
+var h = oh(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = $g(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = rh(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Ig(f, {
+var C = Dg(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41205,29 +41218,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Gg(e, n.doctrine) ? function(e, t, r) {
+Fg(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = gg.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = Eg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = Jg(e, o, r);
+var n = th(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (gg.getEmpire().knownRooms || {})[t], n = null != r ? r : Ig(t, {
+var o = (Eg.getEmpire().knownRooms || {})[t], n = null != r ? r : Dg(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Gg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Fg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41240,7 +41253,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-rh(i);
+ah(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41254,13 +41267,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Mg(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Ng(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: xg(n),
+targetComposition: Ag(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41275,8 +41288,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), rh(i), Kg(0, c), i.state = "forming", i.lastUpdate = Game.time,
-rh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), ah(i), Vg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+ah(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41295,11 +41308,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Wg.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Yg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Wg.delete(c));
+}), Yg.delete(c));
 }
 } catch (t) {
 e = {
@@ -41313,10 +41326,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = th();
-for (var t in e) oh(e[t]);
+var e = nh();
+for (var t in e) ih(e[t]);
 !function() {
-var e = th();
+var e = nh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41394,14 +41407,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = gg.getCluster(t, e);
+var t = "cluster_".concat(e), r = Eg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = gg.getCluster(e);
+var o = Eg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41430,7 +41443,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Xg(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && $g(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41447,7 +41460,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = gg.getSwarmState(t);
+var n, a, i = Eg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41488,7 +41501,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mr(g), f[g] = hh(g);
+p[g] = Mr(g), f[g] = Th(g);
 }
 } catch (e) {
 r = {
@@ -41504,7 +41517,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = Rh(E, m, t);
+d[E] = Ch(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41523,13 +41536,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = uh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = dh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = dh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = yh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, ph(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, vh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = mh(h, b, g.roomName, R), k = 0; k < O; k++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = fh(h, b, g.roomName, R), k = 0; k < O; k++) {
 var M = A.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41541,13 +41554,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").con
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: ch(g.urgency),
+priority: mh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: nh,
-defenseSquadId: fh(M.roomName, g.roomName, e.now),
+task: sh,
+defenseSquadId: gh(M.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41587,7 +41600,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) Eh(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) Sh(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41602,7 +41615,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Fy);
+}(e, Ky);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41614,7 +41627,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = Oh(f, bh(e, f, t)), v = y.reduce(function(e, t) {
+var y = Mh(f, kh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41625,7 +41638,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-Sh(f, R.role, Ch(f, R.role) - 1), l.push({
+bh(f, R.role, xh(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41692,28 +41705,28 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Uh = new Mh, _h = /^([WE])(\d+)([NS])(\d+)$/;
+}(), Ph = new Nh, Ih = /^([WE])(\d+)([NS])(\d+)$/;
 
-function Nh(e) {
-return _h.test(e);
+function Gh(e) {
+return Ih.test(e);
 }
 
-var Ph = {
+var Lh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Ih = function() {
+}, Dh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ph), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Lh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
 var e = InterShardMemory.getLocal();
 if (e) {
-var t = Op(e);
+var t = Mp(e);
 if (t) {
 this.updateEnemyIntelligence(t);
-var r = bp(t);
+var r = kp(t);
 InterShardMemory.setLocal(r);
 }
 }
@@ -41779,7 +41792,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (Nh(x)) {
+if (e.isAlly(x)) f.add(x); else if (Gh(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41847,7 +41860,7 @@ subsystem: "CrossShardIntel"
 }, e.prototype.getGlobalEnemies = function() {
 var e = InterShardMemory.getLocal();
 if (!e) return [];
-var t = Op(e);
+var t = Mp(e);
 return t && t.globalTargets.enemies || [];
 }, n([ Oi("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: ha.LOW,
@@ -41855,7 +41868,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Gh = new Ih, Lh = function() {
+}(), Fh = new Dh, Bh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41932,9 +41945,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), Dh = new Lh, Fh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), Wh = new Bh, Kh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Bh(e, t) {
+function Hh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41957,13 +41970,13 @@ if (r) throw r.error;
 return n;
 }
 
-function Wh(e) {
+function Yh(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function Kh(e, t, r) {
-if (!Wh(e)) return 0;
-var o = Bh(e.name, t);
+function Vh(e, t, r) {
+if (!Yh(e)) return 0;
+var o = Hh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += oc(e.mineralType),
@@ -41972,7 +41985,7 @@ n += sc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += uc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function Hh(e, t) {
+function qh(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -41982,13 +41995,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Fh.has(e.type);
+return e.hits > 0 && Kh.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function Yh(e, t, r) {
+function jh(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -41998,7 +42011,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function Vh(e) {
+function zh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42009,8 +42022,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function qh(e) {
-var t = Vh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function Qh(e) {
+var t = zh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42029,14 +42042,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var jh = {
+var Xh = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, zh = function() {
+}, Zh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, jh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Xh), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42127,7 +42140,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = Vh(e);
+var t = zh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42139,14 +42152,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return qh(Qh(e));
+return Qh(Jh(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = qh(Qh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = Qh(Jh(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function Qh(e) {
+function Jh(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42178,11 +42191,11 @@ swamps: d
 };
 }
 
-var Xh = new zh, Zh = /^([WE])(\d+)([NS])(\d+)$/, Jh = {
+var $h = new Zh, eR = /^([WE])(\d+)([NS])(\d+)$/, tR = {
 allies: []
-}, $h = function() {
+}, rR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Jh), e);
+void 0 === e && (e = {}), this.config = o(o({}, tR), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42202,7 +42215,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!Zh.test(e)) return !1;
+if (!eR.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42310,7 +42323,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return Zh.test(e);
+return eR.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42337,7 +42350,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), eR = new $h, tR = {
+}(), oR = new rR, nR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42350,9 +42363,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, rR = function() {
+}, aR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, tR), e);
+void 0 === e && (e = {}), this.config = o(o({}, nR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42365,7 +42378,7 @@ t.updateExpansionQueue(o);
 }), Ji.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Ji.measureSubsystem("empire:warTargets", function() {
-eR.updateWarTargets(o);
+oR.updateWarTargets(o);
 }), Ji.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Ji.measureSubsystem("empire:gclTracking", function() {
@@ -42373,13 +42386,13 @@ t.trackGCLProgress(o);
 }), s && Ji.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Ji.measureSubsystem("empire:intelRefresh", function() {
-Xh.refreshRoomIntel(o);
+$h.refreshRoomIntel(o);
 }), Ji.measureSubsystem("empire:roomDiscovery", function() {
-Xh.discoverNearbyRooms(o);
+$h.discoverNearbyRooms(o);
 })), s && Ji.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Ji.measureSubsystem("empire:clusterHealth", function() {
-Dh.monitorClusterHealth();
+Wh.monitorClusterHealth();
 }), Ji.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42462,22 +42475,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = Hh(f, u);
+var y = Boolean(Game.rooms[f]), v = qh(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = Bh(f, t);
+var g = Hh(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = Yh(h, u, y);
+var h = e.knownRooms[f], R = jh(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? Kh(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? Vh(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42521,10 +42534,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && Wh(a)) {
-var i = Bh(a.name, t);
+if (a && Yh(a)) {
+var i = Hh(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = Kh(a, t, r);
+var s = Vh(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -42844,13 +42857,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), oR = new rR;
+}(), iR = new aR;
 
-function nR(e) {
+function sR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var aR = {
+var cR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42858,10 +42871,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, iR = function() {
+}, uR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, aR), e);
+this.config = o(o({}, cR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -43005,7 +43018,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, nR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, sR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43180,7 +43193,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), sR = new iR, cR = function() {
+}(), lR = new uR, mR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new ec(o(o({}, Bs), e), {
 getEmpire: function() {
@@ -43216,7 +43229,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), uR = new cR, lR = function() {
+}(), dR = new mR, pR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -43234,9 +43247,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), mR = new (function(e) {
+}(), fR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new lR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new pR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43248,22 +43261,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
 }(Ii));
 
-function dR() {
+function yR() {
 return global;
 }
 
-function pR(e) {
+function vR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function fR(e) {
+function gR(e) {
 return Number(null != e ? e : 0);
 }
 
-var yR = function() {
+var hR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = dR();
+var e = yR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43271,12 +43284,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return dR()._pixelGenerationMemory;
+return yR()._pixelGenerationMemory;
 }, e;
-}(), vR = function(e) {
+}(), RR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new yR) || this;
+var r = e.call(this, t, new hR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43293,7 +43306,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(pR).length : Object.values(null != t ? t : {}).filter(pR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(vR).length : Object.values(null != t ? t : {}).filter(vR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43304,9 +43317,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (fR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (fR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = fR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = fR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (gR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (gR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = gR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = gR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43328,9 +43341,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Li), gR = new vR;
+}(Li), ER = new RR;
 
-function hR(e, t) {
+function TR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -43352,7 +43365,7 @@ lost: !1
 };
 }
 
-function RR(e, t, r) {
+function CR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43366,20 +43379,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var ER = Ue().cpu.bucketThresholds.highMode + 1800, TR = {
+var SR = Ue().cpu.bucketThresholds.highMode + 1800, wR = {
 updateInterval: 250,
-minBucket: ER,
+minBucket: SR,
 maxSitesPerRemotePerTick: 2
 };
 
-function CR(e, t) {
+function xR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var SR = function() {
+var bR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, TR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, wR), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43396,8 +43409,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = hR(l);
-m.lost && m.reason && RR(e, u, m.reason);
+var m = TR(l);
+m.lost && m.reason && CR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43415,10 +43428,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = CR("remoteInfrastructure.intent", function() {
+var i = xR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-CR("remoteInfrastructure.execute", function() {
+xR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43584,13 +43597,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = CR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = xR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = CR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = xR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43623,7 +43636,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = CR("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = xR("remoteInfrastructure.calculateRemoteRoads", function() {
 return xn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43652,14 +43665,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = CR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = xR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? CR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? xR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43676,7 +43689,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? CR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? xR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43694,7 +43707,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return CR("remoteInfrastructure.findSources", function() {
+return xR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43791,10 +43804,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: ha.LOW,
 interval: 1e3,
-minBucket: ER,
+minBucket: SR,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), wR = new SR, xR = new (function(e) {
+}(), OR = new bR, AR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43806,7 +43819,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Pp)), bR = function() {
+}(Lp)), kR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43850,7 +43863,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-wf.applyDiffusion(o);
+Of.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -43896,7 +43909,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ki() ], e);
-}(), OR = new bR, AR = new (function() {
+}(), MR = new kR, UR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43943,7 +43956,7 @@ if (e) throw e.error;
 Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(OR, Ns, Ds, ls, oR, vc, sR, wR, As, mR, gR, uR, qc, Zc, xR, Gh, Bc, Uh, za, Pa),
+}(MR, Ns, Ds, ls, iR, vc, lR, OR, As, fR, ER, dR, qc, Zc, AR, Fh, Bc, Ph, za, Pa),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -44010,9 +44023,9 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), kR = "_ownedRooms", MR = "_ownedRoomsTick";
+}), _R = "_ownedRooms", NR = "_ownedRoomsTick";
 
-function UR(e) {
+function PR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44022,13 +44035,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var _R = Ei("NativeCallsTracker");
+var IR = Ei("NativeCallsTracker");
 
-function NR(e, t, r) {
+function GR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) _R.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) IR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44044,7 +44057,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-_R.warn("Failed to wrap method", {
+IR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44054,30 +44067,30 @@ error: String(e)
 }
 }
 
-var PR, IR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], GR = "shard1", LR = {
+var LR, DR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], FR = "shard1", BR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, DR = {
+}, WR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, FR = {
+}, KR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function BR() {
+function HR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function WR() {
+function YR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: IR,
+targetShards: DR,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44087,11 +44100,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = IR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = DR),
 Memory.interShardOperation;
 }
 
-function KR() {
+function VR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -44106,7 +44119,7 @@ lastSync: 0,
 checksum: 0
 };
 var t = InterShardMemory.getLocal();
-return t && null !== (e = Op(t)) && void 0 !== e ? e : {
+return t && null !== (e = Mp(t)) && void 0 !== e ? e : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -44132,33 +44145,33 @@ checksum: 0
 }
 }
 
-function HR(e) {
+function qR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
-InterShardMemory.setLocal(bp(e));
+InterShardMemory.setLocal(kp(e));
 } catch (e) {}
 }
 
-function YR() {
-var e, t, r, o, n, i, s, c = KR(), u = BR();
+function jR() {
+var e, t, r, o, n, i, s, c = VR(), u = HR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: IR,
+targetShards: DR,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : IR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : DR,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && VR() ? "established" : "unreached",
+status: p === u && zR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44176,7 +44189,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === GR ? "core" : "frontier",
+role: u === FR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44193,24 +44206,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), HR(c), c.footprintOperation;
+}), qR(c), c.footprintOperation;
 }
 
-function VR() {
+function zR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function qR() {
+function QR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function jR(e, t) {
+function XR(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44229,9 +44242,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(qR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(QR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Fy.getPendingRequests(p.name).filter(function(r) {
+s += Ky.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44250,7 +44263,7 @@ if (n) throw n.error;
 return s;
 }
 
-function zR(e) {
+function ZR(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44294,7 +44307,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = KR().shards[BR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = VR().shards[HR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44304,8 +44317,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function QR(e, t) {
-if (!(jR("scout", t) >= 1)) {
+function JR(e, t) {
+if (!(XR("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44343,13 +44356,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Fy.addRequest({
+r && Ky.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: FR,
-priority: wy.LOW + 5,
+body: KR,
+priority: Oy.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44360,14 +44373,14 @@ task: "interShardPortalScout"
 }
 }
 
-function XR(e, t, r) {
-jR("interShardClaimer", t) >= 1 || Fy.addRequest({
+function $R(e, t, r) {
+XR("interShardClaimer", t) >= 1 || Ky.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: LR,
-priority: wy.NORMAL + 50,
+body: BR,
+priority: Oy.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44380,14 +44393,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function ZR(e, t, r) {
-jR("interShardScout", t) >= 1 || Fy.addRequest({
+function eE(e, t, r) {
+XR("interShardScout", t) >= 1 || Ky.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: FR,
-priority: wy.NORMAL,
+body: KR,
+priority: Oy.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44400,15 +44413,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function JR(e, t, r) {
+function tE(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (jR("interShardPioneer", t.shard) >= 3 || Fy.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (XR("interShardPioneer", t.shard) >= 3 || Ky.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: DR,
-priority: wy.NORMAL + 25,
+body: WR,
+priority: Oy.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44421,19 +44434,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function $R(e) {
+function rE(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = BR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = HR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : IR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : DR), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Op(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Mp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44465,9 +44478,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(qR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(QR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Fy.getPendingRequests(l.name).filter(function(e) {
+n += Ky.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44486,22 +44499,22 @@ return n;
 }() < o;
 }
 
-(PR = {
-optimizeBody: Iy,
+(LR = {
+optimizeBody: Dy,
 spawnQueue: {
 addRequest: function(e) {
-return Fy.addRequest(e);
+return Ky.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: wy.LOW,
-NORMAL: wy.NORMAL,
-HIGH: wy.HIGH
+LOW: Oy.LOW,
+NORMAL: Oy.NORMAL,
+HIGH: Oy.HIGH
 }
-}).optimizeBody && (Gp.optimizeBody = PR.optimizeBody), PR.spawnQueue && (Gp.spawnQueue = PR.spawnQueue),
-PR.spawnPriorities && (Gp.spawnPriorities = o(o({}, Gp.spawnPriorities), PR.spawnPriorities));
+}).optimizeBody && (Fp.optimizeBody = LR.optimizeBody), LR.spawnQueue && (Fp.spawnQueue = LR.spawnQueue),
+LR.spawnPriorities && (Fp.spawnPriorities = o(o({}, Fp.spawnPriorities), LR.spawnPriorities));
 
-var eE, tE = function() {
+var oE, nE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44545,7 +44558,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function rE(e) {
+function aE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44566,7 +44579,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function oE(e, t, r) {
+function iE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44632,16 +44645,16 @@ return u;
 });
 }
 
-function nE(e) {
+function sE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(eE || (eE = {}));
+}(oE || (oE = {}));
 
-var aE = function() {
+var cE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44679,8 +44692,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = oE(h.pos, T.pos, this.logger);
-if (nE(C)) {
+var T = E.value, C = iE(h.pos, T.pos, this.logger);
+if (sE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44707,8 +44720,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, k = oE(A, u.pos, this.logger);
-nE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
+var A = O.value, k = iE(A, u.pos, this.logger);
+sE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44747,8 +44760,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = oE(e, t, this.logger);
-if (nE(n)) {
+var n = iE(e, t, this.logger);
+if (sE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44758,7 +44771,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), iE = function() {
+}(), uE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44768,7 +44781,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = rE(s);
+var c = aE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44794,7 +44807,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), sE = function() {
+}(), lE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44843,7 +44856,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), cE = {
+}(), mE = {
 debug: function(e, t) {
 return k("RemoteMining").debug(e, t);
 },
@@ -44856,7 +44869,7 @@ return k("RemoteMining").warn(e, t);
 error: function(e, t) {
 return k("RemoteMining").error(e, t);
 }
-}, uE = {
+}, dE = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44883,26 +44896,26 @@ direction: a
 }
 return t;
 }
-}, lE = {
+}, pE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = vm.MEDIUM), Om.register({
+void 0 === o && (o = fm.MEDIUM), xm.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== vm.CRITICAL
+skippable: o !== fm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, mE = new aE(uE, cE), dE = new iE(cE, lE, mE), pE = new sE(cE, uE, mE, Gu.moveTo);
+}, fE = new cE(dE, mE), yE = new uE(mE, pE, fE), vE = new lE(mE, dE, fE, Gu.moveTo);
 
-function fE(e, t, r, o) {
-return pE.moveToWithRemoteCache(e, t, r, o);
+function gE(e, t, r, o) {
+return vE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var yE, vE = function() {
+var hE, RE = function() {
 function e() {
 this.logger = k("Pathfinding");
 }
@@ -44915,12 +44928,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), gE = function() {
+}(), EE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), hE = function() {
+}(), TE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44965,28 +44978,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), RE = function() {
+}(), CE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return rE(e);
+return aE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-mE.precacheRemoteRoutes(e, t);
+fE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), EE = new tE(new vE, new gE, new hE, new RE), TE = {
+}(), SE = new nE(new RE, new EE, new TE, new CE), wE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, CE = function() {
+}, xE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, TE), e);
+this.config = o(o({}, wE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45080,123 +45093,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new CE, (yE = {})[FIND_STRUCTURES] = {
+new xE, (hE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, yE[FIND_MY_STRUCTURES] = {
+}, hE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, yE[FIND_HOSTILE_STRUCTURES] = {
+}, hE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, yE[FIND_SOURCES_ACTIVE] = {
+}, hE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, yE[FIND_SOURCES] = {
+}, hE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, yE[FIND_MINERALS] = {
+}, hE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, yE[FIND_DEPOSITS] = {
+}, hE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, yE[FIND_MY_CONSTRUCTION_SITES] = {
+}, hE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, yE[FIND_CONSTRUCTION_SITES] = {
+}, hE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, yE[FIND_CREEPS] = {
+}, hE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, yE[FIND_MY_CREEPS] = {
+}, hE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, yE[FIND_HOSTILE_CREEPS] = {
+}, hE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, yE[FIND_DROPPED_RESOURCES] = {
+}, hE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, yE[FIND_TOMBSTONES] = {
+}, hE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, yE[FIND_RUINS] = {
+}, hE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, yE[FIND_FLAGS] = {
+}, hE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, yE[FIND_MY_SPAWNS] = {
+}, hE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, yE[FIND_HOSTILE_SPAWNS] = {
+}, hE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, yE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, hE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, yE[FIND_NUKES] = {
+}, hE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, yE[FIND_POWER_CREEPS] = {
+}, hE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, yE[FIND_MY_POWER_CREEPS] = {
+}, hE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, yE[FIND_HOSTILE_POWER_CREEPS] = {
+}, hE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, yE[FIND_EXIT_TOP] = {
+}, hE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, yE[FIND_EXIT_RIGHT] = {
+}, hE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, yE[FIND_EXIT_BOTTOM] = {
+}, hE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, yE[FIND_EXIT_LEFT] = {
+}, hE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, yE[FIND_EXIT] = {
+}, hE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var SE = new le({}, mr), wE = new Ee({}, mr);
+var bE = new le({}, mr), OE = new Ee({}, mr);
 
-function xE(e) {
+function AE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45204,11 +45217,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var bE = !1;
+var kE = !1;
 
-function OE() {
+function ME() {
 var e, t;
-bE || (ii({
+kE || (ii({
 level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45223,11 +45236,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (By.getPendingTransfers = function(e) {
+r.getPendingTransfers && (Hy.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (By.needsCarrier = function(e) {
+}), r.needsCarrier && (Hy.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (By.getActiveRequests = function() {
+}), r.getActiveRequests && (Hy.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45241,47 +45254,47 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Wy.predictConsumption = function(e) {
+a.predictConsumption && (Yy.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Wy.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Yy.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Wy.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Yy.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Wy.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Yy.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Ky.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Vy.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Ky.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Vy.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Ky.needsCarriers = function(e) {
+}), i.needsCarriers && (Vy.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Ky.requestSpawns = function(e) {
+}), i.requestSpawns && (Vy.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-Hy.getEmergencyState = function(e) {
+qy.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: bt,
 powerBankHarvestingManager: qc,
-resourceTransferCoordinator: Dp,
+resourceTransferCoordinator: Wp,
 emergencyResponseManager: Ba,
 kernel: Ja
 }), function(e) {
 var t, r, o, n;
-id = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : ad.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : ad.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : ad.getLabOverflow
-} : ad;
+sd = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : id.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : id.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : id.getLabOverflow
+} : id;
 }({
 getLabResourceNeeds: function(e) {
 return Ru.getLabResourceNeeds(e);
@@ -45295,7 +45308,7 @@ return Ru.getLabOverflow(e);
 }), Ji.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) _R.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) IR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45309,7 +45322,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-_R.warn("Failed to wrap PathFinder.search", {
+IR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45317,11 +45330,11 @@ error: String(e)
 }
 }
 }
-}(), NR(e = Creep.prototype, "moveTo", "moveTo"), NR(e, "move", "move"), NR(e, "harvest", "harvest"),
-NR(e, "transfer", "transfer"), NR(e, "withdraw", "withdraw"), NR(e, "build", "build"),
-NR(e, "repair", "repair"), NR(e, "upgradeController", "upgradeController"), NR(e, "attack", "attack"),
-NR(e, "rangedAttack", "rangedAttack"), NR(e, "heal", "heal"), NR(e, "dismantle", "dismantle"),
-NR(e, "say", "say")), function(e, t, r) {
+}(), GR(e = Creep.prototype, "moveTo", "moveTo"), GR(e, "move", "move"), GR(e, "harvest", "harvest"),
+GR(e, "transfer", "transfer"), GR(e, "withdraw", "withdraw"), GR(e, "build", "build"),
+GR(e, "repair", "repair"), GR(e, "upgradeController", "upgradeController"), GR(e, "attack", "attack"),
+GR(e, "rangedAttack", "rangedAttack"), GR(e, "heal", "heal"), GR(e, "dismantle", "dismantle"),
+GR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -45337,15 +45350,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, wf), EE.initializePathCacheEvents(), dE.initialize(vm.MEDIUM), Tl = fE,
-Ft.initialize(), xR.initialize(), bE = !0), mr.initialize();
-var r = AR.configureForCurrentTick();
+}(Ja, mr, Of), SE.initializePathCacheEvents(), yE.initialize(fm.MEDIUM), Tl = gE,
+Ft.initialize(), AR.initialize(), kE = !0), mr.initialize();
+var r = UR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = WR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, YR(), function() {
-var e, t, r, o, n = KR(), a = n.footprintOperation, i = BR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = YR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, jR(), function() {
+var e, t, r, o, n = VR(), a = n.footprintOperation, i = HR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45358,15 +45371,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, HR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, qR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = WR();
+var e, t, r, n, i, s, c = YR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : IR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === GR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : DR), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === FR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45384,10 +45397,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !VR())) try {
+}(), !zR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || $p(s), "interShardPioneer" === c && Jp(s);
+"interShardClaimer" !== c && "interShardScout" !== c || rf(s), "interShardPioneer" === c && tf(s);
 }
 } catch (t) {
 e = {
@@ -45411,17 +45424,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: bE
+systemsInitialized: kE
 }
-}), AR.ensureProcessesRegistered(), Ji.startTick(), ku.clear(), AR.startEventTick();
+}), UR.ensureProcessesRegistered(), Ji.startTick(), ku.clear(), UR.startEventTick();
 var i = function(e) {
-var t = e.cache[kR], r = e.cache[MR];
+var t = e.cache[_R], r = e.cache[NR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[kR] = o, e.cache[MR] = e.tick, o;
+return e.cache[_R] = o, e.cache[NR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45458,18 +45471,18 @@ if (e) throw e.error;
 }
 }), Ji.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = WR();
+var e, t, r, o = YR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = YR();
+var n = jR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : IR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : DR), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== BR()) try {
+if (d !== HR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Op(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Mp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45487,20 +45500,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = qR().sort(function(e, t) {
+var i = QR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : IR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : DR), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== BR()) {
+if (u !== HR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = zR(u);
+var m = ZR(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? JR(i, l, m) : $R() ? XR(i, u, m) : (ZR(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (QR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? tE(i, l, m) : rE() ? $R(i, u, m) : (eE(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (JR(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45517,8 +45530,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = KR();
-d.footprintOperation = n, HR(d);
+var d = VR();
+d.footprintOperation = n, qR(d);
 }
 }
 })(), function() {
@@ -45526,8 +45539,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || xE(s))) {
-var c = lg(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || AE(s))) {
+var c = pg(s, mr.getOrInitSwarmState(s.name));
 Ji.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45544,20 +45557,20 @@ if (e) throw e.error;
 }
 }();
 }), Gu.preTick(), Ji.measureSubsystem("processSync", function() {
-mf.syncCreepProcesses(), dy.syncRoomProcesses();
+ff.syncCreepProcesses(), yy.syncRoomProcesses();
 }), Ji.measureSubsystem("kernel", function() {
-AR.runProcesses();
+UR.runProcesses();
 }), Ji.measureSubsystem("eventQueue", function() {
-AR.processQueuedEvents();
+UR.processQueuedEvents();
 }), Ji.measureSubsystem("ss2PacketQueue", function() {
-fg.processQueue();
+gg.processQueue();
 }), Ja.hasCpuBudget() && Ji.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && ef(n);
+void 0 !== n.ticksToLive && of(n);
 }
 } catch (t) {
 e = {
@@ -45571,7 +45584,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), UR({
+}), PR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("visualizations", function() {
@@ -45581,8 +45594,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = SE.getConfig(), s = wE.getConfig();
-SE.setConfig(n.roomVisualizerConfig), n.renderMap && wE.setConfig(n.mapVisualizerConfig);
+var i = bE.getConfig(), s = OE.getConfig();
+bE.setConfig(n.roomVisualizerConfig), n.renderMap && OE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45593,7 +45606,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-SE.draw(m);
+bE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45615,14 +45628,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-wE.draw();
+OE.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-SE.setConfig(i), wE.setConfig(s);
+bE.setConfig(i), OE.setConfig(s);
 }
 }
 }
@@ -45707,19 +45720,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Gu.reconcileTraffic(), UR({
+}), Gu.reconcileTraffic(), PR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Om.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), xm.run(e);
 }), mr.persistHeapCache(), Ji.collectProcessStats(Ja.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), Ji.collectKernelBudgetStats(Ja), Ji.setSkippedProcesses(Ja.getSkippedProcessesThisTick()),
 Ji.finalizeTick(), Ci.flush();
 }
 
-var AE = function() {
+var UE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45727,25 +45740,25 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = SE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = bE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-SE.toggle(o);
-var n = SE.getConfig()[o];
+bE.toggle(o);
+var n = bE.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = wE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = OE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-wE.toggle(o);
-var n = wE.getConfig()[o];
+OE.toggle(o);
+var n = OE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = wE.getConfig();
+var e = OE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45868,15 +45881,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), kE = function() {
+}(), _E = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = xR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = AR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = xR.getAllShards();
+var e, t, r = AR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45898,9 +45911,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (xR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (AR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = xR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = AR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45925,19 +45938,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = xR.getOptimalPortalRoute(e, t);
+var r, o = AR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (xR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (AR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (xR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (AR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Dp.getActiveRequests();
+var e, t, r = Wp.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -45958,7 +45971,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = xR.getCurrentShardState();
+var e, t, r = AR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45979,7 +45992,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = xR.getActiveTransferTasks();
+var e, t, r, o = AR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -46000,16 +46013,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = xR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Mp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = AR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Np, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = xR.getMemoryStats();
+var e = AR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return xR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return AR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = KR().footprintOperation;
+var e, t, r, o = VR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46115,9 +46128,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), ME = new kE;
+}(), NE = new _E;
 
-function UE(e) {
+function PE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46147,10 +46160,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? UE(e.metadata.usage) : void 0
+params: e.metadata.usage ? PE(e.metadata.usage) : void 0
 };
 });
-return Gm({
+return Pm({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46201,12 +46214,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Gm.apply(void 0, s([], i(o), !1));
+return Pm.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return Nm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Um("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Im.form("spawnCreep", [ {
+return Nm.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46240,20 +46253,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return Nm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Um("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += Nm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += Nm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Im.button({
+o += '<div style="margin-bottom: 10px;">', o += Um("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Um("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Nm.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Im.button({
+}), o += " ", (o += Nm.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Im.form("configureLogging", [ {
+return Nm.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46278,7 +46291,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Im.form("configureVisualization", [ {
+return Nm.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46302,21 +46315,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Im.button({
+e += Nm.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += Im.button({
+}), e += " ", e += Nm.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Im.button({
+}), e += " ", (e += Nm.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += Nm("✓ Success message", "green", !0) + "\n", e += Nm("⚠ Warning message", "yellow", !0) + "\n",
-e += Nm("✗ Error message", "red", !0) + "\n", e += Nm("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + Nm("colored text", "green") + " normal text\n") + "Bold text: " + Nm("important", null, !0) + "\n";
+return e += Um("✓ Success message", "green", !0) + "\n", e += Um("⚠ Warning message", "yellow", !0) + "\n",
+e += Um("✗ Error message", "red", !0) + "\n", e += Um("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Um("colored text", "green") + " normal text\n") + "Bold text: " + Um("important", null, !0) + "\n";
 }, n([ Tt({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46362,39 +46375,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var _E = new fy, NE = new AE, PE = new yy, IE = new bu, GE = new py, LE = new vy, DE = new gy, FE = "__screepsGlobalRuntimeDiagnostics";
+var IE = new gy, GE = new UE, LE = new hy, DE = new bu, FE = new vy, BE = new Ry, WE = new Ey, KE = "__screepsGlobalRuntimeDiagnostics";
 
-function BE() {
+function HE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function WE(e, t) {
+function YE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function KE(e, t) {
+function VE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function HE(e) {
+function qE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function YE(e) {
+function jE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: WE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: WE(n.switchCount, 0),
-lastTick: KE(n.lastTick, Game.time),
-lastResetTick: KE(n.lastResetTick, Game.time),
-lastSwitchTick: HE(n.lastSwitchTick),
-lastSwitchPreviousTick: HE(n.lastSwitchPreviousTick),
-lastWarningTick: HE(n.lastWarningTick)
+resetCount: YE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: YE(n.switchCount, 0),
+lastTick: VE(n.lastTick, Game.time),
+lastResetTick: VE(n.lastResetTick, Game.time),
+lastSwitchTick: qE(n.lastSwitchTick),
+lastSwitchPreviousTick: qE(n.lastSwitchPreviousTick),
+lastWarningTick: qE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46408,13 +46421,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var VE = Ei("Main");
+var zE = Ei("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(_E), Ct(NE), Ct(PE), Ct(IE), Ct(GE), Ct(LE), Ct(DE), Ct(Su),
-Ct(wu), Ct(xu), Ct(ME), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
+Et.initialize(), Ct(IE), Ct(GE), Ct(LE), Ct(DE), Ct(FE), Ct(BE), Ct(WE), Ct(Su),
+Ct(wu), Ct(xu), Ct(NE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -46429,12 +46442,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : BE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[FE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : HE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[KE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[FE] = s, function(e, t) {
-var r, o = YE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[KE] = s, function(e, t) {
+var r, o = jE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46452,7 +46465,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = YE(e.heapId);
+var n, a = jE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46473,14 +46486,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = YE(s.heapId);
+var u = jE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: VE
-}), OE();
+logger: zE
+}), ME();
 } catch (e) {
-throw VE.error("Critical error in main loop: ".concat(String(e)), {
+throw zE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-bot/src/roles/economy/index.ts
+++ b/packages/screeps-bot/src/roles/economy/index.ts
@@ -18,7 +18,8 @@ import {
   createContext,
   evaluateEconomyBehavior,
   evaluateWithStateMachine,
-  executeAction
+  executeAction,
+  getEconomyStateInterrupt
 } from "@ralphschuler/screeps-roles";
 
 /**
@@ -27,6 +28,6 @@ import {
  */
 export function runEconomyRole(creep: Creep): void {
   const ctx = createContext(creep);
-  const action = evaluateWithStateMachine(ctx, evaluateEconomyBehavior);
+  const action = evaluateWithStateMachine(ctx, evaluateEconomyBehavior, { interrupt: getEconomyStateInterrupt });
   executeAction(creep, action, ctx);
 }


### PR DESCRIPTION
## Summary

Adds a task-board-aware economy interrupt for carried-energy creeps so long-running economy states can preempt for critical refill work instead of leaving refill tasks unreserved.

## Linked issue

Refs #3119

## Changes

### Code changes
- Added `getEconomyStateInterrupt()` in `@ralphschuler/screeps-roles` and wired it through framework and bot economy role runners.
- Interrupts build/repair/upgrade states for critical refill task-board assignments when the creep is carrying energy.
- Preserves the existing active-hauler upgrader gate so upgraders do not abandon controller work when haulers should handle extension refill.
- Repairs stale `assignedTaskId` memory when a creep already has a valid reservation under a different task id.

### Test changes
- Added task-board regression coverage for economy state interruption.
- Added stale assignment-memory cleanup and repair coverage.
- Added active-hauler upgrader non-interruption coverage.

### Docs changes
- None; internal runtime behavior only.

## Validation

- PASS: `npm test -w @ralphschuler/screeps-roles -- --grep "interrupts a committed builder|clears stale creep assignment|repairs stale assignment|active-hauler upgraders"`
- PASS: `npm test -w @ralphschuler/screeps-roles -- --grep TaskBoard`
- PASS: `npm run test:roles`
- PASS: `npm run build:roles`
- PASS: `npm run lint:roles`
- PASS: `npm run build:bot`
- PASS: `npm run lint -w screeps-typescript-starter -- --max-warnings=0`
- PASS: `npm run check:alliance-safety`
- PASS: `npm run build`
- PASS: `npm run test:server:smoke` (`packages/screeps-server/artifacts/smoke/summary.md`: Status passed, 49/49 screepsmod-testing checks)
- PASS: reviewer subagent re-review found no must-fix findings.

## Deployment impact

Affects screeps.com runtime economy role scheduling and task-board reservations. Updated `packages/screeps-bot/dist/main.js` is included for deploy path.

## Live bot evidence

Pre-implementation read-only live analysis updated #3119, #3242, #3105, and #3104. Current #3119 evidence showed shard1 task-board total `45`, assigned `0`, unassigned `45` at tick `72121769` with healthy bucket, so assignment throughput remains the live target.

## Follow-up issues

None created per operator constraint. Existing related live issues remain #3105 and #3104.
