### PR TITLE
[codex] Prioritize recovery-critical build sites

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
@@ -22,18 +22,20 @@ const logger = createLogger("CreepContext");
 /**
  * Priority order for construction sites.
  * Higher values = higher priority.
- * 
- * Defense structures (walls, ramparts) have high priority to ensure
- * room security is established early, especially at RCL 2-3.
+ *
+ * Recovery rooms need built defensive/economy anchors before spending builder
+ * throughput on extension backlogs or noncritical perimeter work.
  */
 const CONSTRUCTION_PRIORITY: Record<string, number> = {
   [STRUCTURE_SPAWN]: 100,
-  [STRUCTURE_EXTENSION]: 90,
-  [STRUCTURE_TOWER]: 80,
-  [STRUCTURE_RAMPART]: 75,
-  [STRUCTURE_WALL]: 70,
-  [STRUCTURE_STORAGE]: 70,
-  [STRUCTURE_CONTAINER]: 60,
+  [STRUCTURE_TOWER]: 95,
+  [STRUCTURE_STORAGE]: 90,
+  [STRUCTURE_EXTENSION]: 80,
+  [STRUCTURE_TERMINAL]: 75,
+  [STRUCTURE_LINK]: 70,
+  [STRUCTURE_CONTAINER]: 65,
+  [STRUCTURE_RAMPART]: 55,
+  [STRUCTURE_WALL]: 50,
   [STRUCTURE_ROAD]: 30
 };
 

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -13,6 +13,8 @@ import {
   remoteWorker,
   evaluateWithStateMachine,
   TaskPriority,
+  clearRoomCaches,
+  createContext as createRuntimeContext,
   setLabManagerProvider,
   setRemoteMoveHandler,
   soldier,
@@ -110,6 +112,41 @@ describe("Behavior Contracts", () => {
       expect(action).to.have.property("type");
       expect(action.type).to.be.a("string");
     }
+  });
+
+  it("prioritizes recovery-critical tower and storage construction before extension backlog", () => {
+    const room = createMockRoom("W1N1", {
+      controller: { my: true, level: 5 }
+    });
+    const sites = [
+      { id: "extension-site", structureType: STRUCTURE_EXTENSION, pos: new RoomPosition(24, 25, room.name) },
+      { id: "road-site", structureType: STRUCTURE_ROAD, pos: new RoomPosition(23, 25, room.name) },
+      { id: "storage-site", structureType: STRUCTURE_STORAGE, pos: new RoomPosition(25, 25, room.name) },
+      { id: "wall-site", structureType: STRUCTURE_WALL, pos: new RoomPosition(26, 25, room.name) },
+      { id: "tower-site", structureType: STRUCTURE_TOWER, pos: new RoomPosition(25, 24, room.name) }
+    ] as unknown as ConstructionSite[];
+    (room as unknown as { find: Room["find"] }).find = ((type: FindConstant) => {
+      if (type === FIND_MY_CONSTRUCTION_SITES) return sites;
+      return [];
+    }) as Room["find"];
+    const creep = createMockCreep("builder1", {
+      room,
+      memory: { role: "builder", homeRoom: room.name, working: true }
+    });
+
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    clearRoomCaches();
+
+    const ctx = createRuntimeContext(creep);
+
+    expect(ctx.prioritizedSites.map(site => site.structureType)).to.deep.equal([
+      STRUCTURE_TOWER,
+      STRUCTURE_STORAGE,
+      STRUCTURE_EXTENSION,
+      STRUCTURE_WALL,
+      STRUCTURE_ROAD
+    ]);
   });
 
   it("keeps builder and upgrader critical energy delivery priority aligned", () => {

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -22346,9 +22346,10 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Mu = k("CreepContext"), Uu = ((fu = {})[STRUCTURE_SPAWN] = 100, fu[STRUCTURE_EXTENSION] = 90,
-fu[STRUCTURE_TOWER] = 80, fu[STRUCTURE_RAMPART] = 75, fu[STRUCTURE_WALL] = 70, fu[STRUCTURE_STORAGE] = 70,
-fu[STRUCTURE_CONTAINER] = 60, fu[STRUCTURE_ROAD] = 30, fu), _u = new Map;
+}(), Mu = k("CreepContext"), Uu = ((fu = {})[STRUCTURE_SPAWN] = 100, fu[STRUCTURE_TOWER] = 95,
+fu[STRUCTURE_STORAGE] = 90, fu[STRUCTURE_EXTENSION] = 80, fu[STRUCTURE_TERMINAL] = 75,
+fu[STRUCTURE_LINK] = 70, fu[STRUCTURE_CONTAINER] = 65, fu[STRUCTURE_RAMPART] = 55,
+fu[STRUCTURE_WALL] = 50, fu[STRUCTURE_ROAD] = 30, fu), _u = new Map;
 
 function Nu(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);


### PR DESCRIPTION
## Summary
- Reorders role framework construction-site priorities so builders/larva workers/engineers build recovery-critical towers and storage before extension backlogs.
- Keeps spawn as top priority and pushes noncritical wall/road backlog behind critical economy/defense anchors.

## Linked issue
Refs #3242

## Changes
- Code: updates `@ralphschuler/screeps-roles` context construction priority ordering.
- Tests: adds behavior coverage for an RCL5 recovery-style site backlog where tower/storage must be selected before extensions/walls/roads.
- Dist: updates `packages/screeps-bot/dist/main.js` for deploy bundle parity.

## Validation
- PASS: `npm run test -w @ralphschuler/screeps-roles -- --grep "recovery-critical tower"` (confirmed failing before implementation, then passing)
- PASS: `npm run test -w @ralphschuler/screeps-roles`
- PASS: `npm run build -w @ralphschuler/screeps-roles`
- PASS: `npm run lint -w @ralphschuler/screeps-roles`
- PASS: `npm run build:bot`
- PASS: `npm run check:alliance-safety`
- PASS: `git diff --check`
- TIMEOUT: `npm run build` timed out locally after 300s during repeated workspace builds; targeted role build and bot bundle build passed.

## Deployment impact
- Affects live builder target selection through the roles framework.
- Expected impact: W18S28-style RCL5 recovery rooms spend builder work on tower/storage anchors before remaining extension/wall/road backlog.

## Scope notes
- No new issues created.
- This is a focused implementation slice for #3242; leave the issue open until post-deploy live verification shows W18S28 critical infrastructure progressing enough to satisfy the full issue.
- Broader construction/hauling throughput remains in existing #3119/#3105 and live verification comments on #3242.
