### PR TITLE
[codex] Harden alliance safety scanner

### DIFF
--- a/scripts/check-alliance-safety.js
+++ b/scripts/check-alliance-safety.js
@@ -63,27 +63,197 @@ function isApproved(relativePath) {
   return approvedFiles.has(relativePath);
 }
 
-function isCommentOnlyLine(line) {
-  const trimmed = line.trim();
-  return trimmed.startsWith("//") || trimmed.startsWith("/*") || trimmed.startsWith("*");
+function stripCommentsFromLines(lines) {
+  let inBlockComment = false;
+  let quote = null;
+  let escaped = false;
+
+  return lines.map(line => {
+    let code = "";
+
+    for (let index = 0; index < line.length; index++) {
+      const current = line[index];
+      const next = line[index + 1];
+
+      if (inBlockComment) {
+        if (current === "*" && next === "/") {
+          inBlockComment = false;
+          index++;
+        }
+        continue;
+      }
+
+      if (quote) {
+        code += current;
+        if (escaped) {
+          escaped = false;
+        } else if (current === "\\") {
+          escaped = true;
+        } else if (current === quote) {
+          quote = null;
+        }
+        continue;
+      }
+
+      if (current === '"' || current === "'" || current === "`") {
+        quote = current;
+        code += current;
+        continue;
+      }
+
+      if (current === "/" && next === "*") {
+        inBlockComment = true;
+        index++;
+        continue;
+      }
+
+      if (current === "/" && next === "/") {
+        break;
+      }
+
+      code += current;
+    }
+
+    if (quote !== "`") {
+      quote = null;
+      escaped = false;
+    }
+
+    return code;
+  });
 }
 
-function isRawHostileUsage(line) {
-  if (isCommentOnlyLine(line)) {
-    return false;
+function codeOnlyLine(line) {
+  return line;
+}
+
+function isCommentOnlyLine(line) {
+  return codeOnlyLine(line).trim() === "";
+}
+
+const rawFindCallPatterns = [
+  ".find(",
+  "safeFind(",
+  "safeFindClosestByRange(",
+  "cachedRoomFind(",
+  "cachedFindHostile"
+];
+
+function stripStringLiterals(text) {
+  let stripped = "";
+  let quote = null;
+  let escaped = false;
+
+  for (const character of text) {
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      stripped += " ";
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+      stripped += " ";
+      continue;
+    }
+
+    stripped += character;
   }
 
-  if (!hostilePatterns.some(pattern => line.includes(pattern))) {
-    return false;
+  return stripped;
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function containsIdentifier(text, identifier) {
+  return new RegExp(`(^|[^A-Za-z0-9_$])${escapeRegExp(identifier)}([^A-Za-z0-9_$]|$)`).test(text);
+}
+
+function containsHostilePattern(text, hostileIdentifiers = hostilePatterns) {
+  const code = stripStringLiterals(text);
+  return [...hostileIdentifiers].some(identifier => containsIdentifier(code, identifier));
+}
+
+function containsRawFindCall(text) {
+  return rawFindCallPatterns.some(pattern => text.includes(pattern));
+}
+
+function compactSnippet(text) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function countSyntaxCharacter(text, character) {
+  return [...stripStringLiterals(text)].filter(candidate => candidate === character).length;
+}
+
+function collectHostileAliases(lines) {
+  const aliases = new Set();
+  let statement = "";
+  let parenBalance = 0;
+
+  for (const line of lines) {
+    const code = codeOnlyLine(line);
+    if (isCommentOnlyLine(code)) {
+      continue;
+    }
+
+    statement = `${statement}\n${code}`;
+    parenBalance += countSyntaxCharacter(code, "(") - countSyntaxCharacter(code, ")");
+
+    const match = statement.match(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b[^=]*=\s*([\s\S]+)/);
+    if (match) {
+      const [, alias, initializer] = match;
+      if (containsHostilePattern(initializer) || containsHostilePattern(initializer, aliases)) {
+        aliases.add(alias);
+      }
+    }
+
+    const trimmed = code.trimEnd();
+    const continues = !code.includes(";") && (parenBalance > 0 || /[=([{,?:|&]$/.test(trimmed));
+    if (!continues) {
+      statement = "";
+      parenBalance = 0;
+    }
   }
 
-  return (
-    line.includes(".find(") ||
-    line.includes("safeFind(") ||
-    line.includes("safeFindClosestByRange(") ||
-    line.includes("cachedRoomFind(") ||
-    line.includes("cachedFindHostile")
-  );
+  return aliases;
+}
+
+function rawHostileUsageSnippet(lines, startIndex, hostileIdentifiers) {
+  const line = codeOnlyLine(lines[startIndex]);
+  if (isCommentOnlyLine(line) || !containsRawFindCall(line)) {
+    return null;
+  }
+
+  let parenBalance = 0;
+  const statementLines = [];
+
+  for (let index = startIndex; index < lines.length; index++) {
+    const code = codeOnlyLine(lines[index]);
+    if (!isCommentOnlyLine(code)) {
+      statementLines.push(code);
+      parenBalance += countSyntaxCharacter(code, "(") - countSyntaxCharacter(code, ")");
+    }
+
+    const statement = statementLines.join("\n");
+    if (containsHostilePattern(statement, hostileIdentifiers)) {
+      return compactSnippet(statement);
+    }
+
+    if (parenBalance <= 0) {
+      break;
+    }
+  }
+
+  return null;
 }
 
 const violations = [];
@@ -96,11 +266,13 @@ for (const file of files) {
   }
 
   const contents = await readFile(file, "utf8");
-  const lines = contents.split("\n");
+  const lines = stripCommentsFromLines(contents.split("\n"));
+  const hostileIdentifiers = [...hostilePatterns, ...collectHostileAliases(lines)];
 
-  lines.forEach((line, index) => {
-    if (isRawHostileUsage(line)) {
-      violations.push(`${relativePath}:${index + 1}: ${line.trim()}`);
+  lines.forEach((_, index) => {
+    const snippet = rawHostileUsageSnippet(lines, index, hostileIdentifiers);
+    if (snippet) {
+      violations.push(`${relativePath}:${index + 1}: ${snippet}`);
     }
   });
 }

--- a/scripts/test/alliance-safety.test.mjs
+++ b/scripts/test/alliance-safety.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const checkerPath = fileURLToPath(new URL("../check-alliance-safety.js", import.meta.url));
+
+function makeWorkspace() {
+  return mkdtempSync(path.join(tmpdir(), "screeps-alliance-safety-"));
+}
+
+function writeRuntimeSource(root, relativePath, contents) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+function runChecker(root) {
+  return spawnSync(process.execPath, [checkerPath], {
+    cwd: root,
+    encoding: "utf8",
+  });
+}
+
+function withWorkspace(callback) {
+  const root = makeWorkspace();
+  try {
+    return callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("alliance safety checker fails raw multiline hostile Room.find usage in any runtime package", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/nested/unsafe.ts",
+      `export function unsafe(room) {\n  return room.find(\n    FIND_HOSTILE_CREEPS,\n  );\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /Alliance safety check failed/);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/nested\/unsafe\.ts:2/);
+    assert.match(result.stderr, /FIND_HOSTILE_CREEPS/);
+  });
+});
+
+test("alliance safety checker allows central ally-safe wrapper implementations", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@ralphschuler/screeps-core/src/alliance.ts",
+      `export function getKnownHostileCreeps(room) {\n  return room.find(\n    FIND_HOSTILE_CREEPS,\n  );\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Alliance safety check passed/);
+  });
+});
+
+test("alliance safety checker fails hostile constant aliases used in raw Room.find calls", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/alias.ts",
+      `export function unsafe(room) {\n  const hostileFind: FindConstant = FIND_HOSTILE_CREEPS;\n  return room.find(hostileFind);\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/alias\.ts:3/);
+    assert.match(result.stderr, /hostileFind/);
+  });
+});
+
+test("alliance safety checker fails multiline hostile aliases used in raw Room.find calls", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/multiline-alias.ts",
+      `export function unsafe(room) {\n  const hostileFind =\n    FIND_HOSTILE_CREEPS;\n  return room.find(hostileFind);\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/multiline-alias\.ts:4/);
+  });
+});
+
+test("alliance safety checker fails hostile aliases with valid dollar-prefixed identifiers", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/dollar-alias.ts",
+      `export function unsafe(room) {\n  const $hostileFind = FIND_HOSTILE_CREEPS;\n  return room.find($hostileFind);\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/dollar-alias\.ts:3/);
+  });
+});
+
+test("alliance safety checker scans complete multiline find statements without an 8-line limit", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/long-call.ts",
+      `export function unsafe(room) {\n  return room.find(\n\n\n\n\n\n\n\n\n    FIND_HOSTILE_CREEPS,\n  );\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/long-call\.ts:2/);
+  });
+});
+
+test("alliance safety checker fails raw hostile finds in generator methods", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/generator.ts",
+      `export const scan = {\n  *unsafe(room) { return room.find(FIND_HOSTILE_CREEPS); },\n};\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/generator\.ts:2/);
+  });
+});
+
+test("alliance safety checker does not attach semicolonless safe finds to the next hostile constant", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/semicolonless.ts",
+      `export const mine = room.find(FIND_MY_CREEPS)\nconst hostileConstant = FIND_HOSTILE_CREEPS;\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("alliance safety checker ignores parentheses inside strings when ending safe multiline finds", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/string-parens.ts",
+      `export const mine = room.find(\n  FIND_MY_CREEPS,\n  { filter: creep => creep.name.includes("(") },\n)\nconst hostileConstant = FIND_HOSTILE_CREEPS;\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("alliance safety checker still catches unsafe finds after comment tokens inside strings", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/string-comments.ts",
+      `export function unsafe(room) {\n  const marker = "/*";\n  const url = "https://example.invalid";\n  return room.find(FIND_HOSTILE_CREEPS);\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/string-comments\.ts:4/);
+  });
+});
+
+test("alliance safety checker still catches same-line unsafe finds after string line-comment markers", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/string-line-comment.ts",
+      `export function unsafe(room) {\n  const marker = "//"; return room.find(FIND_HOSTILE_CREEPS);\n}\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/string-line-comment\.ts:2/);
+  });
+});
+
+test("alliance safety checker catches unsafe finds inside template interpolation", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/template-expression.ts",
+      "export function unsafe(room) {\n  return `${room.find(FIND_HOSTILE_CREEPS).length}`;\n}\n",
+    );
+
+    const result = runChecker(root);
+
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(result.stderr, /packages\/\@example\/runtime\/src\/template-expression\.ts:2/);
+  });
+});
+
+test("alliance safety checker ignores hostile constants in comments", () => {
+  withWorkspace(root => {
+    writeRuntimeSource(
+      root,
+      "packages/@example/runtime/src/comments.ts",
+      `// room.find(FIND_HOSTILE_CREEPS) is an example only.\n/*\nroom.find(\n  FIND_HOSTILE_CREEPS,\n);\n*/\nexport const ok = true;\nexport const mine = room.find(\n  FIND_MY_CREEPS, // docs mention FIND_HOSTILE_CREEPS only\n);\nconst hostileConstant = FIND_HOSTILE_CREEPS;\n`,
+    );
+
+    const result = runChecker(root);
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the alliance-safety CI scanner so raw hostile queries cannot bypass the guard through multiline calls, hostile constant aliases, comments/strings, or generator methods.

