### PR TITLE
[codex] Guard internal workspace imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8949,6 +8949,7 @@
       "license": "Unlicense",
       "dependencies": {
         "@ralphschuler/screeps-core": "*",
+        "@ralphschuler/screeps-kernel": "*",
         "@ralphschuler/screeps-memory": "*",
         "@ralphschuler/screeps-utils": "*"
       },
@@ -9021,6 +9022,9 @@
         "@ralphschuler/screeps-cache": "*",
         "@ralphschuler/screeps-core": "*",
         "@ralphschuler/screeps-defense": "*",
+        "@ralphschuler/screeps-intershard": "*",
+        "@ralphschuler/screeps-memory": "*",
+        "@ralphschuler/screeps-stats": "*",
         "@ralphschuler/screeps-utils": "*",
         "screeps-cartographer": "^1.8.15"
       },

--- a/packages/@ralphschuler/screeps-pheromones/package.json
+++ b/packages/@ralphschuler/screeps-pheromones/package.json
@@ -11,7 +11,7 @@
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
-    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-utils --if-present"
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-utils --if-present"
   },
   "keywords": [
     "screeps",
@@ -24,6 +24,7 @@
   "license": "Unlicense",
   "dependencies": {
     "@ralphschuler/screeps-core": "*",
+    "@ralphschuler/screeps-kernel": "*",
     "@ralphschuler/screeps-memory": "*",
     "@ralphschuler/screeps-utils": "*"
   },

--- a/packages/@ralphschuler/screeps-roles/package.json
+++ b/packages/@ralphschuler/screeps-roles/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
-    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-cache -w @ralphschuler/screeps-defense -w @ralphschuler/screeps-utils --if-present",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-cache -w @ralphschuler/screeps-defense -w @ralphschuler/screeps-intershard -w @ralphschuler/screeps-memory -w @ralphschuler/screeps-stats -w @ralphschuler/screeps-utils --if-present",
     "build": "tsc",
     "test": "mocha test/**/*.test.ts",
     "prepublishOnly": "npm run build",
@@ -32,12 +32,14 @@
   },
   "homepage": "https://github.com/ralphschuler/screeps/tree/main/packages/@ralphschuler/screeps-roles#readme",
   "dependencies": {
-    "screeps-cartographer": "^1.8.15",
-    "@ralphschuler/screeps-core": "*",
     "@ralphschuler/screeps-cache": "*",
+    "@ralphschuler/screeps-core": "*",
     "@ralphschuler/screeps-defense": "*",
+    "@ralphschuler/screeps-intershard": "*",
+    "@ralphschuler/screeps-memory": "*",
+    "@ralphschuler/screeps-stats": "*",
     "@ralphschuler/screeps-utils": "*",
-    "@ralphschuler/screeps-memory": "*"
+    "screeps-cartographer": "^1.8.15"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/scripts/sync-framework-deps.js
+++ b/scripts/sync-framework-deps.js
@@ -15,6 +15,7 @@
 
 import fs from "fs";
 import path from "path";
+import ts from "typescript";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -33,7 +34,9 @@ function exitWithError(message) {
 }
 
 // Load shared dependencies configuration
-const sharedDepsPath = path.join(__dirname, "shared-dependencies.json");
+const sharedDepsPath = process.env.FRAMEWORK_DEPS_SHARED_CONFIG
+  ? path.resolve(process.env.FRAMEWORK_DEPS_SHARED_CONFIG)
+  : path.join(__dirname, "shared-dependencies.json");
 
 let sharedDepsConfig;
 try {
@@ -66,7 +69,9 @@ const sharedDevDeps = sharedDepsConfig.framework.devDependencies;
 
 // Find all framework packages: any package.json under packages/ whose name starts with @ralphschuler/screeps-
 // Excludes server, tasks, and posis packages which have different dependency requirements
-const packagesDir = path.join(__dirname, "..", "packages");
+const packagesDir = process.env.FRAMEWORK_DEPS_PACKAGES_DIR
+  ? path.resolve(process.env.FRAMEWORK_DEPS_PACKAGES_DIR)
+  : path.join(__dirname, "..", "packages");
 
 if (!fs.existsSync(packagesDir)) {
   exitWithError(
@@ -127,6 +132,161 @@ function findFrameworkPackageJsons(rootDir) {
   return results;
 }
 
+const SOURCE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs"]);
+const SOURCE_DIR_EXCLUDES = new Set([
+  "node_modules",
+  "dist",
+  "coverage",
+  "test",
+  "tests",
+  "__tests__",
+]);
+function sortObjectByKey(value) {
+  return Object.fromEntries(
+    Object.entries(value ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+function extractPackageName(specifier) {
+  if (
+    typeof specifier !== "string" ||
+    specifier.startsWith(".") ||
+    specifier.startsWith("/")
+  ) {
+    return null;
+  }
+  const parts = specifier.split("/");
+  if (specifier.startsWith("@")) {
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
+  }
+  return parts[0] || null;
+}
+
+function findSourceFiles(packageRoot) {
+  const srcDir = path.join(packageRoot, "src");
+  const root = fs.existsSync(srcDir) ? srcDir : packageRoot;
+  const files = [];
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SOURCE_DIR_EXCLUDES.has(entry.name)) walk(fullPath);
+        continue;
+      }
+      if (entry.isFile() && SOURCE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(root);
+  return files;
+}
+
+function scriptKindForFile(sourceFile) {
+  switch (path.extname(sourceFile)) {
+    case ".js":
+    case ".mjs":
+    case ".cjs":
+      return ts.ScriptKind.JS;
+    case ".tsx":
+      return ts.ScriptKind.TSX;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+function collectImportSpecifiers(sourceFile, source) {
+  const ast = ts.createSourceFile(
+    sourceFile,
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    scriptKindForFile(sourceFile),
+  );
+  const specifiers = [];
+
+  function addModuleSpecifier(moduleSpecifier) {
+    if (moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier)) {
+      specifiers.push(moduleSpecifier.text);
+    }
+  }
+
+  function visit(node) {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      addModuleSpecifier(node.moduleSpecifier);
+    } else if (ts.isCallExpression(node)) {
+      const [firstArg] = node.arguments;
+      const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+      const isRequire = ts.isIdentifier(node.expression) && node.expression.text === "require";
+      if ((isDynamicImport || isRequire) && firstArg) addModuleSpecifier(firstArg);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(ast);
+  return specifiers;
+}
+
+function collectInternalImports(packageRoot, internalPackageNames) {
+  const imports = new Set();
+  for (const sourceFile of findSourceFiles(packageRoot)) {
+    let source;
+    try {
+      source = fs.readFileSync(sourceFile, "utf8");
+    } catch {
+      continue;
+    }
+
+    for (const specifier of collectImportSpecifiers(sourceFile, source)) {
+      const packageName = extractPackageName(specifier);
+      if (packageName && internalPackageNames.has(packageName)) imports.add(packageName);
+    }
+  }
+  return imports;
+}
+
+function collectDeclaredPackageDependencies(pkg) {
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+}
+
+function findMissingInternalDependencies(pkgPath, pkg, internalPackageNames) {
+  const importedPackages = collectInternalImports(
+    path.dirname(pkgPath),
+    internalPackageNames,
+  );
+  const declaredPackages = collectDeclaredPackageDependencies(pkg);
+  importedPackages.delete(pkg.name);
+  return [...importedPackages]
+    .filter((packageName) => !declaredPackages.has(packageName))
+    .sort();
+}
+
+function loadInternalPackageNames(packageJsonPaths) {
+  const names = new Set();
+  for (const pkgPath of packageJsonPaths) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      if (typeof pkg.name === "string") names.add(pkg.name);
+    } catch {
+      // Invalid package files are handled in the main package loop.
+    }
+  }
+  return names;
+}
+
 let packageDirs;
 try {
   packageDirs = findFrameworkPackageJsons(packagesDir);
@@ -139,6 +299,8 @@ if (packageDirs.length === 0) {
     `No framework packages found in: ${packagesDir}\nExpected at least one package with name starting with @ralphschuler/screeps-.`,
   );
 }
+
+const internalPackageNames = loadInternalPackageNames(packageDirs);
 
 // Check if running in check-only mode
 const checkOnly = process.argv.includes("--check");
@@ -192,6 +354,19 @@ packageDirs.forEach((pkgPath) => {
     }
   }
 
+  // Check for missing internal workspace package declarations. Framework packages
+  // should be independently buildable/publishable from their package manifests.
+  const missingInternalDependencies = findMissingInternalDependencies(
+    pkgPath,
+    pkg,
+    internalPackageNames,
+  );
+  for (const depName of missingInternalDependencies) {
+    inconsistencies.push(
+      `  + ${depName}: * (missing internal workspace dependency)`,
+    );
+  }
+
   // Check for dependencies that are in package but not in shared config
   // These might be package-specific dependencies or removed shared dependencies
   const sharedDepNames = Object.keys(sharedDevDeps);
@@ -220,14 +395,18 @@ packageDirs.forEach((pkgPath) => {
         ...sharedDevDeps,
       };
 
+      if (missingInternalDependencies.length > 0) {
+        pkg.dependencies = {
+          ...(pkg.dependencies ?? {}),
+        };
+        for (const depName of missingInternalDependencies) {
+          pkg.dependencies[depName] = "*";
+        }
+        pkg.dependencies = sortObjectByKey(pkg.dependencies);
+      }
+
       // Sort devDependencies alphabetically for consistency
-      const sortedDevDeps = {};
-      Object.keys(pkg.devDependencies)
-        .sort()
-        .forEach((key) => {
-          sortedDevDeps[key] = pkg.devDependencies[key];
-        });
-      pkg.devDependencies = sortedDevDeps;
+      pkg.devDependencies = sortObjectByKey(pkg.devDependencies);
 
       // Write back to file with consistent formatting
       try {

--- a/scripts/test/sync-framework-deps.test.mjs
+++ b/scripts/test/sync-framework-deps.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = new URL("../..", import.meta.url);
+const sharedDevDependencies = JSON.parse(
+  readFileSync(new URL("../shared-dependencies.json", import.meta.url), "utf8"),
+).framework.devDependencies;
+
+function writePackage(
+  packagesDir,
+  shortName,
+  { dependencies = {}, devDependencies = {}, source = "" } = {},
+) {
+  const packageDir = path.join(packagesDir, "@ralphschuler", shortName);
+  mkdirSync(path.join(packageDir, "src"), { recursive: true });
+  writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `@ralphschuler/${shortName}`,
+        version: "0.0.0-test",
+        dependencies,
+        devDependencies: {
+          ...sharedDevDependencies,
+          ...devDependencies,
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFileSync(path.join(packageDir, "src", "index.ts"), source);
+}
+
+function makePackagesFixture() {
+  return mkdtempSync(path.join(tmpdir(), "screeps-framework-deps-"));
+}
+
+function runSyncDeps(packagesDir, args = ["--check"]) {
+  return spawnSync(process.execPath, ["scripts/sync-framework-deps.js", ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      FRAMEWORK_DEPS_PACKAGES_DIR: packagesDir,
+    },
+    encoding: "utf8",
+  });
+}
+
+function runSyncDepsCheck(packagesDir) {
+  return runSyncDeps(packagesDir, ["--check"]);
+}
+
+test("sync deps check fails when a framework package imports an undeclared internal workspace dependency", () => {
+  const packagesDir = makePackagesFixture();
+  writePackage(packagesDir, "screeps-alpha", {
+    source: 'import { beta } from "@ralphschuler/screeps-beta";\nexport const alpha = beta;\n',
+  });
+  writePackage(packagesDir, "screeps-beta", {
+    source: "export const beta = 1;\n",
+  });
+
+  const result = runSyncDepsCheck(packagesDir);
+
+  assert.notEqual(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout + result.stderr, /missing internal workspace dependenc/i);
+  assert.match(result.stdout + result.stderr, /@ralphschuler\/screeps-alpha/);
+  assert.match(result.stdout + result.stderr, /@ralphschuler\/screeps-beta/);
+});
+
+test("sync deps check passes when internal workspace imports are declared in package manifests", () => {
+  const packagesDir = makePackagesFixture();
+  writePackage(packagesDir, "screeps-alpha", {
+    dependencies: { "@ralphschuler/screeps-beta": "*" },
+    source: 'import { beta } from "@ralphschuler/screeps-beta";\nexport const alpha = beta;\n',
+  });
+  writePackage(packagesDir, "screeps-beta", {
+    source: "export const beta = 1;\n",
+  });
+
+  const result = runSyncDepsCheck(packagesDir);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});
+
+test("devDependencies do not satisfy framework source imports", () => {
+  const packagesDir = makePackagesFixture();
+  writePackage(packagesDir, "screeps-alpha", {
+    devDependencies: { "@ralphschuler/screeps-beta": "*" },
+    source: 'import { beta } from "@ralphschuler/screeps-beta";\nexport const alpha = beta;\n',
+  });
+  writePackage(packagesDir, "screeps-beta", {
+    source: "export const beta = 1;\n",
+  });
+
+  const result = runSyncDepsCheck(packagesDir);
+
+  assert.notEqual(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout + result.stderr, /missing internal workspace dependenc/i);
+});
+
+test("commented internal import examples are ignored", () => {
+  const packagesDir = makePackagesFixture();
+  writePackage(packagesDir, "screeps-alpha", {
+    source: '// import { beta } from "@ralphschuler/screeps-beta";\nexport const alpha = 1;\n',
+  });
+  writePackage(packagesDir, "screeps-beta", {
+    source: "export const beta = 1;\n",
+  });
+
+  const result = runSyncDepsCheck(packagesDir);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});
+
+test("sync deps writes missing internal imports into package dependencies", () => {
+  const packagesDir = makePackagesFixture();
+  writePackage(packagesDir, "screeps-alpha", {
+    source: 'export { beta } from "@ralphschuler/screeps-beta";\n',
+  });
+  writePackage(packagesDir, "screeps-beta", {
+    source: "export const beta = 1;\n",
+  });
+
+  const result = runSyncDeps(packagesDir, []);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  const packageJson = JSON.parse(
+    readFileSync(path.join(packagesDir, "@ralphschuler", "screeps-alpha", "package.json"), "utf8"),
+  );
+  assert.equal(packageJson.dependencies["@ralphschuler/screeps-beta"], "*");
+});


### PR DESCRIPTION
## Summary

Adds a dependency-contract guard so framework packages cannot import internal workspace packages without declaring them in their package manifests.

## Linked issue

Closes #3163

## Changes

### Code changes
- Extends `scripts/sync-framework-deps.js` to scan framework source imports using the TypeScript parser.
- Fails `--check` when an internal workspace import is missing from `dependencies`, `peerDependencies`, or `optionalDependencies`.
- Allows `npm run sync:deps` to add missing internal deps to `dependencies`.
- Supports fixture testing through `FRAMEWORK_DEPS_PACKAGES_DIR`.
- Adds missing internal deps and prebuild ordering for `@ralphschuler/screeps-pheromones` and `@ralphschuler/screeps-roles`.
- Updates `package-lock.json` workspace dependency metadata.

### Test changes
- Adds `scripts/test/sync-framework-deps.test.mjs` covering:
  - missing internal import failure,
  - declared dependency pass,
  - devDependencies not satisfying source imports,
  - comment-only import examples ignored,
  - sync mode writing missing deps.

### Docs changes
- None; script output documents the failure and existing `npm run sync:deps` remediation.

## Validation

- `node --test scripts/test/sync-framework-deps.test.mjs` ✅
- `npm run sync:deps:check` ✅
- `npm run test:scripts` ✅
- `npm run build -w @ralphschuler/screeps-pheromones` ✅
- `npm run build -w @ralphschuler/screeps-roles` ✅
- `npm run build` ✅
- Independent reviewer subagent re-review: no findings ✅

## Deployment impact

No direct Screeps runtime behavior change. Deploy path still builds; this is a tooling/package-manifest guard.

## Live bot evidence

Current live analysis was run before issue selection. No new issues created per operator constraint. Existing live issues updated: #3119, #3105, #3242, #3184.

## Follow-up issues

None created; operator requested processing existing issues only.
