### PR TITLE
[codex] Publish idle shard telemetry

### DIFF
--- a/packages/@ralphschuler/screeps-stats/src/unifiedStats.ts
+++ b/packages/@ralphschuler/screeps-stats/src/unifiedStats.ts
@@ -244,6 +244,16 @@ export class UnifiedStatsManager {
   }
 
   /**
+   * Publish a fresh zero/idle tick without room or process work.
+   * Runtime shells use this on abandoned or respawning shards so external
+   * diagnostics can distinguish intentional idleness from stale telemetry.
+   */
+  public publishIdleTick(): void {
+    this.startTick();
+    this.finalizeTick();
+  }
+
+  /**
    * End of tick - finalize and publish stats
    */
   public finalizeTick(): void {
@@ -1551,29 +1561,31 @@ export class UnifiedStatsManager {
    * Finalize creep stats - collect stats for all creeps if not already recorded
    */
   private finalizeCreepStats(): void {
-    for (const creep of Object.values(Game.creeps)) {
+    for (const [creepName, creep] of Object.entries(Game.creeps)) {
+      const name = creep.name ?? creepName;
       // Only record if not already recorded this tick
-      if (!this.currentSnapshot.creeps[creep.name]) {
-        const creepMemory = creep.memory as unknown as { 
-          role?: string; 
-          homeRoom?: string; 
-          state?: { action?: string }; 
-          working?: boolean 
+      if (!this.currentSnapshot.creeps[name]) {
+        const creepMemory = (creep.memory ?? {}) as unknown as {
+          role?: string;
+          homeRoom?: string;
+          state?: { action?: string };
+          working?: boolean
         };
         const action = creepMemory.state?.action ?? (creepMemory.working ? "working" : "idle");
+        const currentRoom = creep.room?.name ?? creepMemory.homeRoom ?? "unknown";
         
-        this.currentSnapshot.creeps[creep.name] = {
-          name: creep.name,
+        this.currentSnapshot.creeps[name] = {
+          name,
           role: creepMemory.role ?? "unknown",
-          homeRoom: creepMemory.homeRoom ?? creep.room.name,
-          currentRoom: creep.room.name,
+          homeRoom: creepMemory.homeRoom ?? currentRoom,
+          currentRoom,
           cpu: 0, // Will be filled in by creep runner if tracking
           action,
           ticksToLive: creep.ticksToLive ?? 0,
-          hits: creep.hits,
-          hitsMax: creep.hitsMax,
-          bodyParts: creep.body.length,
-          fatigue: creep.fatigue,
+          hits: creep.hits ?? 0,
+          hitsMax: creep.hitsMax ?? 0,
+          bodyParts: creep.body?.length ?? 0,
+          fatigue: creep.fatigue ?? 0,
           actionsThisTick: 0
         };
       }

--- a/packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts
+++ b/packages/@ralphschuler/screeps-stats/test/unifiedStats.test.ts
@@ -100,6 +100,52 @@ describe("UnifiedStatsManager", () => {
     expect(profiler?.rooms.W17S29.samples).to.equal(42);
   });
 
+  it("publishes a fresh zero-room idle tick for abandoned shards", () => {
+    const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
+    const game = Game as unknown as { time: number; cpu: typeof Game.cpu };
+    const originalCpu = game.cpu;
+
+    try {
+      game.time = 76166543;
+      game.cpu = {
+        ...(Game.cpu as unknown as object),
+        bucket: 906,
+        limit: 20,
+        getUsed: () => 0
+      } as typeof Game.cpu;
+
+      manager.publishIdleTick();
+
+      const stats = (Memory as unknown as { stats: { tick: number; rooms: Record<string, unknown>; cpu: { bucket: number }; empire: { rooms: number } } }).stats;
+      expect(stats.tick).to.equal(76166543);
+      expect(stats.cpu.bucket).to.equal(906);
+      expect(stats.empire.rooms).to.equal(0);
+      expect(stats.rooms).to.deep.equal({});
+    } finally {
+      game.cpu = originalCpu;
+    }
+  });
+
+  it("keeps idle tick publishing robust when legacy creep mocks lack room data", () => {
+    const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
+    (Game as unknown as { creeps: Record<string, unknown> }).creeps = {
+      legacyDrone: {
+        memory: undefined,
+        hits: undefined,
+        hitsMax: undefined,
+        body: undefined,
+        fatigue: undefined
+      }
+    };
+
+    manager.publishIdleTick();
+
+    const creepStats = (Memory as unknown as { stats: { creeps: Record<string, { current_room: string; home_room: string; body_parts: number }> } }).stats.creeps.legacyDrone;
+    expect(creepStats.current_room).to.equal("unknown");
+    expect(creepStats.home_room).to.equal("unknown");
+    expect(creepStats.body_parts).to.equal(0);
+  });
+
   it("drops stale room stats when room ownership is lost", () => {
     const manager = new UnifiedStatsManager({ logInterval: 0, segmentUpdateInterval: Number.MAX_SAFE_INTEGER });
     const state = manager as unknown as { currentSnapshot: { rooms: Record<string, unknown> } };

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -13373,6 +13373,8 @@ if (e) throw e.error;
 }
 Ki.reset();
 }
+}, e.prototype.publishIdleTick = function() {
+this.startTick(), this.finalizeTick();
 }, e.prototype.finalizeTick = function() {
 var e, t, r, n, a, c, u, l, m, d, p, f, y, v, g, h;
 if (this.config.enabled) {
@@ -14253,24 +14255,24 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.finalizeCreepStats = function() {
-var e, t, r, o, n, i, s;
+var e, t, r, o, n, s, c, u, l, m, d, p, f, y, v, g, h;
 try {
-for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
-var l = u.value;
-if (!this.currentSnapshot.creeps[l.name]) {
-var m = l.memory, d = null !== (o = null === (r = m.state) || void 0 === r ? void 0 : r.action) && void 0 !== o ? o : m.working ? "working" : "idle";
-this.currentSnapshot.creeps[l.name] = {
-name: l.name,
-role: null !== (n = m.role) && void 0 !== n ? n : "unknown",
-homeRoom: null !== (i = m.homeRoom) && void 0 !== i ? i : l.room.name,
-currentRoom: l.room.name,
+for (var R = a(Object.entries(Game.creeps)), E = R.next(); !E.done; E = R.next()) {
+var T = i(E.value, 2), C = T[0], S = T[1], w = null !== (r = S.name) && void 0 !== r ? r : C;
+if (!this.currentSnapshot.creeps[w]) {
+var x = null !== (o = S.memory) && void 0 !== o ? o : {}, b = null !== (s = null === (n = x.state) || void 0 === n ? void 0 : n.action) && void 0 !== s ? s : x.working ? "working" : "idle", O = null !== (l = null !== (u = null === (c = S.room) || void 0 === c ? void 0 : c.name) && void 0 !== u ? u : x.homeRoom) && void 0 !== l ? l : "unknown";
+this.currentSnapshot.creeps[w] = {
+name: w,
+role: null !== (m = x.role) && void 0 !== m ? m : "unknown",
+homeRoom: null !== (d = x.homeRoom) && void 0 !== d ? d : O,
+currentRoom: O,
 cpu: 0,
-action: d,
-ticksToLive: null !== (s = l.ticksToLive) && void 0 !== s ? s : 0,
-hits: l.hits,
-hitsMax: l.hitsMax,
-bodyParts: l.body.length,
-fatigue: l.fatigue,
+action: b,
+ticksToLive: null !== (p = S.ticksToLive) && void 0 !== p ? p : 0,
+hits: null !== (f = S.hits) && void 0 !== f ? f : 0,
+hitsMax: null !== (y = S.hitsMax) && void 0 !== y ? y : 0,
+bodyParts: null !== (g = null === (v = S.body) || void 0 === v ? void 0 : v.length) && void 0 !== g ? g : 0,
+fatigue: null !== (h = S.fatigue) && void 0 !== h ? h : 0,
 actionsThisTick: 0
 };
 }
@@ -14281,7 +14283,7 @@ error: t
 };
 } finally {
 try {
-u && !u.done && (t = c.return) && t.call(c);
+E && !E.done && (t = R.return) && t.call(R);
 } finally {
 if (e) throw e.error;
 }
@@ -45420,7 +45422,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 if (0 === n) return Game.time % 100 == 0 && Ci.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), void Ci.flush();
+}), Ji.publishIdleTick(), void Ci.flush();
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {

--- a/packages/screeps-bot/src/SwarmBot.ts
+++ b/packages/screeps-bot/src/SwarmBot.ts
@@ -221,6 +221,15 @@ function runVisualizations(ownedRooms: Room[], profile: ReturnType<typeof resolv
 }
 
 /**
+ * Publish fresh minimal stats for abandoned/respawning shards before skipping
+ * colony work. This keeps live diagnostics from seeing stale or missing
+ * `Memory.stats` while preserving the no-owned-room CPU-saving guard.
+ */
+function publishIdleShardStats(): void {
+  unifiedStats.publishIdleTick();
+}
+
+/**
  * Main loop for SwarmBot
  */
 export function loop(): void {
@@ -255,7 +264,10 @@ export function loop(): void {
     if (Game.time % 100 === 0) {
       logger.info(`Shard idle (no owned rooms) at tick ${Game.time}`, { subsystem: "SwarmBot" });
     }
-    // Skip colony work to save CPU on abandoned shards
+    // Skip colony work to save CPU on abandoned shards, but still publish a fresh
+    // zero-room stats snapshot so live diagnostics can distinguish intentional
+    // idleness from stale/missing telemetry.
+    publishIdleShardStats();
     logger.flush();
     return;
   }

--- a/packages/screeps-bot/test/unit/swarmBotLogging.test.ts
+++ b/packages/screeps-bot/test/unit/swarmBotLogging.test.ts
@@ -74,6 +74,43 @@ describe("SwarmBot logging", () => {
     sinon.assert.called(kernelRunStub);
   });
 
+  it("publishes fresh idle-shard stats before returning with no owned rooms", async () => {
+    const bot = await reloadSwarmBot();
+
+    const startTickSpy = sandbox.spy(bot.unifiedStats, "startTick");
+    const finalizeTickSpy = sandbox.spy(bot.unifiedStats, "finalizeTick");
+    const kernelRunSpy = sandbox.spy(Kernel.prototype, "run");
+
+    // @ts-ignore: test setup for Game globals
+    global.Game.time = 76166543;
+    // @ts-ignore: test setup for Game globals
+    global.Game.cpu = { ...global.Game.cpu, bucket: 906, limit: 20 };
+    // @ts-ignore: test setup for Game globals
+    global.Game.rooms = {
+      W9N1: {
+        name: "W9N1",
+        controller: { my: false } as any,
+        find: () => []
+      } as any
+    };
+    // @ts-ignore: test setup for Memory globals
+    global.Memory.stats = { tick: 70000000, rooms: { W1N1: {} } };
+
+    bot.loop();
+
+    sinon.assert.calledOnce(startTickSpy);
+    sinon.assert.calledOnce(finalizeTickSpy);
+    sinon.assert.notCalled(kernelRunSpy);
+    // @ts-ignore: test setup for Memory globals
+    assert.equal(global.Memory.stats.tick, 76166543);
+    // @ts-ignore: test setup for Memory globals
+    assert.equal(global.Memory.stats.cpu.bucket, 906);
+    // @ts-ignore: test setup for Memory globals
+    assert.equal(global.Memory.stats.empire.rooms, 0);
+    // @ts-ignore: test setup for Memory globals
+    assert.deepEqual(global.Memory.stats.rooms, {});
+  });
+
   it("logs visualization errors through the logger", async () => {
     // Set up spies/stubs before reloading modules to ensure they're properly intercepted
     const errorSpy = sandbox.spy(loggerModule.logger, "error");


### PR DESCRIPTION
## Summary

Publishes fresh minimal stats on shards with no owned rooms before the idle guard returns, so live diagnostics can distinguish intentional idle/abandoned shards from stale or missing telemetry.

## Linked issue

Closes #3184

## Changes

- Code changes
  - Added `UnifiedStatsManager.publishIdleTick()` to run a zero-room stats tick without room/kernel work.
  - Calls idle stats publishing from the `SwarmBot` no-owned-room guard while still skipping colony/kernel processing.
  - Hardened creep stats finalization for legacy/mocked creeps without name/room/body/memory fields.
  - Updated tracked bot bundle in `packages/screeps-bot/dist/main.js`.
- Test changes
  - Added stats-package coverage for zero-room idle shard snapshots.
  - Added robustness coverage for legacy creep mocks without room/memory data.
  - Added bot-loop coverage that idle shards publish stats and do not run the kernel.
- Docs changes
  - None; runtime behavior is covered by issue and tests.

## Validation

- ✅ `npm run check-versions`
- ✅ `npm run sync:deps:check`
- ✅ `npm run build:stats`
- ✅ `npm test -w @ralphschuler/screeps-stats`
- ✅ `npm --workspace screeps-typescript-starter run test:unit -- --grep "SwarmBot logging"`
- ✅ `npm run lint -w @ralphschuler/screeps-stats`
- ✅ `npm run lint`
- ✅ `npm run build:bot`
- ✅ `npm run build`
- ✅ `npm run test:server:smoke` (`49/49` screepsmod-testing checks passed; smoke summary status passed)
- ✅ `git diff --check`

## Deployment impact

Affects live Screeps runtime telemetry only on zero-owned-room/idle shards. It should add a small stats publish cost on those shards while preserving the guard that skips colony/kernel work.

## Live bot evidence

Pre-fix live read-only analysis at `artifacts/live-analysis-20260705T-current-cycle/` still showed:
- `shard0` game tick `76169473`
- `Memory.stats.tick` missing, freshness `missing`
- bucket `906`, CPU avg/max `0/0`
- no room/process/role telemetry

## Follow-up issues

- Updated existing #3239 with smoke-harness log evidence observed during validation.
- No new issues created per operator instruction.
