### PR TITLE
[codex] Guard TooAngel inbound messages

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -19160,7 +19160,9 @@ return "string" == typeof e && e.trimStart().startsWith("{");
 function Ec(e) {
 var t;
 if (!e.controller) return null;
-var r = function(e) {
+var r = e.controller;
+if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
+var o = function(e) {
 var t = Rc(e);
 if (!t) return null;
 try {
@@ -19168,14 +19170,14 @@ var r = JSON.parse(t);
 if ("quest" === r.type && r.id && r.origin && "string" == typeof r.info) return r;
 } catch (e) {}
 return null;
-}(null === (t = e.controller.sign) || void 0 === t ? void 0 : t.text);
-if (!r) return null;
-var o = e.terminal;
+}(r.sign.text);
+if (!o) return null;
+var n = e.terminal;
 return {
 roomName: e.name,
 lastSeen: Game.time,
-hasTerminal: void 0 !== o && !o.my,
-availableQuests: [ r.id ]
+hasTerminal: void 0 !== n && !n.my,
+availableQuests: [ o.id ]
 };
 }
 
@@ -19206,22 +19208,64 @@ lastUpdated: 0
 npcRooms: {},
 activeQuests: {},
 completedQuests: [],
-lastProcessedTick: 0
+lastProcessedTick: 0,
+recentTransactionIds: []
 }), e.tooangel.reputation || (e.tooangel.reputation = {
 value: 0,
 lastUpdated: 0
 }), e.tooangel.npcRooms || (e.tooangel.npcRooms = {}), e.tooangel.activeQuests || (e.tooangel.activeQuests = {}),
-e.tooangel.completedQuests || (e.tooangel.completedQuests = []), e.tooangel;
+e.tooangel.completedQuests || (e.tooangel.completedQuests = []), "number" != typeof e.tooangel.lastProcessedTick && (e.tooangel.lastProcessedTick = 0),
+Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionIds = []),
+e.tooangel;
 }
 
