### PR TITLE
[codex] Remove bot-local factory production drift

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -35262,29 +35262,7 @@ hasNetwork: a >= 2
 };
 }, e.prototype.runResourceProcessing = function(e, t, r) {
 var o = this.getRoomEconomyIntent(e, r);
-o.processing.labs && this.labWorkflow.run(e, t), o.processing.factory && this.runFactory(e, r.factory),
-o.processing.powerSpawn && this.runPowerSpawn(e, r.powerSpawn);
-}, e.prototype.runFactory = function(e, t) {
-var r, o;
-if (t && !(t.cooldown > 0)) {
-var n = [ RESOURCE_UTRIUM, RESOURCE_LEMERGIUM, RESOURCE_KEANIUM, RESOURCE_ZYNTHIUM, RESOURCE_HYDROGEN, RESOURCE_OXYGEN ];
-try {
-for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
-var c = s.value;
-if (t.store.getUsedCapacity(c) >= 500 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 200 && t.produce(RESOURCE_UTRIUM_BAR) === OK) break;
-}
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-s && !s.done && (o = i.return) && o.call(i);
-} finally {
-if (r) throw r.error;
-}
-}
-}
+o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this.runPowerSpawn(e, r.powerSpawn);
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;

--- a/packages/screeps-bot/src/core/managers/RoomEconomyManager.ts
+++ b/packages/screeps-bot/src/core/managers/RoomEconomyManager.ts
@@ -3,14 +3,12 @@
  *
  * Responsibilities:
  * - Lab reactions and boosting
- * - Factory production
  * - Power spawn processing
- * - Labs, factory, and power spawn processing
+ * - Labs, factory capability, and power spawn processing intent
  *
- * Link transfers are centralized in @ralphschuler/screeps-economy LinkManager.
+ * Factory and link side effects are centralized in @ralphschuler/screeps-economy managers.
  */
 
-/* eslint-disable no-undef */
 import type { SwarmState } from "@ralphschuler/screeps-memory";
 import { labEconomyWorkflow, type LabWorkflowResult } from "../../labs/labEconomyWorkflow";
 
@@ -79,40 +77,11 @@ export class RoomEconomyManager {
       this.labWorkflow.run(room, swarm);
     }
 
-    if (intent.processing.factory) {
-      this.runFactory(room, cache.factory);
-    }
-
     if (intent.processing.powerSpawn) {
       this.runPowerSpawn(room, cache.powerSpawn);
     }
 
