### PR TITLE
[codex] Document safe LAN local-server opt-in

### DIFF
--- a/packages/screeps-server/INTEGRATION_TEST_GUIDE.md
+++ b/packages/screeps-server/INTEGRATION_TEST_GUIDE.md
@@ -21,13 +21,13 @@ Password: ci-password
 Server password: ci-password
 ```
 
-Use LAN binding only when needed:
+Use LAN binding only when needed, and set non-default server and bot passwords because shared-network clients can reach the local server:
 
 ```bash
-npm run server:local:up -- --serverHost=0.0.0.0
+npm run server:local:up -- --serverHost=0.0.0.0 --serverPassword=<strong-server-password> --password=<strong-bot-password>
 ```
 
-If a running container still exposes `0.0.0.0`, recreate/reset it:
+A LAN bind with either default `ci-password` credential is rejected before Docker Compose starts. If a running container still exposes `0.0.0.0`, recreate/reset it:
 
 ```bash
 npm run server:local:down

--- a/packages/screeps-server/README.md
+++ b/packages/screeps-server/README.md
@@ -46,13 +46,13 @@ Password: ci-password
 Server password: ci-password
 ```
 
-LAN access is explicit opt-in:
+LAN access is explicit opt-in and requires non-default passwords because shared-network clients can reach the local server:
 
 ```bash
-npm run server:local:up -- --serverHost=0.0.0.0
+npm run server:local:up -- --serverHost=0.0.0.0 --serverPassword=<strong-server-password> --password=<strong-bot-password>
 ```
 
-If Docker still shows a stale `0.0.0.0` bind, recreate or reset the local stack:
+A LAN bind with the default `ci-password` server or bot password fails before Docker Compose starts. If Docker still shows a stale `0.0.0.0` bind, recreate or reset the local stack:
 
 ```bash
 npm run server:local:down

--- a/packages/screeps-server/test/scripts/start-local-server.test.ts
+++ b/packages/screeps-server/test/scripts/start-local-server.test.ts
@@ -33,11 +33,20 @@ describe('start-local-server credential validation', () => {
   });
 
   it('rejects LAN binds when server or bot password still uses the default', () => {
-    expect(() => validateLocalServerCredentials({
-      host: '0.0.0.0',
-      serverPassword: 'ci-password',
-      password: 'bot-secret'
-    })).to.throw(/default credentials/i);
+    let error: Error | null = null;
+    try {
+      validateLocalServerCredentials({
+        host: '0.0.0.0',
+        serverPassword: 'ci-password',
+        password: 'bot-secret'
+      });
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error?.message).to.match(/default credentials/i);
+    expect(error?.message).to.include('--serverPassword=<strong-server-password> --password=<strong-bot-password>');
+    expect(error?.message).to.match(/shared-network/i);
 
     expect(() => validateLocalServerCredentials({
       host: '192.168.1.20',

--- a/skills/screeps-private-server/SKILL.md
+++ b/skills/screeps-private-server/SKILL.md
@@ -66,13 +66,13 @@ npm run server:ci:up
 npm run server:ci:down
 ```
 
-LAN access is opt-in only:
+LAN access is opt-in only and requires non-default server and bot passwords because shared-network clients can reach the local server:
 
 ```bash
-npm run server:local:up -- --serverHost=0.0.0.0
+npm run server:local:up -- --serverHost=0.0.0.0 --serverPassword=<strong-server-password> --password=<strong-bot-password>
 ```
 
-If Docker shows stale `0.0.0.0`, recreate/reset:
+A LAN bind with either default `ci-password` credential is rejected before Docker Compose starts. If Docker shows stale `0.0.0.0`, recreate/reset:
 
 ```bash
 npm run server:local:down


### PR DESCRIPTION
## Summary
- Document the safe LAN local-server opt-in command with explicit non-default passwords.
- Strengthen the credential-policy test to assert the failure message includes the safe command and shared-network warning.

## Linked issue
Closes #3053

## Changes
- Updated private-server README and integration guide LAN examples.
- Updated the project private-server skill guidance so agents do not suggest unsafe LAN defaults.
- Added assertions for the local-server credential rejection guidance.

## Validation
- PASS: `nvm use --silent 24 && npm run check-versions`
- PASS: `nvm use --silent 24 && npm run sync:deps:check`
- PASS: `nvm use --silent 24 && npm run test:packages -w @ralphschuler/screeps-server`
- PASS: `nvm use --silent 24 && npm run typecheck -w @ralphschuler/screeps-server`
- PASS: `nvm use --silent 24 && npm run build:docs`
- PASS: `nvm use --silent 24 && npm run build`

## Deployment impact
- No runtime bot logic change.
- Deploy path still builds; deployment is safe but will only publish the current bot bundle, not change Screeps runtime behavior.

## Scope notes
- Existing credential validation and LAN default rejection logic was already present on `main`; this PR closes the remaining documentation/test-assertion gap for #3053.
