### PR TITLE
[codex] Add deploy preflight before Screeps upload

### DIFF
--- a/.github/ENVIRONMENT_SETUP.md
+++ b/.github/ENVIRONMENT_SETUP.md
@@ -140,7 +140,7 @@ This indicates the rollup-plugin-screeps is running in `dryRun` mode (simulating
 **Solution:**
 - Check the deploy logs for the configuration output
 - Verify the credentials in the environment configuration
-- Ensure the workflow calls `npm run push` (which sets `DEST=screeps`)
+- Ensure the workflow runs `npm run deploy:preflight` before `npm run push` (which sets `DEST=screeps`)
 
 ### How to test locally
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      # Keep deploy credentials scoped to the upload step so dependency installation
-      # and package lifecycle scripts cannot read Screeps secrets.
+      - name: Deploy preflight
+        run: npm run deploy:preflight
+
+      # Keep deploy credentials scoped to the upload step so dependency installation,
+      # validation, and package lifecycle scripts cannot read Screeps secrets.
       - name: Push to Screeps
         env:
           SCREEPS_PASS: ${{ secrets.SCREEPS_PASS }}

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ Permanent ally safety is mandatory: never target or attack `TooAngel` or `TedRoa
 Configure Screeps credentials through environment variables or the package `.env` flow, then run:
 
 ```bash
+npm run deploy:preflight
 npm run push
 ```
 
-`npm run build` is safe build-only mode. `npm run push` sets `DEPLOY=true` and uploads the bundle to the configured Screeps branch.
+`npm run build` is safe build-only mode. `npm run deploy:preflight` runs deploy-gate validation without secrets. `npm run push` sets `DEPLOY=true` and uploads the bundle to the configured Screeps branch.
 
 ## Documentation
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -24,10 +24,12 @@ The deploy path is `npm run push` / `npm run deploy`. Build-only validation is `
 3. Validate before upload:
 
    ```bash
-   npm run build
+   npm run deploy:preflight
    npm run test:unit
    npm run lint:all
    ```
+
+   `npm run deploy:preflight` runs dependency sync validation, alliance-safety checks, and a full repository build so framework package outputs exist before upload.
 
 4. Upload:
 
@@ -42,7 +44,7 @@ The deploy path is `npm run push` / `npm run deploy`. Build-only validation is `
 
 Workflow: `.github/workflows/deploy.yml`.
 
-Deploy can run from `workflow_dispatch` or after the release workflow succeeds. It uses GitHub environments for server-specific variables/secrets.
+Deploy can run from `workflow_dispatch` or after the release workflow succeeds. It uses GitHub environments for server-specific variables/secrets. Every deploy job runs `npm run deploy:preflight` before the secret-scoped Screeps upload step.
 
 Required environment variables/secrets:
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "profile:live:cpu": "node scripts/live-cpu-profile.mjs --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile",
     "check:alliance-safety": "node scripts/check-alliance-safety.js",
     "verify": "npm run build && npm run typecheck && npm run lint:all && npm run test:all && npm run check:alliance-safety && npm audit --omit=dev --audit-level=high",
+    "deploy:preflight": "npm run sync:deps:check && npm run check:alliance-safety && npm run build",
     "build": "npm run build:framework && npm run build:bot",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "build:bot": "npm run build -w screeps-typescript-starter",

--- a/scripts/test/deploy-workflow.test.mjs
+++ b/scripts/test/deploy-workflow.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const workflow = readFileSync(new URL("../../.github/workflows/deploy.yml", import.meta.url), "utf8");
+const rootPackage = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
 
 function parseDeployTargets() {
   const matrixBlock = workflow.match(/matrix:\n(?<block>[\s\S]*?)\n\s{4}env:/)?.groups?.block;
@@ -16,6 +17,44 @@ function parseDeployTargets() {
     }),
   );
 }
+
+function stepIndex(name) {
+  const index = workflow.indexOf(`      - name: ${name}`);
+  assert.notEqual(index, -1, `deploy workflow should include step ${name}`);
+  return index;
+}
+
+function stepBlock(name) {
+  const start = stepIndex(name);
+  const next = workflow.indexOf("\n      - name:", start + 1);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
+
+test("deploy workflow runs preflight before secret-scoped upload", () => {
+  assert.equal(
+    rootPackage.scripts["deploy:preflight"],
+    "npm run sync:deps:check && npm run check:alliance-safety && npm run build",
+    "root package should define the deploy preflight command used by the workflow",
+  );
+
+  assert.ok(
+    stepIndex("Deploy preflight") > stepIndex("Install dependencies"),
+    "deploy preflight should run after dependency installation",
+  );
+  assert.ok(
+    stepIndex("Push to Screeps") > stepIndex("Deploy preflight"),
+    "deploy preflight should run before Screeps upload",
+  );
+
+  const preflight = stepBlock("Deploy preflight");
+  assert.match(preflight, /run: npm run deploy:preflight/, "preflight should use the deploy:preflight script");
+  assert.doesNotMatch(preflight, /SCREEPS_(PASS|TOKEN)/, "preflight must not receive Screeps upload secrets");
+
+  const push = stepBlock("Push to Screeps");
+  assert.match(push, /SCREEPS_PASS:\s*\$\{\{ secrets\.SCREEPS_PASS \}\}/, "upload step should receive password secret");
+  assert.match(push, /SCREEPS_TOKEN:\s*\$\{\{ secrets\.SCREEPS_TOKEN \}\}/, "upload step should receive token secret");
+  assert.match(push, /run: npm run push/, "upload step should still run the Screeps push command");
+});
 
 test("deploy workflow keeps screeps.com required and marks optional targets non-blocking", () => {
   assert.match(


### PR DESCRIPTION
## Summary
- Adds a secret-free deploy preflight step before every Screeps upload.
- Defines `npm run deploy:preflight` as dependency sync check + alliance safety + full repo build so framework package outputs exist before bot upload.
- Updates deploy workflow tests and docs for the preflight behavior.

## Linked issue
Refs #3067
Closes #3250

## Changes
- Code changes: root `deploy:preflight` script and deploy workflow pre-upload step.
- Test changes: workflow test asserts preflight ordering, command, and Screeps secret scoping.
- Docs changes: README and deployment docs mention the deploy preflight command.

## Validation
- ✅ `npm run sync:deps:check`
- ✅ `node --test scripts/test/deploy-workflow.test.mjs`
- ✅ `npm run deploy:preflight`
- ✅ `npm run test:scripts`
- ✅ `git diff --check`

## Deployment impact
- Affects GitHub deploy workflow safety only.
- `Push to Screeps` still performs the upload and is the only step receiving `SCREEPS_PASS` / `SCREEPS_TOKEN`.
- The preflight build should fix the current deploy failure where bot typecheck ran before framework package outputs existed.

## Scope notes
- This is a first #3067 stage. Broader production approval/private-server smoke policy remains in #3067.
- Known generated bundle drift from `npm run build` remains tracked in #3145; no generated bundle changes are included.