-var wc = {
+var wc = [ "applied", "active" ];
+
+function xc(e) {
+var t, r;
+return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
+}
+
+function bc(e, t) {
+return !!function(e, t) {
+if (e.sender) return "TooAngel" === e.sender.username;
+var r = function(e) {
+var t, r, o = new Set(Object.keys(e.npcRooms || {}));
+try {
+for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
+var s = i.value;
+wc.includes(s.status) && s.originRoom && o.add(s.originRoom);
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+i && !i.done && (r = n.return) && r.call(n);
+} finally {
+if (t) throw t.error;
+}
+}
+return o;
+}(Sc());
+return !!r.has(e.from) && (void 0 === t || r.has(t));
+}(e, t) && !function(e) {
+return Sc().recentTransactionIds.includes(xc(e));
+}(e) && (function(e) {
+var t = Sc(), r = xc(e);
+t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
+}(e), !0);
+}
+
+var Oc = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function xc(e) {
+function Ac(e) {
 var t = Rc(e);
 if (!t) return null;
 try {
@@ -19233,24 +19277,24 @@ subsystem: "TooAngel"
 return null;
 }
 
-function bc() {
+function kc() {
 return Sc().activeQuests || {};
 }
 
-function Oc() {
-var e = bc();
+function Mc() {
+var e = kc();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < wc.MAX_ACTIVE_QUESTS;
+}).length < Oc.MAX_ACTIVE_QUESTS;
 }
 
-function Ac(e) {
-return wc.SUPPORTED_TYPES.includes(e);
+function Uc(e) {
+return Oc.SUPPORTED_TYPES.includes(e);
 }
 
-function kc(e, t, r) {
+function _c(e, t, r) {
 var o, n;
-if (!Oc()) return U.debug("Cannot accept more quests (at max capacity)", {
+if (!Mc()) return U.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19267,14 +19311,14 @@ if (!n || !n.terminal || !n.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < wc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(wc.MIN_APPLICATION_ENERGY), {
+if (l < Oc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Oc.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, wc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, Oc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (U.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
 }), Sc().activeQuests[e] = {
@@ -19290,7 +19334,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Mc(e) {
+function Nc(e) {
 var t = Sc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (U.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
@@ -19301,12 +19345,12 @@ subsystem: "TooAngel"
 });
 }
 
-function Uc() {
+function Pc() {
 var e;
 return (null === (e = Sc().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function _c(e) {
+function Ic(e) {
 var t = Rc(e);
 if (!t) return null;
 try {
@@ -19316,7 +19360,7 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function Nc(e) {
+function Gc(e) {
 var t, r, o, n = Sc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return U.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
@@ -19356,7 +19400,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Pc(e) {
+function Lc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19446,7 +19490,7 @@ l.notifyComplete && (U.info("Quest ".concat(e.id, " (buildcs) completed! All con
 subsystem: "TooAngel"
 }), function(e, t) {
 var r, o, n = function(e) {
-return bc()[e] || null;
+return kc()[e] || null;
 }(e);
 if (!n) return U.warn("Cannot notify completion for unknown quest: ".concat(e), {
 subsystem: "TooAngel"
@@ -19498,7 +19542,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Ic, Gc, Lc = Ue().cpu.bucketThresholds.highMode + 1e3, Dc = Lc, Fc = function() {
+var Dc, Fc, Bc = Ue().cpu.bucketThresholds.highMode + 1e3, Wc = Bc, Kc = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19516,7 +19560,7 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, U.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < Dc)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < Wc)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
@@ -19527,8 +19571,8 @@ var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = _c(i.description);
-null !== s && (U.info("Received reputation update from TooAngel: ".concat(s), {
+var s = Ic(i.description);
+null !== s && bc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19563,12 +19607,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = xc(i.description);
-if (s) {
+var s = Ac(i.description);
+if (s && bc(i, s.origin)) {
 if (U.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-Mc(s);
+Nc(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19582,7 +19626,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Ac(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
+}, Uc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19619,7 +19663,7 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (U.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Pc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Lc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
@@ -19627,7 +19671,7 @@ subsystem: "TooAngel"
 var e = Sc().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - wc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - Oc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19668,12 +19712,12 @@ r.length > 0 && U.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-Nc();
+Gc();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (Oc()) {
-var r = Tc(), o = bc();
+if (Mc()) {
+var r = Tc(), o = kc();
 for (var n in r) {
 var i = r[n];
 try {
@@ -19681,7 +19725,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return U.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void kc(u, n);
+}), void _c(u, n);
 }
 } catch (t) {
 e = {
@@ -19698,11 +19742,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return Uc();
+return Pc();
 }, e.prototype.getActiveQuests = function() {
-return bc();
+return kc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return kc(e, t, r);
+return _c(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -19719,27 +19763,27 @@ return n.join("\n");
 }, n([ Oi("empire:tooangel", "TooAngel Manager", {
 priority: ha.LOW,
 interval: 100,
-minBucket: Lc
+minBucket: Bc
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Bc = new Fc, Wc = {
+}(), Hc = new Kc, Yc = {
 status: function() {
-return Bc.getStatus();
+return Hc.getStatus();
 },
 enable: function() {
-return Bc.enable(), "TooAngel integration enabled";
+return Hc.enable(), "TooAngel integration enabled";
 },
 disable: function() {
-return Bc.disable(), "TooAngel integration disabled";
+return Hc.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = Uc();
+var e = Pc();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return Nc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return Gc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
-var e, t = bc(), r = [ "Active Quests:" ];
+var e, t = kc(), r = [ "Active Quests:" ];
 if (0 === Object.keys(t).length) r.push("  No active quests"); else for (var o in t) {
 var n = t[o], a = n.deadline - Game.time, i = (null === (e = n.assignedCreeps) || void 0 === e ? void 0 : e.length) || 0;
 r.push("  ".concat(o, ":")), r.push("    Type: ".concat(n.type)), r.push("    Target: ".concat(n.targetRoom)),
@@ -19758,12 +19802,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return kc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return _c(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, Kc = function() {
+}, Vc = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -19931,16 +19975,16 @@ usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), Hc = new Kc, Yc = {
+}(), qc = new Vc, jc = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, Vc = function() {
+}, zc = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, Yc), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, jc), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
@@ -20277,16 +20321,16 @@ interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), qc = new Vc, jc = {
+}(), Qc = new zc, Xc = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, zc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], Qc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], Xc = function() {
+}, Zc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], Jc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], $c = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, jc), e);
+this.config = o(o({}, Xc), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20440,7 +20484,7 @@ return l.homeRoom = a, l.role = o, U.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? zc : Qc).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? Zc : Jc).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20584,211 +20628,211 @@ interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Zc = new Xc, Jc = {
+}(), eu = new $c, tu = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, $c = ((Ic = {})[RESOURCE_HYDROXIDE] = {
+}, ru = ((Dc = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Ic[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Dc[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Ic[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Dc[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Ic[RESOURCE_GHODIUM] = {
+}, Dc[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Ic[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Dc[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Ic[RESOURCE_UTRIUM_OXIDE] = {
+}, Dc[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Ic[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Dc[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Ic[RESOURCE_KEANIUM_OXIDE] = {
+}, Dc[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Ic[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Dc[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Ic[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Dc[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Ic[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Dc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Ic[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Dc[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Ic[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Dc[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Ic[RESOURCE_GHODIUM_OXIDE] = {
+}, Dc[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Ic[RESOURCE_UTRIUM_ACID] = {
+}, Dc[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Dc[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_KEANIUM_ACID] = {
+}, Dc[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Dc[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_LEMERGIUM_ACID] = {
+}, Dc[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Dc[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_ZYNTHIUM_ACID] = {
+}, Dc[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Dc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_GHODIUM_ACID] = {
+}, Dc[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Dc[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Ic[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Dc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Dc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Dc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Dc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Dc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Dc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Dc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Dc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Dc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Dc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Ic), eu = ((Gc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Gc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Gc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Gc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Gc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Gc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Gc[RESOURCE_GHODIUM] = 5e3, Gc[RESOURCE_HYDROXIDE] = 5e3, Gc);
+}, Dc), ou = ((Fc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Fc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Fc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Fc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Fc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Fc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Fc[RESOURCE_GHODIUM] = 5e3, Fc[RESOURCE_HYDROXIDE] = 5e3, Fc);
 
-function tu(e, t) {
-var r, o, n, a = null !== (r = eu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function nu(e, t) {
+var r, o, n, a = null !== (r = ou[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function ru(e) {
+function au(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var ou = function() {
+var iu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : Jc;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : tu;
 }
 return e.prototype.getReaction = function(e) {
-return $c[e];
+return ru[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = $c[e];
+var c = ru[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -20810,11 +20854,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = ru(t);
+var d = au(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if ($c[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < tu(y, t)) {
+if (ru[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < nu(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -20873,12 +20917,12 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = ru(t);
+var h = au(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = $c[T];
+var T = E.value, C = ru[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = tu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = nu(T, t), x = w - S;
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), A = {};
 try {
@@ -20994,7 +21038,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), nu = [ {
+}(), su = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21012,13 +21056,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function au(e) {
-return nu.find(function(t) {
+function cu(e) {
+return su.find(function(t) {
 return t.role === e;
 });
 }
 
-function iu(e, t) {
+function uu(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21035,29 +21079,29 @@ return;
 }
 }
 
-function su(e, t) {
+function lu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function cu(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : lu(e, t) && lu(e, r) ? "output" : "boost";
+function mu(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : pu(e, t) && pu(e, r) ? "output" : "boost";
 }
 
-function uu(e, t) {
+function du(e, t) {
 return t.filter(function(t) {
-return e.id !== t.id && lu(e, t);
+return e.id !== t.id && pu(e, t);
 }).length;
 }
 
-function lu(e, t) {
+function pu(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var mu, du = function() {
+var fu, yu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : Jc;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : tu;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21173,7 +21217,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = iu(s.role, o);
+var s = i.value, c = uu(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21195,13 +21239,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, uu(t, e) ];
+return [ t.id, du(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && lu(e, s) && lu(e, c);
+return t !== a && t !== i && pu(e, s) && pu(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21214,19 +21258,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(su)[0];
+return n.sort(lu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: cu(e, t.input1, t.input2)
+role: mu(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, uu(r, e));
+return Math.max(t, du(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21370,17 +21414,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), pu = function() {
+}(), vu = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = au(o.role);
+var n = cu(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = au(n.role);
+var r, o, n = e.memory, i = cu(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21458,7 +21502,7 @@ return 0 === c.length && (n.boosted = !0, U.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = au(t);
+var r, o, n = cu(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21489,7 +21533,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = au(t);
+var r, o, n = cu(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21523,7 +21567,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ au("soldier"), au("ranger"), au("healer"), au("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ cu("soldier"), cu("ranger"), cu("healer"), cu("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21580,7 +21624,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = au(e);
+var r = cu(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21590,7 +21634,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = au(e);
+var n = cu(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21624,7 +21668,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), fu = new pu, yu = {
+}(), gu = new vu, hu = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -21637,10 +21681,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, vu = function() {
+}, Ru = function() {
 function e() {
-this.manager = new du({
-logger: yu
+this.manager = new yu({
+logger: hu
 });
 }
 return e.prototype.initialize = function(e) {
@@ -21710,14 +21754,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), gu = new vu, hu = function() {
+}(), Eu = new Ru, Tu = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = gu.getConfig(e);
+var s = Eu.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = gu.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = Eu.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -21729,7 +21773,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = gu.getBoostLabs(e), f = function(e) {
+var p = Eu.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -21760,9 +21804,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = gu.getConfig(e);
+var c = Eu.getConfig(e);
 if (!c) return [];
-var u = [], l = gu.getOutputLabs(e);
+var u = [], l = Eu.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -21787,7 +21831,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = gu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = Eu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -21823,15 +21867,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = gu.getConfig(e);
+var r, o, n, i, s = Eu.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = gu.getInputLabs(e), u = c.input1, l = c.input2;
+var c = Eu.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = gu.getOutputLabs(e);
+var m = Eu.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -21853,23 +21897,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-gu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
+Eu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = gu.setActiveReaction(e, t, r, o);
+var n = Eu.setActiveReaction(e, t, r, o);
 return n && U.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return gu.runReactions(e);
+return Eu.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return gu.getBoostLabs(e).length > 0;
+return Eu.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = gu.getConfig(e);
+var r, o, n, i, s, c = Eu.getConfig(e);
 if (!c) return null;
-var u = gu.getBoostLabs(e);
+var u = Eu.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -21973,17 +22017,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = gu.getConfig(e);
+var t = Eu.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-gu.loadFromMemory(e), gu.initialize(e);
+Eu.loadFromMemory(e), Eu.initialize(e);
 }, e.prototype.save = function(e) {
-gu.saveToMemory(e);
+Eu.saveToMemory(e);
 }, e;
-}(), Ru = new hu, Eu = function() {
+}(), Cu = new Tu, Su = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = gu.getConfig(e);
+var t, r, o, n, i, s, c, u, l = Eu.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22006,7 +22050,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = Ru.getLabResourceNeeds(e);
+var h = Cu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22026,7 +22070,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = Ru.getLabOverflow(e);
+var C = Cu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22048,13 +22092,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return Ru.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return Cu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return Ru.clearReactions(e), "Cleared active reactions in ".concat(e);
+return Cu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = fu.areBoostLabsReady(n, t), s = fu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = gu.areBoostLabsReady(n, t), s = gu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22100,7 +22144,7 @@ usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), Tu = function() {
+}(), wu = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22157,10 +22201,10 @@ usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), Cu = function() {
+}(), xu = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = Zc.getGPLState();
+var e = eu.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22169,7 +22213,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = Zc.getAssignments();
+var e, t, r = eu.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22191,7 +22235,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = qc.getActiveOperations();
+var e, t, r = Qc.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22216,7 +22260,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return Zc.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return eu.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22290,7 +22334,7 @@ usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), Su = new Eu, wu = new Tu, xu = new Cu, bu = function() {
+}(), bu = new Su, Ou = new wu, Au = new xu, ku = function() {
 function e() {}
 return e.prototype.showConfig = function() {
 var e = Ue(), t = si();
@@ -22302,30 +22346,30 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Ou = k("CreepContext"), Au = ((mu = {})[STRUCTURE_SPAWN] = 100, mu[STRUCTURE_EXTENSION] = 90,
-mu[STRUCTURE_TOWER] = 80, mu[STRUCTURE_RAMPART] = 75, mu[STRUCTURE_WALL] = 70, mu[STRUCTURE_STORAGE] = 70,
-mu[STRUCTURE_CONTAINER] = 60, mu[STRUCTURE_ROAD] = 30, mu), ku = new Map;
+}(), Mu = k("CreepContext"), Uu = ((fu = {})[STRUCTURE_SPAWN] = 100, fu[STRUCTURE_EXTENSION] = 90,
+fu[STRUCTURE_TOWER] = 80, fu[STRUCTURE_RAMPART] = 75, fu[STRUCTURE_WALL] = 70, fu[STRUCTURE_STORAGE] = 70,
+fu[STRUCTURE_CONTAINER] = 60, fu[STRUCTURE_ROAD] = 30, fu), _u = new Map;
 
-function Mu(e) {
+function Nu(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function Uu(e) {
+function Pu(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-var r, o, n = null !== (r = Au[e.structureType]) && void 0 !== r ? r : 50;
-return (null !== (o = Au[t.structureType]) && void 0 !== o ? o : 50) - n;
+var r, o, n = null !== (r = Uu[e.structureType]) && void 0 !== r ? r : 50;
+return (null !== (o = Uu[t.structureType]) && void 0 !== o ? o : 50) - n;
 })), e._prioritizedSites;
 }
 
-function _u(e) {
-return void 0 === e._repairTargets && (Mu(e), e._repairTargets = e.allStructures.filter(function(e) {
+function Iu(e) {
+return void 0 === e._repairTargets && (Nu(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function Nu(e) {
+function Gu(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = ku.get(e.name);
+var t = _u.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22334,9 +22378,9 @@ hostiles: j(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return ku.set(e.name, r), r;
+return _u.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Ou.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Mu.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -22401,10 +22445,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return Uu(i).length;
+return Pu(i).length;
 },
 get damagedStructureCount() {
-return _u(i).length;
+return Iu(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -22415,13 +22459,13 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return void 0 === (e = i)._containers && (Mu(e), e._containers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._containers && (Nu(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 var e;
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (Mu(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (Nu(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -22450,10 +22494,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return Uu(i);
+return Pu(i);
 },
 get repairTargets() {
-return _u(i);
+return Iu(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -22487,9 +22531,9 @@ var e;
 };
 }
 
-var Pu, Iu = {}, Gu = function() {
-if (Pu) return Iu;
-Pu = 1, Object.defineProperty(Iu, "__esModule", {
+var Lu, Du = {}, Fu = function() {
+if (Lu) return Du;
+Lu = 1, Object.defineProperty(Du, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== qt ? qt : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -24166,14 +24210,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, Ms = "_rsi";
-return Iu.CachingStrategies = vi, Iu.CoordListSerializer = fi, Iu.CoordSerializer = pi,
-Iu.Keys = ji, Iu.MoveTargetListSerializer = li, Iu.MoveTargetSerializer = ui, Iu.NumberSerializer = Oa,
-Iu.PositionListSerializer = di, Iu.PositionSerializer = mi, Iu.adjacentWalkablePositions = xi,
-Iu.blockSquare = function(e) {
+return Du.CachingStrategies = vi, Du.CoordListSerializer = fi, Du.CoordSerializer = pi,
+Du.Keys = ji, Du.MoveTargetListSerializer = li, Du.MoveTargetSerializer = ui, Du.NumberSerializer = Oa,
+Du.PositionListSerializer = di, Du.PositionSerializer = mi, Du.adjacentWalkablePositions = xi,
+Du.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, Iu.cachePath = ys, Iu.cachedPathKey = ps, Iu.calculateAdjacencyMatrix = Ti, Iu.calculateAdjacentPositions = Ci,
-Iu.calculateNearbyPositions = Si, Iu.calculatePositionsAtRange = wi, Iu.cleanAllCaches = yi,
-Iu.clearCachedPath = As, Iu.compressPath = e => {
+}, Du.cachePath = ys, Du.cachedPathKey = ps, Du.calculateAdjacencyMatrix = Ti, Du.calculateAdjacentPositions = Ci,
+Du.calculateNearbyPositions = Si, Du.calculatePositionsAtRange = wi, Du.cleanAllCaches = yi,
+Du.clearCachedPath = As, Du.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24182,19 +24226,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, Iu.config = Ta, Iu.decompressPath = e => {
+}, Du.config = Ta, Du.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, Iu.fastRoomPosition = Ga, Iu.fixEdgePosition = Ei, Iu.follow = function(e, t) {
+}, Du.fastRoomPosition = Ga, Du.fixEdgePosition = Ei, Du.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, Iu.followPath = hs, Iu.fromGlobalPosition = ti, Iu.generatePath = ts, Iu.getCachedPath = vs,
-Iu.getMoveIntents = ns, Iu.getRangeTo = ri, Iu.globalPosition = ei, Iu.isExit = hi,
-Iu.isPositionWalkable = bi, Iu.move = ds, Iu.moveByPath = function(e, t, r) {
+}, Du.followPath = hs, Du.fromGlobalPosition = ti, Du.generatePath = ts, Du.getCachedPath = vs,
+Du.getMoveIntents = ns, Du.getRangeTo = ri, Du.globalPosition = ei, Du.isExit = hi,
+Du.isPositionWalkable = bi, Du.move = ds, Du.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, Ms));
@@ -24223,9 +24267,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = ki(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : ks(e, d, r)) : ERR_NO_PATH;
-}, Iu.moveTo = ks, Iu.normalizeTargets = Ri, Iu.offsetRoomPosition = Da, Iu.packCoord = qa,
-Iu.packCoordList = za, Iu.packPos = Ya, Iu.packPosList = Xa, Iu.packRoomName = ii,
-Iu.packRoomNames = ni, Iu.posAtDirection = oi, Iu.preTick = function() {
+}, Du.moveTo = ks, Du.normalizeTargets = Ri, Du.offsetRoomPosition = Da, Du.packCoord = qa,
+Du.packCoordList = za, Du.packPos = Ya, Du.packPosList = Xa, Du.packRoomName = ii,
+Du.packRoomNames = ni, Du.posAtDirection = oi, Du.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) Ui(e), Bi(e);
 !function() {
@@ -24237,34 +24281,34 @@ n.expires && n.expires < Game.time ? (null === (e = Fi.get(n.room1)) || void 0 =
 null === (t = Fi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, Iu.reconcileTraffic = function(e) {
+}, Du.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 _a.with(Oa).set(cs, Game.time);
-}, Iu.reconciledRecently = us, Iu.resetCachedPath = gs, Iu.roomNameFromCoords = $a,
-Iu.roomNameToCoords = Ja, Iu.sameRoomPosition = La, Iu.unpackCoord = ja, Iu.unpackCoordList = Qa,
-Iu.unpackPos = Va, Iu.unpackPosList = Za, Iu.unpackRoomName = si, Iu.unpackRoomNames = ai,
-Iu;
+}, Du.reconciledRecently = us, Du.resetCachedPath = gs, Du.roomNameFromCoords = $a,
+Du.roomNameToCoords = Ja, Du.sameRoomPosition = La, Du.unpackCoord = ja, Du.unpackCoordList = Qa,
+Du.unpackPos = Va, Du.unpackPosList = Za, Du.unpackRoomName = si, Du.unpackRoomNames = ai,
+Du;
 }();
 
-function Lu(e) {
+function Bu(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var Du, Fu = 5e5;
+var Wu, Ku = 5e5;
 
-function Bu(e) {
+function Hu(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Fu;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Ku;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Fu), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Ku), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24276,21 +24320,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(Du || (Du = {}));
+}(Wu || (Wu = {}));
 
-var Wu = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Ku = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Hu = new Set([ "build", "repair", "upgrade" ]), Yu = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Yu = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Vu = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], qu = new Set([ "build", "repair", "upgrade" ]), ju = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function Vu(e, t) {
+function zu(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function qu() {
+function Qu() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function ju() {
+function Xu() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24305,8 +24349,8 @@ rooms: {}
 };
 }
 
-function zu(e) {
-var t = ju();
+function Zu(e) {
+var t = Xu();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24325,32 +24369,32 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Qu(e, t, r) {
+function Ju(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Xu(e) {
+function $u(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function Zu(e) {
-return Ku.includes(e);
+function el(e) {
+return Vu.includes(e);
 }
 
-function Ju(e) {
-return Hu.has(e);
+function tl(e) {
+return qu.has(e);
 }
 
-function $u(e) {
+function rl(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY);
 }
 
-function el(e, t) {
+function ol(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function tl(e, t) {
+function nl(e, t) {
 if (!t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -24358,12 +24402,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return $u(e.creep) > 0;
+return rl(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return $u(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return rl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -24382,7 +24426,7 @@ return !1;
 }
 }
 
-function rl(e, t) {
+function al(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24399,7 +24443,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function ol(e) {
+function il(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24407,36 +24451,36 @@ roomName: e.roomName
 };
 }
 
-function nl(e, t, r, o, n) {
+function sl(e, t, r, o, n) {
 return {
-id: Qu(e, t, r.id),
+id: Ju(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: ol(r.pos),
+targetPos: il(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: Wu,
+allowedRoles: Yu,
 expiresTick: Game.time + 50
 };
 }
 
-function al(e, t) {
+function cl(e, t) {
 var r, o, n, i, s, c, u = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = qu()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = Qu()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < u)) {
 t.lastGeneratedTick = Game.time;
-var l = Vu("taskBoard.findMyStructures", function() {
+var l = zu("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p, f = d.value;
-f.structureType !== STRUCTURE_SPAWN ? f.structureType !== STRUCTURE_EXTENSION ? f.structureType === STRUCTURE_TOWER && (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && rl(t, nl(e.name, "refillTower", f, p, Du.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && rl(t, nl(e.name, "refillExtension", f, p, Du.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && rl(t, nl(e.name, "refillSpawn", f, p, Du.CRITICAL));
+f.structureType !== STRUCTURE_SPAWN ? f.structureType !== STRUCTURE_EXTENSION ? f.structureType === STRUCTURE_TOWER && (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && al(t, sl(e.name, "refillTower", f, p, Wu.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && al(t, sl(e.name, "refillExtension", f, p, Wu.HIGH)) : (p = f.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && al(t, sl(e.name, "refillSpawn", f, p, Wu.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24449,24 +24493,24 @@ d && !d.done && (o = m.return) && o.call(m);
 if (r) throw r.error;
 }
 }
-var y = Bu(e);
-y && rl(t, nl(e.name, "fillTerminalEnergy", y.terminal, y.amount, Du.NORMAL)), e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0 && rl(t, nl(e.name, "storeEnergy", e.storage, e.storage.store.getFreeCapacity(RESOURCE_ENERGY), Du.LOW));
-var v = Vu("taskBoard.findHostiles", function() {
+var y = Hu(e);
+y && al(t, sl(e.name, "fillTerminalEnergy", y.terminal, y.amount, Wu.NORMAL)), e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0 && al(t, sl(e.name, "storeEnergy", e.storage, e.storage.store.getFreeCapacity(RESOURCE_ENERGY), Wu.LOW));
+var v = zu("taskBoard.findHostiles", function() {
 return j(e);
 });
 try {
 for (var g = a(v.slice(0, 5)), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-rl(t, {
-id: Qu(e.name, "defend", R.id),
+al(t, {
+id: Ju(e.name, "defend", R.id),
 roomName: e.name,
 type: "defend",
-priority: Du.CRITICAL,
+priority: Wu.CRITICAL,
 targetId: R.id,
-targetPos: ol(R.pos),
+targetPos: il(R.pos),
 amount: R.hits,
 maxAssignments: 3,
-allowedRoles: Yu,
+allowedRoles: ju,
 expiresTick: Game.time + 50
 });
 }
@@ -24481,7 +24525,7 @@ h && !h.done && (i = g.return) && i.call(g);
 if (n) throw n.error;
 }
 }
-var E = Vu("taskBoard.findInjuredAllies", function() {
+var E = zu("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -24491,13 +24535,13 @@ return e.hits < e.hitsMax;
 try {
 for (var T = a(E.slice(0, 5)), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-rl(t, {
-id: Qu(e.name, "heal", S.id),
+al(t, {
+id: Ju(e.name, "heal", S.id),
 roomName: e.name,
 type: "heal",
-priority: Du.HIGH,
+priority: Wu.HIGH,
 targetId: S.id,
-targetPos: ol(S.pos),
+targetPos: il(S.pos),
 amount: S.hitsMax - S.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -24518,17 +24562,17 @@ if (s) throw s.error;
 }
 }
 
-function il(e) {
+function ul(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function sl(e) {
+function ll(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && V(e));
 }
 
-function cl(e) {
+function ml(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -24540,7 +24584,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? Bu(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? Hu(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -24553,11 +24597,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !sl(t);
+return !ll(t);
 }
 }
 
-function ul(e, t) {
+function dl(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -24579,7 +24623,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function ll(e, t) {
+function pl(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -24587,7 +24631,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (Ju(m.type)) ul(e, m); else {
+if (tl(m.type)) dl(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -24604,7 +24648,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-il(m), Game.time > m.expiresTick || !cl(m) ? ul(e, m) : (Xu(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Zu(m.type)) && (m.status = "assigned");
+ul(m), Game.time > m.expiresTick || !ml(m) ? dl(e, m) : ($u(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !el(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -24622,7 +24666,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function ml(e, t, r) {
+function fl(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -24630,15 +24674,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-il(t);
+ul(t);
 }
 }
 
-function dl(e, t) {
+function yl(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function pl(e, t, r) {
+function vl(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -24651,39 +24695,39 @@ return e.reservations[t];
 });
 }(e, t.creep.name, t.memory.assignedTaskId);
 if (s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId,
-s && dl(s, r) && cl(s) && tl(t, s)) {
+s && yl(s, r) && ml(s) && nl(t, s)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Du.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Wu.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var c = fl(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Du.CRITICAL);
+var c = gl(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Wu.CRITICAL);
 if (!c || u < l || !m) return s;
-ml(0, s, t.creep.name), e.stats.preemptions++;
+fl(0, s, t.creep.name), e.stats.preemptions++;
 }
-var d = fl(e, t, r);
+var d = gl(e, t, r);
 if (!d) return null;
-var p = Math.min(Math.max(1, Xu(d)), function(e, t) {
+var p = Math.min(Math.max(1, $u(d)), function(e, t) {
 return "harvest" === t.type ? function(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
-}(e) : Math.max(1, $u(e));
+}(e) : Math.max(1, rl(e));
 }(t.creep, d));
 return t.memory.assignedTaskId = d.id, d.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: p,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, d.updatedTick = Game.time, il(d), e.stats.assigned++, d;
+}, d.updatedTick = Game.time, ul(d), e.stats.assigned++, d;
 }
 
-function fl(e, t, r) {
+function gl(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (dl(l, r) && tl(t, l) && cl(l) && !(Xu(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Zu(l.type))) {
-var m = yl(t.creep, l), d = 1e3 * l.priority - m;
+if (yl(l, r) && nl(t, l) && ml(l) && !($u(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || el(l.type))) {
+var m = hl(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -24701,7 +24745,7 @@ if (o) throw o.error;
 return i;
 }
 
-function yl(e, t) {
+function hl(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -24709,7 +24753,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function vl(e, t) {
+function Rl(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -24723,7 +24767,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: el(e, t.creep.name)
+amount: ol(e, t.creep.name)
 };
 
 case "build":
@@ -24752,7 +24796,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (sl(t)) return null;
+if (ll(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -24771,57 +24815,57 @@ return null;
 }
 }
 
-var gl = function() {
+var El = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== ju().enabled;
+return !1 !== Xu().enabled;
 }, e.prototype.setEnabled = function(e) {
-ju().enabled = e;
+Xu().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !qu()) return null;
-var r = zu(e.room.name);
-Vu("taskBoard.cleanup", function() {
-return ll(r);
-}), Vu("taskBoard.generate", function() {
-return al(e.room, r);
+if (!this.isEnabled() || !Qu()) return null;
+var r = Zu(e.room.name);
+zu("taskBoard.cleanup", function() {
+return pl(r);
+}), zu("taskBoard.generate", function() {
+return cl(e.room, r);
 });
-var o = pl(r, e, {
+var o = vl(r, e, {
 allowedTypes: t
 });
-return o ? vl(o, e) : null;
+return o ? Rl(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !qu()) return null;
-var t = zu(e.room.name);
-Vu("taskBoard.cleanup", function() {
-return ll(t);
-}), Vu("taskBoard.generate", function() {
-return al(e.room, t);
+if (!this.isEnabled() || !Qu()) return null;
+var t = Zu(e.room.name);
+zu("taskBoard.cleanup", function() {
+return pl(t);
+}), zu("taskBoard.generate", function() {
+return cl(e.room, t);
 });
-var r = pl(t, e, {
+var r = vl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: Du.NORMAL,
+preemptPriority: Wu.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = vl(r, e);
+var o = Rl(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = qu();
+var r, o = Qu();
 if (!this.isEnabled() || !o) return !1;
-var n = zu(e);
-Vu("taskBoard.cleanup", function() {
-return ll(n);
+var n = Zu(e);
+zu("taskBoard.cleanup", function() {
+return pl(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && Vu("taskBoard.generate", function() {
-return al(a, n);
+return a && zu("taskBoard.generate", function() {
+return cl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && cl(e);
+return t.includes(e.type) && ml(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && qu()) {
+if (this.isEnabled() && Qu()) {
 !function(e) {
-var t, r, o, n, s = ju();
+var t, r, o, n, s = Xu();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -24842,20 +24886,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = zu(e.name);
-Vu("taskBoard.cleanup", function() {
-return ll(t);
-}), Vu("taskBoard.generate", function() {
-return al(e, t);
+var t = Zu(e.name);
+zu("taskBoard.cleanup", function() {
+return pl(t);
+}), zu("taskBoard.generate", function() {
+return cl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = ju(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = Xu(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) ml(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) fl(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -24882,26 +24926,26 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = ju(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && Zu(c.type) && cl(c))) return delete e.memory.assignedTaskId,
+var a = Xu(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && el(c.type) && ml(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = el(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = ol(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-il(c), u.amount);
+ul(c), u.amount);
 }, e.prototype.clear = function(e) {
-var t = ju();
+var t = Xu();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = qu();
+var t, r = Qu();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = zu(e);
-Vu("taskBoard.cleanup", function() {
-return ll(n, !0);
-}), Vu("taskBoard.generate", function() {
-return al(o, n);
+var n = Zu(e);
+zu("taskBoard.cleanup", function() {
+return pl(n, !0);
+}), zu("taskBoard.generate", function() {
+return cl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -24926,10 +24970,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = qu(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = Qu(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = zu(e);
-ll(i, !0), al(n, i);
+var i = Zu(e);
+pl(i, !0), cl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -24951,8 +24995,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = zu(e);
-ll(s, !0);
+var t, r, o, n, i, s = Zu(e);
+pl(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -24987,15 +25031,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), hl = new gl;
+}(), Tl = new El;
 
-function Rl(e) {
+function Cl(e) {
 return e === ERR_NO_PATH;
 }
 
-function El(e) {
+function Sl(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && Rl(e.moveResult),
+clearState: void 0 !== e.moveResult && Cl(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25006,11 +25050,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var Tl, Cl = k("ActionExecutor");
+var wl, xl = k("ActionExecutor");
 
-function Sl(e, t, r) {
+function bl(e, t, r) {
 var o;
-return !!V(r) && (Cl.warn("Refusing harmful action against known ally target", {
+return !!V(r) && (xl.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25018,37 +25062,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (Gu.clearCachedPath(e.creep), $e(e.creep)),
-hl.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (Fu.clearCachedPath(e.creep), $e(e.creep)),
+Tl.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function wl(e, t, r) {
+function Ol(e, t, r) {
 var o, n;
-if (!t || !t.type) return Cl.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return xl.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && Cl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-"idle" === a.type ? Cl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Cl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && xl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+"idle" === a.type ? xl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : xl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25072,7 +25116,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = bl(e, function() {
+i = kl(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25086,92 +25130,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (Sl(r, a.type, a.target)) {
+if (bl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = bl(e, function() {
+i = kl(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (Sl(r, a.type, a.target)) {
+if (bl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-bl(e, function() {
+kl(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (Sl(r, a.type, a.target)) {
+if (bl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-bl(e, function() {
+kl(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-bl(e, function() {
+kl(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), Rl(Gu.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), Cl(Fu.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = bl(e, function() {
+i = kl(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (Sl(r, a.type, a.target)) {
+if (bl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = bl(e, function() {
+i = kl(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-Rl(Gu.moveTo(e, a.target)) && (i = !0);
+Cl(Fu.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-Rl(Gu.moveTo(e, {
+Cl(Fu.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25180,11 +25224,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-Rl(xl(e, a.target, a.routeType)) && (i = !0);
+Cl(Al(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), Rl(xl(e, {
+c = new RoomPosition(25, 25, a.roomName), Cl(Al(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25199,40 +25243,40 @@ pos: e,
 range: 10
 };
 });
-Rl(Gu.moveTo(e, u, {
+Cl(Fu.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (Gu.isExit(e.pos)) {
+if (Fu.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-Gu.moveTo(e, l, {
+Fu.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || Rl(Gu.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || Cl(Fu.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-Rl(Gu.moveTo(e, a.target, {
+Cl(Fu.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (Gu.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), Gu.moveTo(e, l, {
+if (Fu.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), Fu.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = Lu(m.name);
+var d = Bu(m.name);
 if (d && !e.pos.isEqualTo(d)) {
-Rl(Gu.moveTo(e, d, {
+Cl(Fu.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25241,7 +25285,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && Gu.moveTo(e, {
+p && Fu.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25249,8 +25293,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, Gu.clearCachedPath(e), $e(e), hl.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || hl.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, Fu.clearCachedPath(e), $e(e), Tl.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || Tl.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25258,27 +25302,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function xl(e, t, r, o) {
-if (!Tl) return Gu.moveTo(e, t, o);
+function Al(e, t, r, o) {
+if (!wl) return Fu.moveTo(e, t, o);
 try {
-return Tl(e, t, r, o);
+return wl(e, t, r, o);
 } catch (n) {
-return Cl.warn("Remote movement handler failed; falling back to default movement", {
+return xl.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), Gu.moveTo(e, t, o);
+}), Fu.moveTo(e, t, o);
 }
 }
 
-function bl(e, t, r, o, n, a) {
+function kl(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = Gu.moveTo(e, r);
-return s !== OK && Cl.info("Movement attempt returned non-OK result", {
+var s = Fu.moveTo(e, r);
+return s !== OK && xl.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25286,12 +25330,12 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), El({
+}), Sl({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = El({
+var c = Sl({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
@@ -25357,7 +25401,7 @@ os(e).upgradeProgress += t;
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (Cl.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (xl.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25368,13 +25412,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Ol, Al = k("StateMachine");
+var Ml, Ul = k("StateMachine");
 
-function kl(e) {
+function _l(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function Ml(e, t, r) {
+function Nl(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25396,12 +25440,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== kl(e.amount) ? {
+}, void 0 !== _l(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), Al.info(r, {
+}(t), Ul.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25409,13 +25453,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : Al.info("Behavior returned idle action", {
+})) : Ul.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (Al.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (Ul.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25426,11 +25470,11 @@ type: "idle"
 });
 }
 
-function Ul(e, t, r) {
+function Pl(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, Ml(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, Nl(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -25510,7 +25554,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) Al.info("State completed, evaluating new action", {
+}(a, e)) Ul.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25560,7 +25604,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = kl(e.data.amount);
+var c = _l(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -25634,11 +25678,11 @@ return null;
 }(a);
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return c;
-var u = e.memory.assignedTaskId, l = hl.refreshCreepReservation(e, c);
+var u = e.memory.assignedTaskId, l = Tl.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-Al.info("Task-board delivery reservation missing, re-evaluating behavior", {
+Ul.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25648,7 +25692,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-Al.info("State reconstruction failed, re-evaluating behavior", {
+Ul.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25656,7 +25700,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (Al.info("State invalid, re-evaluating behavior", {
+} else a && (Ul.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -25665,33 +25709,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return Ml(e, t(e), "Committed new state action");
+return Nl(e, t(e), "Committed new state action");
 }
 
-(Ol = {})[FIND_SOURCES] = 5e3, Ol[FIND_MINERALS] = 5e3, Ol[FIND_DEPOSITS] = 100,
-Ol[FIND_STRUCTURES] = 50, Ol[FIND_MY_STRUCTURES] = 50, Ol[FIND_HOSTILE_STRUCTURES] = 20,
-Ol[FIND_MY_SPAWNS] = 100, Ol[FIND_MY_CONSTRUCTION_SITES] = 20, Ol[FIND_CONSTRUCTION_SITES] = 20,
-Ol[FIND_CREEPS] = 5, Ol[FIND_MY_CREEPS] = 5, Ol[FIND_HOSTILE_CREEPS] = 3, Ol[FIND_DROPPED_RESOURCES] = 5,
-Ol[FIND_TOMBSTONES] = 10, Ol[FIND_RUINS] = 10, Ol[FIND_FLAGS] = 50, Ol[FIND_NUKES] = 20,
-Ol[FIND_POWER_CREEPS] = 10, Ol[FIND_MY_POWER_CREEPS] = 10;
+(Ml = {})[FIND_SOURCES] = 5e3, Ml[FIND_MINERALS] = 5e3, Ml[FIND_DEPOSITS] = 100,
+Ml[FIND_STRUCTURES] = 50, Ml[FIND_MY_STRUCTURES] = 50, Ml[FIND_HOSTILE_STRUCTURES] = 20,
+Ml[FIND_MY_SPAWNS] = 100, Ml[FIND_MY_CONSTRUCTION_SITES] = 20, Ml[FIND_CONSTRUCTION_SITES] = 20,
+Ml[FIND_CREEPS] = 5, Ml[FIND_MY_CREEPS] = 5, Ml[FIND_HOSTILE_CREEPS] = 3, Ml[FIND_DROPPED_RESOURCES] = 5,
+Ml[FIND_TOMBSTONES] = 10, Ml[FIND_RUINS] = 10, Ml[FIND_FLAGS] = 50, Ml[FIND_NUKES] = 20,
+Ml[FIND_POWER_CREEPS] = 10, Ml[FIND_MY_POWER_CREEPS] = 10;
 
-var _l, Nl, Pl = {}, Il = {}, Gl = {}, Ll = {};
+var Il, Gl, Ll = {}, Dl = {}, Fl = {}, Bl = {};
 
-function Dl() {
-if (_l) return Ll;
-_l = 1;
+function Wl() {
+if (Il) return Bl;
+Il = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Ll.encode = function(t) {
+return Bl.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, Ll;
+}, Bl;
 }
 
-function Fl() {
-if (Nl) return Gl;
-Nl = 1;
-const e = Dl();
-return Gl.encode = function(t) {
+function Kl() {
+if (Gl) return Fl;
+Gl = 1;
+const e = Wl();
+return Fl.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25699,23 +25743,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Gl;
+}, Fl;
 }
 
-var Bl, Wl, Kl, Hl = {}, Yl = jt(Object.freeze({
+var Hl, Yl, Vl, ql = {}, jl = jt(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Vl() {
-return Wl ? Bl : (Wl = 1, Bl = "function" == typeof URL ? URL : Yl.URL);
+function zl() {
+return Yl ? Hl : (Yl = 1, Hl = "function" == typeof URL ? URL : jl.URL);
 }
 
-function ql() {
-if (Kl) return Hl;
-Kl = 1;
-const e = Vl();
-Hl.getArg = function(e, t, r) {
+function Ql() {
+if (Vl) return ql;
+Vl = 1;
+const e = zl();
+ql.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25735,16 +25779,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Hl.toSetString = t ? r : function(e) {
+ql.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Hl.fromSetString = t ? r : function(e) {
+}, ql.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Hl.compareByGeneratedPositionsInflated = function(e, t) {
+}, ql.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Hl.parseSourceMapInput = function(e) {
+}, ql.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25798,7 +25842,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Hl.normalize = f, Hl.join = y, Hl.relative = function(t, r) {
+return ql.normalize = f, ql.join = y, ql.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25810,18 +25854,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Hl.computeSourceURL = function(e, t, r) {
+}, ql.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Hl;
+}, ql;
 }
 
-var jl, zl = {};
+var Xl, Zl = {};
 
-function Ql() {
-if (jl) return zl;
-jl = 1;
+function Jl() {
+if (Xl) return Zl;
+Xl = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -25854,19 +25898,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return zl.ArraySet = e, zl;
+return Zl.ArraySet = e, Zl;
 }
 
-var Xl, Zl, Jl = {};
+var $l, em, tm = {};
 
-function $l() {
-if (Zl) return Il;
-Zl = 1;
-const e = Fl(), t = ql(), r = Ql().ArraySet, o = function() {
-if (Xl) return Jl;
-Xl = 1;
-const e = ql();
-return Jl.MappingList = class {
+function rm() {
+if (em) return Dl;
+em = 1;
+const e = Kl(), t = Ql(), r = Jl().ArraySet, o = function() {
+if ($l) return tm;
+$l = 1;
+const e = Ql();
+return tm.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -25886,7 +25930,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, Jl;
+}, tm;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26015,13 +26059,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Il.SourceMapGenerator = n, Il;
+return n.prototype._version = 3, Dl.SourceMapGenerator = n, Dl;
 }
 
-var em, tm = {}, rm = {};
+var om, nm = {}, am = {};
 
-function om() {
-return em || (em = 1, function(e) {
+function im() {
+return om || (om = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26033,36 +26077,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(rm)), rm;
+}(am)), am;
 }
 
-var nm, am, im, sm, cm = {
+var sm, cm, um, lm, mm = {
 exports: {}
 };
 
-function um() {
-if (nm) return cm.exports;
-nm = 1;
+function dm() {
+if (sm) return mm.exports;
+sm = 1;
 let e = null;
-return cm.exports = function() {
+return mm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, cm.exports.initialize = t => {
+}, mm.exports.initialize = t => {
 e = t;
-}, cm.exports;
+}, mm.exports;
 }
 
-function lm() {
-if (im) return am;
-im = 1;
-const e = um();
+function pm() {
+if (um) return cm;
+um = 1;
+const e = dm();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return am = function() {
+return cm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26129,28 +26173,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, am;
+}, cm;
 }
 
-var mm, dm, pm, fm, ym = {};
+var fm, ym, vm, gm, hm = {};
 
-function vm(e, t, r) {
+function Rm(e, t, r) {
 return e - t >= r;
 }
 
-function gm(e, t) {
+function Em(e, t) {
 return e.priority - t.priority;
 }
 
-function hm(e, t, r, o) {
+function Tm(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function Rm(e, t, r, o) {
+function Cm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Em(e) {
+function Sm(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26168,12 +26212,12 @@ if (t) throw t.error;
 return o;
 }
 
-dm || (dm = 1, Pl.SourceMapGenerator = $l().SourceMapGenerator, Pl.SourceMapConsumer = function() {
-if (sm) return tm;
-sm = 1;
-const e = ql(), t = om(), r = Ql().ArraySet;
-Fl();
-const o = um(), n = lm(), a = Symbol("smcInternal");
+ym || (ym = 1, Ll.SourceMapGenerator = rm().SourceMapGenerator, Ll.SourceMapConsumer = function() {
+if (lm) return nm;
+lm = 1;
+const e = Ql(), t = im(), r = Jl().ArraySet;
+Kl();
+const o = dm(), n = pm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26210,7 +26254,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, tm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, nm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26400,7 +26444,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, tm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, nm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26509,11 +26553,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return tm.IndexedSourceMapConsumer = c, tm;
-}().SourceMapConsumer, Pl.SourceNode = function() {
-if (mm) return ym;
-mm = 1;
-const e = $l().SourceMapGenerator, t = ql(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return nm.IndexedSourceMapConsumer = c, nm;
+}().SourceMapConsumer, Ll.SourceNode = function() {
+if (fm) return hm;
+fm = 1;
+const e = rm().SourceMapGenerator, t = Ql(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26652,27 +26696,27 @@ map: o
 };
 }
 }
-return ym.SourceNode = n, ym;
+return hm.SourceNode = n, hm;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(fm || (fm = {}));
+}(gm || (gm = {}));
 
-var Tm, Cm = [ fm.CRITICAL, fm.HIGH, fm.MEDIUM, fm.LOW ], Sm = {
-bucketThresholds: (pm = {}, pm[fm.CRITICAL] = 0, pm[fm.HIGH] = 2e3, pm[fm.MEDIUM] = 5e3,
-pm[fm.LOW] = 8e3, pm),
+var wm, xm = [ gm.CRITICAL, gm.HIGH, gm.MEDIUM, gm.LOW ], bm = {
+bucketThresholds: (vm = {}, vm[gm.CRITICAL] = 0, vm[gm.HIGH] = 2e3, vm[gm.MEDIUM] = 5e3,
+vm[gm.LOW] = 8e3, vm),
 defaultMaxCpu: 5,
 logExecution: !1
-}, wm = function() {
+}, Om = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Em(Cm),
+tasksByPriority: Sm(xm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, Sm), e);
+}, this.config = o(o({}, bm), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26686,13 +26730,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(gm), l = 0;
+var u = Array.from(this.tasks.values()).sort(Em), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (vm(Game.time, p.lastRun, p.interval)) if (hm(p.priority, s, this.config.bucketThresholds, fm.CRITICAL)) this.stats.skippedThisTick++; else {
+if (Rm(Game.time, p.lastRun, p.interval)) if (Tm(p.priority, s, this.config.bucketThresholds, gm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (Rm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Cm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26740,7 +26784,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Em(Cm);
+var t, r, o = Sm(xm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26757,22 +26801,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), xm = ((Tm = global)._computationScheduler || (Tm._computationScheduler = new wm),
-Tm._computationScheduler), bm = new Map;
+}(), Am = ((wm = global)._computationScheduler || (wm._computationScheduler = new Om),
+wm._computationScheduler), km = new Map;
 
-function Om(e) {
-var t = bm.get(e);
+function Mm(e) {
+var t = km.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, bm.set(e, t)), t;
+}, km.set(e, t)), t;
 }
 
-function Am(e, t, r) {
+function Um(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return km(e, t[0], r), t[0];
-var i = Om(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return _m(e, t[0], r), t[0];
+var i = Mm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26789,32 +26833,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && km(e, s, r), s;
+return s && _m(e, s, r), s;
 }
 
-function km(e, t, r) {
-var o = Om(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function _m(e, t, r) {
+var o = Mm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var Mm = {
+var Nm = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function Um(e, t, r) {
+function Pm(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(Mm[t], ";") : "";
+var o = t ? "color: ".concat(Nm[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function _m(e) {
+function Im(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Nm = {
+var Gm = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26828,7 +26872,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(_m((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(Im((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -26845,44 +26889,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(_m(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(Im(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Pm() {
+function Lm() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Lm() + Dm() + '<div class="module-help">'.concat(e.map(Im).join(""), "</div>");
+return Bm() + Wm() + '<div class="module-help">'.concat(e.map(Dm).join(""), "</div>");
 }
 
-var Im = function(e) {
-var t = e.api.map(Gm).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Um(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Um(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Gm = function(e) {
+var Dm = function(e) {
+var t = e.api.map(Fm).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Pm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Pm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Fm = function(e) {
 var t = [];
-e.describe && t.push(Um(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(Um(e.name, "blue"), ": ").concat(Um(e.desc, "green"));
+e.describe && t.push(Pm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Pm(e.name, "blue"), ": ").concat(Pm(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return Um(e.name, "blue");
-}).join(", ") : "", o = Um(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Pm(e.name, "blue");
+}).join(", ") : "", o = Pm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Um(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Lm = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Pm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, Bm = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, Dm = function() {
+}, Wm = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Fm = k("EnergyCollection"), Bm = [ "refillSpawn", "refillExtension", "refillTower" ];
+}, Km = k("EnergyCollection"), Hm = [ "refillSpawn", "refillExtension", "refillTower" ];
 
-function Wm(e) {
+function Ym(e) {
 if (e.droppedResources.length > 0) {
 var t = Je(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Km.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -26892,22 +26936,22 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Am(e.creep, r, "energy_container");
-if (o) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Um(e.creep, r, "energy_container");
+if (o) return Km.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(r)) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
+if (Km.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(r)) return Km.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "withdraw",
 target: a,
 resourceType: RESOURCE_ENERGY
 };
 }
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Km.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -26917,35 +26961,35 @@ var n = ze(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (n.length > 0) {
-var a, i = Am(e.creep, n, "energy_source");
-if (i) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
+var a, i = Um(e.creep, n, "energy_source");
+if (i) return Km.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
-if (Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(n)) return Fm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
+if (Km.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(n)) return Km.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "harvest",
 target: a
 };
 }
-return Fm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Km.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Km(e) {
-var t = hl.getAssignedAction(e, Bm);
+function Vm(e) {
+var t = Tl.getAssignedAction(e, Hm);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Hm(e) {
-return hl.hasActiveTask(e.room.name, Bm);
+function qm(e) {
+return Tl.hasActiveTask(e.room.name, Hm);
 }
 
-function Ym(e, t) {
+function jm(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -26972,11 +27016,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Vm(e) {
-var t = hl.getAssignedDeliveryAction(e);
+function zm(e) {
+var t = Tl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Hm(e)) {
-var r = Ym(e, "deliver");
+if (!qm(e)) {
+var r = jm(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -26998,7 +27042,7 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-function qm(e) {
+function Qm(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27007,11 +27051,11 @@ var n = e.memory.working;
 return o !== n && et(e.creep), n;
 }
 
-function jm(e) {
+function Xm(e) {
 e.memory.working = !1, et(e.creep);
 }
 
-var zm = function() {
+var Zm = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27106,16 +27150,16 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), Qm = new zm, Xm = k("LarvaWorkerBehavior");
+}(), Jm = new Zm, $m = k("LarvaWorkerBehavior");
 
-function Zm(e) {
-if (qm(e)) {
-Xm.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var t = Vm(e);
-if (t) return Xm.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
+function ed(e) {
+if (Qm(e)) {
+$m.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var t = zm(e);
+if (t) return $m.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(t.type)),
 t;
 var r = function(e) {
-var t, r = Qm.getSwarmState(e.room.name);
+var t, r = Jm.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (r) {
@@ -27132,7 +27176,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Xm.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return $m.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27141,52 +27185,52 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Xm.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return $m.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Xm.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-jm(e);
+$m.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+Xm(e);
 }
-return Wm(e);
+return Ym(e);
 }
 
-function Jm(e) {
+function td(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function $m(e) {
+function rd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function ed(e) {
+function od(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var td = k("HarvesterBehavior"), rd = k("HaulerBehavior"), od = [ "refillSpawn", "refillExtension" ];
+var nd = k("HarvesterBehavior"), ad = k("HaulerBehavior"), id = [ "refillSpawn", "refillExtension" ];
 
-function nd(e, t, r) {
+function sd(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return km(e, c, r), c;
+if (c) return _m(e, c, r), c;
 }
-var u = Am(e, t, r);
+var u = Um(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function ad(e) {
+function cd(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27200,7 +27244,7 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-var id = {
+var ud = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27210,11 +27254,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, sd = id, cd = function(e) {
-return sd.getLabResourceNeeds(e);
+}, ld = ud, md = function(e) {
+return ld.getLabResourceNeeds(e);
 };
 
-function ud(e) {
+function dd(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27236,7 +27280,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = cd(e.room.name);
+var n = md(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27264,7 +27308,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, sd.getLabOverflow(r));
+var t, r, o = (r = e.room.name, ld.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27279,7 +27323,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = cd(e.room.name);
+var i = md(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27298,8 +27342,8 @@ type: "idle"
 }(e);
 }
 
-var ld = {
-larvaWorker: Zm,
+var pd = {
+larvaWorker: ed,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27310,12 +27354,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(Jm).length > 0) return {
+if (e.hostiles.filter(td).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (qm(e)) {
+if (Qm(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27334,7 +27378,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Wm(e);
+return Ym(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27368,10 +27412,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some($m)) return {
+if (e.hostiles.some(rd)) return {
 type: "idle"
 };
-if (qm(e)) {
+if (Qm(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27390,10 +27434,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Wm(e);
+return Ym(e);
 },
 harvester: function(e) {
-var t, r = (t = ed(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = od(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27442,8 +27486,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), td.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return td.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), nd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return nd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -27471,7 +27515,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return td.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return nd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -27492,20 +27536,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (td.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (nd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (td.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (nd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = qm(e), o = "defenseRefuel" === e.memory.task;
-if (rd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = Qm(e), o = "defenseRefuel" === e.memory.task;
+if (ad.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -27518,9 +27562,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = hl.getAssignedAction(e, od);
+var t = Tl.getAssignedAction(e, id);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (hl.hasActiveTask(e.room.name, od)) return null;
+if (Tl.hasActiveTask(e.room.name, id)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27540,13 +27584,13 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = hl.getAssignedDeliveryAction(e);
+var c = Tl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Hm(e)) {
+if (!qm(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return rd.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return ad.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
 {
 type: "transfer",
 target: p,
@@ -27572,7 +27616,7 @@ resourceType: RESOURCE_ENERGY
 var d = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Bu(e.room);
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Hu(e.room);
 return r < 2e4 && o > 5e4 && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
@@ -27599,12 +27643,12 @@ type: "transfer",
 target: p,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return rd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return ad.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-rd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-jm(e);
+ad.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+Xm(e);
 }
 if (o) {
 var y = function(e) {
@@ -27612,7 +27656,7 @@ var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = nd(e.creep, t, "energy_container");
+var r = sd(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -27656,16 +27700,16 @@ var R = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (R.length > 0) {
-var E = nd(e.creep, R, "energy_container");
-if (E) return rd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var E = sd(e.creep, R, "energy_container");
+if (E) return ad.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: E,
 resourceType: RESOURCE_ENERGY
 };
-rd.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+ad.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
 var T = e.creep.pos.findClosestByRange(R);
-if (T) return rd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+if (T) return ad.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
 {
 type: "withdraw",
 target: T,
@@ -27673,7 +27717,7 @@ resourceType: RESOURCE_ENERGY
 };
 }
 if (e.mineralContainers.length > 0) {
-var C = nd(e.creep, e.mineralContainers, "mineral_container");
+var C = sd(e.creep, e.mineralContainers, "mineral_container");
 if (C) {
 if (S = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
@@ -27683,11 +27727,11 @@ target: C,
 resourceType: S
 };
 } else {
-rd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+ad.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var S, w = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (w && (S = Object.keys(w.store).find(function(e) {
 return e !== RESOURCE_ENERGY && w.store.getUsedCapacity(e) > 0;
-}))) return rd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
+}))) return ad.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
 {
 type: "withdraw",
 target: w,
@@ -27701,7 +27745,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > 5e4 || Bu(e.room)) return {
+if (o < 2e4 && n > 5e4 || Hu(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -27732,27 +27776,27 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (rd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (ad.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
 {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : (rd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+}) : (ad.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 }));
 },
 builder: function(e) {
-if (qm(e)) {
-var t = Km(e);
+if (Qm(e)) {
+var t = Vm(e);
 if (t) return t;
-if (!Hm(e)) {
-var r = Ym(e, "builder");
+if (!qm(e)) {
+var r = jm(e, "builder");
 if (r) return r;
 }
 var o = function(e) {
 if (!e.room) return null;
-var t = ed(e);
+var t = od(e);
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r) return r;
@@ -27775,15 +27819,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Wm(e);
+return Ym(e);
 },
 upgrader: function(e) {
-if (qm(e)) {
-if (ad(e)) {
-var t = Km(e);
+if (Qm(e)) {
+if (cd(e)) {
+var t = Vm(e);
 if (t) return t;
-if (!Hm(e)) {
-var r = Ym(e, "upgrader");
+if (!qm(e)) {
+var r = jm(e, "upgrader");
 if (r) return r;
 }
 }
@@ -27856,7 +27900,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (qm(e)) {
+if (Qm(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -27880,7 +27924,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Vm(e) || (e.storage ? {
+} : zm(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28000,15 +28044,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : ud(e);
+} : dd(e);
 },
-labSupply: ud,
+labSupply: dd,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (qm(e)) {
+if (Qm(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28188,7 +28232,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = qm(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = Qm(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28211,9 +28255,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : Vm(e) || (e.isEmpty || e.room.name !== o ? {
+} : zm(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (jm(e), {
+} : (Xm(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28312,18 +28356,18 @@ roomName: o
 }
 };
 
-function md(e) {
+function fd(e) {
 var t;
-return (null !== (t = ld[e.memory.role]) && void 0 !== t ? t : Zm)(e);
+return (null !== (t = pd[e.memory.role]) && void 0 !== t ? t : ed)(e);
 }
 
-var dd = new Set([ "build", "repair", "upgrade" ]);
+var yd = new Set([ "build", "repair", "upgrade" ]);
 
-function pd(e, t) {
-return dd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || ad(e) ? Km(e) : null : null;
+function vd(e, t) {
+return yd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || cd(e) ? Vm(e) : null : null;
 }
 
-var fd = "patrol", yd = [ {
+var gd = "patrol", hd = [ {
 x: 10,
 y: 5
 }, {
@@ -28359,7 +28403,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], vd = [ {
+} ], Rd = [ {
 x: 10,
 y: 10
 }, {
@@ -28376,7 +28420,7 @@ x: 25,
 y: 25
 } ];
 
-function gd(e) {
+function Ed(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28384,7 +28428,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function hd(e) {
+function Td(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28394,9 +28438,9 @@ roomName: e.roomName
 });
 }
 
-function Rd(e) {
+function Cd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Fe.get(e.name, {
-namespace: fd
+namespace: gd
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28416,25 +28460,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(yd), !1), i(vd), !1);
-}(t).map(gd).filter(function(e) {
+}(e)), !1), i(hd), !1), i(Rd), !1);
+}(t).map(Ed).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Fe.set(e.name, {
-waypoints: hd(n),
+waypoints: Td(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: fd,
+namespace: gd,
 ttl: 1e3
 }), n;
 }
 
-function Ed(e, t) {
+function Sd(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28444,87 +28488,87 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var Td = k("MilitaryBehaviors"), Cd = "defenseAssist";
+var wd = k("MilitaryBehaviors"), xd = "defenseAssist";
 
-function Sd(e) {
+function bd(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Cd ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === xd ? e.targetRoom : void 0;
 }
 
-function wd(e) {
+function Od(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === Cd && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === xd && (delete e.task,
 delete e.targetRoom);
 }
 
-function xd(e, t) {
+function Ad(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function bd(e) {
+function kd(e) {
 return Ir(Mr(e));
 }
 
-function Od(e) {
+function Md(e) {
 return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
 }
 
-function Ad(e) {
+function Ud(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function kd(e, t) {
+function _d(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Md(e) {
-return kd(e, "guard") + kd(e, "ranger") + kd(e, "healer");
-}
-
-function Ud(e, t, r) {
-var o = e.memory;
-return Sd(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
-}
-
-function _d(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-return Ud(r, e, t);
-});
-}
-
-function Nd(e, t) {
-return "defenseAssist:".concat(e, ":").concat(t, ":active");
+function Nd(e) {
+return _d(e, "guard") + _d(e, "ranger") + _d(e, "healer");
 }
 
 function Pd(e, t, r) {
-return kd(e, t) > function(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-var o = r.memory;
-return !r.spawning && o.role === t && Sd(o) === e;
-}).length;
-}(e.roomName, t) || Md(e) > 0 && bd(e.roomName) && function(e, t) {
-return _d(e, t).length;
-}(e.roomName, r) < 5;
+var o = e.memory;
+return bd(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
 function Id(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+return Pd(r, e, t);
+});
+}
+
+function Gd(e, t) {
+return "defenseAssist:".concat(e, ":").concat(t, ":active");
+}
+
+function Ld(e, t, r) {
+return _d(e, t) > function(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+var o = r.memory;
+return !r.spawning && o.role === t && bd(o) === e;
+}).length;
+}(e.roomName, t) || Nd(e) > 0 && kd(e.roomName) && function(e, t) {
+return Id(e, t).length;
+}(e.roomName, r) < 5;
+}
+
+function Dd(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== Cd) return null;
-if (Od(e)) return null;
+if (t.task && t.task !== xd) return null;
+if (Md(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ad).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ud).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== j(l).length && Pd(u, t.role, e.homeRoom)) return t.task = Cd, t.targetRoom = u.roomName,
-t.assistTarget = u.roomName, t.defenseSquadId = Nd(e.homeRoom, u.roomName), t.defenseSquadSize = bd(u.roomName) ? Math.max(5, Md(u)) : Math.max(1, Md(u)),
+if (l && 0 !== j(l).length && Ld(u, t.role, e.homeRoom)) return t.task = xd, t.targetRoom = u.roomName,
+t.assistTarget = u.roomName, t.defenseSquadId = Gd(e.homeRoom, u.roomName), t.defenseSquadSize = kd(u.roomName) ? Math.max(5, Nd(u)) : Math.max(1, Nd(u)),
 t.defenseSquadCreatedAt = Game.time, u.roomName;
 }
 } catch (e) {
@@ -28541,7 +28585,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Gd(e) {
+function Fd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28549,19 +28593,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Ld(e, t) {
+function Bd(e, t) {
 if (!function(e) {
-return Boolean(Sd(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(bd(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = Sd(t);
+var r = bd(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = Mr(r), n = Ir(o), a = n ? _d(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = Sd(e);
+var o = Mr(r), n = Ir(o), a = n ? Id(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = bd(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Ud(e, r, o);
+return e.memory.defenseSquadId === t && Pd(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28575,7 +28619,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return _d(e, t).reduce(function(e, t) {
+return Id(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = br(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28597,16 +28641,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return xd(t, "parity-ready"), null;
-if (c >= u) return xd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Ad(t, "parity-ready"), null;
+if (c >= u) return Ad(t, "squad-quorum"), null;
 if (l) {
-if (!n) return xd(t, "expired-staging"), null;
+if (!n) return Ad(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Gd(e) - Gd(t);
+var r = Fd(e) - Fd(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28614,20 +28658,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return xd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Ad(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return xd(t, "squad-quorum"), null;
-if (l) return xd(t, "expired-staging"), null;
+if (c >= u) return Ad(t, "squad-quorum"), null;
+if (l) return Ad(t, "expired-staging"), null;
 }
-var m = Lu(e.room.name);
+var m = Bu(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function Dd(e) {
+function Wd(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28659,21 +28703,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Fd(e, t) {
+function Kd(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Bd(e, t) {
+function Hd(e, t) {
 if (!e.swarmState) return null;
-var r = Lu(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (Td.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = Bu(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (wd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Wd(e) {
+function Yd(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28697,7 +28741,7 @@ if (t) throw t.error;
 }
 }
 
-function Kd(e) {
+function Vd(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28705,23 +28749,23 @@ return Boolean(e);
 });
 }
 
-function Hd(e) {
+function qd(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Yd(e) {
+function jd(e) {
 var t, r = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Wd(e.memory.squadId);
-if (o) return Vd(e, o);
+var o = Yd(e.memory.squadId);
+if (o) return zd(e, o);
 }
-var n = null !== (t = Id(e, r)) && void 0 !== t ? t : Sd(r);
-if (n && !Od(e)) {
-var a = Ld(e, r);
+var n = null !== (t = Dd(e, r)) && void 0 !== t ? t : bd(r);
+if (n && !Md(e)) {
+var a = Bd(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28734,9 +28778,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Dd(e);
+var s = Wd(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Fd(e.creep, RANGED_ATTACK), l = Fd(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Kd(e.creep, RANGED_ATTACK), l = Kd(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28748,7 +28792,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Fd(e.creep, RANGED_ATTACK), l = Fd(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Kd(e.creep, RANGED_ATTACK), l = Kd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28759,7 +28803,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (wd(r), e.creep.room.name !== e.homeRoom) return {
+} else if (Od(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28768,8 +28812,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Dd(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Fd(e.creep, RANGED_ATTACK), l = Fd(e.creep, ATTACK),
+var m = Wd(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Kd(e.creep, RANGED_ATTACK), l = Kd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28780,7 +28824,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = Rd(e.room), p = Ed(e.creep, d);
+var d = Cd(e.room), p = Sd(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28794,7 +28838,7 @@ type: "idle"
 };
 }
 
-function Vd(e, t) {
+function zd(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28802,7 +28846,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Hd(t);
+var n = qd(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28810,7 +28854,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Kd(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Vd(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -28833,7 +28877,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Kd(e).filter(function(t) {
+var t, r, o = Vd(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -28862,7 +28906,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Kd(t).filter(function(t) {
+var r = Vd(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -28878,7 +28922,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Kd(t).sort(function(e, t) {
+var a = Vd(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -28915,7 +28959,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Kd(t).filter(function(e) {
+var l = Vd(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -28932,7 +28976,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Kd(e).find(function(e) {
+return null !== (t = Vd(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -28943,7 +28987,7 @@ target: m
 type: "idle"
 };
 }
-var d = Dd(e);
+var d = Wd(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -28955,10 +28999,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Fd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Kd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Fd(e.creep, ATTACK) && p <= 1 ? {
+} : Kd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -28974,10 +29018,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Fd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Kd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Fd(e.creep, ATTACK) && p <= 1 ? {
+} : Kd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -28993,7 +29037,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Hd(t)
+target: qd(t)
 };
 
 case "dissolving":
@@ -29011,8 +29055,8 @@ type: "idle"
 }
 }
 
-var qd = {
-guard: Yd,
+var Qd = {
+guard: jd,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29021,8 +29065,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = Rd(e.room);
-return (o = Ed(e.creep, r)) ? {
+var r = Cd(e.room);
+return (o = Sd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29043,7 +29087,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = Rd(e.room), (o = Ed(e.creep, r)) ? {
+} : (r = Cd(e.room), (o = Sd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29057,11 +29101,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Fd(e, HEAL);
+return Kd(e, HEAL);
 }), t.filter(function(e) {
-return Fd(e, RANGED_ATTACK);
+return Kd(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Fd(e, ATTACK);
+return Kd(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29082,7 +29126,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Fd(e.creep, RANGED_ATTACK), u = Fd(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Kd(e.creep, RANGED_ATTACK), u = Kd(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29113,19 +29157,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Wd(e.memory.squadId);
-if (o) return Vd(e, o);
+var o = Yd(e.memory.squadId);
+if (o) return zd(e, o);
 }
-var n = null !== (t = Id(e, r)) && void 0 !== t ? t : Sd(r);
-if (n && !Od(e)) {
-var a = Ld(e, r);
+var n = null !== (t = Dd(e, r)) && void 0 !== t ? t : bd(r);
+if (n && !Md(e)) {
+var a = Bd(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === j(i).length) return wd(r), {
+if (0 === j(i).length) return Od(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29133,7 +29177,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== Cd && !r.assistTarget) {
+if (r.targetRoom && r.task !== xd && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -29193,7 +29237,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || Sd(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || bd(r) === t);
 }(e, t);
 }
 });
@@ -29219,7 +29263,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = Rd(e.room), v = Ed(e.creep, y);
+var y = Cd(e.room), v = Sd(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29230,8 +29274,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Wd(e.memory.squadId);
-if (r) return Vd(e, r);
+var r = Yd(e.memory.squadId);
+if (r) return zd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29253,9 +29297,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Dd(e);
+var a = Wd(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Fd(e.creep, RANGED_ATTACK), c = Fd(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Kd(e.creep, RANGED_ATTACK), c = Kd(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29274,7 +29318,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = Rd(e.room), m = Ed(e.creep, l);
+var l = Cd(e.room), m = Sd(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29296,8 +29340,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Wd(e.memory.squadId);
-if (r) return Vd(e, r);
+var r = Yd(e.memory.squadId);
+if (r) return zd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29358,9 +29402,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Bd(e, "siegeUnit");
+var p = Hd(e, "siegeUnit");
 if (p) return p;
-var f = Rd(e.room), y = Ed(e.creep, f);
+var f = Cd(e.room), y = Sd(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29371,8 +29415,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Wd(e.memory.squadId);
-if (r) return Vd(e, r);
+var r = Yd(e.memory.squadId);
+if (r) return zd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29389,7 +29433,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Bd(e, "harasser (no target)") || {
+if (!t) return Hd(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29431,9 +29475,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Bd(e, "harasser (no targets)");
+var c = Hd(e, "harasser (no targets)");
 if (c) return c;
-var u = Rd(e.room), l = Ed(e.creep, u);
+var u = Cd(e.room), l = Sd(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29446,9 +29490,9 @@ var t, r, o = e.creep.memory;
 if (Ia(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Wd(e.memory.squadId))) return Vd(e, a);
+if (e.memory.squadId && (a = Yd(e.memory.squadId))) return zd(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (Sd(o) && wd(o), e.room.name !== e.homeRoom) return {
+if (bd(o) && Od(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29462,9 +29506,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Id(e, o)) && void 0 !== t ? t : Sd(o);
-if (i && !Od(e)) {
-var s = Ld(e, o);
+var a, i = null !== (t = Dd(e, o)) && void 0 !== t ? t : bd(o);
+if (i && !Md(e)) {
+var s = Bd(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29474,14 +29518,14 @@ roomName: i
 var u = j(c), l = z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return wd(o), {
+if (0 === u.length && 0 === l.length) return Od(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Dd(e);
+var m = Wd(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29501,8 +29545,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Wd(e.memory.squadId))) return Vd(e, a);
-var p, f = Dd(e);
+if (e.memory.squadId && (a = Yd(e.memory.squadId))) return zd(e, a);
+var p, f = Wd(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29513,7 +29557,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = Rd(e.room), v = Ed(e.creep, y);
+var y = Cd(e.room), v = Sd(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29534,21 +29578,21 @@ type: "idle"
 }
 };
 
-function jd(e) {
+function Xd(e) {
 var t;
-return hl.getAssignedAction(e) || (null !== (t = qd[e.memory.role]) && void 0 !== t ? t : Yd)(e);
+return Tl.getAssignedAction(e) || (null !== (t = Qd[e.memory.role]) && void 0 !== t ? t : jd)(e);
 }
 
-var zd = k("PowerExecutor");
+var Zd = k("PowerExecutor");
 
-function Qd(e, t) {
+function Jd(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Xd(e) {
+function $d(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29590,8 +29634,8 @@ type: "idle"
 };
 }
 
-var Zd = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Jd = {
-powerHarvester: Xd,
+var ep = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), tp = {
+powerHarvester: $d,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29663,65 +29707,65 @@ roomName: e.homeRoom
 }
 };
 
-function $d(e) {
+function rp(e) {
 var t;
-return (null !== (t = Jd[e.memory.role]) && void 0 !== t ? t : Xd)(e);
+return (null !== (t = tp[e.memory.role]) && void 0 !== t ? t : $d)(e);
 }
 
-function ep(e) {
+function op(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var tp = {
+var np = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, rp = {
+}, ap = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, op = {
+}, ip = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, np = {
+}, sp = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, ap = {
+}, cp = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, ip = {
+}, up = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, sp = {
+}, lp = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, cp = {
+}, mp = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function up(e) {
+function dp(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function lp(e) {
+function pp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29729,7 +29773,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function mp(e) {
+function fp(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29737,12 +29781,12 @@ y: parseInt(n, 10)
 };
 }
 
-function dp(e) {
+function yp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = pp(s);
+o[s.n] = vp(s);
 }
 } catch (e) {
 t = {
@@ -29758,23 +29802,23 @@ if (t) throw t.error;
 return o;
 }
 
-function pp(e) {
+function vp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = rp[e.r]) && void 0 !== t ? t : "core",
-health: fp(e.h),
+role: null !== (t = ap[e.r]) && void 0 !== t ? t : "core",
+health: gp(e.h),
 activeTasks: e.t,
-portals: e.p.map(yp),
+portals: e.p.map(hp),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(vp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Rp)
 };
 }
 
-function fp(e) {
+function gp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = np[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = sp[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29787,11 +29831,11 @@ lastUpdate: e.u
 };
 }
 
-function yp(e) {
+function hp(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: lp(e.sp),
+sourcePos: pp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29801,7 +29845,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function vp(e) {
+function Rp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29810,7 +29854,7 @@ bucketLevel: e.b
 };
 }
 
-function gp(e) {
+function Ep(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -29820,12 +29864,12 @@ isAlly: 1 === e.a
 };
 }
 
-function hp(e) {
+function Tp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Rp(u);
+i[u.n] = Cp(u);
 }
 } catch (e) {
 t = {
@@ -29848,13 +29892,13 @@ updatedAt: e.u
 };
 }
 
-function Rp(e) {
+function Cp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: mp(e.pp),
+portalPos: fp(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -29865,46 +29909,46 @@ lastUpdate: e.u
 };
 }
 
-function Ep(e) {
+function Sp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = ip[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = up[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = cp[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = mp[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function Tp(e, t) {
+function wp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function Cp(e) {
+function xp(e) {
 var t;
 return {
-c: null !== (t = op[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: Tp(e.cpuUsage, 2),
+c: null !== (t = ip[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: wp(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: Tp(e.avgRCL, 1),
+rl: wp(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function Sp(e) {
+function bp(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: up(e.sourcePos),
+sp: dp(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -29913,27 +29957,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function wp(e) {
+function Op(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: Tp(e.cpuUsed, 2),
+u: wp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function xp(e) {
+function Ap(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(bp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(kp)
 };
 }
 
-function bp(e) {
+function kp(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -29943,23 +29987,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Op(e) {
+function Mp(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = ap[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = cp[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = sp[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = lp[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Ap(e) {
+function Up(e) {
 return {
 name: e,
 role: "core",
@@ -29982,7 +30026,7 @@ cpuLimit: 0
 };
 }
 
-function kp(e) {
+function _p(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -29992,16 +30036,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = tp[t.role]) && void 0 !== r ? r : t.role[0],
-h: Cp(t.health),
+r: null !== (r = np[t.role]) && void 0 !== r ? r : t.role[0],
+h: xp(t.health),
 t: t.activeTasks,
-p: t.portals.map(Sp),
+p: t.portals.map(bp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(wp)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Op)
 };
 }(t[0], t[1]);
 }),
-g: xp(e.globalTargets),
+g: Ap(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30015,7 +30059,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? up(t.portalPos) : void 0,
+pp: t.portalPos ? dp(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30027,20 +30071,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Op),
+k: e.tasks.map(Mp),
 ls: e.lastSync
 };
 var t;
-}(e), r = ep(JSON.stringify(t));
+}(e), r = op(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Mp(e) {
+function Np(e) {
 try {
-var t = JSON.parse(e), r = ep(JSON.stringify(t.d));
+var t = JSON.parse(e), r = op(JSON.stringify(t.d));
 return t.c !== r ? (va.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30049,13 +30093,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: dp(a.s),
+shards: yp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(gp)), n),
-footprintOperation: a.o ? hp(a.o) : void 0,
-tasks: a.k.map(Ep),
+o.en && (n.enemies = o.en.map(Ep)), n),
+footprintOperation: a.o ? Tp(a.o) : void 0,
+tasks: a.k.map(Sp),
 lastSync: a.ls,
 checksum: i
 });
@@ -30067,34 +30111,34 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Up, _p, Np = 102400;
+var Pp, Ip, Gp = 102400;
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Up || (Up = {})), function(e) {
+}(Pp || (Pp = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(_p || (_p = {}));
+}(Ip || (Ip = {}));
 
-var Pp = null != va ? va : {
+var Lp = null != va ? va : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Ip = {
+}, Dp = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Gp = {
+}, Fp = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Lp = function() {
+}, Bp = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ip), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Dp), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30111,19 +30155,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Mp(r);
-o && (this.interShardMemory = o, Pp.debug("Loaded InterShardMemory", {
+var o = Np(r);
+o && (this.interShardMemory = o, Lp.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Pp.error("Failed to load InterShardMemory: ".concat(n), {
+Lp.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Ap(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Up(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30284,25 +30328,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Pp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Lp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Pp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Lp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Pp.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Lp.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Pp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Lp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30335,7 +30379,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Pp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Lp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30365,12 +30409,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Pp.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Lp.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Pp.info("War ended, transitioning to ".concat(i), {
+Lp.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Pp.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Lp.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30396,7 +30440,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Gp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Fp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30448,13 +30492,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Pp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Lp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Pp.debug("Could not set shard limits: ".concat(S), {
+Lp.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30462,27 +30506,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Pp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Lp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
 try {
-var t = InterShardMemory.getLocal(), r = t ? Mp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
+var t = InterShardMemory.getLocal(), r = t ? Np(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
 o && (!n || o.updatedAt >= n.updatedAt) && (this.interShardMemory.footprintOperation = o);
 } catch (e) {}
-var a = kp(this.interShardMemory);
-if (a.length > Np) {
-Pp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Np), {
+var a = _p(this.interShardMemory);
+if (a.length > Gp) {
+Lp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Gp), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var i = kp(this.interShardMemory);
-return i.length > Np ? (Pp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Np), {
+var i = _p(this.interShardMemory);
+return i.length > Gp ? (Lp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Gp), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(i);
 }
 InterShardMemory.setLocal(a), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var s = e instanceof Error ? e.message : String(e);
-Pp.error("Failed to sync InterShardMemory: ".concat(s), {
+Lp.error("Failed to sync InterShardMemory: ".concat(s), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30520,7 +30564,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Ap(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Up(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30538,40 +30582,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Pp.info("Repaired InterShardMemory structure", {
+Lp.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Pp.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Lp.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Mp(r);
-if (!o) return void Pp.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Np(r);
+if (!o) return void Lp.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Pp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Lp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Pp.warn("InterShardMemory verification failed: ".concat(a), {
+Lp.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Pp.info("Attempting InterShardMemory recovery", {
+Lp.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Mp(r);
-if (o) return this.interShardMemory = o, void Pp.info("Recovered InterShardMemory from storage", {
+var o = Np(r);
+if (o) return this.interShardMemory = o, void Lp.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30586,12 +30630,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Ap(n), Pp.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Up(n), Lp.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Pp.error("InterShardMemory recovery failed: ".concat(a), {
+Lp.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30601,7 +30645,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Pp.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Lp.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30617,7 +30661,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Pp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Lp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30633,7 +30677,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Pp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Lp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30648,7 +30692,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Pp.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Lp.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30667,7 +30711,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Pp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Lp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30713,11 +30757,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Pp.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Lp.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = kp(this.interShardMemory).length, o = r / Np * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = _p(this.interShardMemory).length, o = r / Gp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30744,11 +30788,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Pp.info("Forcing InterShardMemory sync with validation", {
+Lp.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = kp(this.interShardMemory).length, n = kp(o(o({}, this.interShardMemory), {
+var e, t, r = _p(this.interShardMemory).length, n = _p(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -30772,8 +30816,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: Np,
-percent: Math.round(r / Np * 1e4) / 100,
+limit: Gp,
+percent: Math.round(r / Gp * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -30781,10 +30825,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Up.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Pp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), Dp = new Lp, Fp = {
+}(), Wp = new Bp, Kp = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -30795,11 +30839,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: _p.LOW,
-NORMAL: _p.NORMAL,
-HIGH: _p.HIGH
+LOW: Ip.LOW,
+NORMAL: Ip.NORMAL,
+HIGH: Ip.HIGH
 }
-}, Bp = function() {
+}, Hp = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -30809,7 +30853,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = Dp.getActiveTransferTasks();
+var n = Wp.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -30836,7 +30880,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = Dp.getOptimalPortalRoute(e.targetShard);
+var t = Wp.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -30904,7 +30948,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-Dp.updateTaskProgress(e.taskId, t);
+Wp.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -30920,7 +30964,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = Fp.optimizeBody({
+i = Kp.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -30931,8 +30975,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Fp.spawnPriorities.LOW;
-e.priority >= 80 ? d = Fp.spawnPriorities.HIGH : e.priority >= 50 && (d = Fp.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Kp.spawnPriorities.LOW;
+e.priority >= 80 ? d = Kp.spawnPriorities.HIGH : e.priority >= 50 && (d = Kp.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -30950,7 +30994,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-Fp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Kp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -30977,7 +31021,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void Dp.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Wp.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", va.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -30989,8 +31033,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, Dp.updateTaskProgress(e.taskId, 100, "complete"),
-Dp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Wp.updateTaskProgress(e.taskId, 100, "complete"),
+Wp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31020,12 +31064,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Wp = new Bp;
+}(), Yp = new Hp;
 
-function Kp(e, t, r) {
+function Vp(e, t, r) {
 var o, n, a, i;
 try {
-var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Mp(c)) && void 0 !== a ? a : {
+var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Np(c)) && void 0 !== a ? a : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -31040,11 +31084,11 @@ if (!(null == l ? void 0 : l.targets[s])) return;
 var m = l.targets[s];
 m.status = e, null !== (i = m.arrivedAt) && void 0 !== i || (m.arrivedAt = Game.time),
 m.claimTargetRoom = null != t ? t : m.claimTargetRoom, m.blockedReason = r, m.lastUpdate = Game.time,
-"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(kp(u));
+"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(_p(u));
 } catch (e) {}
 }
 
-function Hp(e) {
+function qp(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31072,15 +31116,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Kp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Vp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || j(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Kp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Vp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Kp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Vp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31097,24 +31141,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Kp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Vp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Kp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Vp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Yp(e) {
+function jp(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Vp(e, t) {
+function zp(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31148,14 +31192,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (A.mineralType = y.mineralType), u[e.name] = A;
 }
 
-function qp(e, t) {
+function Qp(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function jp(e) {
-var t = Qm.getEmpire();
-if (Gu.isExit(e.creep.pos)) return Yp(e.room.name);
+function Xp(e) {
+var t = Jm.getEmpire();
+if (Fu.isExit(e.creep.pos)) return jp(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31170,7 +31214,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ qp(t.x, t.y - 1), qp(t.x + 1, t.y), qp(t.x, t.y + 1), qp(t.x - 1, t.y) ] : [];
+return t ? [ Qp(t.x, t.y - 1), Qp(t.x + 1, t.y), Qp(t.x, t.y + 1), Qp(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31233,13 +31277,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Vp(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (zp(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Vp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (zp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31249,19 +31293,19 @@ type: "idle"
 };
 }
 
-function zp(e) {
+function Zp(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function Qp(e) {
-return e.hostiles.some(zp);
+function Jp(e) {
+return e.hostiles.some(Zp);
 }
 
-function Xp(e) {
+function $p(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function Zp(e) {
+function ef(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31284,8 +31328,8 @@ type: "idle"
 };
 }
 
-var Jp = {
-scout: jp,
+var tf = {
+scout: Xp,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31319,7 +31363,7 @@ return {
 type: "idle"
 };
 }
-if (Gu.isExit(e.creep.pos)) return Yp(e.room.name);
+if (Fu.isExit(e.creep.pos)) return jp(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31341,8 +31385,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Hp,
-interShardScout: Hp,
+interShardClaimer: qp,
+interShardScout: qp,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31418,8 +31462,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return Zp(e);
-if (Qp(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return ef(e);
+if (Jp(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31460,7 +31504,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return Xp(t) - Xp(e);
+return $p(t) - $p(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31480,7 +31524,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : Zp(e);
+} : ef(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31569,9 +31613,9 @@ type: "idle"
 }
 };
 
-function $p(e, t) {
+function rf(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Qp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Jp(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31579,26 +31623,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function ef(e) {
-var t;
-return (null !== (t = Jp[e.memory.role]) && void 0 !== t ? t : jp)(e);
-}
-
-function tf(e) {
-var t = Nu(e);
-wl(e, Ul(t, md, {
-interrupt: pd
-}), t);
-}
-
-function rf(e) {
-var t = Nu(e);
-wl(e, Ul(t, ef, {
-interrupt: $p
-}), t);
-}
-
 function of(e) {
+var t;
+return (null !== (t = tf[e.memory.role]) && void 0 !== t ? t : Xp)(e);
+}
+
+function nf(e) {
+var t = Gu(e);
+Ol(e, Pl(t, fd, {
+interrupt: vd
+}), t);
+}
+
+function af(e) {
+var t = Gu(e);
+Ol(e, Pl(t, of, {
+interrupt: rf
+}), t);
+}
+
+function sf(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31639,8 +31683,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Zd.has(i) && V(s))) {
-zd.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && ep.has(i) && V(s))) {
+Zd.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31651,16 +31695,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && Gu.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && Fu.moveTo(e, t.target);
 break;
 
 case "moveTo":
-Gu.moveTo(e, t.target);
+Fu.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-Gu.moveTo(e, {
+Fu.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -31669,11 +31713,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && Gu.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && Fu.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && Gu.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && Fu.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -31705,7 +31749,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Qd(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Jd(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31715,7 +31759,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Qd(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Jd(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31726,7 +31770,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Qd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Jd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -31779,7 +31823,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Qd(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Jd(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -31821,7 +31865,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Qd(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Jd(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -31831,7 +31875,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Qd(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Jd(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -31839,7 +31883,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && j(e.room).length > 0) {
 var o = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Qd(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Jd(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -31851,7 +31895,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Qd(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Jd(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -31859,12 +31903,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Qd(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Jd(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Qd(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Jd(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -31898,18 +31942,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function nf(e) {
+function cf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var af = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), sf = -1, cf = Object.create(null);
+var uf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), lf = -1, mf = Object.create(null);
 
-function uf(e) {
+function df(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var lf = {
+var pf = {
 harvester: ha.CRITICAL,
 queenCarrier: ha.CRITICAL,
 hauler: ha.HIGH,
@@ -31944,12 +31988,12 @@ labTech: ha.IDLE,
 factoryWorker: ha.IDLE
 };
 
-function mf(e) {
+function ff(e) {
 var t;
-return null !== (t = lf[e]) && void 0 !== t ? t : ha.MEDIUM;
+return null !== (t = pf[e]) && void 0 !== t ? t : ha.MEDIUM;
 }
 
-function df(e) {
+function yf(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -31965,20 +32009,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && uf(o) === e && t++;
+o && df(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (sf !== Game.time && (sf = Game.time, cf = function() {
+}(e) : null !== (r = (lf !== Game.time && (lf = Game.time, mf = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = uf(o);
+var n = df(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), cf)[e]) && void 0 !== r ? r : 0;
+}()), mf)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Ue().cpu.disableCreepBootstrapCountCache
@@ -31988,7 +32032,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!af.has(t.role)) return !1;
+if (!uf.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -31998,7 +32042,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !nf(r)) return !1;
+if (!r || !cf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32012,7 +32056,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !nf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !cf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32020,7 +32064,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !nf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !cf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32028,7 +32072,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !nf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !cf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32036,7 +32080,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && nf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && cf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32052,7 +32096,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !nf(r)) return !1;
+if (!r || !cf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32092,31 +32136,31 @@ switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = Nu(e);
-wl(e, Ul(t, md, {
-interrupt: pd
+var t = Gu(e);
+Ol(e, Pl(t, fd, {
+interrupt: vd
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = Nu(e);
-wl(e, Ul(t, jd), t);
+var t = Gu(e);
+Ol(e, Pl(t, Xd), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = Nu(e);
-wl(e, Ul(t, ef), t);
+var t = Gu(e);
+Ol(e, Pl(t, of), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = Nu(e);
-wl(e, Ul(t, $d), t);
+var t = Gu(e);
+Ol(e, Pl(t, rp), t);
 }(e);
 }
 });
@@ -32137,7 +32181,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var pf = function() {
+var vf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32178,7 +32222,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = mf(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = ff(r), n = "creep:".concat(e.name);
 Ja.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -32194,7 +32238,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && df(t);
+t && !t.spawning && yf(t);
 }
 }), this.registeredCreeps.add(e.name), Ci.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32219,7 +32263,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = mf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = ff(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32244,20 +32288,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), ff = new pf;
+}(), gf = new vf;
 
-function yf(e) {
+function hf(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, vf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, Rf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function vf(e) {
+function Rf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function gf(e) {
+function Ef(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32270,14 +32314,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function hf(e, t) {
+function Tf(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var Rf = {
+var Cf = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32305,11 +32349,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function Ef(e, t) {
+function Sf(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function Tf(e) {
+function wf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32319,9 +32363,9 @@ tick: Game.time
 }, a;
 }
 
-var Cf = [ "defense", "war", "expand", "siege" ];
+var xf = [ "defense", "war", "expand", "siege" ];
 
-function Sf(e) {
+function bf(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32334,11 +32378,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function wf(e, t, r) {
-t >= 2 && (e.pheromones.war = Ef(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ef(e.pheromones.siege + 20, r));
+function Of(e, t, r) {
+t >= 2 && (e.pheromones.war = Sf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Sf(e.pheromones.siege + 20, r));
 }
 
-var xf = function() {
+var Af = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32353,27 +32397,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), bf = function() {
+}(), kf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Rf), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Cf), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new xf(10),
-energySpawning: new xf(10),
-energyConstruction: new xf(10),
-energyRepair: new xf(10),
-energyTower: new xf(10),
-controllerProgress: new xf(10),
-hostileCount: new xf(5),
-damageReceived: new xf(5),
-idleWorkers: new xf(10),
+energyHarvested: new Af(10),
+energySpawning: new Af(10),
+energyConstruction: new Af(10),
+energyRepair: new Af(10),
+energyTower: new Af(10),
+controllerProgress: new Af(10),
+hostileCount: new Af(5),
+damageReceived: new Af(5),
+idleWorkers: new Af(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = Tf(e);
+var o = wf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32446,7 +32490,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = Ef(e[s] * c, t);
+e[s] = Sf(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32462,43 +32506,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = Tf(t);
+var o = wf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = Ef(e.harvest + n / 3e3 * 10, r);
+e.harvest = Sf(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = Ef(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = Sf(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = Ef(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = Sf(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = Ef(e.defense + 10 * o, r));
+o > 0 && (e.defense = Sf(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = Ef(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ef(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = Sf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Sf(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = Ef(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = Sf(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = Ef(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = Sf(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Ef(e.pheromones.defense + 5 * t, o), wf(e, r, o),
+e.danger = r, e.pheromones.defense = Sf(e.pheromones.defense + 5 * t, o), Of(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32506,7 +32550,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Ef(t / 10, o), wf(e, r, o);
+e.danger = r, e.pheromones.defense = Sf(t / 10, o), Of(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32519,8 +32563,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = Ef(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = Ef(f + y, o);
+var p = Sf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = Sf(f + y, o);
 }
 }
 }
@@ -32539,18 +32583,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = Ef(e.pheromones.defense + 5, r), e.pheromones.build = Ef(e.pheromones.build + 10, r),
+e.pheromones.defense = Sf(e.pheromones.defense + 5, r), e.pheromones.build = Sf(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ef(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Sf(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = Ef(e.pheromones.siege + 50, t), e.pheromones.defense = Ef(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = Sf(e.pheromones.siege + 50, t), e.pheromones.defense = Sf(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = Ef(e.pheromones.expand - 10, t), e.pheromones.defense = Ef(e.pheromones.defense + 5, t);
+e.pheromones.expand = Sf(e.pheromones.expand - 10, t), e.pheromones.defense = Sf(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32560,10 +32604,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Sf(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(bf(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Cf)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(xf)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32617,7 +32661,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = Ef(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = Sf(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32652,7 +32696,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), Of = new bf, Af = {
+}(), Mf = new kf, Uf = {
 seedNest: {
 rcl: 1
 },
@@ -32693,7 +32737,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, kf = {
+}, _f = {
 eco: {
 economy: .75,
 military: .05,
@@ -32736,7 +32780,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Mf = {
+}, Nf = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -32793,13 +32837,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Uf = function() {
+}, Pf = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Af.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Af.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Af.fortifiedHive.rcl ? "fortifiedHive" : s >= Af.matureColony.rcl ? "matureColony" : s >= Af.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Uf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Uf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Uf.fortifiedHive.rcl ? "fortifiedHive" : s >= Uf.matureColony.rcl ? "matureColony" : s >= Uf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Fe.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -32834,7 +32878,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Af[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Uf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -32847,7 +32891,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), _f = function() {
+}(), If = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -32869,9 +32913,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return kf[e];
+return _f[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return Mf[e];
+return Nf[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -32881,15 +32925,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Nf = new Uf, Pf = new _f;
+}(), Gf = new Pf, Lf = new If;
 
-function If(e) {
+function Df(e) {
 return !Y(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Gf(e, t, r) {
+function Ff(e, t, r) {
 if (!e) return null;
 var o = mr.getEmpire();
 if (Y(e, {
@@ -32928,11 +32972,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Lf() {
+function Bf() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var Df = new Map, Ff = function() {
+var Wf = new Map, Kf = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = j(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33076,7 +33120,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: Df.get(e.name),
+previousStructures: Wf.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33106,7 +33150,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && Df.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Wf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33115,7 +33159,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-If(u) && o.add(u.owner.username);
+Df(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33129,7 +33173,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Gf(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Ff(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33145,7 +33189,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? Of.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Of.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Of.onNukeDetected(t);
+"danger" === y.type ? Mf.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Mf.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Mf.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33205,10 +33249,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Lf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = Bf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Lf()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = Bf()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33251,7 +33295,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Pf.isCombatPosture(t.posture),
+isCombatPosture: Lf.isCombatPosture(t.posture),
 wallRepairTarget: so(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33275,27 +33319,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Bf = new Ff, Wf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Hf = new Kf, Yf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Kf() {
+function Vf() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Hf(e, t, r, o) {
+function qf(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Kf()
+selectedAt: Vf()
 });
 }
 
-function Yf(e) {
+function jf(e) {
 return e >= 2 && e <= 3;
 }
 
-function Vf(e, t) {
+function zf(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33308,7 +33352,7 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-function qf(e, t) {
+function Qf(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -33322,10 +33366,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var jf = function() {
+var Xf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Yf(e) ? 5 : 10;
+return jf(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33723,16 +33767,16 @@ y: e.y - R.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Hf(t, v, E.name, f);
+qf(t, v, E.name, f);
 var T = f >= 3 && (t.danger >= 1 || function(e, t) {
-var r = qf(STRUCTURE_TOWER, t);
-return r > 0 && Vf(e, STRUCTURE_TOWER) < r;
+var r = Qf(STRUCTURE_TOWER, t);
+return r > 0 && zf(e, STRUCTURE_TOWER) < r;
 }(e, f)), C = T ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = qf(STRUCTURE_TOWER, g), R = Vf(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Qf(STRUCTURE_TOWER, g), R = zf(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34129,7 +34173,7 @@ var r, o, n, i = Vo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && Vf(e, u) < l) return !0;
+if (!(l <= 0) && zf(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34145,8 +34189,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + S + w + C >= 10 && !x) t.metrics.constructionSites = p.length + S + w + C; else {
-if (!Pf.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Kf());
+if (!Lf.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Vf());
 }(t, v)) {
 var b = function(e, t, r, o, n) {
 var i, s;
@@ -34304,7 +34348,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Wf.has(e.structureType);
+return Yf.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34313,7 +34357,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = Yf(f) ? 2 : 3;
+var M = jf(f) ? 2 : 3;
 (k = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -34989,13 +35033,13 @@ anchor: l
 }
 return null;
 }(e, f);
-L && (Hf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
+L && (qf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), zf = new jf;
+}(), Zf = new Xf;
 
-function Qf(e) {
+function Jf(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35017,7 +35061,7 @@ siege: e.pheromones.siege
 };
 }
 
-var Xf = {
+var $f = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35030,10 +35074,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Zf = new (function() {
+}, ey = new (function() {
 function e() {
-this.manager = new ou({
-logger: Xf
+this.manager = new iu({
+logger: $f
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35043,23 +35087,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = Qf(t);
+var r = Jf(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = Qf(t);
+var r = Jf(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), Jf = {
-labManager: Ru,
-boostManager: fu,
-chemistryPlanner: Zf,
-labConfigManager: gu,
+}()), ty = {
+labManager: Cu,
+boostManager: gu,
+chemistryPlanner: ey,
+labConfigManager: Eu,
 logger: Ci
-}, $f = function() {
+}, ry = function() {
 function e(e) {
-void 0 === e && (e = Jf), this.deps = e;
+void 0 === e && (e = ty), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35098,9 +35142,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), ey = new $f, ty = function() {
+}(), oy = new ry, ny = function() {
 function e(e) {
-void 0 === e && (e = ey), this.labWorkflow = e;
+void 0 === e && (e = oy), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35145,27 +35189,27 @@ if (r) throw r.error;
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), ry = new ty, oy = {
+}(), ay = new ny, iy = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, ny = new Map;
+}, sy = new Map;
 
-function ay(e) {
+function cy(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function iy(e) {
+function uy(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var sy = function() {
+var ly = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, oy), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, iy), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35207,7 +35251,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = ny.get(e.name);
+var t = sy.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35229,28 +35273,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return ny.set(e.name, o), o;
+return sy.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Of.updateMetrics(i, c),
-Bf.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Mf.updateMetrics(i, c),
+Hf.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Nf.updateEvolutionStage(c, i, e),
-s || Nf.updateMissingStructures(c, i)), Pf.updatePosture(c), this.config.enablePheromones && !s && Of.updatePheromones(c, i),
-this.config.enableTowers && Bf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = zf.getConstructionInterval(l), d = Pf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Gf.updateEvolutionStage(c, i, e),
+s || Gf.updateMissingStructures(c, i)), Lf.updatePosture(c), this.config.enablePheromones && !s && Mf.updatePheromones(c, i),
+this.config.enableTowers && Hf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Zf.getConstructionInterval(l), d = Lf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = ay(r), n = iy(e);
+var o = cy(r), n = uy(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (zf.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (Zf.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = ay(r), n = iy(e);
+var o = cy(r), n = uy(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && ry.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && ay.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35260,7 +35304,7 @@ var f = Game.cpu.getUsed() - n;
 Ji.recordRoom(i, f), Ji.endRoom(this.roomName, n);
 } else Ji.endRoom(this.roomName, n);
 }, e;
-}(), cy = function() {
+}(), my = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35274,7 +35318,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new sy(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new ly(v.name));
 }
 } catch (t) {
 e = {
@@ -35337,7 +35381,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new sy(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new ly(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35358,9 +35402,9 @@ stack: c
 }
 }
 }, e;
-}(), uy = new cy;
+}(), dy = new my;
 
-function ly(e) {
+function py(e) {
 var t, r, o;
 if (j(e).length > 0) return ha.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
@@ -35371,14 +35415,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
 }
 
-function my(e) {
+function fy(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function dy(e, t, r) {
+function yy(e, t, r) {
 var o;
 return t === ha.CRITICAL ? {
 tickModulo: void 0,
@@ -35398,7 +35442,7 @@ tickOffset: void 0
 };
 }
 
-var py, fy = function() {
+var vy, gy = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35414,7 +35458,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = ly(n), u = my(n);
+var i = "room:".concat(o), s = Ja.getProcess(i), c = py(n), u = fy(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35433,7 +35477,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = ly(e), o = my(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = dy(e, r, a);
+var t, r = py(e), o = fy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = yy(e, r, a);
 Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35450,7 +35494,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && uy.runRoom(t);
+t && dy.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35458,7 +35502,7 @@ Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = dy(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = yy(e, t, a);
 Ja.unregisterProcess(n), Ja.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35475,7 +35519,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && uy.runRoom(t);
+t && dy.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35497,7 +35541,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = ly(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = py(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35524,7 +35568,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), yy = new fy, vy = function() {
+}(), hy = new gy, Ry = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Ja.getStatsSummary(), t = Ja.getConfig();
@@ -35601,11 +35645,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(gf(e.summary.byLayer)), "Groups: ".concat(gf(e.summary.byGroup)), "States: ".concat(gf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Ef(e.summary.byLayer)), "Groups: ".concat(Ef(e.summary.byGroup)), "States: ".concat(Ef(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(hf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(Tf)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(yf(m));
+c.push(hf(m));
 }
 } catch (e) {
 t = {
@@ -35704,7 +35748,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = ff.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = gf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35723,7 +35767,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = yy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = hy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35870,7 +35914,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), gy = function() {
+}(), Ey = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -35903,7 +35947,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), hy = function() {
+}(), Ty = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36428,7 +36472,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Ry = function() {
+}(), Cy = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36447,22 +36491,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), Ey = function() {
+}(), Sy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? hl.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? Tl.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? hl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? Tl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return hl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return Tl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ Tt({
 name: "tasks",
 description: "Show room creep task queue",
@@ -36482,21 +36526,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), Ty = ((py = {})[MOVE] = 50, py[WORK] = 100, py[CARRY] = 50, py[ATTACK] = 80,
-py[RANGED_ATTACK] = 150, py[HEAL] = 250, py[CLAIM] = 600, py[TOUGH] = 10, py);
+}(), wy = ((vy = {})[MOVE] = 50, vy[WORK] = 100, vy[CARRY] = 50, vy[ATTACK] = 80,
+vy[RANGED_ATTACK] = 150, vy[HEAL] = 250, vy[CLAIM] = 600, vy[TOUGH] = 10, vy);
 
-function Cy(e, t) {
+function xy(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, Ty), t);
+var r = o(o({}, wy), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : Ty[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : wy[t]);
 }, 0);
 }
 
-function Sy(e, t) {
+function by(e, t) {
 void 0 === t && (t = 0);
-var r = Cy(e);
+var r = xy(e);
 return {
 parts: e,
 cost: r,
@@ -36504,7 +36548,7 @@ minCapacity: t || r
 };
 }
 
-function wy() {
+function Oy() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36512,11 +36556,11 @@ return Array(o).fill(r);
 });
 }
 
-var xy, by, Oy, Ay = {
+var Ay, ky, My, Uy = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Sy([ WORK, CARRY ], 150), Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Sy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Sy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ by([ WORK, CARRY ], 150), by([ WORK, CARRY, MOVE ], 200), by([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), by([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), by([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36524,7 +36568,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Sy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Sy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ by([ WORK, CARRY, MOVE ], 200), by([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), by([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), by([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36532,7 +36576,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Sy([ WORK, CARRY, MOVE, MOVE ], 250), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ by([ WORK, CARRY, MOVE, MOVE ], 250), by([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36540,7 +36584,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Sy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Sy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ by([ WORK, CARRY, MOVE ], 200), by([ WORK, WORK, CARRY, MOVE, MOVE ], 350), by([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), by([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), by([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36548,7 +36592,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Sy([ CARRY, CARRY, MOVE, MOVE ], 200), Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Sy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ by([ CARRY, CARRY, MOVE, MOVE ], 200), by([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), by(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36556,7 +36600,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Sy([ WORK, CARRY, MOVE ], 200), Sy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ by([ WORK, CARRY, MOVE ], 200), by([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), by([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), by([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36564,7 +36608,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Sy([ WORK, CARRY, MOVE, MOVE ], 250), Sy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ by([ WORK, CARRY, MOVE, MOVE ], 250), by([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), by([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36572,7 +36616,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ by([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36580,7 +36624,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Sy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ by([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), by([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36588,7 +36632,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ by([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36596,7 +36640,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ by([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36604,7 +36648,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Sy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Sy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Sy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ by([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), by([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), by([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), by([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36612,7 +36656,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Sy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ by([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), by(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36620,7 +36664,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Sy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Sy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ by([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), by([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36628,16 +36672,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Sy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Sy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Sy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Sy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ by(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), by(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), by(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), by(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, ky = {
+}, _y = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Sy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Sy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ by([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), by([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), by([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), by([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36645,7 +36689,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Sy([ TOUGH, ATTACK, MOVE, MOVE ], 190), Sy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Sy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ by([ TOUGH, ATTACK, MOVE, MOVE ], 190), by([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), by([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36653,7 +36697,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Sy([ HEAL, MOVE, MOVE ], 350), Sy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Sy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ by([ HEAL, MOVE, MOVE ], 350), by([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), by([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), by([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36661,7 +36705,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Sy([ ATTACK, ATTACK, MOVE, MOVE ], 260), Sy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ by([ ATTACK, ATTACK, MOVE, MOVE ], 260), by([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), by([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36669,7 +36713,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Sy([ WORK, WORK, MOVE, MOVE ], 300), Sy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ by([ WORK, WORK, MOVE, MOVE ], 300), by([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), by([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36677,7 +36721,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Sy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Sy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Sy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Sy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ by([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), by([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), by([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), by([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36685,16 +36729,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Sy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Sy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Sy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ by([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), by([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), by([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, My = {
+}, Ny = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Sy(wy([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Sy(wy([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ by(Oy([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), by(Oy([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36702,16 +36746,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Sy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Sy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ by(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), by(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Uy = {
+}, Py = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Sy([ MOVE ], 50) ],
+bodies: [ by([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36719,7 +36763,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Sy([ MOVE ], 50) ],
+bodies: [ by([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36727,7 +36771,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Sy([ CLAIM, MOVE ], 650) ],
+bodies: [ by([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36735,7 +36779,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Sy([ CLAIM, MOVE ], 650), Sy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ by([ CLAIM, MOVE ], 650), by([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36743,7 +36787,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Sy([ WORK, CARRY, MOVE, MOVE ], 250), Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ by([ WORK, CARRY, MOVE, MOVE ], 250), by([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36751,30 +36795,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Sy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Sy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ by([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), by([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, _y = o(o(o(o({}, Ay), ky), Uy), My);
+}, Iy = o(o(o(o({}, Uy), _y), Py), Ny);
 
 try {
-for (var Ny = a(Object.values(_y)), Py = Ny.next(); !Py.done; Py = Ny.next()) Py.value.bodies.sort(function(e, t) {
+for (var Gy = a(Object.values(Iy)), Ly = Gy.next(); !Ly.done; Ly = Gy.next()) Ly.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-xy = {
+Ay = {
 error: e
 };
 } finally {
 try {
-Py && !Py.done && (by = Ny.return) && by.call(Ny);
+Ly && !Ly.done && (ky = Gy.return) && ky.call(Gy);
 } finally {
-if (xy) throw xy.error;
+if (Ay) throw Ay.error;
 }
 }
 
-function Iy(e) {
+function Dy(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36789,11 +36833,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Gy(o);
+return Fy(o);
 }
 
-function Gy(e) {
-var t = Cy(e);
+function Fy(e) {
+var t = xy(e);
 return {
 parts: e,
 cost: t,
@@ -36801,16 +36845,16 @@ minCapacity: t
 };
 }
 
-function Ly(e, t) {
+function By(e, t) {
 var r;
-return null !== (r = e.map(Gy).filter(function(e) {
+return null !== (r = e.map(Fy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Dy(e) {
+function Wy(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36824,7 +36868,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = Cy(a);
+var s = xy(a);
 return {
 parts: a,
 cost: s,
@@ -36849,8 +36893,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: Cy(p),
-minCapacity: Cy(p)
+cost: xy(p),
+minCapacity: xy(p)
 };
 }(e);
 
@@ -36861,7 +36905,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return Iy([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Dy([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -36882,7 +36926,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return Iy([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Dy([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -36891,13 +36935,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Gy).filter(function(e) {
+var u = n.map(Fy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Ly(n, t);
+var l = By(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -36907,7 +36951,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Ly(n, t);
+var u = By(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -36916,14 +36960,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Ly(r, t);
+var a = By(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Fy(e) {
+function Ky(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -36934,9 +36978,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function By(e, t) {
+function Hy(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Fy(t)
+memory: Ky(t)
 });
 var r;
 }
@@ -36944,9 +36988,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Oy || (Oy = {}));
+}(My || (My = {}));
 
-var Wy = function() {
+var Yy = function() {
 function e() {
 this.queues = new Map;
 }
@@ -37041,7 +37085,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = By(m, d);
+var p = Hy(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37061,7 +37105,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Oy.EMERGENCY;
+return e.priority >= My.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37079,7 +37123,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Oy.EMERGENCY ? n.emergency++ : c.priority >= Oy.HIGH ? n.high++ : c.priority >= Oy.NORMAL ? n.normal++ : n.low++;
+c.priority >= My.EMERGENCY ? n.emergency++ : c.priority >= My.HIGH ? n.high++ : c.priority >= My.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37094,14 +37138,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Ky = new Wy, Hy = {
+}(), Vy = new Yy, qy = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Yy = {
+}, jy = {
 predictConsumption: function() {
 return 0;
 },
@@ -37120,7 +37164,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Vy = {
+}, zy = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37137,44 +37181,44 @@ healers: 0,
 powerCarriers: 0
 };
 }
-}, qy = {
+}, Qy = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function jy(e, t, r, o, n) {
+function Xy(e, t, r, o, n) {
 return rc(e, t, r, o, n);
 }
 
-var zy = new Map, Qy = -1, Xy = null;
+var Zy = new Map, Jy = -1, $y = null;
 
-function Zy() {
-Qy === Game.time && Xy === Game.creeps || (zy.clear(), Qy = Game.time, Xy = Game.creeps);
+function ev() {
+Jy === Game.time && $y === Game.creeps || (Zy.clear(), Jy = Game.time, $y = Game.creeps);
 }
 
-function Jy(e) {
+function tv(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function $y(e, t) {
+function rv(e, t) {
 var r;
-void 0 === t && (t = !1), Zy();
-var o = t ? "".concat(e, "_active") : e, n = zy.get(o);
+void 0 === t && (t = !1), ev();
+var o = t ? "".concat(e, "_active") : e, n = Zy.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Jy(c);
+var u = tv(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return zy.set(o, a), a;
+return Zy.set(o, a), a;
 }
 
-function ev(e, t, r) {
+function ov(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37195,22 +37239,22 @@ if (o) throw o.error;
 return i;
 }
 
-function tv(e) {
+function nv(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var rv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var av = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function ov(e) {
-return rv.includes(e);
+function iv(e) {
+return av.includes(e);
 }
 
-function nv(e) {
+function sv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function av(e, t, r, o) {
+function cv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37223,10 +37267,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return jy(e, t, ze(r).length, o, {
-reserved: nv(r)
+if (r) return Xy(e, t, ze(r).length, o, {
+reserved: sv(r)
 }).recommendedHaulers;
-var n = jy(e, t, 2, o, {
+var n = Xy(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37237,7 +37281,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: tv
+filter: nv
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37248,7 +37292,7 @@ return 2;
 }
 }
 
-function iv(e, t) {
+function uv(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37258,13 +37302,13 @@ return null;
 }
 }
 
-function sv() {
+function lv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function cv(e) {
-var t = sv(), r = function(e) {
+function mv(e) {
+var t = lv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37276,14 +37320,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function uv(e) {
+function dv(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = sv();
+var r = lv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function lv(e) {
+function pv(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37291,11 +37335,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function mv(e) {
+function fv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function dv() {
+function yv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37305,7 +37349,7 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-function pv(e, t) {
+function vv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37317,8 +37361,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(dv()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Ky.getPendingRequests(c).some(function(r) {
+for (var i = a(yv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Vy.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37338,7 +37382,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function fv(e, t) {
+function gv(e, t) {
 var r, o, n, c = mr.getEmpire(), u = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37348,15 +37392,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !pv(e.roomName, "claim");
+return !vv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || lv(t));
+return !(!r || r.my || r.owner || r.reservation || pv(t));
 }
-return !uv(e);
+return !dv(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37375,7 +37419,7 @@ return e.roomName;
 })), !1)) : new Set;
 if (l) {
 var p = c.claimQueue.find(function(e) {
-return !e.claimed && !pv(e.roomName, "claim");
+return !e.claimed && !vv(e.roomName, "claim");
 });
 if (p) return {
 targetRoom: p.roomName,
@@ -37387,20 +37431,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = sv();
+var l = lv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !pv(p, "claim")) {
+if (!t.has(p) && !vv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || cv(y)) continue;
-if (lv(f)) continue;
+if (y.owner || mv(y)) continue;
+if (pv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !pv(p, "reserve")) return p;
-} else if (!uv(p) && !pv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !vv(p, "reserve")) return p;
+} else if (!dv(p) && !vv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37422,34 +37466,34 @@ task: "reserve"
 } : null;
 }
 
-function yv(e) {
+function hv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function vv(e) {
-return yv(e) ? Oy.EMERGENCY : Oy.HIGH;
+function Rv(e) {
+return hv(e) ? My.EMERGENCY : My.HIGH;
 }
 
-function gv(e, t, r) {
+function Ev(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!mv(e)) return !1;
+if (!fv(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function hv(e, t, r) {
+function Tv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return gv(e, t, r);
+return Ev(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = iv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = uv(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37457,18 +37501,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function Rv(e, t) {
+function Cv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !gv(n, e, t)) return null;
+if (!n || !Ev(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !mv(e);
+return !fv(e);
 }).filter(function(e) {
-return !lv(e);
+return !pv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37489,9 +37533,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(dv()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(yv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Ky.getPendingRequests(d).filter(function(t) {
+i += Vy.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37508,12 +37552,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (yv(e) ? 3 : 1);
+}(e.name) < (hv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = iv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = uv(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37521,10 +37565,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (hv(u.room, e, t) === e) return {
+if (Tv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: vv(u.room)
+priority: Rv(u.room)
 };
 }
 } catch (e) {
@@ -37541,10 +37585,10 @@ if (r) throw r.error;
 return null;
 }
 
-function Ev(e, t) {
+function Sv(e, t) {
 if (t <= 0) return null;
 try {
-var r = Dy({
+var r = Wy({
 maxEnergy: t,
 role: e
 });
@@ -37554,18 +37598,18 @@ return null;
 }
 }
 
-function Tv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : Ev(e, t);
+function wv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : Sv(e, t);
 }
 
-function Cv(e) {
+function xv(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Sv(e) {
+function bv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37579,7 +37623,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Cv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += xv(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37600,7 +37644,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Cv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += xv(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37616,23 +37660,23 @@ return i;
 }(e)) : r;
 }
 
-var wv = "defenseAssist", xv = [ "guard", "ranger", "healer" ];
+var Ov = "defenseAssist", Av = [ "guard", "ranger", "healer" ];
 
-function bv(e, t) {
+function kv(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function Ov(e, t, r, o) {
+function Mv(e, t, r, o) {
 void 0 === o && (o = Mr(e.roomName));
-var n = bv(e, t);
+var n = kv(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = Uv(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, bv(e, "guard") - i.guard),
-ranger: Math.max(0, bv(e, "ranger") - i.ranger),
-healer: Math.max(0, bv(e, "healer") - i.healer)
-}, Nv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = Pv(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, kv(e, "guard") - i.guard),
+ranger: Math.max(0, kv(e, "ranger") - i.ranger),
+healer: Math.max(0, kv(e, "healer") - i.healer)
+}, Gv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37647,7 +37691,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && Pv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Lv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37665,30 +37709,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function Av(e) {
+function Uv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function kv(e) {
+function _v(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === wv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Ov ? e.targetRoom : void 0;
 }
 
-function Mv(e, t) {
-var r = Mr(e.roomName), o = Uv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, bv(e, "guard") - o.guard),
-ranger: Math.max(0, bv(e, "ranger") - o.ranger),
-healer: Math.max(0, bv(e, "healer") - o.healer)
-}, Nv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function Nv(e, t) {
+var r = Mr(e.roomName), o = Pv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, kv(e, "guard") - o.guard),
+ranger: Math.max(0, kv(e, "ranger") - o.ranger),
+healer: Math.max(0, kv(e, "healer") - o.healer)
+}, Gv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = xv.filter(function(o) {
-return !(Ov(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = Av.filter(function(o) {
+return !(Mv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function Uv(e) {
+function Pv(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37697,7 +37741,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && kv(d) === e && u[p]++;
+Br(p) && _v(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37711,9 +37755,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Ky.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Vy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === wv && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Ov && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37729,21 +37773,21 @@ if (o) throw o.error;
 return u;
 }
 
-function _v(e, t, r) {
+function Iv(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function Nv(e) {
+function Gv(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && kv(f) === e) {
+if (Br(y) && _v(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && _v(l, y, v);
+v.length > 0 && Iv(l, y, v);
 }
 }
 } catch (e) {
@@ -37758,9 +37802,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Ky.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Vy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === wv && E.targetRoom === e) && _v(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Ov && E.targetRoom === e) && Iv(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37776,27 +37820,27 @@ if (o) throw o.error;
 return l;
 }
 
-function Pv(e) {
+function Lv(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function Iv(e, t, r) {
+function Dv(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
 }
 
-function Gv(e, t, r, o) {
+function Fv(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && Tv("guard", Sv(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && wv("guard", bv(r), o) ? 1 : 0;
 }
 
-function Lv(e, t) {
+function Bv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !Pv(o)) return null;
+if (!o || !Lv(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -37821,7 +37865,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Av);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Uv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -37829,15 +37873,15 @@ return t.roomName !== e;
 var r = Mr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(Ov(e, t, n, r), Gv(e, t, o, r))
+helperNeed: Math.max(Mv(e, t, n, r), Fv(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return Av(e.request);
+return Uv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? Uv(e)[t] : 0;
+return Br(t) ? Pv(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -37862,28 +37906,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: wv,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Oy.EMERGENCY : Oy.HIGH,
-defenseSquadId: Iv(e, r, n.createdAt),
-defenseSquadSize: Mv(r, t),
+task: Ov,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? My.EMERGENCY : My.HIGH,
+defenseSquadId: Dv(e, r, n.createdAt),
+defenseSquadSize: Nv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var Dv = "defenseRefuel", Fv = {
+var Wv = "defenseRefuel", Kv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Bv(e, t) {
+function Hv(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Fv.cost);
-}(n) ? Sv(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Kv.cost);
+}(n) ? bv(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -37920,9 +37964,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Ky.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Vy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Dv && s++;
+"hauler" === p.role && f === Wv && s++;
 }
 } catch (e) {
 o = {
@@ -37937,24 +37981,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Dv,
-priority: Oy.EMERGENCY,
-body: Fv
+task: Wv,
+priority: My.EMERGENCY,
+body: Kv
 } : null : null;
 }
 
-function Wv(e) {
+function Yv(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !cv(t.controller) && !lv(t) : !uv(e);
+return t ? !!t.controller && !mv(t.controller) && !pv(t) : !dv(e);
 }
 
-function Kv(e) {
+function Vv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !cv(t.controller) : !uv(e);
+return (null == t ? void 0 : t.controller) ? !mv(t.controller) : !dv(e);
 }
 
-function Hv(e, t, r) {
-var o = _y[t];
+function qv(e, t, r) {
+var o = Iy[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -37966,13 +38010,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Yv(e, t, r) {
+function jv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Wv(l) && ev(e, t, l) < av(e, l, t, Game.rooms[l])) return l;
+if (Yv(l) && ov(e, t, l) < cv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -37988,10 +38032,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Vv(e, t, r, o) {
+function zv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = _y[t];
+var p = Iy[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -38005,32 +38049,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = _y[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = _y[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Iy[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Iy[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, $y(e), y)) return !1;
+}(t, rv(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (ov(t)) return !("remoteWorker" === t && function(e, t) {
-Zy();
-var r = "".concat(e, ":").concat(t), o = zy.get(r);
+if (iv(t)) return !("remoteWorker" === t && function(e, t) {
+ev();
+var r = "".concat(e, ":").concat(t), o = Zy.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return zy.set(r, n), n;
-}(e, t) >= Hv(e, t, r)) && null !== Yv(e, t, r);
+return Zy.set(r, n), n;
+}(e, t) >= qv(e, t, r)) && null !== jv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Kv(R)) {
+if (Vv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -38038,7 +38082,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && ev(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && ov(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38055,9 +38099,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = $y(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== Rv(e, r);
-if (C >= Hv(e, t, r)) return !1;
+var C = null !== (u = rv(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== Cv(e, r);
+if (C >= qv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38069,14 +38113,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = iv(e, o);
+var a = uv(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== fv(0, r);
+if ("claimer" === t) return null !== gv(0, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38112,7 +38156,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Hy.getActiveRequests) || void 0 === m ? void 0 : m.call(Hy)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = qy.getActiveRequests) || void 0 === m ? void 0 : m.call(qy)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38140,16 +38184,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function qv(e) {
+function Qv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function jv(e) {
-return 0 === qv($y(e, !0));
+function Xv(e) {
+return 0 === Qv(rv(e, !0));
 }
 
-function zv(e) {
+function Zv(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -38172,14 +38216,14 @@ minCount: 1
 } ];
 }
 
-function Qv(e, t) {
-var r, o, n, i, s = $y(e, !0);
-if (0 === qv(s)) return !0;
+function Jv(e, t) {
+var r, o, n, i, s = rv(e, !0);
+if (0 === Qv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = $y(e, !1), u = zv(t);
+var c = rv(e, !1), u = Zv(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38199,57 +38243,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function Xv(e) {
+function $v(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Zv(e, t, r) {
-var n = Hv(e.name, r.roleName, t);
+function eg(e, t, r) {
+var n = qv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Jv(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Oy.EMERGENCY;
+function tg(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return My.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Oy.HIGH;
-if (qy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return My.HIGH;
+if (Qy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Oy.EMERGENCY;
-if (a > 0) return Oy.HIGH;
+if (a >= 100) return My.EMERGENCY;
+if (a > 0) return My.HIGH;
 }
 return function(e) {
-return e >= 90 ? Oy.HIGH : e >= 60 ? Oy.NORMAL : Oy.LOW;
+return e >= 90 ? My.HIGH : e >= 60 ? My.NORMAL : My.LOW;
 }(o);
 }
 
-function $v(e, t) {
+function rg(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-Xv(e);
-var l = $y(e.name), m = jv(e.name), d = [];
-if (Qv(e.name, e)) {
+$v(e);
+var l = rv(e.name), m = Xv(e.name), d = [];
+if (Jv(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === qv($y(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Qv(rv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = $y(e, !1), c = zv(t);
+var s = rv(e, !1), c = Zv(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38264,7 +38308,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Vv(e, m.role, r, !0);
+var p = zv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38295,17 +38339,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = _y[p]) && Vv(e.name, p, t, !0) ? (d.push(Zv(e, t, {
+return p && (g = Iy[p]) && zv(e.name, p, t, !0) ? (d.push(eg(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: Jv(e, 0, p, g.priority, m),
+priority: tg(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(_y)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Bv(e.name, p);
+for (var f = a(Object.entries(Iy)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Hv(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38316,7 +38360,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Lv(e.name, p);
+var E = Bv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38330,8 +38374,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Vv(e.name, p, t, m)) {
-var T = ov(p), C = T ? Yv(e.name, p, t) : null, S = "claimer" === p ? fv(e.name, t) : null, w = "pioneer" === p ? Rv(e.name, t) : null;
+}); else if (zv(e.name, p, t, m)) {
+var T = iv(p), C = T ? jv(e.name, p, t) : null, S = "claimer" === p ? gv(e.name, t) : null, w = "pioneer" === p ? Cv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38341,11 +38385,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(Zv(e, t, {
+}) : d.push(eg(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: Jv(e, 0, p, g.priority, m),
+priority: tg(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38367,7 +38411,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = eg(e, l.value);
+var m = og(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38388,10 +38432,10 @@ requests: c
 };
 }
 
-function eg(e, t) {
+function og(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Yy.getMaxAffordableInTicks(e, l), d = Sv(e), p = t.priority >= Oy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Oy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : Tv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = jy.getMaxAffordableInTicks(e, l), d = bv(e), p = t.priority >= My.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= My.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : wv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38412,7 +38456,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : Dy({
+}(t.def, p)) && void 0 !== c ? c : Wy({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38448,44 +38492,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var tg = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), rg = new Set([ "guard", "ranger", "healer" ]);
+var ng = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), ag = new Set([ "guard", "ranger", "healer" ]);
 
-function og() {
+function ig() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function ng(e) {
+function sg(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function ag(e) {
+function cg(e) {
 var t;
-return e.priority >= Oy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= My.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function ig(e) {
+function ug(e) {
 var t;
-return e.priority >= Oy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= My.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function sg(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Sv(e), m = r.urgency >= 2 || t.danger >= 3 ? Oy.EMERGENCY : Oy.HIGH, d = kr(j(e)), p = function(e) {
+function lg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = bv(e), m = r.urgency >= 2 || t.danger >= 3 ? My.EMERGENCY : My.HIGH, d = kr(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === Oy.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === My.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Ky.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Vy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || cg(u, e) && ("guard" === u.role && (n.guards++,
-lg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, lg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, lg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || mg(u, e) && ("guard" === u.role && (n.guards++,
+pg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, pg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, pg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38513,7 +38557,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && lg(n, u, l);
+0 !== l.length && pg(n, u, l);
 }
 }
 }
@@ -38552,26 +38596,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : ug("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) mg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : ug("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) mg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : ug("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) mg(e, "healer", "military", Oy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : dg("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) fg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : dg("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) fg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : dg("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) fg(e, "healer", "military", My.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < Oy.EMERGENCY || function(e, t) {
+if (!(t < My.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !rg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !ag.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Ky.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Vy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Oy.EMERGENCY || rg.has(c.role) && cg(c, e.name) && c.body.cost <= t && n++;
+c.priority < My.EMERGENCY || ag.has(c.role) && mg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38588,7 +38632,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = Ev(t, e);
+var r = Sv(t, e);
 return r ? {
 role: t,
 body: r
@@ -38603,38 +38647,38 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && mg(e, n.role, "military", Oy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && fg(e, n.role, "military", My.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function cg(e, t) {
+function mg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function ug(e, t, r) {
+function dg(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function lg(e, t, r) {
+function pg(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function mg(e, t, r, o, n, a, i) {
+function fg(e, t, r, o, n, a, i) {
 void 0 === i && (i = null);
 try {
-var s = null != i ? i : Dy({
+var s = null != i ? i : Wy({
 maxEnergy: n,
 role: t
 });
 if (s.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(s.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Ky.addRequest({
+Vy.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38650,34 +38694,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function dg(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Oy.HIGH) return !1;
+function yg(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= My.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Oy.NORMAL) {
-if (Yy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < My.NORMAL) {
+if (jy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Oy.NORMAL && o / e.energyCapacityAvailable < .3 && Yy.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === My.NORMAL && o / e.energyCapacityAvailable < .3 && jy.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function pg(e, t) {
+function vg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Xv(e);
-var s = Ky.getQueueSize(e.name);
+$v(e);
+var s = Vy.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Qv(e.name, e), u = jv(e.name) && !Ky.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = Jv(e.name, e), u = Xv(e.name) && !Vy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && Ky.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && sg(e, t, l, m);
+s > 0 && Vy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && lg(e, t, l, m);
 try {
-for (var d = a($v(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(rg(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Ky.addRequest(f);
+Vy.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38690,7 +38734,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && sg(e, t, l, m), s > 0 && !u) !function(e, t) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && lg(e, t, l, m), s > 0 && !u) !function(e, t) {
 var r, o, n, i = function() {
 var e, t, r, o = Memory;
 return null !== (e = o.spawnPipeline) && void 0 !== e || (o.spawnPipeline = {}),
@@ -38699,13 +38743,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Ky.getPendingRequests(e.name).map(ng));
+var c = new Set(Vy.getPendingRequests(e.name).map(sg));
 try {
-for (var u = a($v(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Oy.HIGH, p = "claimer" === m.role && og(), f = ag(m), y = ig(m);
-if (tg.has(m.role) || d || p || f || y) {
-var v = ng(m);
-c.has(v) || (Ky.addRequest(m), c.add(v));
+for (var u = a(rg(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= My.HIGH, p = "claimer" === m.role && ig(), f = cg(m), y = ug(m);
+if (ng.has(m.role) || d || p || f || y) {
+var v = sg(m);
+c.has(v) || (Vy.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38722,19 +38766,19 @@ if (r) throw r.error;
 }
 }(e, t); else {
 !function(e) {
-var t = Vy.requestSpawns(e.name);
+var t = zy.requestSpawns(e.name);
 if (0 !== t.powerHarvesters || 0 !== t.healers || 0 !== t.powerCarriers) {
-for (var r = e.energyCapacityAvailable, o = Oy.NORMAL, n = 0; n < t.powerHarvesters; n++) mg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.healers; n++) mg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
-for (n = 0; n < t.powerCarriers; n++) mg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
+for (var r = e.energyCapacityAvailable, o = My.NORMAL, n = 0; n < t.powerHarvesters; n++) fg(e, "powerHarvester", "power", o, r, "powerHarvester_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.healers; n++) fg(e, "healer", "military", o, r, "healer_powerBank_".concat(Game.time, "_").concat(n));
+for (n = 0; n < t.powerCarriers; n++) fg(e, "powerCarrier", "power", o, r, "powerCarrier_".concat(Game.time, "_").concat(n));
 U.info("Added power bank spawn requests: ".concat(t.powerHarvesters, " harvesters, ").concat(t.healers, " healers, ").concat(t.powerCarriers, " carriers"), {
 subsystem: "SpawnPipeline"
 });
 }
 }(e);
 try {
-for (var y = a($v(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Ky.addRequest(f);
+for (var y = a(rg(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Vy.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38746,32 +38790,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Ky.getQueueStats(e.name);
+var g = Vy.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Ky.clearQueue(e.name);
+} else s > 0 && Vy.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Ky.getAvailableSpawns(e.name);
+var t, r, o = Vy.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Sv(e);
+var n = 0, i = bv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Ky.getNextRequest(e.name, i);
+var u = c.value, l = Vy.getNextRequest(e.name, i);
 if (!l) break;
-if (dg(e, l, i)) {
+if (yg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = By(u, l);
-m === OK ? (n++, i -= l.body.cost, Ky.markInProgress(e.name, l.id, u.id), Ky.removeRequest(e.name, l.id),
+var m = Hy(u, l);
+m === OK ? (n++, i -= l.body.cost, Vy.markInProgress(e.name, l.id, u.id), Vy.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Ky.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Vy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -38787,7 +38831,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Ky.getQueueStats(e.name);
+}(e), o = Vy.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -38801,7 +38845,7 @@ stats: o
 }(e, t);
 }
 
-var fg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, yg = /^(\d{1,2})\|(.+)$/, vg = k("SS2TerminalComms"), gg = function() {
+var gg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, hg = /^(\d{1,2})\|(.+)$/, Rg = k("SS2TerminalComms"), Eg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -38861,11 +38905,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(fg);
+var t = e.match(gg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(yg);
+var i = a.match(hg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -38900,7 +38944,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-vg.warn("Missing packet in multi-packet message", {
+Rg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -38916,7 +38960,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), vg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), Rg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -38940,7 +38984,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && vg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && Rg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -38952,7 +38996,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return vg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return Rg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -38960,14 +39004,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), vg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), Rg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (vg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (Rg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -38992,7 +39036,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-vg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+Rg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -39004,7 +39048,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-vg.info("Completed sending multi-packet message", {
+Rg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -39012,25 +39056,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? vg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? Rg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (vg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (Rg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else vg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else Rg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else vg.warn("Terminal not found for queue item, removing from queue", {
+} else Rg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39064,7 +39108,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && vg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && Rg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39074,7 +39118,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-vg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+Rg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39165,7 +39209,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (vg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (Rg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39187,7 +39231,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return vg.error("Error parsing JSON", {
+return Rg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39198,7 +39242,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), hg = [ {
+}(), Tg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39218,7 +39262,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Rg = function() {
+} ], Cg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39265,9 +39309,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), Eg = new Rg;
+}(), Sg = new Cg;
 
-function Tg(e) {
+function wg(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39275,19 +39319,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function Cg(e, t) {
+function xg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Sg(e, t) {
+function bg(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var wg = {
+var Og = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39298,9 +39342,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, xg = function() {
+}, Ag = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, wg), e);
+void 0 === e && (e = {}), this.config = o(o({}, Og), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39321,7 +39365,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = Eg.getSwarmState(r.toRoom);
+var o = Sg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39334,7 +39378,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = Eg.getSwarmState(c);
+var l = Sg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39404,9 +39448,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(Cg), u = n.filter(function(e) {
+}).sort(xg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Sg), l = [], m = [], d = function(t) {
+}).sort(bg), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39428,11 +39472,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return Tg({
+return wg({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + Tg({
+}) + wg({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39531,7 +39575,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), bg = new xg, Og = {
+}(), kg = new Ag, Mg = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39552,14 +39596,14 @@ siegeUnits: 1
 }
 };
 
-function Ag(e) {
+function Ug(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function kg(e) {
+function _g(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39582,9 +39626,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function Mg(e) {
+function Ng(e) {
 var t, r, o;
-kg(e);
+_g(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39608,20 +39652,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Ug(e) {
+function Pg(e) {
 var t;
-kg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Mg(e);
+_g(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Ng(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function _g(e) {
-return !!Ug(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function Ig(e) {
+return !!Pg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-kg(e);
+_g(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39632,12 +39676,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = Mg(e);
+var d = Ng(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function Ng(e, t) {
+function Gg(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39658,20 +39702,20 @@ if (r) throw r.error;
 return n;
 }
 
-function Pg(e, t) {
+function Lg(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Og[r]) && void 0 !== t ? t : Og[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Mg[r]) && void 0 !== t ? t : Mg[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Ng(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Gg(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: Ag(r),
+targetComposition: Ug(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39683,7 +39727,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function Ig(e) {
+function Dg(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39703,9 +39747,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function Gg(e) {
+function Fg(e) {
 var t = e.members.length;
-kg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+_g(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39719,7 +39763,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && _g(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && Ig(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39748,7 +39792,7 @@ subsystem: "Squad"
 }
 }
 
-var Lg = {
+var Bg = {
 harassment: {
 composition: {
 harassers: 3,
@@ -39835,7 +39879,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Dg(e, t) {
+function Wg(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -39850,8 +39894,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Fg(e, t) {
-var r, o, n, i = Lg[t], s = 0;
+function Kg(e, t) {
+var r, o, n, i = Bg[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -39877,7 +39921,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Bg, Wg, Kg, Hg = {
+var Hg, Yg, Vg, qg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -39886,11 +39930,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Yg = new Map;
+}, jg = new Map;
 
-function Vg(e, t) {
+function zg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Yg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (jg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -39902,7 +39946,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Lg[p].composition;
+d = Bg[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -39917,19 +39961,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Yg.set(m, y), function(e, t, r, o) {
+v ? (jg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Lg[s].useBoosts;
+i = Bg[s].useBoosts;
 }
-var c = Oy.NORMAL;
-"siege" === t.type ? c = Oy.HIGH : "defense" === t.type && (c = Oy.EMERGENCY);
+var c = My.NORMAL;
+"siege" === t.type ? c = My.HIGH : "defense" === t.type && (c = My.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = qg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Hg[t];
-}, 0), m = i ? zg(r) : [], d = {
+var u = Qg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + qg[t];
+}, 0), m = i ? Zg(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -39958,7 +40002,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Ky.addRequest(d), o.spawnRequests.add(d.id);
+Vy.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -39972,42 +40016,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function qg(e, t, r) {
+function Qg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return jg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return Xg([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return jg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Xg([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return jg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Xg([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return jg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return Xg([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return jg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return Xg([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return jg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return Xg([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function jg(e, t, r) {
+function Xg(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Hg[t];
+return e + qg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Hg[t];
+return e + qg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function zg(e) {
+function Zg(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40038,45 +40082,45 @@ return [];
 }
 }
 
-function Qg(e) {
-return Yg.has(e);
+function Jg(e) {
+return jg.has(e);
 }
 
-function Xg(e) {
-return Ug(e) || _g(e);
+function $g(e) {
+return Pg(e) || Ig(e);
 }
 
-(Bg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Bg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Bg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Wg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Wg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Wg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Wg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Kg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Kg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Kg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Kg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Kg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(Hg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Hg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Hg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Yg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Yg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Yg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Yg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Vg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Vg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Vg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Vg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Vg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var Zg = {
+var eh = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Jg(e, t) {
-var r = Zg[t], o = Eg.getClusters();
+function th(e, t) {
+var r = eh[t], o = Sg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function $g(e, t, r) {
+function rh(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = Eg.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = Sg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Jg(e, i.danger),
+reservedEnergy: th(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40166,7 +40210,7 @@ success: !1
 });
 }
 
-var eh = {
+var oh = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40176,7 +40220,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function th(e, t, r) {
+function nh(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40207,7 +40251,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function rh(e, t, r, o) {
+function ah(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40217,7 +40261,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function oh(e, t) {
+function ih(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40238,19 +40282,19 @@ if (r) throw r.error;
 return n;
 }
 
-function nh() {
-var e = Eg.getEmpire();
+function sh() {
+var e = Sg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function ah(e) {
-nh()[e.id] = e;
+function ch(e) {
+sh()[e.id] = e;
 }
 
-function ih(e) {
+function uh(e) {
 e.lastUpdate = Game.time;
-var t = Eg.getCluster(e.clusterId);
-if (!t) return e.state = "failed", ah(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = Sg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", ch(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40260,12 +40304,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (Xg(r) || Qg(e) || Vg(0, r), Xg(r));
+return !!r && ($g(r) || Jg(e) || zg(0, r), $g(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), ah(e);
+})), ch(e);
 }(e, t);
 break;
 
@@ -40276,7 +40320,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (Gg(o), Ig(o)) {
+if (Fg(o), Dg(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40305,7 +40349,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = Eg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = Sg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40332,14 +40376,14 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), ah(e);
+})), ch(e);
 }(e, t);
 }
 }
 
-var sh = "defenseAssist";
+var lh = "defenseAssist";
 
-function ch(e, t, r) {
+function mh(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40358,11 +40402,11 @@ score: n.score + o.score
 }
 }
 
-function uh(e, t, r) {
+function dh(e, t, r) {
 return Gr(e, t, r);
 }
 
-function lh(e, t) {
+function ph(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40375,11 +40419,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function mh(e) {
+function fh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function dh(e, t, r) {
+function yh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40392,8 +40436,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function ph(e, t, r) {
-var o = uh(t, e.energyCapacityAvailable, r);
+function vh(e, t, r) {
+var o = dh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40401,16 +40445,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function fh(e, t, r, o) {
+function gh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = ph(e, t, o);
-if (s !== ph(n, t, o)) return s ? -1 : 1;
+var a, i, s = vh(e, t, o);
+if (s !== vh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function yh(e, t) {
+function hh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40494,25 +40538,25 @@ if (r) throw r.error;
 return u;
 }
 
-function vh(e, t) {
+function Rh(e, t) {
 return {
-guard: Math.max(0, lh(e, "guard") - t.counts.guard),
-ranger: Math.max(0, lh(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, lh(e, "healer") - t.counts.healer)
+guard: Math.max(0, ph(e, "guard") - t.counts.guard),
+ranger: Math.max(0, ph(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, ph(e, "healer") - t.counts.healer)
 };
 }
 
-function gh(e, t, r) {
+function Eh(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function hh(e) {
+function Th(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function Rh(e, t) {
+function Ch(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return hh(e.role);
+return Th(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40525,12 +40569,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function Eh(e) {
+function Sh(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === sh ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === lh ? e.targetRoom : void 0;
 }
 
-function Th(e) {
+function wh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40542,7 +40586,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-hh(m) && Eh(l) === e && !u.spawning && ch(i, m, u.body.filter(function(e) {
+Th(m) && Sh(l) === e && !u.spawning && mh(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40560,7 +40604,7 @@ if (t) throw t.error;
 return i;
 }
 
-function Ch(e, t, r) {
+function xh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40590,16 +40634,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: Rh(e, r)
+pendingAssist: Ch(e, r)
 };
 }
 }
 
-function Sh(e, t) {
+function bh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = uh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = dh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40620,7 +40664,7 @@ subsystem: "Cluster"
 }
 }
 
-function wh(e, t, r) {
+function Oh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40662,20 +40706,20 @@ exitAccess: a
 };
 }
 
-function xh(e, t) {
+function Ah(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function bh(e, t, r) {
+function kh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function Oh(e) {
+function Mh(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function Ah(e, t) {
+function Uh(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40686,7 +40730,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function kh(e, t, r) {
+function _h(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40697,8 +40741,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = Oh(g);
-h && (g.assistTarget || Ah(v, h) && (t.assignedCreeps.includes(v.name) || xh(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = Mh(g);
+h && (g.assistTarget || Uh(v, h) && (t.assignedCreeps.includes(v.name) || Ah(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40735,7 +40779,7 @@ return e.distance - t.distance;
 });
 }
 
-function Mh(e, t) {
+function Nh(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40760,21 +40804,21 @@ if (r) throw r.error;
 return i;
 }
 
-function Uh(e) {
+function Ph(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var _h = {
+var Ih = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, Nh = function() {
+}, Gh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, _h), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Ih), e);
 }
 return e.prototype.run = function() {
-var e = Eg.getClusters();
+var e = Sg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -40793,7 +40837,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: hg.map(function(t) {
+steps: Tg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -40854,7 +40898,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-bg.processCluster(t);
+kg.processCluster(t);
 break;
 
 case "squads":
@@ -40886,7 +40930,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = wh(e, new RoomPosition(s, c, e.name), "defense");
+var u = Oh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -40935,9 +40979,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = Eg.getSwarmState(i);
+var i = n.value, s = Sg.getSwarmState(i);
 if (s) {
-var c = Jg(i, s.danger);
+var c = th(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -40968,7 +41012,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = Eg.getSwarmState(m);
+var m = l.value, d = Sg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -41000,7 +41044,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += Uh(l.controller.level));
+}).length, i += Ph(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41117,7 +41161,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Gg(i), "gathering" !== i.state || Xg(i) || Qg(i.id) || Vg(0, i), Ig(i) && (i.state = "dissolving");
+Fg(i), "gathering" !== i.state || $g(i) || Jg(i.id) || zg(0, i), Dg(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41142,7 +41186,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Pg(e, s);
+var s = i.value, c = Lg(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41159,7 +41203,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(nh()).filter(function(e) {
+var t = (a = e.id, Object.values(sh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41170,22 +41214,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, eh), n), m = [], d = Eg.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, oh), n), m = [], d = Sg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = th(f, y, d);
+var g = nh(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = oh(e, f);
+var h = ih(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = rh(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = ah(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Dg(f, {
+var C = Wg(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41220,29 +41264,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Fg(e, n.doctrine) ? function(e, t, r) {
+Kg(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = Eg.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = Sg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = th(e, o, r);
+var n = nh(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (Eg.getEmpire().knownRooms || {})[t], n = null != r ? r : Dg(t, {
+var o = (Sg.getEmpire().knownRooms || {})[t], n = null != r ? r : Wg(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Fg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Kg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41255,7 +41299,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-ah(i);
+ch(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41269,13 +41313,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Ng(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Gg(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: Ag(n),
+targetComposition: Ug(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41290,8 +41334,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), ah(i), Vg(0, c), i.state = "forming", i.lastUpdate = Game.time,
-ah(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), ch(i), zg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+ch(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41310,11 +41354,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Yg.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(jg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Yg.delete(c));
+}), jg.delete(c));
 }
 } catch (t) {
 e = {
@@ -41328,10 +41372,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = nh();
-for (var t in e) ih(e[t]);
+var e = sh();
+for (var t in e) uh(e[t]);
 !function() {
-var e = nh();
+var e = sh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41409,14 +41453,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = Eg.getCluster(t, e);
+var t = "cluster_".concat(e), r = Sg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = Eg.getCluster(e);
+var o = Sg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41445,7 +41489,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && $g(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && rh(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41462,7 +41506,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = Eg.getSwarmState(t);
+var n, a, i = Sg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41503,7 +41547,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mr(g), f[g] = Th(g);
+p[g] = Mr(g), f[g] = wh(g);
 }
 } catch (e) {
 r = {
@@ -41519,7 +41563,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = Ch(E, m, t);
+d[E] = xh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41538,13 +41582,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = dh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = yh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = yh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = hh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, vh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, Rh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = fh(h, b, g.roomName, R), k = 0; k < O; k++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = gh(h, b, g.roomName, R), k = 0; k < O; k++) {
 var M = A.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41556,13 +41600,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").con
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: mh(g.urgency),
+priority: fh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: sh,
-defenseSquadId: gh(M.roomName, g.roomName, e.now),
+task: lh,
+defenseSquadId: Eh(M.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41602,7 +41646,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) Sh(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) bh(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41617,7 +41661,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Ky);
+}(e, Vy);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41629,7 +41673,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = Mh(f, kh(e, f, t)), v = y.reduce(function(e, t) {
+var y = Nh(f, _h(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41640,7 +41684,7 @@ var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v
 E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
 E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
 E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-bh(f, R.role, xh(f, R.role) - 1), l.push({
+kh(f, R.role, Ah(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41707,28 +41751,28 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Ph = new Nh, Ih = /^([WE])(\d+)([NS])(\d+)$/;
+}(), Lh = new Gh, Dh = /^([WE])(\d+)([NS])(\d+)$/;
 
-function Gh(e) {
-return Ih.test(e);
+function Fh(e) {
+return Dh.test(e);
 }
 
-var Lh = {
+var Bh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Dh = function() {
+}, Wh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Lh), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Bh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
 var e = InterShardMemory.getLocal();
 if (e) {
-var t = Mp(e);
+var t = Np(e);
 if (t) {
 this.updateEnemyIntelligence(t);
-var r = kp(t);
+var r = _p(t);
 InterShardMemory.setLocal(r);
 }
 }
@@ -41794,7 +41838,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (Gh(x)) {
+if (e.isAlly(x)) f.add(x); else if (Fh(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -41862,7 +41906,7 @@ subsystem: "CrossShardIntel"
 }, e.prototype.getGlobalEnemies = function() {
 var e = InterShardMemory.getLocal();
 if (!e) return [];
-var t = Mp(e);
+var t = Np(e);
 return t && t.globalTargets.enemies || [];
 }, n([ Oi("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: ha.LOW,
@@ -41870,7 +41914,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Fh = new Dh, Bh = function() {
+}(), Kh = new Wh, Hh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -41947,9 +41991,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), Wh = new Bh, Kh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), Yh = new Hh, Vh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Hh(e, t) {
+function qh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -41972,13 +42016,13 @@ if (r) throw r.error;
 return n;
 }
 
-function Yh(e) {
+function jh(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function Vh(e, t, r) {
-if (!Yh(e)) return 0;
-var o = Hh(e.name, t);
+function zh(e, t, r) {
+if (!jh(e)) return 0;
+var o = qh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += oc(e.mineralType),
@@ -41987,7 +42031,7 @@ n += sc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += uc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function qh(e, t) {
+function Qh(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -41997,13 +42041,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Kh.has(e.type);
+return e.hits > 0 && Vh.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function jh(e, t, r) {
+function Xh(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -42013,7 +42057,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function zh(e) {
+function Zh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42024,8 +42068,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function Qh(e) {
-var t = zh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function Jh(e) {
+var t = Zh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42044,14 +42088,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var Xh = {
+var $h = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, Zh = function() {
+}, eR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Xh), e);
+void 0 === e && (e = {}), this.config = o(o({}, $h), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42142,7 +42186,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = zh(e);
+var t = Zh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42154,14 +42198,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return Qh(Jh(e));
+return Jh(tR(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = Qh(Jh(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = Jh(tR(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function Jh(e) {
+function tR(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42193,11 +42237,11 @@ swamps: d
 };
 }
 
-var $h = new Zh, eR = /^([WE])(\d+)([NS])(\d+)$/, tR = {
+var rR = new eR, oR = /^([WE])(\d+)([NS])(\d+)$/, nR = {
 allies: []
-}, rR = function() {
+}, aR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, tR), e);
+void 0 === e && (e = {}), this.config = o(o({}, nR), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42217,7 +42261,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!eR.test(e)) return !1;
+if (!oR.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42325,7 +42369,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return eR.test(e);
+return oR.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42352,7 +42396,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), oR = new rR, nR = {
+}(), iR = new aR, sR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42365,9 +42409,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, aR = function() {
+}, cR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, nR), e);
+void 0 === e && (e = {}), this.config = o(o({}, sR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42380,7 +42424,7 @@ t.updateExpansionQueue(o);
 }), Ji.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Ji.measureSubsystem("empire:warTargets", function() {
-oR.updateWarTargets(o);
+iR.updateWarTargets(o);
 }), Ji.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Ji.measureSubsystem("empire:gclTracking", function() {
@@ -42388,13 +42432,13 @@ t.trackGCLProgress(o);
 }), s && Ji.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Ji.measureSubsystem("empire:intelRefresh", function() {
-$h.refreshRoomIntel(o);
+rR.refreshRoomIntel(o);
 }), Ji.measureSubsystem("empire:roomDiscovery", function() {
-$h.discoverNearbyRooms(o);
+rR.discoverNearbyRooms(o);
 })), s && Ji.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Ji.measureSubsystem("empire:clusterHealth", function() {
-Wh.monitorClusterHealth();
+Yh.monitorClusterHealth();
 }), Ji.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42477,22 +42521,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = qh(f, u);
+var y = Boolean(Game.rooms[f]), v = Qh(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = Hh(f, t);
+var g = qh(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = jh(h, u, y);
+var h = e.knownRooms[f], R = Xh(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? Vh(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? zh(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42536,10 +42580,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && Yh(a)) {
-var i = Hh(a.name, t);
+if (a && jh(a)) {
+var i = qh(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = Vh(a, t, r);
+var s = zh(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -42859,13 +42903,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), iR = new aR;
+}(), uR = new cR;
 
-function sR(e) {
+function lR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var cR = {
+var mR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -42873,10 +42917,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, uR = function() {
+}, dR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, cR), e);
+this.config = o(o({}, mR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -43020,7 +43064,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, sR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, lR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43195,7 +43239,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), lR = new uR, mR = function() {
+}(), pR = new dR, fR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new ec(o(o({}, Bs), e), {
 getEmpire: function() {
@@ -43231,7 +43275,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), dR = new mR, pR = function() {
+}(), yR = new fR, vR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -43249,9 +43293,9 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), fR = new (function(e) {
+}(), gR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new pR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new vR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43263,22 +43307,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
 }(Ii));
 
-function yR() {
+function hR() {
 return global;
 }
 
-function vR(e) {
+function RR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function gR(e) {
+function ER(e) {
 return Number(null != e ? e : 0);
 }
 
-var hR = function() {
+var TR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = yR();
+var e = hR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43286,12 +43330,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return yR()._pixelGenerationMemory;
+return hR()._pixelGenerationMemory;
 }, e;
-}(), RR = function(e) {
+}(), CR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new hR) || this;
+var r = e.call(this, t, new TR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43308,7 +43352,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(vR).length : Object.values(null != t ? t : {}).filter(vR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(RR).length : Object.values(null != t ? t : {}).filter(RR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43319,9 +43363,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (gR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (gR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = gR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = gR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (ER(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (ER(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = ER(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = ER(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43343,9 +43387,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Li), ER = new RR;
+}(Li), SR = new CR;
 
-function TR(e, t) {
+function wR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -43367,7 +43411,7 @@ lost: !1
 };
 }
 
-function CR(e, t, r) {
+function xR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43381,20 +43425,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var SR = Ue().cpu.bucketThresholds.highMode + 1800, wR = {
+var bR = Ue().cpu.bucketThresholds.highMode + 1800, OR = {
 updateInterval: 250,
-minBucket: SR,
+minBucket: bR,
 maxSitesPerRemotePerTick: 2
 };
 
-function xR(e, t) {
+function AR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var bR = function() {
+var kR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, wR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, OR), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43411,8 +43455,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = TR(l);
-m.lost && m.reason && CR(e, u, m.reason);
+var m = wR(l);
+m.lost && m.reason && xR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43430,10 +43474,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = xR("remoteInfrastructure.intent", function() {
+var i = AR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-xR("remoteInfrastructure.execute", function() {
+AR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43599,13 +43643,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = xR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = AR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = xR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = AR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43638,7 +43682,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = xR("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = AR("remoteInfrastructure.calculateRemoteRoads", function() {
 return xn(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43667,14 +43711,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = xR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = AR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? xR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? AR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43691,7 +43735,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? xR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? AR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43709,7 +43753,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return xR("remoteInfrastructure.findSources", function() {
+return AR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -43806,10 +43850,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: ha.LOW,
 interval: 1e3,
-minBucket: SR,
+minBucket: bR,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), OR = new bR, AR = new (function(e) {
+}(), MR = new kR, UR = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -43821,7 +43865,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Lp)), kR = function() {
+}(Bp)), _R = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -43865,7 +43909,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Of.applyDiffusion(o);
+Mf.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -43874,7 +43918,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-gu.initialize(i.name);
+Eu.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -43911,7 +43955,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ki() ], e);
-}(), MR = new kR, UR = new (function() {
+}(), NR = new _R, PR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -43958,7 +44002,7 @@ if (e) throw e.error;
 Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(MR, Ns, Ds, ls, iR, vc, lR, OR, As, fR, ER, dR, qc, Zc, AR, Fh, Bc, Ph, za, Pa),
+}(NR, Ns, Ds, ls, uR, vc, pR, MR, As, gR, SR, yR, Qc, eu, UR, Kh, Hc, Lh, za, Pa),
 function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -44025,9 +44069,9 @@ if (e) throw e.error;
 subsystem: "ProcessRegistry"
 });
 }
-}), _R = "_ownedRooms", NR = "_ownedRoomsTick";
+}), IR = "_ownedRooms", GR = "_ownedRoomsTick";
 
-function PR(e) {
+function LR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44037,13 +44081,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var IR = Ei("NativeCallsTracker");
+var DR = Ei("NativeCallsTracker");
 
-function GR(e, t, r) {
+function FR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) IR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) DR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44059,7 +44103,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-IR.warn("Failed to wrap method", {
+DR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44069,30 +44113,30 @@ error: String(e)
 }
 }
 
-var LR, DR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], FR = "shard1", BR = {
+var BR, WR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], KR = "shard1", HR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, WR = {
+}, YR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, KR = {
+}, VR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function HR() {
+function qR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function YR() {
+function jR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: DR,
+targetShards: WR,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44102,11 +44146,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = DR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = WR),
 Memory.interShardOperation;
 }
 
-function VR() {
+function zR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -44121,7 +44165,7 @@ lastSync: 0,
 checksum: 0
 };
 var t = InterShardMemory.getLocal();
-return t && null !== (e = Mp(t)) && void 0 !== e ? e : {
+return t && null !== (e = Np(t)) && void 0 !== e ? e : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -44147,33 +44191,33 @@ checksum: 0
 }
 }
 
-function qR(e) {
+function QR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
-InterShardMemory.setLocal(kp(e));
+InterShardMemory.setLocal(_p(e));
 } catch (e) {}
 }
 
-function jR() {
-var e, t, r, o, n, i, s, c = VR(), u = HR();
+function XR() {
+var e, t, r, o, n, i, s, c = zR(), u = qR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: DR,
+targetShards: WR,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : DR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : WR,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && zR() ? "established" : "unreached",
+status: p === u && ZR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44191,7 +44235,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === FR ? "core" : "frontier",
+role: u === KR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44208,24 +44252,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), qR(c), c.footprintOperation;
+}), QR(c), c.footprintOperation;
 }
 
-function zR() {
+function ZR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function QR() {
+function JR() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function XR(e, t) {
+function $R(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44244,9 +44288,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(QR()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(JR()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Ky.getPendingRequests(p.name).filter(function(r) {
+s += Vy.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44265,7 +44309,7 @@ if (n) throw n.error;
 return s;
 }
 
-function ZR(e) {
+function eE(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44309,7 +44353,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = VR().shards[HR()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = zR().shards[qR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44319,8 +44363,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function JR(e, t) {
-if (!(XR("scout", t) >= 1)) {
+function tE(e, t) {
+if (!($R("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44358,13 +44402,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Ky.addRequest({
+r && Vy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: KR,
-priority: Oy.LOW + 5,
+body: VR,
+priority: My.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44375,14 +44419,14 @@ task: "interShardPortalScout"
 }
 }
 
-function $R(e, t, r) {
-XR("interShardClaimer", t) >= 1 || Ky.addRequest({
+function rE(e, t, r) {
+$R("interShardClaimer", t) >= 1 || Vy.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: BR,
-priority: Oy.NORMAL + 50,
+body: HR,
+priority: My.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44395,14 +44439,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function eE(e, t, r) {
-XR("interShardScout", t) >= 1 || Ky.addRequest({
+function oE(e, t, r) {
+$R("interShardScout", t) >= 1 || Vy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: KR,
-priority: Oy.NORMAL,
+body: VR,
+priority: My.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44415,15 +44459,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function tE(e, t, r) {
+function nE(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (XR("interShardPioneer", t.shard) >= 3 || Ky.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && ($R("interShardPioneer", t.shard) >= 3 || Vy.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: WR,
-priority: Oy.NORMAL + 25,
+body: YR,
+priority: My.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44436,19 +44480,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function rE(e) {
+function aE(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = HR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = qR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : DR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : WR), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Mp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Np(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44480,9 +44524,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(QR()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(JR()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Ky.getPendingRequests(l.name).filter(function(e) {
+n += Vy.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44501,22 +44545,22 @@ return n;
 }() < o;
 }
 
-(LR = {
-optimizeBody: Dy,
+(BR = {
+optimizeBody: Wy,
 spawnQueue: {
 addRequest: function(e) {
-return Ky.addRequest(e);
+return Vy.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Oy.LOW,
-NORMAL: Oy.NORMAL,
-HIGH: Oy.HIGH
+LOW: My.LOW,
+NORMAL: My.NORMAL,
+HIGH: My.HIGH
 }
-}).optimizeBody && (Fp.optimizeBody = LR.optimizeBody), LR.spawnQueue && (Fp.spawnQueue = LR.spawnQueue),
-LR.spawnPriorities && (Fp.spawnPriorities = o(o({}, Fp.spawnPriorities), LR.spawnPriorities));
+}).optimizeBody && (Kp.optimizeBody = BR.optimizeBody), BR.spawnQueue && (Kp.spawnQueue = BR.spawnQueue),
+BR.spawnPriorities && (Kp.spawnPriorities = o(o({}, Kp.spawnPriorities), BR.spawnPriorities));
 
-var oE, nE = function() {
+var iE, sE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44560,7 +44604,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function aE(e) {
+function cE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44581,7 +44625,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function iE(e, t, r) {
+function uE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44647,16 +44691,16 @@ return u;
 });
 }
 
-function sE(e) {
+function lE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(oE || (oE = {}));
+}(iE || (iE = {}));
 
-var cE = function() {
+var mE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44694,8 +44738,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = iE(h.pos, T.pos, this.logger);
-if (sE(C)) {
+var T = E.value, C = uE(h.pos, T.pos, this.logger);
+if (lE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44722,8 +44766,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, k = iE(A, u.pos, this.logger);
-sE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
+var A = O.value, k = uE(A, u.pos, this.logger);
+lE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44762,8 +44806,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = iE(e, t, this.logger);
-if (sE(n)) {
+var n = uE(e, t, this.logger);
+if (lE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -44773,7 +44817,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), uE = function() {
+}(), dE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -44783,7 +44827,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = aE(s);
+var c = cE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -44809,7 +44853,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), lE = function() {
+}(), pE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -44858,7 +44902,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), mE = {
+}(), fE = {
 debug: function(e, t) {
 return k("RemoteMining").debug(e, t);
 },
@@ -44871,7 +44915,7 @@ return k("RemoteMining").warn(e, t);
 error: function(e, t) {
 return k("RemoteMining").error(e, t);
 }
-}, dE = {
+}, yE = {
 getCachedPath: function(e, t) {
 var r = He(e, t), o = Fe.get(r, {
 namespace: Ke
@@ -44898,26 +44942,26 @@ direction: a
 }
 return t;
 }
-}, pE = {
+}, vE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = fm.MEDIUM), xm.register({
+void 0 === o && (o = gm.MEDIUM), Am.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== fm.CRITICAL
+skippable: o !== gm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, fE = new cE(dE, mE), yE = new uE(mE, pE, fE), vE = new lE(mE, dE, fE, Gu.moveTo);
+}, gE = new mE(yE, fE), hE = new dE(fE, vE, gE), RE = new pE(fE, yE, gE, Fu.moveTo);
 
-function gE(e, t, r, o) {
-return vE.moveToWithRemoteCache(e, t, r, o);
+function EE(e, t, r, o) {
+return RE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var hE, RE = function() {
+var TE, CE = function() {
 function e() {
 this.logger = k("Pathfinding");
 }
@@ -44930,12 +44974,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), EE = function() {
+}(), SE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), TE = function() {
+}(), wE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -44980,28 +45024,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), CE = function() {
+}(), xE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return aE(e);
+return cE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-fE.precacheRemoteRoutes(e, t);
+gE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), SE = new nE(new RE, new EE, new TE, new CE), wE = {
+}(), bE = new sE(new CE, new SE, new wE, new xE), OE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, xE = function() {
+}, AE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, wE), e);
+this.config = o(o({}, OE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45095,123 +45139,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new xE, (hE = {})[FIND_STRUCTURES] = {
+new AE, (TE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, hE[FIND_MY_STRUCTURES] = {
+}, TE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, hE[FIND_HOSTILE_STRUCTURES] = {
+}, TE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, hE[FIND_SOURCES_ACTIVE] = {
+}, TE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, hE[FIND_SOURCES] = {
+}, TE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, hE[FIND_MINERALS] = {
+}, TE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, hE[FIND_DEPOSITS] = {
+}, TE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, hE[FIND_MY_CONSTRUCTION_SITES] = {
+}, TE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, hE[FIND_CONSTRUCTION_SITES] = {
+}, TE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, hE[FIND_CREEPS] = {
+}, TE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, hE[FIND_MY_CREEPS] = {
+}, TE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, hE[FIND_HOSTILE_CREEPS] = {
+}, TE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, hE[FIND_DROPPED_RESOURCES] = {
+}, TE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, hE[FIND_TOMBSTONES] = {
+}, TE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, hE[FIND_RUINS] = {
+}, TE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, hE[FIND_FLAGS] = {
+}, TE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, hE[FIND_MY_SPAWNS] = {
+}, TE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, hE[FIND_HOSTILE_SPAWNS] = {
+}, TE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, hE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, TE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, hE[FIND_NUKES] = {
+}, TE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, hE[FIND_POWER_CREEPS] = {
+}, TE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, hE[FIND_MY_POWER_CREEPS] = {
+}, TE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, hE[FIND_HOSTILE_POWER_CREEPS] = {
+}, TE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, hE[FIND_EXIT_TOP] = {
+}, TE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, hE[FIND_EXIT_RIGHT] = {
+}, TE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, hE[FIND_EXIT_BOTTOM] = {
+}, TE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, hE[FIND_EXIT_LEFT] = {
+}, TE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, hE[FIND_EXIT] = {
+}, TE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var bE = new le({}, mr), OE = new Ee({}, mr);
+var kE = new le({}, mr), ME = new Ee({}, mr);
 
-function AE(e) {
+function UE(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45219,11 +45263,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var kE = !1;
+var _E = !1;
 
-function ME() {
+function NE() {
 var e, t;
-kE || (ii({
+_E || (ii({
 level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45238,11 +45282,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Hy.getPendingTransfers = function(e) {
+r.getPendingTransfers && (qy.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Hy.needsCarrier = function(e) {
+}), r.needsCarrier && (qy.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Hy.getActiveRequests = function() {
+}), r.getActiveRequests && (qy.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45256,61 +45300,61 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Yy.predictConsumption = function(e) {
+a.predictConsumption && (jy.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Yy.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (jy.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Yy.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (jy.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Yy.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (jy.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Vy.getActivePowerBanks = function() {
+i.getActivePowerBanks && (zy.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Vy.needsHarvesters = function(e) {
+}), i.needsHarvesters && (zy.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Vy.needsCarriers = function(e) {
+}), i.needsCarriers && (zy.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Vy.requestSpawns = function(e) {
+}), i.requestSpawns && (zy.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-qy.getEmergencyState = function(e) {
+Qy.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: bt,
-powerBankHarvestingManager: qc,
-resourceTransferCoordinator: Wp,
+powerBankHarvestingManager: Qc,
+resourceTransferCoordinator: Yp,
 emergencyResponseManager: Ba,
 kernel: Ja
 }), function(e) {
 var t, r, o, n;
-sd = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : id.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : id.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : id.getLabOverflow
-} : id;
+ld = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : ud.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : ud.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : ud.getLabOverflow
+} : ud;
 }({
 getLabResourceNeeds: function(e) {
-return Ru.getLabResourceNeeds(e);
+return Cu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return Ru.getLabResourceNeeds(e);
+return Cu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return Ru.getLabOverflow(e);
+return Cu.getLabOverflow(e);
 }
 }), Ji.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) IR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) DR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45324,7 +45368,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-IR.warn("Failed to wrap PathFinder.search", {
+DR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45332,11 +45376,11 @@ error: String(e)
 }
 }
 }
-}(), GR(e = Creep.prototype, "moveTo", "moveTo"), GR(e, "move", "move"), GR(e, "harvest", "harvest"),
-GR(e, "transfer", "transfer"), GR(e, "withdraw", "withdraw"), GR(e, "build", "build"),
-GR(e, "repair", "repair"), GR(e, "upgradeController", "upgradeController"), GR(e, "attack", "attack"),
-GR(e, "rangedAttack", "rangedAttack"), GR(e, "heal", "heal"), GR(e, "dismantle", "dismantle"),
-GR(e, "say", "say")), function(e, t, r) {
+}(), FR(e = Creep.prototype, "moveTo", "moveTo"), FR(e, "move", "move"), FR(e, "harvest", "harvest"),
+FR(e, "transfer", "transfer"), FR(e, "withdraw", "withdraw"), FR(e, "build", "build"),
+FR(e, "repair", "repair"), FR(e, "upgradeController", "upgradeController"), FR(e, "attack", "attack"),
+FR(e, "rangedAttack", "rangedAttack"), FR(e, "heal", "heal"), FR(e, "dismantle", "dismantle"),
+FR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -45352,15 +45396,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, Of), SE.initializePathCacheEvents(), yE.initialize(fm.MEDIUM), Tl = gE,
-Ft.initialize(), AR.initialize(), kE = !0), mr.initialize();
-var r = UR.configureForCurrentTick();
+}(Ja, mr, Mf), bE.initializePathCacheEvents(), hE.initialize(gm.MEDIUM), wl = EE,
+Ft.initialize(), UR.initialize(), _E = !0), mr.initialize();
+var r = PR.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = YR();
-if (!1 !== r.enabled && (r.lastRun = Game.time, jR(), function() {
-var e, t, r, o, n = VR(), a = n.footprintOperation, i = HR(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = jR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, XR(), function() {
+var e, t, r, o, n = zR(), a = n.footprintOperation, i = qR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45373,15 +45417,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, qR(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, QR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = YR();
+var e, t, r, n, i, s, c = jR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : DR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === FR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : WR), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === KR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45399,10 +45443,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !zR())) try {
+}(), !ZR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || rf(s), "interShardPioneer" === c && tf(s);
+"interShardClaimer" !== c && "interShardScout" !== c || af(s), "interShardPioneer" === c && nf(s);
 }
 } catch (t) {
 e = {
@@ -45426,17 +45470,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: kE
+systemsInitialized: _E
 }
-}), UR.ensureProcessesRegistered(), Ji.startTick(), ku.clear(), UR.startEventTick();
+}), PR.ensureProcessesRegistered(), Ji.startTick(), _u.clear(), PR.startEventTick();
 var i = function(e) {
-var t = e.cache[_R], r = e.cache[NR];
+var t = e.cache[IR], r = e.cache[GR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[_R] = o, e.cache[NR] = e.tick, o;
+return e.cache[IR] = o, e.cache[GR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45458,7 +45502,7 @@ rooms: i,
 interval: o
 })), s = n.next(); !s.done; s = n.next()) {
 var c = s.value;
-hl.refreshRoom(c);
+Tl.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -45473,18 +45517,18 @@ if (e) throw e.error;
 }
 }), Ji.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = YR();
+var e, t, r, o = jR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = jR();
+var n = XR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : DR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : WR), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== HR()) try {
+if (d !== qR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Mp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Np(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45502,20 +45546,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = QR().sort(function(e, t) {
+var i = JR().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : DR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : WR), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== HR()) {
+if (u !== qR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = ZR(u);
+var m = eE(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? tE(i, l, m) : rE() ? $R(i, u, m) : (eE(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (JR(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? nE(i, l, m) : aE() ? rE(i, u, m) : (oE(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (tE(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45532,8 +45576,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = VR();
-d.footprintOperation = n, qR(d);
+var d = zR();
+d.footprintOperation = n, QR(d);
 }
 }
 })(), function() {
@@ -45541,8 +45585,8 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || AE(s))) {
-var c = pg(s, mr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || UE(s))) {
+var c = vg(s, mr.getOrInitSwarmState(s.name));
 Ji.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -45558,21 +45602,21 @@ if (e) throw e.error;
 }
 }
 }();
-}), Gu.preTick(), Ji.measureSubsystem("processSync", function() {
-ff.syncCreepProcesses(), yy.syncRoomProcesses();
+}), Fu.preTick(), Ji.measureSubsystem("processSync", function() {
+gf.syncCreepProcesses(), hy.syncRoomProcesses();
 }), Ji.measureSubsystem("kernel", function() {
-UR.runProcesses();
+PR.runProcesses();
 }), Ji.measureSubsystem("eventQueue", function() {
-UR.processQueuedEvents();
+PR.processQueuedEvents();
 }), Ji.measureSubsystem("ss2PacketQueue", function() {
-gg.processQueue();
+Eg.processQueue();
 }), Ja.hasCpuBudget() && Ji.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && of(n);
+void 0 !== n.ticksToLive && sf(n);
 }
 } catch (t) {
 e = {
@@ -45586,7 +45630,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), PR({
+}), LR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("visualizations", function() {
@@ -45596,8 +45640,8 @@ var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = bE.getConfig(), s = OE.getConfig();
-bE.setConfig(n.roomVisualizerConfig), n.renderMap && OE.setConfig(n.mapVisualizerConfig);
+var i = kE.getConfig(), s = ME.getConfig();
+kE.setConfig(n.roomVisualizerConfig), n.renderMap && ME.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45608,7 +45652,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-bE.draw(m);
+kE.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -45630,14 +45674,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-OE.draw();
+ME.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-bE.setConfig(i), OE.setConfig(s);
+kE.setConfig(i), ME.setConfig(s);
 }
 }
 }
@@ -45722,19 +45766,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Gu.reconcileTraffic(), PR({
+}), Fu.reconcileTraffic(), LR({
 hasCpuBudget: Ja.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Ji.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), xm.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Am.run(e);
 }), mr.persistHeapCache(), Ji.collectProcessStats(Ja.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), Ji.collectKernelBudgetStats(Ja), Ji.setSkippedProcesses(Ja.getSkippedProcessesThisTick()),
 Ji.finalizeTick(), Ci.flush();
 }
 
-var UE = function() {
+var PE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45742,25 +45786,25 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = bE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = kE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-bE.toggle(o);
-var n = bE.getConfig()[o];
+kE.toggle(o);
+var n = kE.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = OE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = ME.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-OE.toggle(o);
-var n = OE.getConfig()[o];
+ME.toggle(o);
+var n = ME.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = OE.getConfig();
+var e = ME.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -45883,15 +45927,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), _E = function() {
+}(), IE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = AR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = UR.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = AR.getAllShards();
+var e, t, r = UR.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -45913,9 +45957,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (AR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (UR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = AR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = UR.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -45940,19 +45984,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = AR.getOptimalPortalRoute(e, t);
+var r, o = UR.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (AR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (UR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (AR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (UR.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Wp.getActiveRequests();
+var e, t, r = Yp.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -45973,7 +46017,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = AR.getCurrentShardState();
+var e, t, r = UR.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -45994,7 +46038,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = AR.getActiveTransferTasks();
+var e, t, r, o = UR.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -46015,16 +46059,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = AR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Np, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = UR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Gp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = AR.getMemoryStats();
+var e = UR.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return AR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return UR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = VR().footprintOperation;
+var e, t, r, o = zR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46130,9 +46174,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), NE = new _E;
+}(), GE = new IE;
 
-function PE(e) {
+function LE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46162,10 +46206,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? PE(e.metadata.usage) : void 0
+params: e.metadata.usage ? LE(e.metadata.usage) : void 0
 };
 });
-return Pm({
+return Lm({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46216,12 +46260,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Pm.apply(void 0, s([], i(o), !1));
+return Lm.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return Um("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Pm("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Nm.form("spawnCreep", [ {
+return Gm.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46255,20 +46299,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return Um("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Pm("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += Um("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += Um("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Nm.button({
+o += '<div style="margin-bottom: 10px;">', o += Pm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Pm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Gm.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Nm.button({
+}), o += " ", (o += Gm.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Nm.form("configureLogging", [ {
+return Gm.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46293,7 +46337,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Nm.form("configureVisualization", [ {
+return Gm.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46317,21 +46361,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Nm.button({
+e += Gm.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += Nm.button({
+}), e += " ", e += Gm.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Nm.button({
+}), e += " ", (e += Gm.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += Um("✓ Success message", "green", !0) + "\n", e += Um("⚠ Warning message", "yellow", !0) + "\n",
-e += Um("✗ Error message", "red", !0) + "\n", e += Um("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + Um("colored text", "green") + " normal text\n") + "Bold text: " + Um("important", null, !0) + "\n";
+return e += Pm("✓ Success message", "green", !0) + "\n", e += Pm("⚠ Warning message", "yellow", !0) + "\n",
+e += Pm("✗ Error message", "red", !0) + "\n", e += Pm("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Pm("colored text", "green") + " normal text\n") + "Bold text: " + Pm("important", null, !0) + "\n";
 }, n([ Tt({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46377,39 +46421,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var IE = new gy, GE = new UE, LE = new hy, DE = new bu, FE = new vy, BE = new Ry, WE = new Ey, KE = "__screepsGlobalRuntimeDiagnostics";
+var DE = new Ey, FE = new PE, BE = new Ty, WE = new ku, KE = new Ry, HE = new Cy, YE = new Sy, VE = "__screepsGlobalRuntimeDiagnostics";
 
-function HE() {
+function qE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function YE(e, t) {
+function jE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function VE(e, t) {
+function zE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function qE(e) {
+function QE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function jE(e) {
+function XE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: YE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: YE(n.switchCount, 0),
-lastTick: VE(n.lastTick, Game.time),
-lastResetTick: VE(n.lastResetTick, Game.time),
-lastSwitchTick: qE(n.lastSwitchTick),
-lastSwitchPreviousTick: qE(n.lastSwitchPreviousTick),
-lastWarningTick: qE(n.lastWarningTick)
+resetCount: jE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: jE(n.switchCount, 0),
+lastTick: zE(n.lastTick, Game.time),
+lastResetTick: zE(n.lastResetTick, Game.time),
+lastSwitchTick: QE(n.lastSwitchTick),
+lastSwitchPreviousTick: QE(n.lastSwitchPreviousTick),
+lastWarningTick: QE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46423,13 +46467,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var zE = Ei("Main");
+var ZE = Ei("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(IE), Ct(GE), Ct(LE), Ct(DE), Ct(FE), Ct(BE), Ct(WE), Ct(Su),
-Ct(wu), Ct(xu), Ct(NE), Ct(At), Ct(hc), Ct(Hc), global.tooangel = Wc;
+Et.initialize(), Ct(DE), Ct(FE), Ct(BE), Ct(WE), Ct(KE), Ct(HE), Ct(YE), Ct(bu),
+Ct(Ou), Ct(Au), Ct(GE), Ct(At), Ct(hc), Ct(qc), global.tooangel = Yc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
@@ -46444,12 +46488,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : HE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[KE];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : qE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[VE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[KE] = s, function(e, t) {
-var r, o = jE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[VE] = s, function(e, t) {
+var r, o = XE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46467,7 +46511,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = jE(e.heapId);
+var n, a = XE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46488,14 +46532,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = jE(s.heapId);
+var u = XE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: zE
-}), ME();
+logger: ZE
+}), NE();
 } catch (e) {
-throw zE.error("Critical error in main loop: ".concat(String(e)), {
+throw ZE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-bot/src/empire/tooangel/memoryInit.ts
+++ b/packages/screeps-bot/src/empire/tooangel/memoryInit.ts
@@ -23,7 +23,8 @@ export function getTooAngelMemory(): TooAngelMemory {
       npcRooms: {},
       activeQuests: {},
       completedQuests: [],
-      lastProcessedTick: 0
+      lastProcessedTick: 0,
+      recentTransactionIds: []
     };
   }
 
@@ -45,6 +46,14 @@ export function getTooAngelMemory(): TooAngelMemory {
 
   if (!mem.tooangel.completedQuests) {
     mem.tooangel.completedQuests = [];
+  }
+
+  if (typeof mem.tooangel.lastProcessedTick !== "number") {
+    mem.tooangel.lastProcessedTick = 0;
+  }
+
+  if (!Array.isArray(mem.tooangel.recentTransactionIds)) {
+    mem.tooangel.recentTransactionIds = [];
   }
 
   return mem.tooangel;

--- a/packages/screeps-bot/src/empire/tooangel/npcDetector.ts
+++ b/packages/screeps-bot/src/empire/tooangel/npcDetector.ts
@@ -10,6 +10,8 @@ import { logger } from "@ralphschuler/screeps-core";
 import { normalizeJsonObjectMessage } from "./messageParsing";
 import type { TooAngelNPCRoom, TooAngelQuestSign } from "./types";
 
+const TOOANGEL_USERNAME = "TooAngel";
+
 /**
  * Check if a controller sign is a TooAngel quest advertisement
  */
@@ -40,8 +42,12 @@ export function scanRoomForNPC(room: Room): TooAngelNPCRoom | null {
 
   const controller = room.controller;
 
+  if (controller.sign?.username !== TOOANGEL_USERNAME) {
+    return null;
+  }
+
   // Check for quest sign
-  const questSign = parseQuestSign(controller.sign?.text);
+  const questSign = parseQuestSign(controller.sign.text);
 
   if (!questSign) {
     return null;

--- a/packages/screeps-bot/src/empire/tooangel/questManager.ts
+++ b/packages/screeps-bot/src/empire/tooangel/questManager.ts
@@ -13,6 +13,7 @@ import { logger } from "@ralphschuler/screeps-core";
 import { getTooAngelMemory } from "./memoryInit";
 import { normalizeJsonObjectMessage } from "./messageParsing";
 import { getNPCRooms } from "./npcDetector";
+import { shouldProcessTooAngelTransaction } from "./transactionGuards";
 import type { TooAngelQuest, TooAngelQuestMemory, TooAngelQuestType } from "./types";
 
 /**
@@ -209,7 +210,7 @@ export function processQuestMessages(): void {
 
       const quest = parseQuestMessage(transaction.description);
 
-      if (quest) {
+      if (quest && shouldProcessTooAngelTransaction(transaction, quest.origin)) {
         logger.info(`Received quest ${quest.id}: ${quest.quest} in ${quest.room} (deadline: ${quest.end})`, {
           subsystem: "TooAngel"
         });

--- a/packages/screeps-bot/src/empire/tooangel/reputationManager.ts
+++ b/packages/screeps-bot/src/empire/tooangel/reputationManager.ts
@@ -15,6 +15,7 @@ import { logger } from "@ralphschuler/screeps-core";
 import { getTooAngelMemory } from "./memoryInit";
 import { normalizeJsonObjectMessage } from "./messageParsing";
 import { findClosestNPCRoom } from "./npcDetector";
+import { shouldProcessTooAngelTransaction } from "./transactionGuards";
 import type { TooAngelReputationMessage } from "./types";
 
 /**
@@ -81,7 +82,7 @@ export function processReputationUpdates(): void {
 
       const reputation = parseReputationResponse(transaction.description);
 
-      if (reputation !== null) {
+      if (reputation !== null && shouldProcessTooAngelTransaction(transaction)) {
         logger.info(`Received reputation update from TooAngel: ${reputation}`, {
           subsystem: "TooAngel"
         });

--- a/packages/screeps-bot/src/empire/tooangel/transactionGuards.ts
+++ b/packages/screeps-bot/src/empire/tooangel/transactionGuards.ts
@@ -1,0 +1,76 @@
+import { getTooAngelMemory } from "./memoryInit";
+import type { QuestStatus, TooAngelMemory } from "./types";
+
+const TOOANGEL_USERNAME = "TooAngel";
+const REPLAY_RING_LIMIT = 100;
+const TRUSTED_QUEST_STATUSES: readonly QuestStatus[] = ["applied", "active"];
+
+interface TooAngelInboundTransaction {
+  description: string;
+  from: string;
+  sender?: { username: string };
+  time: number;
+  to: string;
+  transactionId: string;
+}
+
+function transactionKey(transaction: TooAngelInboundTransaction): string {
+  if (transaction.transactionId) return transaction.transactionId;
+  return [
+    transaction.time,
+    transaction.sender?.username ?? "unknown",
+    transaction.from,
+    transaction.to,
+    transaction.description
+  ].join("|");
+}
+
+function trustedOriginRooms(memory: TooAngelMemory): Set<string> {
+  const origins = new Set(Object.keys(memory.npcRooms || {}));
+  for (const quest of Object.values(memory.activeQuests || {})) {
+    if (TRUSTED_QUEST_STATUSES.includes(quest.status) && quest.originRoom) {
+      origins.add(quest.originRoom);
+    }
+  }
+  return origins;
+}
+
+export function isTrustedTooAngelTransaction(
+  transaction: TooAngelInboundTransaction,
+  messageOrigin?: string
+): boolean {
+  if (transaction.sender) {
+    return transaction.sender.username === TOOANGEL_USERNAME;
+  }
+
+  const memory = getTooAngelMemory();
+  const trustedOrigins = trustedOriginRooms(memory);
+  if (!trustedOrigins.has(transaction.from)) return false;
+  return messageOrigin === undefined || trustedOrigins.has(messageOrigin);
+}
+
+export function hasSeenTooAngelTransaction(transaction: TooAngelInboundTransaction): boolean {
+  const memory = getTooAngelMemory();
+  return memory.recentTransactionIds.includes(transactionKey(transaction));
+}
+
+export function rememberTooAngelTransaction(transaction: TooAngelInboundTransaction): void {
+  const memory = getTooAngelMemory();
+  const key = transactionKey(transaction);
+  if (memory.recentTransactionIds.includes(key)) return;
+
+  memory.recentTransactionIds.push(key);
+  if (memory.recentTransactionIds.length > REPLAY_RING_LIMIT) {
+    memory.recentTransactionIds.splice(0, memory.recentTransactionIds.length - REPLAY_RING_LIMIT);
+  }
+}
+
+export function shouldProcessTooAngelTransaction(
+  transaction: TooAngelInboundTransaction,
+  messageOrigin?: string
+): boolean {
+  if (!isTrustedTooAngelTransaction(transaction, messageOrigin)) return false;
+  if (hasSeenTooAngelTransaction(transaction)) return false;
+  rememberTooAngelTransaction(transaction);
+  return true;
+}

--- a/packages/screeps-bot/src/empire/tooangel/types.ts
+++ b/packages/screeps-bot/src/empire/tooangel/types.ts
@@ -104,4 +104,6 @@ export interface TooAngelMemory {
   activeQuests: Record<string, TooAngelQuestMemory>;
   completedQuests: string[]; // Quest IDs
   lastProcessedTick: number;
+  /** Bounded ring of recent terminal transaction identities for replay protection. */
+  recentTransactionIds: string[];
 }

--- a/packages/screeps-bot/test/unit/tooAngelInboundMessages.test.ts
+++ b/packages/screeps-bot/test/unit/tooAngelInboundMessages.test.ts
@@ -1,0 +1,233 @@
+import { assert } from "chai";
+import { processQuestMessages } from "../../src/empire/tooangel/questManager";
+import { processReputationUpdates } from "../../src/empire/tooangel/reputationManager";
+import type { TooAngelMemory } from "../../src/empire/tooangel/types";
+
+function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    transactionId: overrides.transactionId ?? "tx-1",
+    time: overrides.time ?? Game.time,
+    sender: overrides.sender,
+    recipient: overrides.recipient,
+    resourceType: overrides.resourceType ?? ("energy" as MarketResourceConstant),
+    amount: overrides.amount ?? 1,
+    from: overrides.from ?? "W9N9",
+    to: overrides.to ?? "W1N1",
+    description: overrides.description ?? "{}",
+    order: overrides.order
+  };
+}
+
+function setIncomingTransactions(transactions: Transaction[]): void {
+  (Game.market as { incomingTransactions: Transaction[] }).incomingTransactions = transactions;
+}
+
+function tooAngelMemory(): TooAngelMemory {
+  return (Memory as Memory & { tooangel: TooAngelMemory }).tooangel;
+}
+
+describe("TooAngel inbound terminal message safety", () => {
+  beforeEach(() => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1000,
+      market: { incomingTransactions: [] }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  it("accepts trusted NPC-room quest messages", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: ["q1"] }
+      }
+    };
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "trusted-quest",
+        from: "W9N9",
+        description: JSON.stringify({ type: "quest", id: "q1", room: "W8N8", quest: "buildcs", end: 2000 })
+      })
+    ]);
+
+    processQuestMessages();
+
+    assert.equal(tooAngelMemory().activeQuests.q1?.targetRoom, "W8N8");
+    assert.equal(tooAngelMemory().activeQuests.q1?.originRoom, "W9N9");
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, ["trusted-quest"]);
+  });
+
+  it("accepts quest replies from an active quest origin", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      activeQuests: {
+        q1: {
+          id: "q1",
+          type: "buildcs",
+          status: "applied",
+          targetRoom: "",
+          originRoom: "W8N8",
+          deadline: 0,
+          appliedAt: 950
+        }
+      }
+    };
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "active-origin-quest",
+        from: "W8N8",
+        description: JSON.stringify({ type: "quest", id: "q1", room: "W7N7", quest: "buildcs", end: 2000 })
+      })
+    ]);
+
+    processQuestMessages();
+
+    assert.equal(tooAngelMemory().activeQuests.q1?.status, "active");
+    assert.equal(tooAngelMemory().activeQuests.q1?.targetRoom, "W7N7");
+  });
+
+  it("ignores untrusted quest-shaped JSON", () => {
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "spoofed-quest",
+        sender: { username: "Enemy" },
+        from: "W1N1",
+        description: JSON.stringify({ type: "quest", id: "q1", room: "W8N8", quest: "buildcs", end: 2000 })
+      })
+    ]);
+
+    processQuestMessages();
+
+    assert.deepEqual(tooAngelMemory().activeQuests, {});
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, []);
+  });
+
+  it("rejects non-TooAngel senders even from cached NPC rooms", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: ["q1"] }
+      }
+    };
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "poisoned-npc-room",
+        sender: { username: "Enemy" },
+        from: "W9N9",
+        description: JSON.stringify({ type: "quest", id: "q1", room: "W8N8", quest: "buildcs", end: 2000 })
+      })
+    ]);
+
+    processQuestMessages();
+
+    assert.deepEqual(tooAngelMemory().activeQuests, {});
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, []);
+  });
+
+  it("rejects non-TooAngel reputation senders even from cached NPC rooms", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: [] }
+      }
+    };
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "poisoned-npc-reputation",
+        sender: { username: "Enemy" },
+        from: "W9N9",
+        description: JSON.stringify({ type: "reputation", reputation: 666 })
+      })
+    ]);
+
+    processReputationUpdates();
+
+    assert.equal(tooAngelMemory().reputation.value, 0);
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, []);
+  });
+
+  it("deduplicates replayed quest transaction IDs", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: ["q1"] }
+      }
+    };
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "replayed-quest",
+        from: "W9N9",
+        description: JSON.stringify({ type: "quest", id: "q1", room: "W8N8", quest: "buildcs", end: 2000 })
+      }),
+      makeTransaction({
+        transactionId: "replayed-quest",
+        from: "W9N9",
+        description: JSON.stringify({ type: "quest", id: "q1", room: "W7N7", quest: "buildcs", end: 2000 })
+      })
+    ]);
+
+    processQuestMessages();
+
+    assert.equal(tooAngelMemory().activeQuests.q1?.targetRoom, "W8N8");
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, ["replayed-quest"]);
+  });
+
+  it("deduplicates replayed reputation transaction IDs", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: [] }
+      }
+    };
+    setIncomingTransactions([
+      makeTransaction({
+        transactionId: "replayed-rep",
+        from: "W9N9",
+        description: JSON.stringify({ type: "reputation", reputation: 42 })
+      }),
+      makeTransaction({
+        transactionId: "replayed-rep",
+        from: "W9N9",
+        description: JSON.stringify({ type: "reputation", reputation: 7 })
+      })
+    ]);
+
+    processReputationUpdates();
+
+    assert.equal(tooAngelMemory().reputation.value, 42);
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, ["replayed-rep"]);
+  });
+
+  it("keeps the replay ring bounded", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: [] }
+      }
+    };
+    setIncomingTransactions(
+      Array.from({ length: 125 }, (_, index) =>
+        makeTransaction({
+          transactionId: `rep-${index}`,
+          time: 1000 + index,
+          from: "W9N9",
+          description: JSON.stringify({ type: "reputation", reputation: index })
+        })
+      )
+    );
+
+    processReputationUpdates();
+
+    assert.lengthOf(tooAngelMemory().recentTransactionIds, 100);
+    assert.equal(tooAngelMemory().recentTransactionIds[0], "rep-25");
+    assert.equal(tooAngelMemory().recentTransactionIds[99], "rep-124");
+  });
+
+  it("keeps malformed trusted messages non-fatal", () => {
+    (Memory as Memory & { tooangel: Partial<TooAngelMemory> }).tooangel = {
+      npcRooms: {
+        W9N9: { roomName: "W9N9", lastSeen: 900, hasTerminal: true, availableQuests: [] }
+      }
+    };
+    setIncomingTransactions([makeTransaction({ transactionId: "bad-json", from: "W9N9", description: "{" })]);
+
+    assert.doesNotThrow(() => {
+      processReputationUpdates();
+      processQuestMessages();
+    });
+    assert.deepEqual(tooAngelMemory().recentTransactionIds, []);
+  });
+});

--- a/packages/screeps-bot/test/unit/tooAngelQuestManager.test.ts
+++ b/packages/screeps-bot/test/unit/tooAngelQuestManager.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { parseQuestSign } from "../../src/empire/tooangel/npcDetector";
+import { parseQuestSign, scanRoomForNPC } from "../../src/empire/tooangel/npcDetector";
 import { parseQuestMessage, processQuestMessages } from "../../src/empire/tooangel/questManager";
 import { parseReputationResponse, processReputationUpdates } from "../../src/empire/tooangel/reputationManager";
 
@@ -38,12 +38,37 @@ describe("TooAngel quest manager", () => {
     }
   });
 
+  it("detects quest NPC rooms only from TooAngel-signed controllers", () => {
+    const sign = JSON.stringify({ type: "quest", id: "q1", origin: "W9N9", info: "https://tooangel.example/q1" });
+    const room = {
+      name: "W9N9",
+      controller: { sign: { username: "TooAngel", text: sign } },
+      terminal: { my: false }
+    } as unknown as Room;
+
+    const npcRoom = scanRoomForNPC(room);
+
+    assert.equal(npcRoom?.roomName, "W9N9");
+    assert.deepEqual(npcRoom?.availableQuests, ["q1"]);
+  });
+
+  it("rejects spoofed quest signs from non-TooAngel controllers", () => {
+    const sign = JSON.stringify({ type: "quest", id: "q1", origin: "W9N9", info: "https://tooangel.example/q1" });
+    const room = {
+      name: "W9N9",
+      controller: { sign: { username: "Enemy", text: sign } },
+      terminal: { my: false }
+    } as unknown as Room;
+
+    assert.isNull(scanRoomForNPC(room));
+  });
+
   it("continues quest processing after malformed transaction descriptions", () => {
     const validQuest = JSON.stringify({ type: "quest", id: "valid", room: "W2N2", quest: "buildcs", end: 3000 });
 
     setupGame(2000, [
       { transactionId: "bad", time: 1999, from: "W0N0", to: "W1N1", description: "undefined" },
-      { transactionId: "valid", time: 2000, from: "W0N0", to: "W1N1", description: validQuest }
+      { transactionId: "valid", time: 2000, sender: { username: "TooAngel" }, from: "W0N0", to: "W1N1", description: validQuest }
     ]);
 
     assert.doesNotThrow(() => processQuestMessages());
@@ -58,7 +83,7 @@ describe("TooAngel quest manager", () => {
 
     setupGame(2000, [
       { transactionId: "bad", time: 1999, from: "W0N0", to: "W1N1", description: "undefined" },
-      { transactionId: "valid", time: 2000, from: "W0N0", to: "W1N1", description: validReputation }
+      { transactionId: "valid", time: 2000, sender: { username: "TooAngel" }, from: "W0N0", to: "W1N1", description: validReputation }
     ]);
 
     assert.doesNotThrow(() => processReputationUpdates());
@@ -70,8 +95,8 @@ describe("TooAngel quest manager", () => {
     const newQuest = JSON.stringify({ type: "quest", id: "new", room: "W2N2", quest: "buildcs", end: 3000 });
 
     setupGame(2000, [
-      { transactionId: "old", time: 1500, from: "W0N0", to: "W1N1", description: oldQuest },
-      { transactionId: "new", time: 2000, from: "W0N0", to: "W1N1", description: newQuest }
+      { transactionId: "old", time: 1500, sender: { username: "TooAngel" }, from: "W0N0", to: "W1N1", description: oldQuest },
+      { transactionId: "new", time: 2000, sender: { username: "TooAngel" }, from: "W0N0", to: "W1N1", description: newQuest }
     ]);
     (global as any).Memory.tooangel = {
       enabled: true,


### PR DESCRIPTION
## Summary

Adds trusted-origin and replay protection for TooAngel inbound terminal messages.

## Linked issue

Closes #3213

## Changes

### Code changes
- Require TooAngel-signed controller signs before caching NPC quest rooms.
- Add shared inbound transaction guard for TooAngel quest/reputation handlers.
- Accept transactions from `sender.username === "TooAngel"`, or senderless transactions from known TooAngel NPC / active quest origins.
- Reject present non-TooAngel senders even when `Memory.tooangel.npcRooms` contains the room.
- Store a bounded `Memory.tooangel.recentTransactionIds` replay ring.

### Test changes
- Add TooAngel inbound message tests for trusted NPC/active quest origin acceptance.
- Add spoofed sender rejection tests for quest and reputation payloads.
- Add replay dedupe and bounded ring tests.
- Update existing malformed/processed transaction tests to model trusted TooAngel senders.

### Docs changes
- No docs change; behavior is internal runtime safety and memory type is documented in code.

## Validation

Run with Node 24 via `nvm use`:
- ✅ `npm run check-versions`
- ✅ `npm run sync:deps:check`
- ✅ `npm run lint -w screeps-typescript-starter -- --max-warnings=0`
- ✅ `npm run build:bot`
- ✅ `npm run test:unit -w screeps-typescript-starter -- --grep TooAngel` (`18 passing`)
- ✅ `npm run test:unit -w screeps-typescript-starter` (`2395 passing`)
- ✅ `npm run check:alliance-safety`

Note: `npm run check-versions` first failed under the pi default Node 22 shell, then passed after `nvm use` selected repo Node 24.

## Deployment impact

Affects screeps.com runtime bundle. Deploy after merge through `npm run push`.

## Live bot evidence

Pre-implementation live analysis updated existing issues #3105, #3242, #3104, and #3184. No new issues created per operator constraint.

## Follow-up issues

None created in this run per operator constraint.