-    // Link transfers are handled by the decorated LinkManager process.
-  }
-
-  /**
-   * Run factory production
-   */
-  private runFactory(room: Room, factory: StructureFactory | undefined): void {
-    if (!factory || factory.cooldown > 0) return;
-
-    // Simple commodity production - compress minerals
-    const minerals: MineralConstant[] = [
-      RESOURCE_UTRIUM,
-      RESOURCE_LEMERGIUM,
-      RESOURCE_KEANIUM,
-      RESOURCE_ZYNTHIUM,
-      RESOURCE_HYDROGEN,
-      RESOURCE_OXYGEN
-    ];
-
-    for (const mineral of minerals) {
-      if (factory.store.getUsedCapacity(mineral) >= 500 && factory.store.getUsedCapacity(RESOURCE_ENERGY) >= 200) {
-        // Try to produce compressed bar
-        const result = factory.produce(RESOURCE_UTRIUM_BAR); // Note: This is simplified
-        if (result === OK) break;
-      }
-    }
+    // Factory production and link transfers are handled by framework economy processes.
   }
 
   /**

--- a/packages/screeps-bot/test/unit/roomEconomyManager.test.ts
+++ b/packages/screeps-bot/test/unit/roomEconomyManager.test.ts
@@ -156,12 +156,53 @@ describe("RoomEconomyManager", () => {
   });
 
   describe("Factory production", () => {
-    it("should skip production if factory is on cooldown", () => {
-      assert.exists(manager);
-    });
+    function createStore(contents: Partial<Record<ResourceConstant, number>>): StoreDefinition {
+      return {
+        ...contents,
+        getUsedCapacity: (resource?: ResourceConstant) => {
+          if (resource) return contents[resource] ?? 0;
+          return Object.values(contents).reduce((sum, amount) => sum + (amount ?? 0), 0);
+        },
+        getFreeCapacity: () => 100000,
+        getCapacity: () => 100000
+      } as unknown as StoreDefinition;
+    }
 
-    it("should produce compressed bars when resources available", () => {
-      assert.exists(manager);
+    it("leaves factory side effects to the framework economy manager", () => {
+      const produced: CommodityConstant[] = [];
+      const factory = {
+        cooldown: 0,
+        store: createStore({ [RESOURCE_LEMERGIUM]: 500, [RESOURCE_ENERGY]: 200 }),
+        produce: ((commodity: CommodityConstant) => {
+          produced.push(commodity);
+          return OK;
+        }) as StructureFactory["produce"]
+      } as unknown as StructureFactory;
+      const room = {
+        name: "W7N1",
+        controller: { level: 7 }
+      } as unknown as Room;
+      const managerWithWorkflow = new RoomEconomyManager({
+        run: workflowRoom => ({
+          roomName: workflowRoom.name,
+          initialized: true,
+          boostPrepared: true,
+          reactionPlanned: false,
+          reactionReady: false,
+          activeReactionChanged: false,
+          reactionExecuted: false,
+          saved: true
+        })
+      });
+
+      managerWithWorkflow.runResourceProcessing(room, {} as SwarmState, {
+        factory,
+        powerSpawn: undefined,
+        links: [],
+        sources: []
+      });
+
+      assert.deepEqual(produced, []);
     });
   });
 

--- a/packages/screeps-economy/test/FactoryManager.test.ts
+++ b/packages/screeps-economy/test/FactoryManager.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import { FactoryManager } from "../src/factories/factoryManager";
+
+type StoreContents = Partial<Record<ResourceConstant, number>>;
+
+function createStore(contents: StoreContents, capacity = 100000): StoreDefinition {
+  return {
+    ...contents,
+    getUsedCapacity: (resource?: ResourceConstant) => {
+      if (resource) return contents[resource] ?? 0;
+      return Object.values(contents).reduce((sum, amount) => sum + (amount ?? 0), 0);
+    },
+    getFreeCapacity: (_resource?: ResourceConstant) => {
+      const used = Object.values(contents).reduce((sum, amount) => sum + (amount ?? 0), 0);
+      return capacity - used;
+    },
+    getCapacity: () => capacity
+  } as unknown as StoreDefinition;
+}
+
+function createRoomWithFactory(
+  factoryStore: StoreDefinition,
+  storageStore: StoreDefinition,
+  produce: StructureFactory["produce"]
+): Room {
+  const factory = {
+    my: true,
+    structureType: STRUCTURE_FACTORY,
+    cooldown: 0,
+    store: factoryStore,
+    produce
+  } as unknown as StructureFactory;
+  const storage = {
+    my: true,
+    structureType: STRUCTURE_STORAGE,
+    store: storageStore
+  } as unknown as StructureStorage;
+  const room = {
+    name: "W1N1",
+    controller: { my: true, level: 8 },
+    storage,
+    find: (_find: FindConstant, options?: { filter?: (structure: Structure) => boolean }) => {
+      const structures = [factory];
+      return options?.filter ? structures.filter(options.filter) : structures;
+    }
+  } as unknown as Room;
+  (factory as unknown as { room: Room }).room = room;
+  (storage as unknown as { room: Room }).room = room;
+  return room;
+}
+
+function runFactory(factoryContents: StoreContents, storageContents: StoreContents): CommodityConstant[] {
+  const produced: CommodityConstant[] = [];
+  const room = createRoomWithFactory(
+    createStore(factoryContents),
+    createStore(storageContents),
+    ((commodity: CommodityConstant) => {
+      produced.push(commodity);
+      return OK;
+    }) as StructureFactory["produce"]
+  );
+  (Game.rooms as Record<string, Room>).W1N1 = room;
+
+  new FactoryManager({ minBucket: 0, minStorageEnergy: 0 }).run();
+
+  return produced;
+}
+
+describe("FactoryManager", () => {
+  beforeEach(() => {
+    (global as any).Game = {
+      ...Game,
+      cpu: { ...Game.cpu, bucket: 10000 },
+      rooms: {}
+    };
+  });
+
+  it("produces the matching level-0 commodity for every ready factory input", () => {
+    const cases: Array<{ input: ResourceConstant; output: CommodityConstant; amount: number }> = [
+      { input: RESOURCE_UTRIUM, output: RESOURCE_UTRIUM_BAR, amount: 500 },
+      { input: RESOURCE_LEMERGIUM, output: RESOURCE_LEMERGIUM_BAR, amount: 500 },
+      { input: RESOURCE_ZYNTHIUM, output: RESOURCE_ZYNTHIUM_BAR, amount: 500 },
+      { input: RESOURCE_KEANIUM, output: RESOURCE_KEANIUM_BAR, amount: 500 },
+      { input: RESOURCE_GHODIUM, output: RESOURCE_GHODIUM_MELT, amount: 500 },
+      { input: RESOURCE_OXYGEN, output: RESOURCE_OXIDANT, amount: 500 },
+      { input: RESOURCE_HYDROGEN, output: RESOURCE_REDUCTANT, amount: 500 },
+      { input: RESOURCE_CATALYST, output: RESOURCE_PURIFIER, amount: 500 },
+      { input: RESOURCE_ENERGY, output: RESOURCE_BATTERY, amount: 600 }
+    ];
+
+    for (const { input, output, amount } of cases) {
+      const factoryContents: StoreContents = { [input]: amount };
+      const storageContents: StoreContents = { [input]: amount * 2, [RESOURCE_ENERGY]: 100000 };
+
+      if (input !== RESOURCE_ENERGY) {
+        factoryContents[RESOURCE_ENERGY] = 200;
+        storageContents[RESOURCE_BATTERY] = 6000;
+      }
+
+      expect(runFactory(factoryContents, storageContents), output).to.deep.equal([output]);
+    }
+  });
+
+  it("skips a higher-priority recipe when its inputs are not ready in the factory", () => {
+    const produced = runFactory(
+      { [RESOURCE_LEMERGIUM]: 500, [RESOURCE_ENERGY]: 200 },
+      { [RESOURCE_LEMERGIUM]: 1000, [RESOURCE_ENERGY]: 100000 }
+    );
+
+    expect(produced).to.deep.equal([RESOURCE_LEMERGIUM_BAR]);
+  });
+});


### PR DESCRIPTION
## Summary
- Removed bot-local direct factory production from `RoomEconomyManager` so factory side effects are owned by `@ralphschuler/screeps-economy`.
- Added economy coverage for level-0 factory recipe production.
- Added bot unit coverage proving room resource processing does not duplicate framework factory `produce` calls.
- Rebuilt `packages/screeps-bot/dist/main.js`.

## Linked issue
Closes #3154

## Changes
- Code changes: removed the bot-local `runFactory` path that hardcoded `RESOURCE_UTRIUM_BAR`.
- Test changes: added `FactoryManager` recipe tests and replaced placeholder bot factory tests with behavior coverage.
- Docs changes: none; runtime ownership is covered by code comments/tests.

## Validation
- PASS: `npm run check-versions` (Node 24.18.0 / npm 11.16.0)
- PASS: `npm run sync:deps:check`
- PASS: `npm run test:economy`
- PASS: `npm run test:unit -w screeps-typescript-starter -- --grep "RoomEconomyManager"`
- PASS: `npm run test:unit`
- PASS: `npm run lint:economy`
- PASS: `npm run lint`
- PASS: `npm run check:alliance-safety`
- PASS: `npm run build`
- PASS: `npm run test:server:smoke` (`packages/screeps-server/artifacts/smoke/summary.md`: status passed, 49/49 checks)

## Deployment impact
- Runtime economy behavior changes: factories are no longer controlled twice per room/tick by bot-local and framework paths.
- Screeps deploy path remains valid; local build confirms credentials are configured without uploading during build.

## Scope notes
- Existing unrelated untracked local artifacts were left untouched.