## Linked issue

Closes #3065

## Changes

- Code changes
  - Extends `scripts/check-alliance-safety.js` to scan full multiline call statements instead of single physical lines.
  - Adds lightweight comment/string handling before scanning runtime source.
  - Detects aliases assigned from `FIND_HOSTILE_*` constants and fails raw find calls that use those aliases.
- Test changes
  - Adds `scripts/test/alliance-safety.test.mjs` with fixture-based CLI regression coverage for raw hostile calls, aliases, multiline calls, comments, string/comment tokens, template interpolation, generator methods, and approved wrapper files.
- Docs changes
  - None; behavior is covered by existing issue and command output.

## Validation

- ✅ `node --test scripts/test/alliance-safety.test.mjs`
- ✅ `npm run check:alliance-safety`
- ✅ `npm run test:scripts`
- ✅ `npm run lint:all`
- ✅ `npm run build` (ran before final JS-only refinements; later changes affect scanner/tests only)

## Deployment impact

No Screeps runtime behavior change. CI/tooling-only safety gate hardening; deploy path remains unchanged.

## Live bot evidence

Pre-implementation read-only live analysis used `screeps-api`, `scripts/live-cpu-profile.mjs`, `packages/screeps-server/scripts/export-live-structural-snapshot.js`, and the local observer. Current owned-room samples preserved ally safety (`TooAngel`, `TedRoastBeef`) and found no owned-room ally-hostile misclassification. This PR addresses the existing alliance-safety enforcement issue rather than a new live finding.

## Follow-up issues

None created per operator constraint. Existing live issues updated with fresh evidence: #3104, #3105, #3118, #3119, #3242.
