### PR TITLE
[codex] Unify cluster defense assist dispatch

### DIFF
--- a/packages/@ralphschuler/screeps-clusters/src/clusterManager.ts
+++ b/packages/@ralphschuler/screeps-clusters/src/clusterManager.ts
@@ -68,7 +68,7 @@ import {
 import { queueDefenseReinforcementSpawns } from "./defenseReinforcements";
 import { updateClusterRallyPoints } from "./rallyPointManager";
 import { assignDefendersToDefenseRequests } from "./defenderAssignments";
-import { coordinateClusterDefense, getActualHostileCreeps, getActualHostileStructures } from "@ralphschuler/screeps-defense";
+import { getActualHostileCreeps, getActualHostileStructures } from "@ralphschuler/screeps-defense";
 import {
   calculateMilitaryReadinessRatio,
   decideClusterRole,
@@ -193,7 +193,6 @@ export class ClusterManager {
         break;
       case "defense":
         this.processDefenseRequests(cluster);
-        coordinateClusterDefense(cluster.id);
         break;
       case "terminals":
         this.balanceTerminalResources(cluster);

--- a/packages/@ralphschuler/screeps-clusters/src/defenderAssignments.ts
+++ b/packages/@ralphschuler/screeps-clusters/src/defenderAssignments.ts
@@ -1,3 +1,4 @@
+import { getDefenseAssistTargetRoom, stageDefenseAssistCreep } from "@ralphschuler/screeps-defense";
 import type { ClusterMemory } from "./types";
 
 type DefenseAssistRole = "guard" | "ranger" | "healer";
@@ -90,7 +91,7 @@ function collectCandidatesForRequest(
       const memory = creep.memory as DefenseAssistMemory;
       const role = getMilitaryAssistRole(memory);
       if (!role) continue;
-      if (memory.assistTarget) continue;
+      if (getDefenseAssistTargetRoom(memory)) continue;
       if (!hasActiveRolePart(creep, role)) continue;
       if (request.assignedCreeps.includes(creep.name)) continue;
       if (getNeededCount(request, role) <= 0) continue;
@@ -151,15 +152,14 @@ export function assignDefendersToDefenseRequests(
     }, new Map<string, number>());
 
     for (const defender of selectedDefenders) {
-      const memory = defender.creep.memory as DefenseAssistMemory;
       const localSquadSize = Math.max(1, Math.min(3, selectedByRoom.get(defender.room.name) ?? 1));
 
-      memory.assistTarget = request.roomName;
-      memory.targetRoom = request.roomName;
-      memory.task = "defenseAssist";
-      memory.defenseSquadId = `defenseAssist:${defender.room.name}:${request.roomName}:${options.now}`;
-      memory.defenseSquadSize = localSquadSize;
-      memory.defenseSquadCreatedAt = options.now;
+      stageDefenseAssistCreep(defender.creep, {
+        homeRoom: defender.room.name,
+        targetRoom: request.roomName,
+        now: options.now,
+        squadSize: localSquadSize
+      });
       request.assignedCreeps.push(defender.creep.name);
       setNeededCount(request, defender.role, getNeededCount(request, defender.role) - 1);
 

--- a/packages/@ralphschuler/screeps-clusters/src/defenseReinforcements.ts
+++ b/packages/@ralphschuler/screeps-clusters/src/defenseReinforcements.ts
@@ -3,6 +3,8 @@ import {
   buildDefenseAssistBody as buildSharedDefenseAssistBody,
   calculateAggregateDefenseResponsePlan,
   calculateCombatPower,
+  createDefenseAssistSquadId,
+  DEFENSE_ASSIST_TASK,
   getActualHostileCreeps,
   getVisibleDefenseAssistThreatProfile,
   type BodyTemplate,
@@ -67,7 +69,6 @@ export interface SpawnQueueForReinforcements {
   addRequest(request: SpawnRequest): void;
 }
 
-const DEFENSE_ASSIST_TASK = "defenseAssist";
 const DEFAULT_MAX_NEW_SPAWNS_PER_HELPER_ROOM = 2;
 const DISTANT_ROOM_PENALTY = 50;
 function createEmptyAssignedDefenseAssistPower(): AssignedDefenseAssistPower {
@@ -243,10 +244,6 @@ function getRemainingRequestNeeds(
   };
 }
 
-function createDefenseSquadId(helperRoom: string, targetRoom: string, now: number): string {
-  return `defenseAssist:${helperRoom}:${targetRoom}:${now}`;
-}
-
 /**
  * Build spawn intents for helper-room reinforcements without mutating Game or Memory.
  */
@@ -298,7 +295,7 @@ export function planDefenseReinforcementSpawns(input: DefenseReinforcementPlanIn
             assistTarget: request.roomName,
             targetRoom: request.roomName,
             task: DEFENSE_ASSIST_TASK,
-            defenseSquadId: createDefenseSquadId(helper.roomName, request.roomName, input.now),
+            defenseSquadId: createDefenseAssistSquadId(helper.roomName, request.roomName, input.now),
             defenseSquadSize: plannedSquadSize,
             defenseSquadCreatedAt: input.now
           },

--- a/packages/@ralphschuler/screeps-clusters/test/clusterManager.test.ts
+++ b/packages/@ralphschuler/screeps-clusters/test/clusterManager.test.ts
@@ -627,6 +627,22 @@ describe("Cluster defense assistance assignments", () => {
     });
 
     expect(cluster.defenseRequests[0]!.assignedCreeps).to.deep.equal(["firstGuard", "ranger"]);
+    expect(firstGuard.memory).to.include({
+      assistTarget: "W1N1",
+      targetRoom: "W1N1",
+      task: "defenseAssist",
+      defenseSquadId: "defenseAssist:W2N1:W1N1:4243",
+      defenseSquadSize: 2,
+      defenseSquadCreatedAt: 4243
+    });
+    expect(ranger.memory).to.include({
+      assistTarget: "W1N1",
+      targetRoom: "W1N1",
+      task: "defenseAssist",
+      defenseSquadId: "defenseAssist:W2N1:W1N1:4243",
+      defenseSquadSize: 2,
+      defenseSquadCreatedAt: 4243
+    });
     expect(spareGuard.memory).to.not.have.property("assistTarget");
     expect(cluster.defenseRequests[0]!).to.include({ guardsNeeded: 0, rangersNeeded: 0, healersNeeded: 0 });
   });

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/military.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/military.ts
@@ -7,13 +7,16 @@
 
 import type { SquadMemory, SwarmCreepMemory } from "../memory/schemas";
 import {
+  DEFENSE_ASSIST_TASK,
   calculateCombatPower,
   checkAndExecuteRetreat,
   getActualHostileCreeps,
   getActualHostileStructures,
+  getDefenseAssistTargetRoom,
   getVisibleDefenseAssistThreatProfile,
   isKnownAllyPlayer,
   isDefenseAssistThreatProfileHard,
+  stageDefenseAssistCreep,
   type CombatPower,
   type DefenseAssistThreatProfile
 } from "@ralphschuler/screeps-defense";
@@ -31,7 +34,6 @@ const DEFENSE_ASSIST_SQUAD_STAGE_TIMEOUT = 250;
 const DEFENSE_ASSIST_HARD_THREAT_STAGE_TIMEOUT = 750;
 const DEFENSE_ASSIST_HARD_THREAT_RELEASE_QUORUM = 5;
 const DEFENSE_ASSIST_HARD_THREAT_TRICKLE_INTERVAL = 50;
-const DEFENSE_ASSIST_TASK = "defenseAssist";
 
 type DefenseAssistRole = "guard" | "ranger" | "healer";
 
@@ -52,10 +54,6 @@ interface MemoryWithDefenseRequests {
 
 interface MemoryWithDefenseAssistTrickleReleases {
   defenseAssistTrickleReleases?: Record<string, number>;
-}
-
-function getDefenseAssistTargetRoom(mem: Partial<SwarmCreepMemory>): string | undefined {
-  return mem.assistTarget ?? (mem.task === DEFENSE_ASSIST_TASK ? mem.targetRoom : undefined);
 }
 
 function clearDefenseAssistAssignment(mem: SwarmCreepMemory): void {
@@ -221,14 +219,15 @@ function tryAcquireDefenseAssistAssignment(ctx: CreepContext, mem: SwarmCreepMem
     if (!targetRoom || getActualHostileCreeps(targetRoom).length === 0) continue;
     if (!shouldAcquireDefenseAssistRequest(request, mem.role, ctx.homeRoom)) continue;
 
-    mem.task = DEFENSE_ASSIST_TASK;
-    mem.targetRoom = request.roomName;
-    mem.assistTarget = request.roomName;
-    mem.defenseSquadId = getActiveDefenseAssistSquadId(ctx.homeRoom, request.roomName);
-    mem.defenseSquadSize = hasVisibleHardDefenseAssistThreat(request.roomName)
-      ? Math.max(DEFENSE_ASSIST_HARD_THREAT_RELEASE_QUORUM, getTotalDefenseAssistRequestNeed(request))
-      : Math.max(1, getTotalDefenseAssistRequestNeed(request));
-    mem.defenseSquadCreatedAt = Game.time;
+    stageDefenseAssistCreep(ctx.creep, {
+      homeRoom: ctx.homeRoom,
+      targetRoom: request.roomName,
+      now: Game.time,
+      squadId: getActiveDefenseAssistSquadId(ctx.homeRoom, request.roomName),
+      squadSize: hasVisibleHardDefenseAssistThreat(request.roomName)
+        ? Math.max(DEFENSE_ASSIST_HARD_THREAT_RELEASE_QUORUM, getTotalDefenseAssistRequestNeed(request))
+        : Math.max(1, getTotalDefenseAssistRequestNeed(request))
+    });
 
     return request.roomName;
   }

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -302,7 +302,7 @@ return C("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 
 var O = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function A(e, t, r, o) {
+function k(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -315,7 +315,7 @@ o.room && (n.room = o.room), o.meta)) for (var a in o.meta) O.has(a) || (n[a] = 
 h(JSON.stringify(n));
 }
 
-function k(e) {
+function A(e) {
 return {
 debug: function(t, r) {
 C(t, "string" == typeof r ? {
@@ -350,7 +350,7 @@ subsystem: e
 }, r));
 },
 stat: function(t, r, n, a) {
-A(t, r, n, "string" == typeof a ? {
+k(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -373,7 +373,7 @@ debug: C,
 info: S,
 warn: w,
 error: x,
-stat: A,
+stat: k,
 measureCpu: b,
 configure: function(e) {
 v = o(o({}, v), e);
@@ -381,7 +381,7 @@ v = o(o({}, v), e);
 getConfig: function() {
 return o({}, v);
 },
-createLogger: k,
+createLogger: A,
 flush: R
 };
 
@@ -737,7 +737,7 @@ return "string" == typeof e && e.length > 0;
 }) : [];
 }
 
-function H(e) {
+function K(e) {
 var t, r, o, n, a;
 void 0 === e && (e = {});
 var c = globalThis.Memory, u = function(e) {
@@ -746,12 +746,12 @@ if (e && "object" == typeof e) return e;
 return s([], i(new Set(l)), !1);
 }
 
-function K(e) {
-return void 0 === e && (e = {}), s([], i(new Set(s(s([], i(F), !1), i(H(e)), !1))), !1);
+function H(e) {
+return void 0 === e && (e = {}), s([], i(new Set(s(s([], i(F), !1), i(K(e)), !1))), !1);
 }
 
 function Y(e, t) {
-return void 0 === t && (t = {}), "string" == typeof e && K(t).includes(e);
+return void 0 === t && (t = {}), "string" == typeof e && H(t).includes(e);
 }
 
 function V(e, t) {
@@ -760,7 +760,7 @@ return void 0 === t && (t = {}), Y(B(e), t);
 
 function q(e, t) {
 void 0 === t && (t = {});
-var r = K(t), o = new Set(r), n = function(e) {
+var r = H(t), o = new Set(r), n = function(e) {
 var t = B(e);
 return "string" == typeof t && o.has(t);
 };
@@ -1262,11 +1262,11 @@ if (s) throw s.error;
 }
 }
 }
-var A = t.terminal;
-if (A && A.store.getUsedCapacity() > 0) {
+var k = t.terminal;
+if (k && k.store.getUsedCapacity() > 0) {
 S = .8, w = -.8;
 try {
-for (var k = a(ce(A.store)), M = k.next(); !M.done; M = k.next()) O = M.value, e.resource(O, A.pos.x + S, A.pos.y + w, .3),
+for (var A = a(ce(k.store)), M = A.next(); !M.done; M = A.next()) O = M.value, e.resource(O, k.pos.x + S, k.pos.y + w, .3),
 S += .6;
 } catch (e) {
 u = {
@@ -1274,7 +1274,7 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (l = k.return) && l.call(k);
+M && !M.done && (l = A.return) && l.call(A);
 } finally {
 if (u) throw u.error;
 }
@@ -1839,9 +1839,9 @@ var t = this.config[e];
 
 new Ee;
 
-var Te, Ce = "#555555", Se = "#AAAAAA", we = "#FFE87B", xe = "#F53547", be = "#181818", Oe = "#8FBB93", Ae = !1;
+var Te, Ce = "#555555", Se = "#AAAAAA", we = "#FFE87B", xe = "#F53547", be = "#181818", Oe = "#8FBB93", ke = !1;
 
-"undefined" == typeof RoomVisual || Ae || (Ae = !0, RoomVisual.prototype.structure = function(e, t, r, n) {
+"undefined" == typeof RoomVisual || ke || (ke = !0, RoomVisual.prototype.structure = function(e, t, r, n) {
 void 0 === n && (n = {});
 var a = o({
 opacity: 1
@@ -2114,7 +2114,7 @@ opacity: .9
 });
 });
 
-var ke = {
+var Ae = {
 pheromone: {
 updateInterval: 5,
 decayFactors: {
@@ -2256,7 +2256,7 @@ debug: !1,
 profiling: !0,
 visualizations: !0,
 lazyLoadConsoleCommands: !0
-}, Me = o({}, ke);
+}, Me = o({}, Ae);
 
 function Ue() {
 return Me;
@@ -2858,14 +2858,14 @@ if (t) throw t.error;
 }
 }
 try {
-for (var O = a(this.stores.values()), A = O.next(); !A.done; A = O.next()) w += A.value.size();
+for (var O = a(this.stores.values()), k = O.next(); !k.done; k = O.next()) w += k.value.size();
 } catch (e) {
 o = {
 error: e
 };
 } finally {
 try {
-A && !A.done && (n = O.return) && n.call(O);
+k && !k.done && (n = O.return) && n.call(O);
 } finally {
 if (o) throw o.error;
 }
@@ -2988,17 +2988,17 @@ return r;
 e.L1 = "L1", e.L2 = "L2", e.L3 = "L3";
 }(Ge || (Ge = {}));
 
-var Be, We = "object", He = "path";
+var Be, We = "object", Ke = "path";
 
-function Ke(e, t) {
+function He(e, t) {
 return "".concat(e.roomName, ":").concat(e.x, ",").concat(e.y, ":").concat(t.roomName, ":").concat(t.x, ",").concat(t.y);
 }
 
 function Ye(e, t, r, o) {
 void 0 === o && (o = {});
-var n = Ke(e, t), a = Room.serializePath(r);
+var n = He(e, t), a = Room.serializePath(r);
 Fe.set(n, a, {
-namespace: He,
+namespace: Ke,
 ttl: o.ttl,
 maxSize: 1e3
 });
@@ -3740,9 +3740,9 @@ d.push("=== Subsystem CPU Usage ==="), y = b.sort(function(e, t) {
 return t.avg_cpu - e.avg_cpu;
 });
 try {
-for (var O = a(y.slice(0, 10)), A = O.next(); !A.done; A = O.next()) {
-var k = A.value, M = k.name || "unknown";
-d.push("  ".concat(M, ": ").concat(k.avg_cpu.toFixed(3), " CPU (calls: ").concat(k.calls, ")"));
+for (var O = a(y.slice(0, 10)), k = O.next(); !k.done; k = O.next()) {
+var A = k.value, M = A.name || "unknown";
+d.push("  ".concat(M, ": ").concat(A.avg_cpu.toFixed(3), " CPU (calls: ").concat(A.calls, ")"));
 }
 } catch (e) {
 i = {
@@ -3750,7 +3750,7 @@ error: e
 };
 } finally {
 try {
-A && !A.done && (s = O.return) && s.call(O);
+k && !k.done && (s = O.return) && s.call(O);
 } finally {
 if (i) throw i.error;
 }
@@ -4064,8 +4064,8 @@ return t.priority - e.priority;
 });
 try {
 for (var S = a(C), w = S.next(); !w.done; w = S.next()) {
-var x = w.value, b = (null !== (o = null === (r = x.stats) || void 0 === r ? void 0 : r.avgCpu) && void 0 !== o ? o : 0).toFixed(4), O = (null !== (c = null === (n = x.stats) || void 0 === n ? void 0 : n.healthScore) && void 0 !== c ? c : 0).toFixed(0), A = (null !== (l = null === (u = x.stats) || void 0 === u ? void 0 : u.healthScore) && void 0 !== l ? l : 0) >= 80 ? "✓" : (null !== (d = null === (m = x.stats) || void 0 === m ? void 0 : m.healthScore) && void 0 !== d ? d : 0) >= 50 ? "⚠" : "✗";
-T += "".concat(x.id, " | ").concat(x.name, " | ").concat(x.priority, " | ").concat(null !== (p = x.frequency) && void 0 !== p ? p : "N/A", " | ").concat(x.state, " | ").concat(null !== (y = null === (f = x.stats) || void 0 === f ? void 0 : f.runCount) && void 0 !== y ? y : 0, " | ").concat(b, " | ").concat(A).concat(O, " | ").concat(null !== (g = null === (v = x.stats) || void 0 === v ? void 0 : v.errorCount) && void 0 !== g ? g : 0, "(").concat(null !== (R = null === (h = x.stats) || void 0 === h ? void 0 : h.consecutiveErrors) && void 0 !== R ? R : 0, ")\n");
+var x = w.value, b = (null !== (o = null === (r = x.stats) || void 0 === r ? void 0 : r.avgCpu) && void 0 !== o ? o : 0).toFixed(4), O = (null !== (c = null === (n = x.stats) || void 0 === n ? void 0 : n.healthScore) && void 0 !== c ? c : 0).toFixed(0), k = (null !== (l = null === (u = x.stats) || void 0 === u ? void 0 : u.healthScore) && void 0 !== l ? l : 0) >= 80 ? "✓" : (null !== (d = null === (m = x.stats) || void 0 === m ? void 0 : m.healthScore) && void 0 !== d ? d : 0) >= 50 ? "⚠" : "✗";
+T += "".concat(x.id, " | ").concat(x.name, " | ").concat(x.priority, " | ").concat(null !== (p = x.frequency) && void 0 !== p ? p : "N/A", " | ").concat(x.state, " | ").concat(null !== (y = null === (f = x.stats) || void 0 === f ? void 0 : f.runCount) && void 0 !== y ? y : 0, " | ").concat(b, " | ").concat(k).concat(O, " | ").concat(null !== (g = null === (v = x.stats) || void 0 === v ? void 0 : v.errorCount) && void 0 !== g ? g : 0, "(").concat(null !== (R = null === (h = x.stats) || void 0 === h ? void 0 : h.consecutiveErrors) && void 0 !== R ? R : 0, ")\n");
 }
 } catch (t) {
 e = {
@@ -4097,8 +4097,8 @@ return (null !== (o = null === (r = e.stats) || void 0 === r ? void 0 : r.health
 x += "Name | Health | Errors | Consecutive | Status | Last Success\n", x += "-".repeat(80) + "\n";
 try {
 for (var b = a(w), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, k = (null !== (o = null === (r = A.stats) || void 0 === r ? void 0 : r.healthScore) && void 0 !== o ? o : 0).toFixed(0), M = (null !== (c = null === (n = A.stats) || void 0 === n ? void 0 : n.healthScore) && void 0 !== c ? c : 0) >= 80 ? "✓" : (null !== (l = null === (u = A.stats) || void 0 === u ? void 0 : u.healthScore) && void 0 !== l ? l : 0) >= 50 ? "⚠" : "✗", U = (null !== (d = null === (m = A.stats) || void 0 === m ? void 0 : m.lastSuccessfulRunTick) && void 0 !== d ? d : 0) > 0 ? Game.time - (null !== (f = null === (p = A.stats) || void 0 === p ? void 0 : p.lastSuccessfulRunTick) && void 0 !== f ? f : 0) : "never", _ = "suspended" === A.state ? "SUSPENDED (".concat(null !== (v = null === (y = A.stats) || void 0 === y ? void 0 : y.suspensionReason) && void 0 !== v ? v : "unknown", ")") : A.state.toUpperCase();
-x += "".concat(A.name, " | ").concat(M, " ").concat(k, "/100 | ").concat(null !== (h = null === (g = A.stats) || void 0 === g ? void 0 : g.errorCount) && void 0 !== h ? h : 0, " | ").concat(null !== (E = null === (R = A.stats) || void 0 === R ? void 0 : R.consecutiveErrors) && void 0 !== E ? E : 0, " | ").concat(_, " | ").concat(U, "\n");
+var k = O.value, A = (null !== (o = null === (r = k.stats) || void 0 === r ? void 0 : r.healthScore) && void 0 !== o ? o : 0).toFixed(0), M = (null !== (c = null === (n = k.stats) || void 0 === n ? void 0 : n.healthScore) && void 0 !== c ? c : 0) >= 80 ? "✓" : (null !== (l = null === (u = k.stats) || void 0 === u ? void 0 : u.healthScore) && void 0 !== l ? l : 0) >= 50 ? "⚠" : "✗", U = (null !== (d = null === (m = k.stats) || void 0 === m ? void 0 : m.lastSuccessfulRunTick) && void 0 !== d ? d : 0) > 0 ? Game.time - (null !== (f = null === (p = k.stats) || void 0 === p ? void 0 : p.lastSuccessfulRunTick) && void 0 !== f ? f : 0) : "never", _ = "suspended" === k.state ? "SUSPENDED (".concat(null !== (v = null === (y = k.stats) || void 0 === y ? void 0 : y.suspensionReason) && void 0 !== v ? v : "unknown", ")") : k.state.toUpperCase();
+x += "".concat(k.name, " | ").concat(M, " ").concat(A, "/100 | ").concat(null !== (h = null === (g = k.stats) || void 0 === g ? void 0 : g.errorCount) && void 0 !== h ? h : 0, " | ").concat(null !== (E = null === (R = k.stats) || void 0 === R ? void 0 : R.consecutiveErrors) && void 0 !== E ? E : 0, " | ").concat(_, " | ").concat(U, "\n");
 }
 } catch (t) {
 e = {
@@ -4567,9 +4567,9 @@ usage: "economy.energy.spawnDelay(roomName, cost)",
 examples: [ "economy.energy.spawnDelay('W1N1', 1000)", "economy.energy.spawnDelay('E1S1', 500)" ],
 category: "Economy"
 }) ], e.prototype, "getSpawnDelay", null), e;
-}(), At = new Ot;
+}(), kt = new Ot;
 
-function kt(e, t) {
+function At(e, t) {
 return {
 id: e,
 coreRoom: t,
@@ -4785,7 +4785,7 @@ if (r) throw r.error;
 }
 return c;
 }, e;
-}(), Ft = new Dt, Bt = k("MemoryMonitor"), Wt = 2097152, Ht = new (function() {
+}(), Ft = new Dt, Bt = A("MemoryMonitor"), Wt = 2097152, Kt = new (function() {
 function e() {
 this.lastCheckTick = 0, this.lastStatus = "normal";
 }
@@ -4874,7 +4874,7 @@ return t.sort(function(e, t) {
 return t.size - e.size;
 }).slice(0, e);
 }, e;
-}()), Kt = {
+}()), Ht = {
 ACTIVE_ROOMS: {
 start: 0,
 end: 9
@@ -5034,7 +5034,7 @@ return t ? t.length : 0;
 }, e.prototype.getActiveSegments = function() {
 return Array.from(this.activeSegments);
 }, e.prototype.suggestSegmentForType = function(e) {
-for (var t = Kt[e], r = t.start; r <= t.end; r++) if (!this.isSegmentLoaded(r) || this.getSegmentSize(r) < 92160) return r;
+for (var t = Ht[e], r = t.start; r <= t.end; r++) if (!this.isSegmentLoaded(r) || this.getSegmentSize(r) < 92160) return r;
 return t.start;
 }, e.prototype.migrateToSegment = function(e, t, r) {
 var o, n, i = e.split("."), s = Memory;
@@ -5091,7 +5091,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -5681,7 +5681,7 @@ return e.prototype.initialize = function() {
 this.lastInitializeTick !== Game.time && (this.lastInitializeTick = Game.time, Ft.initialize(),
 sr.runMigrations(), this.ensureEmpireMemory(), this.ensureClustersMemory(), Game.time - this.lastCleanupTick >= 10 && (this.cleanDeadCreeps(),
 this.lastCleanupTick = Game.time), Game.time - this.lastPruningTick >= 100 && (nr.pruneAll(),
-this.lastPruningTick = Game.time), Game.time - this.lastMonitoringTick >= 50 && (Ht.checkMemoryUsage(),
+this.lastPruningTick = Game.time), Game.time - this.lastMonitoringTick >= 50 && (Kt.checkMemoryUsage(),
 this.lastMonitoringTick = Game.time));
 }, e.prototype.ensureEmpireMemory = function() {
 var e = Memory;
@@ -5731,7 +5731,7 @@ Ft.set(e, r[ur], Mt), t = r[ur];
 return t;
 }, e.prototype.getCluster = function(e, t) {
 var r = this.getClusters();
-return !r[e] && t && (r[e] = kt(e, t)), r[e];
+return !r[e] && t && (r[e] = At(e, t)), r[e];
 }, e.prototype.getSwarmState = function(e) {
 var t, r = "memory:room:".concat(e, ":swarm"), o = Ft.get(r), n = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 if (n) {
@@ -6064,7 +6064,7 @@ score: e.score + t.score
 };
 }
 
-function Ar(e, t) {
+function kr(e, t) {
 return {
 partCount: e.partCount * t,
 attack: e.attack * t,
@@ -6075,7 +6075,7 @@ score: e.score * t
 };
 }
 
-function kr(e) {
+function Ar(e) {
 var t, r;
 if (0 === e.length) return null;
 var o = null, n = {
@@ -6112,7 +6112,7 @@ total: n
 
 function Mr(e) {
 var t = Game.rooms[e];
-return t ? kr(j(t)) : null;
+return t ? Ar(j(t)) : null;
 }
 
 function Ur(e, t, r) {
@@ -6244,7 +6244,7 @@ return o;
 try {
 for (var s = a([ "guard", "ranger", "healer" ]), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t[u];
-l && e[u] > 0 && (i = Or(i, Ar(l, e[u])));
+l && e[u] > 0 && (i = Or(i, kr(l, e[u])));
 }
 } catch (e) {
 o = {
@@ -6398,7 +6398,7 @@ isDismantler: R
 };
 }
 
-function Hr(e) {
+function Kr(e) {
 var t, r, o = j(e);
 if (0 === o.length) return {
 roomName: e.name,
@@ -6469,7 +6469,7 @@ t = null != t ? t : c, r = null != r ? r : u;
 }
 return t <= 0 && (t = 300, r = 1300), Math.ceil(e / t) * r;
 }(i), S = Math.max(1, function(e) {
-return 0 === e || e < Kr ? 0 : e < Yr ? 1 : e < Vr ? 2 : 3;
+return 0 === e || e < Hr ? 0 : e < Yr ? 1 : e < Vr ? 2 : 3;
 }(n));
 return h = n < 100 ? "monitor" : n < 500 && !E ? "defend" : E && n < 1e3 ? "assist" : n > 1e3 || c > 3 ? "safemode" : "defend",
 e.find(FIND_NUKES).length > 0 && (n += 500, h = "safemode", S = 3), {
@@ -6491,7 +6491,7 @@ recommendedResponse: h
 };
 }
 
-var Kr = 100, Yr = 500, Vr = 1e3;
+var Hr = 100, Yr = 500, Vr = 1e3;
 
 function qr(e) {
 var t, r, o = 0;
@@ -6559,41 +6559,23 @@ avgDps: n
 };
 }
 
-function Jr(e) {
-U.info("Threat Assessment for ".concat(e.roomName, ": ") + "Danger=".concat(e.dangerLevel, ", Score=").concat(e.threatScore, ", ") + "Hostiles=".concat(e.hostileCount, ", DPS=").concat(e.totalHostileDPS, ", ") + "Response=".concat(e.recommendedResponse), {
-subsystem: "Defense",
-room: e.roomName,
-meta: {
-threat: {
-dangerLevel: e.dangerLevel,
-threatScore: e.threatScore,
-hostileCount: e.hostileCount,
-boostedCount: e.boostedCount,
-healerCount: e.healerCount,
-dismantlerCount: e.dismantlerCount,
-recommendedResponse: e.recommendedResponse
-}
-}
-});
-}
-
-function $r(e, t, r) {
-var o = ro(t) - ro(e);
+function Jr(e, t, r) {
+var o = to(t) - to(e);
 if (0 !== o) return o;
 if (!r) return 0;
-var n = to(e) - to(t);
-return 0 !== n ? n : eo(e) - eo(t);
+var n = eo(e) - eo(t);
+return 0 !== n ? n : $r(e) - $r(t);
 }
 
-function eo(e) {
+function $r(e) {
 return "number" == typeof e.hits ? e.hits : 1 / 0;
 }
 
-function to(e) {
+function eo(e) {
 return "number" != typeof e.hits || "number" != typeof e.hitsMax || e.hitsMax <= 0 ? 1 : e.hits / e.hitsMax;
 }
 
-function ro(e) {
+function to(e) {
 var t = 0;
 return t += 100 * e.getActiveBodyparts(HEAL), t += 50 * e.getActiveBodyparts(RANGED_ATTACK),
 t += 40 * e.getActiveBodyparts(ATTACK), t += 60 * e.getActiveBodyparts(CLAIM), (t += 30 * e.getActiveBodyparts(WORK)) > 0 && e.body.some(function(e) {
@@ -6601,19 +6583,19 @@ return e.boost;
 }) && (t += 20), t;
 }
 
-function oo(e) {
+function ro(e) {
 return e.hits < e.hitsMax;
 }
 
-function no(e) {
+function oo(e) {
 return e.hits < .8 * e.hitsMax && e.structureType !== STRUCTURE_WALL && e.structureType !== STRUCTURE_RAMPART;
 }
 
-function ao(e) {
+function no(e) {
 return !e.isCombatPosture;
 }
 
-function io(e) {
+function ao(e) {
 var t, r = e.hostiles.length > 0 ? function(e, t) {
 var r, o;
 void 0 === t && (t = {});
@@ -6621,7 +6603,7 @@ var n = !1 !== t.preferWoundedTargets, i = null;
 try {
 for (var s = a(e), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-(!i || $r(u, i, n) < 0) && (i = u);
+(!i || Jr(u, i, n) < 0) && (i = u);
 }
 } catch (e) {
 r = {
@@ -6650,7 +6632,7 @@ var t = function(e) {
 return function(e) {
 return "siege" !== e.posture || !1 !== e.allowSiegeHealing;
 }(e) ? e.tower.pos.findClosestByRange(FIND_MY_CREEPS, {
-filter: oo
+filter: ro
 }) : null;
 }(e);
 if (t) return {
@@ -6663,8 +6645,8 @@ return void 0 !== e.repairReserveEnergy ? Math.max(0, Math.min(TOWER_CAPACITY, e
 }(e);
 }(e)) return null;
 var r = function(e) {
-return ao(e) ? e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
-filter: no
+return no(e) ? e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
+filter: oo
 }) : null;
 }(e);
 if (r) return {
@@ -6672,7 +6654,7 @@ type: "repair",
 target: r
 };
 var o = function(e) {
-return !ao(e) || e.hostiles.length > 0 ? null : e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
+return !no(e) || e.hostiles.length > 0 ? null : e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
 filter: function(t) {
 return function(e, t) {
 return function(e) {
@@ -6691,7 +6673,7 @@ type: "idle"
 };
 }
 
-function so(e, t) {
+function io(e, t) {
 var r, o, n = null !== (r = {
 1: 0,
 2: 3e5,
@@ -6712,7 +6694,7 @@ var a = null !== (o = {
 return Math.floor(n * a);
 }
 
-var co = [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_FACTORY, STRUCTURE_POWER_SPAWN, STRUCTURE_NUKER, STRUCTURE_OBSERVER ], uo = [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE ], lo = [ {
+var so = [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_FACTORY, STRUCTURE_POWER_SPAWN, STRUCTURE_NUKER, STRUCTURE_OBSERVER ], co = [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE ], uo = [ {
 x: -2,
 y: 0
 }, {
@@ -6942,7 +6924,7 @@ x: 6,
 y: 4
 } ];
 
-function mo(e) {
+function lo(e) {
 return [ {
 x: e.x - 1,
 y: e.y - 1
@@ -6970,7 +6952,7 @@ y: e.y + 1
 } ];
 }
 
-function po(e, t, r) {
+function mo(e, t, r) {
 var o, n, i = [];
 try {
 for (var s = a(r), c = s.next(); !c.done; c = s.next()) for (var u = c.value, l = 1; l <= t; l++) switch (u) {
@@ -7015,7 +6997,7 @@ if (o) throw o.error;
 return i;
 }
 
-function fo(e, t) {
+function po(e, t) {
 return e.filter(function(e) {
 return t.includes(e.structureType);
 }).map(function(e) {
@@ -7026,7 +7008,7 @@ y: e.y
 });
 }
 
-function yo(e) {
+function fo(e) {
 var t = Number.isFinite(e) ? e : 1;
 return {
 1: {
@@ -7123,15 +7105,15 @@ powerSpawn: 1
 }[Math.min(8, Math.max(1, Math.floor(t)))];
 }
 
-function vo(e, t) {
+function yo(e, t) {
 return "".concat(e, ",").concat(t);
 }
 
-function go(e, t) {
+function vo(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function ho(e) {
+function go(e) {
 return e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_LINK;
@@ -7139,8 +7121,8 @@ return e.structureType === STRUCTURE_LINK;
 });
 }
 
-function Ro(e) {
-var t, r, o, n, i, s, c = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, u = null !== (i = yo(c)[STRUCTURE_LINK]) && void 0 !== i ? i : 0, l = [];
+function ho(e) {
+var t, r, o, n, i, s, c = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, u = null !== (i = fo(c)[STRUCTURE_LINK]) && void 0 !== i ? i : 0, l = [];
 if (!(null === (s = e.controller) || void 0 === s ? void 0 : s.my) || c < 5 || u <= 0) return {
 roomName: e.name,
 rcl: c,
@@ -7152,7 +7134,7 @@ var t, r, o, n, i = new Set, s = e.find(FIND_STRUCTURES);
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-l.structureType !== STRUCTURE_LINK && i.add(vo(l.pos.x, l.pos.y));
+l.structureType !== STRUCTURE_LINK && i.add(yo(l.pos.x, l.pos.y));
 }
 } catch (e) {
 t = {
@@ -7168,7 +7150,7 @@ if (t) throw t.error;
 try {
 for (var m = a(e.find(FIND_MY_CONSTRUCTION_SITES)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-i.add(vo(p.pos.x, p.pos.y));
+i.add(yo(p.pos.x, p.pos.y));
 }
 } catch (e) {
 o = {
@@ -7187,14 +7169,14 @@ return function(a, i, s, c, u, l) {
 if (i && !(t.length >= r)) {
 var m = function(e, t, r, o, n, a, i) {
 for (var s = [], c = e.getTerrain(), u = t.x - o; u <= t.x + o; u += 1) for (var l = t.y - o; l <= t.y + o; l += 1) {
-var m = go({
+var m = vo({
 x: u,
 y: l
 }, t);
 if (!(m < r || m > o || u < 1 || u > 48 || l < 1 || l > 48 || c.get(u, l) === TERRAIN_MASK_WALL)) {
-var d = vo(u, l);
+var d = yo(u, l);
 if (!n.has(d) && !a.has(d)) {
-var p = i ? go({
+var p = i ? vo({
 x: u,
 y: l
 }, i) : 0;
@@ -7220,20 +7202,20 @@ roomName: e.name,
 role: a,
 targetId: i.id,
 priority: u
-}), n.add(vo(m.x, m.y)));
+}), n.add(yo(m.x, m.y)));
 }
 };
 }(e, l, u, m, d);
 v("controller", f, 2, 2, 400, null != p ? p : y);
 var g = null != p ? p : f, h = function(e, t) {
 return e.find(FIND_SOURCES).slice().sort(function(e, r) {
-return go(r.pos, t.pos) - go(e.pos, t.pos);
+return vo(r.pos, t.pos) - vo(e.pos, t.pos);
 });
 }(e, g), R = p && c >= 6 ? 1 : 0, E = y && c >= 8 ? 1 : 0, T = Math.max(0, u - l.length - R - E);
 try {
 for (var C = a(h.slice(0, T)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
-v("source", w, 1, 1, 300 + go(w.pos, g.pos), null != p ? p : f);
+v("source", w, 1, 1, 300 + vo(w.pos, g.pos), null != p ? p : f);
 }
 } catch (e) {
 t = {
@@ -7255,15 +7237,15 @@ placements: l
 };
 }
 
-function Eo(e, t) {
+function Ro(e, t) {
 var r;
 return null !== (r = function(e, t) {
 return function(e, t) {
-var r, o = vo(t.x, t.y);
+var r, o = yo(t.x, t.y);
 return null === (r = e.find(function(e) {
-return vo(e.x, e.y) === o;
+return yo(e.x, e.y) === o;
 })) || void 0 === r ? void 0 : r.role;
-}(Ro(e).placements, t);
+}(ho(e).placements, t);
 }(e, t.pos)) && void 0 !== r ? r : function(e, t) {
 return e.controller && t.pos.getRangeTo(e.controller) <= 2 ? "controller" : e.storage && t.pos.getRangeTo(e.storage) <= 2 ? "storage" : e.find(FIND_MY_SPAWNS).some(function(e) {
 return t.pos.getRangeTo(e) <= 2;
@@ -7273,27 +7255,27 @@ return t.pos.getRangeTo(e) <= 2;
 }(e, t);
 }
 
-function To(e, t) {
+function Eo(e, t) {
 return "".concat(e, ",").concat(t);
 }
 
-function Co(e, t) {
+function To(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
+function Co(e, t) {
+var r = Eo(e.pos.x, e.pos.y);
+return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
+}
+
 function So(e, t) {
-var r = To(e.pos.x, e.pos.y);
+var r = Eo(e.pos.x, e.pos.y);
 return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
 }
 
-function wo(e, t) {
-var r = To(e.pos.x, e.pos.y);
-return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
-}
-
-function xo(e, t, r, o, n, a, i, s) {
+function wo(e, t, r, o, n, a, i, s) {
 if (!(r < 1 || r > 48 || o < 1 || o > 48)) {
-var c = To(r, o), u = a.has(c), l = i.has(c);
+var c = Eo(r, o), u = a.has(c), l = i.has(c);
 if (!u && !l) {
 if (t.getTerrain().get(r, o) === TERRAIN_MASK_WALL) return;
 if (s.has(c)) return;
@@ -7310,19 +7292,19 @@ distanceToHub: Math.max(Math.abs(r - n.x), Math.abs(o - n.y))
 }
 }
 
-function bo(e, t) {
+function xo(e, t) {
 return 0 === t.length ? 0 : Math.min.apply(Math, s([], i(t.map(function(t) {
-return Co(e, t);
+return To(e, t);
 })), !1));
 }
 
-var Oo = "spawn", Ao = "extension", ko = "road", Mo = "rampart", Uo = "container", _o = "tower", No = "storage", Po = "link", Io = "terminal", Go = "extractor", Lo = "lab", Do = "factory", Fo = "nuker", Bo = "observer", Wo = "powerSpawn", Ho = [ Oo, Ao, _o, No, Po, Io, Go, Lo, Do, Fo, Bo, Wo ];
+var bo = "spawn", Oo = "extension", ko = "road", Ao = "rampart", Mo = "container", Uo = "tower", _o = "storage", No = "link", Po = "terminal", Io = "extractor", Go = "lab", Lo = "factory", Do = "nuker", Fo = "observer", Bo = "powerSpawn", Wo = [ bo, Oo, Uo, _o, No, Po, Io, Go, Lo, Do, Fo, Bo ];
 
 function Ko(e) {
 return Math.min(8, Math.max(1, Math.floor(Number.isFinite(e) ? e : 1)));
 }
 
-function Yo(e) {
+function Ho(e) {
 var t, r, o, n, i = Ko(e);
 if ("undefined" != typeof CONTROLLER_STRUCTURES) {
 var s = {};
@@ -7344,13 +7326,13 @@ if (t) throw t.error;
 }
 return s;
 }
-return yo(i);
+return fo(i);
 }
 
-function Vo(e) {
-var t, r, o, n = Yo(e), i = {};
+function Yo(e) {
+var t, r, o, n = Ho(e), i = {};
 try {
-for (var s = a(Ho), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Wo), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (o = n[u]) && void 0 !== o ? o : 0;
 l > 0 && (i[u] = l);
 }
@@ -7368,10 +7350,10 @@ if (t) throw t.error;
 return i;
 }
 
-var qo = {
+var Vo = {
 x: 0,
 y: 0
-}, jo = {
+}, qo = {
 name: "seedNest",
 rcl: 1,
 type: "spread",
@@ -7381,8 +7363,8 @@ x: 25,
 y: 25
 },
 structures: [ {
-x: qo.x,
-y: qo.y,
+x: Vo.x,
+y: Vo.y,
 structureType: STRUCTURE_SPAWN
 }, {
 x: -2,
@@ -7405,12 +7387,12 @@ x: -2,
 y: -2,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s([], i(mo(qo)), !1),
+roads: s([], i(lo(Vo)), !1),
 ramparts: []
-}, zo = {
+}, jo = {
 x: 0,
 y: 0
-}, Qo = {
+}, zo = {
 name: "foragingExpansion",
 rcl: 3,
 type: "spread",
@@ -7512,7 +7494,7 @@ x: -3,
 y: -3,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s(s(s(s([], i(mo(zo)), !1), [ {
+roads: s(s(s(s([], i(lo(jo)), !1), [ {
 x: -2,
 y: -1
 }, {
@@ -7536,7 +7518,7 @@ y: 2
 }, {
 x: 1,
 y: 2
-} ], !1), i(po(zo, 3, [ "north", "south", "east", "west" ])), !1), [ {
+} ], !1), i(mo(jo, 3, [ "north", "south", "east", "west" ])), !1), [ {
 x: 3,
 y: 3
 }, {
@@ -7547,10 +7529,10 @@ x: 3,
 y: 4
 } ], !1),
 ramparts: []
-}, Xo = {
+}, Qo = {
 x: 0,
 y: 0
-}, Zo = {
+}, Xo = {
 name: "matureColony",
 rcl: 5,
 type: "spread",
@@ -7728,7 +7710,7 @@ x: 1,
 y: 5,
 structureType: STRUCTURE_LINK
 } ],
-roads: s(s(s([], i(mo(Xo)), !1), [ {
+roads: s(s(s([], i(lo(Qo)), !1), [ {
 x: 3,
 y: -1
 }, {
@@ -7776,8 +7758,8 @@ y: 2
 }, {
 x: 1,
 y: 2
-} ], !1), i(po(Xo, 3, [ "north", "south", "east", "west" ])), !1),
-ramparts: fo([ {
+} ], !1), i(mo(Qo, 3, [ "north", "south", "east", "west" ])), !1),
+ramparts: po([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_SPAWN
@@ -7802,7 +7784,7 @@ x: 1,
 y: 5,
 structureType: STRUCTURE_LINK
 } ], [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_LINK ])
-}, Jo = {
+}, Zo = {
 name: "fortifiedHive",
 rcl: 7,
 type: "spread",
@@ -7952,13 +7934,13 @@ x: 3,
 y: -1,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s(s(s(s([], i(mo({
+roads: s(s(s(s([], i(lo({
 x: 0,
 y: 0
-})), !1), i(mo({
+})), !1), i(lo({
 x: -5,
 y: -1
-})), !1), i(mo({
+})), !1), i(lo({
 x: 5,
 y: -1
 })), !1), [ {
@@ -7998,7 +7980,7 @@ y: 2
 x: 1,
 y: 2
 } ], !1),
-ramparts: fo([ {
+ramparts: po([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_SPAWN
@@ -8051,7 +8033,7 @@ x: -1,
 y: 5,
 structureType: STRUCTURE_POWER_SPAWN
 } ], [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_NUKER, STRUCTURE_POWER_SPAWN ])
-}, $o = {
+}, Jo = {
 name: "compactBunker",
 rcl: 8,
 type: "bunker",
@@ -8484,7 +8466,7 @@ y: 3
 x: 3,
 y: 3
 } ],
-ramparts: s(s([], i(fo([ {
+ramparts: s(s([], i(po([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_STORAGE
@@ -8597,7 +8579,7 @@ y: -2
 } ]), !1)
 };
 
-function en(e, t, r) {
+function $o(e, t, r) {
 for (var o = e.getTerrain(), n = -1; n <= 1; n++) for (var a = -1; a <= 1; a++) {
 var i = t + n, s = r + a;
 if (i < 1 || i > 48 || s < 1 || s > 48) return !1;
@@ -8606,7 +8588,7 @@ if (o.get(i, s) === TERRAIN_MASK_WALL) return !1;
 return !0;
 }
 
-function tn(e, t, r) {
+function en(e, t, r) {
 var o, n, i, s, c, u = e.getTerrain(), l = null !== (c = r.minSpaceRadius) && void 0 !== c ? c : 7, m = 0, d = 0;
 if (t.x < l || t.x > 49 - l || t.y < l || t.y > 49 - l) return {
 fits: !1,
@@ -8666,7 +8648,7 @@ totalTiles: d
 };
 }
 
-function rn(e, t) {
+function tn(e, t) {
 var r, o, n, i, s, c = e.controller;
 if (!c) return null;
 var u = e.find(FIND_SOURCES), l = c.pos.x, m = c.pos.y;
@@ -8688,14 +8670,14 @@ for (var f = Math.round(l / (u.length + 1)), y = Math.round(m / (u.length + 1)),
 for (var R = -h; R <= h; R++) for (var E = -h; E <= h; E++) if (!(Math.abs(R) !== h && Math.abs(E) !== h && h > 0)) {
 var T = f + R, C = y + E;
 if (!(T < v || T > 49 - v || C < v || C > 49 - v)) {
-var S = new RoomPosition(T, C, e.name), w = tn(e, S, t);
+var S = new RoomPosition(T, C, e.name), w = en(e, S, t);
 if (w.fits) {
 var x = 1e3, b = S.getRangeTo(c);
 b >= 4 && b <= 8 ? x += 100 : b < 4 ? x -= 50 : b > 12 && (x -= 30);
 var O = 0;
 try {
-for (var A = (n = void 0, a(u)), k = A.next(); !k.done; k = A.next()) {
-var M = k.value;
+for (var k = (n = void 0, a(u)), A = k.next(); !A.done; A = k.next()) {
+var M = A.value;
 O += S.getRangeTo(M);
 }
 } catch (e) {
@@ -8704,7 +8686,7 @@ error: e
 };
 } finally {
 try {
-k && !k.done && (i = A.return) && i.call(A);
+A && !A.done && (i = k.return) && i.call(k);
 } finally {
 if (n) throw n.error;
 }
@@ -8730,8 +8712,8 @@ return t.score - e.score;
 return null;
 }
 
-function on(e, t) {
-var r, o = yo(t), n = {}, a = e.structures.filter(function(e) {
+function rn(e, t) {
+var r, o = fo(t), n = {}, a = e.structures.filter(function(e) {
 var t, r, a = e.structureType, i = null !== (t = o[a]) && void 0 !== t ? t : 0, s = null !== (r = n[a]) && void 0 !== r ? r : 0;
 return !(s >= i || (n[a] = s + 1, 0));
 }), c = null !== (r = o[STRUCTURE_EXTENSION]) && void 0 !== r ? r : 0;
@@ -8741,9 +8723,9 @@ return e.structureType === STRUCTURE_EXTENSION;
 }).length;
 if (r <= 0) return e;
 var o = function() {
-for (var e = [], t = 0; t < Math.min(80, lo.length); t++) e.push({
-x: lo[t].x,
-y: lo[t].y,
+for (var e = [], t = 0; t < Math.min(80, uo.length); t++) e.push({
+x: uo[t].x,
+y: uo[t].y,
 structureType: STRUCTURE_EXTENSION
 });
 return e;
@@ -8756,7 +8738,7 @@ return s(s([], i(e), !1), i(a), !1);
 }(a, c)), a;
 }
 
-function nn(e) {
+function on(e) {
 switch (e) {
 case STRUCTURE_SPAWN:
 return 100;
@@ -8784,18 +8766,18 @@ return 20;
 }
 }
 
-function an(e, t, r) {
+function nn(e, t, r) {
 return !(t < 1 || t > 48 || r < 1 || r > 48) && e.getTerrain().get(t, r) !== TERRAIN_MASK_WALL;
 }
 
-function sn(e, t, r, o, n) {
-if (void 0 === n && (n = 6), an(e, t, r) && !o.has("".concat(t, ",").concat(r))) return {
+function an(e, t, r, o, n) {
+if (void 0 === n && (n = 6), nn(e, t, r) && !o.has("".concat(t, ",").concat(r))) return {
 x: t,
 y: r
 };
 for (var a = 1; a <= n; a++) for (var i = -a; i <= a; i++) for (var s = -a; s <= a; s++) if (Math.abs(i) === a || Math.abs(s) === a) {
 var c = t + i, u = r + s;
-if (an(e, c, u) && !o.has("".concat(c, ",").concat(u))) return {
+if (nn(e, c, u) && !o.has("".concat(c, ",").concat(u))) return {
 x: c,
 y: u
 };
@@ -8803,13 +8785,13 @@ y: u
 return null;
 }
 
-var cn = {
+var sn = {
 recalculateInterval: 1e3,
 maxPathOps: 2e3,
 includeRemoteRoads: !0
-}, un = new Map, ln = new Map;
+}, cn = new Map, un = new Map;
 
-function mn(e) {
+function ln(e) {
 var t, r, o, n, i = Game.rooms[e], s = new PathFinder.CostMatrix;
 if (!i) return s;
 var c = i.find(FIND_STRUCTURES);
@@ -8849,11 +8831,11 @@ if (o) throw o.error;
 return s;
 }
 
-function dn(e) {
+function mn(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function pn(e) {
+function dn(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(r, 10),
@@ -8861,12 +8843,12 @@ y: parseInt(o, 10)
 };
 }
 
-function fn(e, t) {
+function pn(e, t) {
 var r, o, n;
 try {
 for (var i = a(t), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-e.has(c.roomName) || e.set(c.roomName, new Set), null === (n = e.get(c.roomName)) || void 0 === n || n.add(dn(c));
+e.has(c.roomName) || e.set(c.roomName, new Set), null === (n = e.get(c.roomName)) || void 0 === n || n.add(mn(c));
 }
 } catch (e) {
 r = {
@@ -8881,7 +8863,7 @@ if (r) throw r.error;
 }
 }
 
-function yn(e, t, r, o) {
+function fn(e, t, r, o) {
 return PathFinder.search(e, {
 pos: t,
 range: 0
@@ -8890,18 +8872,18 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return e === r && mn(e);
+return e === r && ln(e);
 }
 });
 }
 
-function vn(e, t, r) {
+function yn(e, t, r) {
 t.incomplete || function(e, t, r) {
 var o, n;
 try {
 for (var i = a(t), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.roomName === r && e.add(dn(c));
+c.roomName === r && e.add(mn(c));
 }
 } catch (e) {
 o = {
@@ -8917,7 +8899,7 @@ if (o) throw o.error;
 }(e, t.path, r);
 }
 
-function gn(e, t, r, o, n) {
+function vn(e, t, r, o, n) {
 var i, s;
 try {
 for (var c = a(function(e, t, r, o) {
@@ -8929,7 +8911,7 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return e === r && mn(e);
+return e === r && ln(e);
 }
 });
 if (!c.incomplete) try {
@@ -8954,7 +8936,7 @@ if (n) throw n.error;
 return s;
 }(t, r, o, n)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-e.add(dn(l));
+e.add(mn(l));
 }
 } catch (e) {
 i = {
@@ -8969,20 +8951,20 @@ if (i) throw i.error;
 }
 }
 
-function hn(e, t, r) {
+function gn(e, t, r) {
 var n, i, s, c, u, l, m;
 void 0 === r && (r = {});
-var d = o(o({}, cn), r), p = function(e, t, r) {
+var d = o(o({}, sn), r), p = function(e, t, r) {
 var o, n, a, i = null === (o = e.storage) || void 0 === o ? void 0 : o.pos, s = i ? "".concat(i.x, ",").concat(i.y) : "none", c = null !== (a = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== a ? a : 0;
 return [ e.name, "anchor:".concat(t.x, ",").concat(t.y), "storage:".concat(s), "rcl:".concat(c), "ops:".concat(r.maxPathOps), "remote:".concat(r.includeRemoteRoads ? 1 : 0) ].join("|");
 }(e, t, d), f = function(e, t) {
-var r = un.get(e);
+var r = cn.get(e);
 if (r && Game.time - r.lastCalculated < t) return r;
 }(p, d.recalculateInterval);
 if (f) return f;
 var y = new Set, v = null !== (l = null === (u = e.controller) || void 0 === u ? void 0 : u.level) && void 0 !== l ? l : 0, g = e.find(FIND_SOURCES), h = e.controller, R = e.storage, E = e.find(FIND_MINERALS)[0], T = null !== (m = null == R ? void 0 : R.pos) && void 0 !== m ? m : t;
 try {
-for (var C = a(g), S = C.next(); !S.done; S = C.next()) gn(y, T, S.value.pos, e.name, d.maxPathOps);
+for (var C = a(g), S = C.next(); !S.done; S = C.next()) vn(y, T, S.value.pos, e.name, d.maxPathOps);
 } catch (e) {
 n = {
 error: e
@@ -8994,10 +8976,10 @@ S && !S.done && (i = C.return) && i.call(C);
 if (n) throw n.error;
 }
 }
-if (h && gn(y, T, h.pos, e.name, d.maxPathOps), E && v >= 6 && gn(y, T, E.pos, e.name, d.maxPathOps),
+if (h && vn(y, T, h.pos, e.name, d.maxPathOps), E && v >= 6 && vn(y, T, E.pos, e.name, d.maxPathOps),
 !R) {
 try {
-for (var w = a(g), x = w.next(); !x.done; x = w.next()) gn(y, t, x.value.pos, e.name, d.maxPathOps);
+for (var w = a(g), x = w.next(); !x.done; x = w.next()) vn(y, t, x.value.pos, e.name, d.maxPathOps);
 } catch (e) {
 s = {
 error: e
@@ -9009,7 +8991,7 @@ x && !x.done && (c = w.return) && c.call(w);
 if (s) throw s.error;
 }
 }
-h && gn(y, t, h.pos, e.name, d.maxPathOps);
+h && vn(y, t, h.pos, e.name, d.maxPathOps);
 }
 var b = {
 roomName: e.name,
@@ -9017,13 +8999,13 @@ positions: y,
 lastCalculated: Game.time
 };
 return function(e, t) {
-un.set(e, t);
+cn.set(e, t);
 }(p, b), U.debug("Calculated road network for ".concat(e.name, ": ").concat(y.size, " positions"), {
 subsystem: "RoadNetwork"
 }), b;
 }
 
-function Rn(e) {
+function hn(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return null;
 var r = parseInt(t[2], 10), o = parseInt(t[4], 10);
@@ -9033,14 +9015,14 @@ y: "N" === t[3] ? o : -o - 1
 };
 }
 
-function En(e, t) {
-var r = Rn(e), o = Rn(t);
+function Rn(e, t) {
+var r = hn(e), o = hn(t);
 if (!r || !o) return null;
 var n = o.x - r.x, a = o.y - r.y;
 return Math.abs(n) + Math.abs(a) !== 1 ? null : 1 === n ? "right" : -1 === n ? "left" : 1 === a ? "top" : -1 === a ? "bottom" : null;
 }
 
-function Tn(e, t) {
+function En(e, t) {
 var r = [], o = Game.map.getRoomTerrain(e);
 switch (t) {
 case "top":
@@ -9061,7 +9043,7 @@ for (a = 0; a < 50; a++) o.get(49, a) !== TERRAIN_MASK_WALL && r.push(new RoomPo
 return r;
 }
 
-function Cn(e, t) {
+function Tn(e, t) {
 var r, o;
 if (0 === t.length) return null;
 var n = t[0], i = e.getRangeTo(n);
@@ -9084,11 +9066,11 @@ if (r) throw r.error;
 return n;
 }
 
-function Sn(e, t) {
+function Cn(e, t) {
 return e.x <= t || e.x >= 49 - t || e.y <= t || e.y >= 49 - t;
 }
 
-function wn(e, t, r, o) {
+function Sn(e, t, r, o) {
 var n = new RoomPosition(25, 25, r), a = PathFinder.search(t, {
 pos: n,
 range: 20
@@ -9097,16 +9079,16 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return mn(e);
+return ln(e);
 }
 });
-a.incomplete || fn(e, a.path);
+a.incomplete || pn(e, a.path);
 }
 
-function xn(e, t, r) {
+function wn(e, t, r) {
 var n, i;
 void 0 === r && (r = {});
-var s = o(o({}, cn), r), c = new Map;
+var s = o(o({}, sn), r), c = new Map;
 if (!s.includeRemoteRoads) return c;
 var u = function(e) {
 var t, r = e.storage, o = e.find(FIND_MY_SPAWNS)[0];
@@ -9117,20 +9099,20 @@ try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 try {
-var p = En(e.name, d);
+var p = Rn(e.name, d);
 if (p) {
-var f = Tn(e.name, p);
+var f = En(e.name, p);
 if (0 === f.length) U.warn("No valid exit positions found in ".concat(e.name, " towards ").concat(d), {
 subsystem: "RoadNetwork"
 }); else {
-var y = Cn(u, f);
+var y = Tn(u, f);
 if (y) {
-var v = yn(u, y, e.name, s.maxPathOps);
-v.incomplete || fn(c, v.path);
+var v = fn(u, y, e.name, s.maxPathOps);
+v.incomplete || pn(c, v.path);
 }
 }
 }
-wn(c, u, d, s.maxPathOps);
+Sn(c, u, d, s.maxPathOps);
 } catch (e) {
 var g = e instanceof Error ? e.message : String(e);
 U.warn("Failed to calculate remote road to ".concat(d, ": ").concat(g), {
@@ -9152,9 +9134,9 @@ if (n) throw n.error;
 return c;
 }
 
-var bn = [ "top", "bottom", "left", "right" ];
+var xn = [ "top", "bottom", "left", "right" ];
 
-function On(e, t, r, n) {
+function bn(e, t, r, n) {
 var c, u;
 void 0 === n && (n = []);
 var l = new Set(function(e, t, r, n) {
@@ -9165,9 +9147,9 @@ return "".concat(e.x, ",").concat(e.y);
 }).sort().join(";"), a = s([], i(o), !1).sort().join(",");
 return "".concat(e, "|").concat(t.x, ",").concat(t.y, "|").concat(n, "|").concat(a);
 }(e.name, t, r, n), u = function(e) {
-var t = ln.get(e);
+var t = un.get(e);
 if (t && function(e) {
-return Game.time - e.lastCalculated < cn.recalculateInterval;
+return Game.time - e.lastCalculated < sn.recalculateInterval;
 }(t)) return t.positions;
 }(c);
 if (u) return u;
@@ -9177,7 +9159,7 @@ var n, i, s = t.getTerrain();
 try {
 for (var c = a(o), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = r.x + l.x, d = r.y + l.y;
-m >= 1 && m <= 48 && d >= 1 && d <= 48 && s.get(m, d) !== TERRAIN_MASK_WALL && e.add(dn({
+m >= 1 && m <= 48 && d >= 1 && d <= 48 && s.get(m, d) !== TERRAIN_MASK_WALL && e.add(mn({
 x: m,
 y: d
 }));
@@ -9194,7 +9176,7 @@ if (n) throw n.error;
 }
 }
 }(l, e, t, r), function(e, t, r) {
-var o, n, i = hn(t, r);
+var o, n, i = gn(t, r);
 try {
 for (var s = a(i.positions), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
@@ -9217,19 +9199,19 @@ if (u) {
 var l = function(e, t, r) {
 var n, i;
 void 0 === r && (r = {});
-var s = o(o({}, cn), r), c = new Set;
+var s = o(o({}, sn), r), c = new Set;
 try {
-for (var u = a(bn), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(xn), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-var d = Tn(e.name, m);
+var d = En(e.name, m);
 if (0 === d.length) continue;
-var p = Cn(t, d);
+var p = Tn(t, d);
 if (!p) continue;
-var f = yn(t, p, e.name, s.maxPathOps);
+var f = fn(t, p, e.name, s.maxPathOps);
 f.incomplete ? U.warn("Incomplete path when calculating exit road for ".concat(m, " in ").concat(e.name, " (target exit: ").concat(p.x, ",").concat(p.y, "). Path length: ").concat(f.path.length), {
 subsystem: "RoadNetwork"
-}) : vn(c, f, e.name);
+}) : yn(c, f, e.name);
 } catch (t) {
 var y = t instanceof Error ? t.message : String(t);
 U.warn("Failed to calculate exit road for ".concat(m, " in ").concat(e.name, ": ").concat(y), {
@@ -9270,7 +9252,7 @@ if (r) throw r.error;
 }(l, e), function(e, t, r) {
 var o, n;
 if (0 !== r.length) {
-var i = xn(t, r).get(t.name);
+var i = wn(t, r).get(t.name);
 if (i) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
@@ -9289,7 +9271,7 @@ if (o) throw o.error;
 }
 }
 }(l, e, n), function(e, t) {
-ln.set(e, t);
+un.set(e, t);
 }(c, {
 roomName: e.name,
 positions: l,
@@ -9310,7 +9292,7 @@ return e.structureType === STRUCTURE_ROAD;
 try {
 for (var l = a(c), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-Sn(d.pos, t) && s.add(dn(d.pos));
+Cn(d.pos, t) && s.add(mn(d.pos));
 }
 } catch (e) {
 r = {
@@ -9326,7 +9308,7 @@ if (r) throw r.error;
 try {
 for (var p = a(u), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Sn(y.pos, t) && s.add(dn(y.pos));
+Cn(y.pos, t) && s.add(mn(y.pos));
 }
 } catch (e) {
 n = {
@@ -9360,9 +9342,9 @@ if (c) throw c.error;
 return l;
 }
 
-var An = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], kn = new Set(An);
+var On = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], kn = new Set(On);
 
-var Mn = {
+var An = {
 id: "EXT10_DIAMOND",
 name: "EXT10 diamond extension pod",
 members: [ {
@@ -9398,7 +9380,7 @@ dy: 2
 } ].map(function(e, t) {
 return {
 id: "extension-".concat(t + 1),
-structureType: Ao,
+structureType: Oo,
 dx: e.dx,
 dy: e.dy,
 minRcl: 2,
@@ -9450,12 +9432,12 @@ minRcl: 2,
 priority: 50 - t
 };
 })
-}, Un = {
+}, Mn = {
 id: "HUB_CORE",
 name: "Storage-centered hub core",
 members: [ {
 id: "spawn-1",
-structureType: Oo,
+structureType: bo,
 dx: -2,
 dy: 0,
 minRcl: 1,
@@ -9466,7 +9448,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "storage",
-structureType: No,
+structureType: _o,
 dx: 0,
 dy: 0,
 minRcl: 4,
@@ -9477,7 +9459,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "hub-link",
-structureType: Po,
+structureType: No,
 dx: -1,
 dy: -1,
 minRcl: 5,
@@ -9488,7 +9470,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "terminal",
-structureType: Io,
+structureType: Po,
 dx: 0,
 dy: 1,
 minRcl: 6,
@@ -9499,7 +9481,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "factory",
-structureType: Do,
+structureType: Lo,
 dx: 1,
 dy: 1,
 minRcl: 7,
@@ -9510,7 +9492,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "spawn-2",
-structureType: Oo,
+structureType: bo,
 dx: 2,
 dy: 0,
 minRcl: 7,
@@ -9521,7 +9503,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "spawn-3",
-structureType: Oo,
+structureType: bo,
 dx: 0,
 dy: -2,
 minRcl: 8,
@@ -9532,7 +9514,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "tower-1",
-structureType: _o,
+structureType: Uo,
 dx: -2,
 dy: -2,
 minRcl: 3,
@@ -9543,7 +9525,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-2",
-structureType: _o,
+structureType: Uo,
 dx: 2,
 dy: -2,
 minRcl: 5,
@@ -9554,7 +9536,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-3",
-structureType: _o,
+structureType: Uo,
 dx: -2,
 dy: 2,
 minRcl: 7,
@@ -9631,12 +9613,12 @@ dy: 0,
 minRcl: 1,
 priority: 97
 } ]
-}, _n = {
+}, Un = {
 id: "SOURCE_MINING",
 name: "Anchored source mining support",
 members: [ {
 id: "container",
-structureType: Uo,
+structureType: Mo,
 dx: 0,
 dy: 0,
 minRcl: 2,
@@ -9646,7 +9628,7 @@ group: "source",
 fallback: "nearSource"
 }, {
 id: "source-link",
-structureType: Po,
+structureType: No,
 dx: 1,
 dy: 0,
 minRcl: 5,
@@ -9663,12 +9645,12 @@ dy: 1,
 minRcl: 1,
 priority: 60
 } ]
-}, Nn = {
+}, _n = {
 id: "CONTROLLER_STAMP",
 name: "Controller upgrading support",
 members: [ {
 id: "controller-container",
-structureType: Uo,
+structureType: Mo,
 dx: 0,
 dy: 0,
 minRcl: 2,
@@ -9678,7 +9660,7 @@ group: "controller",
 fallback: "nearController"
 }, {
 id: "controller-link",
-structureType: Po,
+structureType: No,
 dx: 1,
 dy: 0,
 minRcl: 5,
@@ -9701,7 +9683,7 @@ dy: 1,
 minRcl: 1,
 priority: 54
 } ]
-}, Pn = {
+}, Nn = {
 id: "LAB3_TO_LAB10",
 name: "Expandable compact lab cluster",
 members: [ {
@@ -9757,7 +9739,7 @@ priority: 211
 } ].map(function(e, t) {
 return {
 id: "lab-".concat(t + 1),
-structureType: Lo,
+structureType: Go,
 dx: e.dx,
 dy: e.dy,
 minRcl: e.minRcl,
@@ -9799,12 +9781,12 @@ dy: -1,
 minRcl: 6,
 priority: 86
 } ]
-}, In = {
+}, Pn = {
 id: "DEFENSE_TOWER_PAIR",
 name: "Late-game defended tower group",
 members: [ {
 id: "tower-4",
-structureType: _o,
+structureType: Uo,
 dx: 0,
 dy: 0,
 minRcl: 8,
@@ -9815,7 +9797,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-5",
-structureType: _o,
+structureType: Uo,
 dx: 1,
 dy: 0,
 minRcl: 8,
@@ -9826,7 +9808,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-6",
-structureType: _o,
+structureType: Uo,
 dx: 0,
 dy: 1,
 minRcl: 8,
@@ -9861,12 +9843,12 @@ dy: -1,
 minRcl: 8,
 priority: 77
 } ]
-}, Gn = {
+}, In = {
 id: "LATE_GAME_HEAVY",
 name: "Protected late-game heavy structures",
 members: [ {
 id: "power-spawn",
-structureType: Wo,
+structureType: Bo,
 dx: 0,
 dy: 0,
 minRcl: 8,
@@ -9877,7 +9859,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "nuker",
-structureType: Fo,
+structureType: Do,
 dx: 2,
 dy: 0,
 minRcl: 8,
@@ -9888,7 +9870,7 @@ fallback: "protectedFlexible",
 rampart: !0
 }, {
 id: "observer",
-structureType: Bo,
+structureType: Fo,
 dx: -2,
 dy: 0,
 minRcl: 8,
@@ -9923,12 +9905,12 @@ dy: 0,
 minRcl: 8,
 priority: 67
 } ]
-}, Ln = {
+}, Gn = {
 id: "MINERAL_STAMP",
 name: "Fixed mineral extractor support",
 members: [ {
 id: "extractor",
-structureType: Go,
+structureType: Io,
 dx: 0,
 dy: 0,
 minRcl: 6,
@@ -9938,7 +9920,7 @@ group: "mineral",
 fallback: "none"
 }, {
 id: "mineral-container",
-structureType: Uo,
+structureType: Mo,
 dx: 1,
 dy: 0,
 minRcl: 6,
@@ -9956,11 +9938,11 @@ priority: 52
 } ]
 };
 
-function Dn(e) {
+function Ln(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function Fn(e, t, r) {
+function Dn(e, t, r) {
 return t >= 1 && t <= 48 && r >= 1 && r <= 48 && !function(e, t, r) {
 var o = "undefined" == typeof TERRAIN_MASK_WALL ? 1 : TERRAIN_MASK_WALL;
 return 0 !== (function(e, t, r) {
@@ -9970,11 +9952,11 @@ return e.terrain instanceof Map ? null !== (o = e.terrain.get("".concat(t, ",").
 }(e, t, r);
 }
 
-function Bn(e) {
-return e === Oo || e === _o || e === No || e === Io || e === Do || e === Po || e === Lo || e === Wo || e === Fo || e === Bo;
+function Fn(e) {
+return e === bo || e === Uo || e === _o || e === Po || e === Lo || e === No || e === Go || e === Bo || e === Do || e === Fo;
 }
 
-function Wn(e, t, r) {
+function Bn(e, t, r) {
 var o, n, a, i;
 if (r.localAnchor) return r.localAnchor;
 switch (r.fallback) {
@@ -9992,14 +9974,14 @@ return t.anchor;
 }
 }
 
-function Hn(e, t, r, o) {
-return !!Fn(e, r, o) && !function(e) {
-return new Set(e.structures.map(Dn));
+function Wn(e, t, r, o) {
+return !!Dn(e, r, o) && !function(e) {
+return new Set(e.structures.map(Ln));
 }(t).has("".concat(r, ",").concat(o));
 }
 
 function Kn(e, t, r, o, n) {
-var i = Wn(e, t, r), s = Math.max(Math.abs(i.x - o), Math.abs(i.y - n)), c = Math.max(Math.abs(t.anchor.x - o), Math.abs(t.anchor.y - n)), u = e.controller ? Math.max(Math.abs(e.controller.x - o), Math.abs(e.controller.y - n)) : 0, l = function(e, t, r) {
+var i = Bn(e, t, r), s = Math.max(Math.abs(i.x - o), Math.abs(i.y - n)), c = Math.max(Math.abs(t.anchor.x - o), Math.abs(t.anchor.y - n)), u = e.controller ? Math.max(Math.abs(e.controller.x - o), Math.abs(e.controller.y - n)) : 0, l = function(e, t, r) {
 var o, n;
 if (!e || 0 === e.length) return 0;
 var i = 1 / 0;
@@ -10040,9 +10022,9 @@ if (o) throw o.error;
 }
 return i;
 }(t, o, n), d = Math.min(o, n, 49 - o, 49 - n), p = 1e3 - 18 * s - 2 * c + m + 2 * Math.min(d, 10);
-return r.structureType === _o && (p += 4 * Math.max(0, 14 - Math.min(c, u))), r.structureType === Ao && (p += m + 2 * Math.max(0, 16 - c)),
-r.structureType === Po && (p += 4 * Math.max(0, 10 - Math.min(l, u, c))), r.structureType === Lo && (p += 8 * Math.max(0, 8 - c)),
-r.structureType === Go && e.mineral && (p += e.mineral.x === o && e.mineral.y === n ? 1e4 : -1e4),
+return r.structureType === Uo && (p += 4 * Math.max(0, 14 - Math.min(c, u))), r.structureType === Oo && (p += m + 2 * Math.max(0, 16 - c)),
+r.structureType === No && (p += 4 * Math.max(0, 10 - Math.min(l, u, c))), r.structureType === Go && (p += 8 * Math.max(0, 8 - c)),
+r.structureType === Io && e.mineral && (p += e.mineral.x === o && e.mineral.y === n ? 1e4 : -1e4),
 {
 x: o,
 y: n,
@@ -10051,12 +10033,12 @@ reason: "fallback ".concat(r.fallback, " score ").concat(Math.round(p))
 };
 }
 
-function Yn(e, t, r, o) {
-if (void 0 === o && (o = "global"), r.structureType === Go && e.mineral) return Hn(e, t, e.mineral.x, e.mineral.y) ? [ Kn(e, t, r, e.mineral.x, e.mineral.y) ] : [];
-for (var n = Wn(e, t, r), a = "local" === o ? 6 : 22, i = [], s = 0; s <= a; s++) {
+function Hn(e, t, r, o) {
+if (void 0 === o && (o = "global"), r.structureType === Io && e.mineral) return Wn(e, t, e.mineral.x, e.mineral.y) ? [ Kn(e, t, r, e.mineral.x, e.mineral.y) ] : [];
+for (var n = Bn(e, t, r), a = "local" === o ? 6 : 22, i = [], s = 0; s <= a; s++) {
 for (var c = -s; c <= s; c++) for (var u = -s; u <= s; u++) if (!(s > 0 && Math.abs(c) !== s && Math.abs(u) !== s)) {
 var l = n.x + c, m = n.y + u;
-Hn(e, t, l, m) && i.push(Kn(e, t, r, l, m));
+Wn(e, t, l, m) && i.push(Kn(e, t, r, l, m));
 }
 if ("local" === o && i.length > 0) break;
 }
@@ -10065,38 +10047,38 @@ return t.score - e.score;
 });
 }
 
-function Vn(e) {
+function Yn(e) {
 return e.length > 0 ? e[0] : null;
 }
 
-var qn, jn = "stamp-v1";
+var Vn = "stamp-v1";
 
-function zn(e) {
+function qn(e) {
 return Math.max(9, Math.min(40, Math.round(e)));
 }
 
-function Qn(e) {
+function jn(e) {
 return {
-x: zn(e.x),
-y: zn(e.y)
+x: qn(e.x),
+y: qn(e.y)
 };
 }
 
-function Xn(e, t) {
+function zn(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function Zn(e, t) {
+function Qn(e, t) {
 var r;
 return null !== (r = e.counts[t]) && void 0 !== r ? r : 0;
 }
 
-function Jn(e, t) {
-e.counts[t] = Zn(e, t) + 1;
+function Xn(e, t) {
+e.counts[t] = Qn(e, t) + 1;
 }
 
-function $n(e, t, r, o, n, a) {
-if (!(a > e.plan.rcl) && Fn(e.facts, t, r) && !e.occupied.has("".concat(t, ",").concat(r))) {
+function Zn(e, t, r, o, n, a) {
+if (!(a > e.plan.rcl) && Dn(e.facts, t, r) && !e.occupied.has("".concat(t, ",").concat(r))) {
 var i = "".concat(t, ",").concat(r);
 e.roadKeys.has(i) || (e.plan.roads.push({
 x: t,
@@ -10108,13 +10090,13 @@ minRcl: a
 }
 }
 
-function ea(e, t, r) {
+function Jn(e, t, r) {
 return void 0 === r && (r = !1), !!function(e, t, r, o) {
 var n, a = null !== (n = e.limits[t]) && void 0 !== n ? n : 0;
-return !(a <= 0 || Zn(e, t) >= a || !Fn(e.facts, r, o) || e.occupied.has("".concat(r, ",").concat(o)));
-}(e, t.structureType, t.x, t.y) && (e.plan.structures.push(t), e.occupied.add(Dn(t)),
-Jn(e, t.structureType), (r || Bn(t.structureType)) && function(e, t, r, o, n, a) {
-if (!(a > e.plan.rcl) && Fn(e.facts, t, r)) {
+return !(a <= 0 || Qn(e, t) >= a || !Dn(e.facts, r, o) || e.occupied.has("".concat(r, ",").concat(o)));
+}(e, t.structureType, t.x, t.y) && (e.plan.structures.push(t), e.occupied.add(Ln(t)),
+Xn(e, t.structureType), (r || Fn(t.structureType)) && function(e, t, r, o, n, a) {
+if (!(a > e.plan.rcl) && Dn(e.facts, t, r)) {
 var i = "".concat(t, ",").concat(r);
 e.rampartKeys.has(i) || (e.plan.ramparts.push({
 x: t,
@@ -10127,12 +10109,12 @@ minRcl: a
 }(e, t.x, t.y, "".concat(t.source, ":rampart"), t.priority, t.minRcl), !0);
 }
 
-function ta(e, t, r) {
+function $n(e, t, r) {
 var o, n, i;
 try {
 for (var s = a(null != t ? t : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== ko && u.structureType !== Mo && Fn(e.facts, u.x, u.y)) {
+if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== ko && u.structureType !== Ao && Dn(e.facts, u.x, u.y)) {
 var l = "".concat(u.x, ",").concat(u.y);
 if (!e.occupied.has(l)) {
 var m = {
@@ -10144,7 +10126,7 @@ priority: 1e3,
 source: r,
 placedBy: "fixed"
 };
-e.plan.structures.push(m), e.occupied.add(l), Jn(e, u.structureType);
+e.plan.structures.push(m), e.occupied.add(l), Xn(e, u.structureType);
 }
 }
 }
@@ -10161,7 +10143,7 @@ if (o) throw o.error;
 }
 }
 
-function ra(e, t, r, o) {
+function ea(e, t, r, o) {
 return {
 structureType: e.structureType,
 priority: e.priority,
@@ -10176,17 +10158,17 @@ minRcl: e.minRcl
 };
 }
 
-function oa(e, t) {
+function ta(e, t) {
 var r, o = null !== (r = e.limits[t.structureType]) && void 0 !== r ? r : 0;
-return o > 0 && Zn(e, t.structureType) < o;
+return o > 0 && Qn(e, t.structureType) < o;
 }
 
-function na(e, t, r, o) {
-return o.minRcl > e.plan.rcl || !oa(e, {
+function ra(e, t, r, o) {
+return o.minRcl > e.plan.rcl || !ta(e, {
 structureType: o.structureType,
 priority: o.priority,
 fallback: o.fallback
-}) || ea(e, {
+}) || Jn(e, {
 x: r.x + o.dx,
 y: r.y + o.dy,
 structureType: o.structureType,
@@ -10197,13 +10179,13 @@ placedBy: "stamp"
 }, o.rampart);
 }
 
-function aa(e, t, r) {
+function oa(e, t, r) {
 var o, n, i, s, c = [], u = !0;
 e.plan.stamps.push(t.id);
 try {
 for (var l = a(t.roads), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-$n(e, r.x + d.dx, r.y + d.dy, "".concat(t.id, ":").concat(d.id), d.priority, d.minRcl);
+Zn(e, r.x + d.dx, r.y + d.dy, "".concat(t.id, ":").concat(d.id), d.priority, d.minRcl);
 }
 } catch (e) {
 o = {
@@ -10224,7 +10206,7 @@ return t.priority - e.priority;
 try {
 for (var f = a(p), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-na(e, t, r, v) || ((v.required || oa(e, ra(v, t.id, r, "stamp member blocked"))) && c.push(ra(v, t.id, r, "preferred stamp tile blocked")),
+ra(e, t, r, v) || ((v.required || ta(e, ea(v, t.id, r, "stamp member blocked"))) && c.push(ea(v, t.id, r, "preferred stamp tile blocked")),
 v.required && (u = !1));
 }
 } catch (e) {
@@ -10244,20 +10226,20 @@ missing: c
 };
 }
 
-function ia(e, t, r, o, n) {
+function na(e, t, r, o, n) {
 for (var a = t.x, i = t.y, s = 0; (a !== r.x || i !== r.y) && s < 80 && (a < r.x ? a++ : a > r.x && a--,
-i < r.y ? i++ : i > r.y && i--, a !== r.x || i !== r.y); ) $n(e, a, i, o, 40, n),
+i < r.y ? i++ : i > r.y && i--, a !== r.x || i !== r.y); ) Zn(e, a, i, o, 40, n),
 s++;
 }
 
-function sa(e, t, r) {
+function aa(e, t, r) {
 for (var o, n = null, a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) if (0 !== a || 0 !== i) {
 var s = {
 x: t.x + a,
 y: t.y + i
 };
-if (Fn(e.facts, s.x, s.y) && !e.occupied.has("".concat(s.x, ",").concat(s.y))) {
-var c = -Xn(s, r);
+if (Dn(e.facts, s.x, s.y) && !e.occupied.has("".concat(s.x, ",").concat(s.y))) {
+var c = -zn(s, r);
 (!n || c > n.score) && (n = {
 point: s,
 score: c
@@ -10267,9 +10249,9 @@ score: c
 return null !== (o = null == n ? void 0 : n.point) && void 0 !== o ? o : null;
 }
 
-function ca(e, t) {
-if (!oa(e, t)) return !0;
-var r = Vn(Yn(e.facts, e.plan, t, "local")), o = null != r ? r : Vn(Yn(e.facts, e.plan, t, "global"));
+function ia(e, t) {
+if (!ta(e, t)) return !0;
+var r = Yn(Hn(e.facts, e.plan, t, "local")), o = null != r ? r : Yn(Hn(e.facts, e.plan, t, "global"));
 if (!o) return !1;
 var n = function(e, t, r) {
 var o;
@@ -10283,11 +10265,11 @@ source: r,
 placedBy: "fallback"
 };
 }(o, t, t.sourceStamp ? "".concat(t.sourceStamp, ":fallback") : "fallback");
-return !!ea(e, n, Bn(t.structureType)) && (function(e, t) {
+return !!Jn(e, n, Fn(t.structureType)) && (function(e, t) {
 var r, o;
 if (!function(e, t) {
 return e.roads.some(function(e) {
-return 1 === Xn(e, t);
+return 1 === zn(e, t);
 });
 }(e.plan, t)) {
 var n = [ {
@@ -10315,12 +10297,12 @@ y: t.y + 1
 x: t.x + 1,
 y: t.y - 1
 } ].sort(function(t, r) {
-return Xn(t, e.plan.anchor) - Xn(r, e.plan.anchor);
+return zn(t, e.plan.anchor) - zn(r, e.plan.anchor);
 });
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (Fn(e.facts, c.x, c.y) && !e.occupied.has("".concat(c.x, ",").concat(c.y))) return void $n(e, c.x, c.y, "fallback:road-access", 30, 1);
+if (Dn(e.facts, c.x, c.y) && !e.occupied.has("".concat(c.x, ",").concat(c.y))) return void Zn(e, c.x, c.y, "fallback:road-access", 30, 1);
 }
 } catch (e) {
 r = {
@@ -10337,24 +10319,24 @@ if (r) throw r.error;
 }(e, n), !0);
 }
 
-function ua(e) {
+function sa(e) {
 switch (e) {
-case Ao:
+case Oo:
 return "nearRoad";
 
-case _o:
+case Uo:
 return "defenseCoverage";
 
-case No:
-case Io:
-case Do:
-case Wo:
+case _o:
+case Po:
+case Lo:
+case Bo:
 return "nearStorage";
 
-case Lo:
+case Go:
 return "labCluster";
 
-case Go:
+case Io:
 return "nearMineral";
 
 default:
@@ -10362,37 +10344,37 @@ return "protectedFlexible";
 }
 }
 
-function la(e) {
+function ca(e) {
 var t;
 return (null !== (t = function(e) {
 var t;
-return null !== (t = Yo(8)[e]) && void 0 !== t ? t : 0;
+return null !== (t = Ho(8)[e]) && void 0 !== t ? t : 0;
 }(e)) && void 0 !== t ? t : 0) > 0;
 }
 
-function ma(e) {
+function ua(e) {
 return "".concat(e.structureType, ":").concat(e.x, ",").concat(e.y);
 }
 
-function da(e) {
+function la(e) {
 switch (e) {
-case Oo:
-case Uo:
+case bo:
+case Mo:
 return "P0";
 
+case _o:
+case Oo:
 case No:
-case Ao:
-case Po:
 return "P1";
 
-case _o:
-case Mo:
+case Uo:
+case Ao:
 return "P2";
 
+case Po:
+case Go:
 case Io:
 case Lo:
-case Go:
-case Do:
 return "P3";
 
 default:
@@ -10400,7 +10382,7 @@ return "P4";
 }
 }
 
-function pa(e) {
+function ma(e) {
 switch (e) {
 case "P0":
 return 500;
@@ -10419,7 +10401,7 @@ return 100;
 }
 }
 
-function fa(e, t) {
+function da(e, t) {
 var r, o, n, i, s, c, u, l, m;
 void 0 === t && (t = {});
 var d = null !== (u = t.currentRcl) && void 0 !== u ? u : e.rcl, p = null !== (l = t.existingStructureKeys) && void 0 !== l ? l : new Set, f = null !== (m = t.existingSiteKeys) && void 0 !== m ? m : new Set, y = [];
@@ -10432,11 +10414,11 @@ x: h.x,
 y: h.y,
 structureType: h.structureType,
 minRcl: h.minRcl,
-priority: da(h.structureType),
-score: pa(da(h.structureType)) + h.priority,
+priority: la(h.structureType),
+score: ma(la(h.structureType)) + h.priority,
 source: h.source
 };
-p.has(ma(R)) || f.has(ma(R)) || y.push(R);
+p.has(ua(R)) || f.has(ua(R)) || y.push(R);
 }
 }
 } catch (e) {
@@ -10461,7 +10443,7 @@ minRcl: C.minRcl,
 priority: "P1",
 score: 360 + C.priority,
 source: C.source
-}, p.has(ma(R)) || f.has(ma(R)) || y.push(R));
+}, p.has(ua(R)) || f.has(ua(R)) || y.push(R));
 }
 } catch (e) {
 n = {
@@ -10480,12 +10462,12 @@ var x = w.value;
 x.minRcl > d || (R = {
 x: x.x,
 y: x.y,
-structureType: Mo,
+structureType: Ao,
 minRcl: x.minRcl,
 priority: "P2",
 score: 300 + x.priority,
 source: x.source
-}, p.has(ma(R)) || f.has(ma(R)) || y.push(R));
+}, p.has(ua(R)) || f.has(ua(R)) || y.push(R));
 }
 } catch (e) {
 s = {
@@ -10503,43 +10485,373 @@ return t.score - e.score || e.structureType.localeCompare(t.structureType);
 }), "number" == typeof t.maxItems ? y.slice(0, t.maxItems) : y;
 }
 
+var pa, fa = "defenseAssist";
+
+function ya(e, t, r) {
+return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
+}
+
+function va(e, t) {
+Object.assign(e.memory, function(e) {
+var t, r, o = null !== (t = e.createdAt) && void 0 !== t ? t : e.now;
+return {
+assistTarget: e.targetRoom,
+targetRoom: e.targetRoom,
+task: fa,
+defenseSquadId: null !== (r = e.squadId) && void 0 !== r ? r : ya(e.homeRoom, e.targetRoom, o),
+defenseSquadSize: Math.max(1, e.squadSize),
+defenseSquadCreatedAt: o
+};
+}(t));
+}
+
+function ga(e) {
+var t;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === fa ? e.targetRoom : void 0;
+}
+
+function ha(e) {
+return !!function(e, t) {
+if ("retreat" === t.recommendedResponse || "safemode" === t.recommendedResponse) return !0;
+var r = e.room.find(FIND_MY_CREEPS, {
+filter: function(e) {
+var t = e.memory;
+return "defender" === t.role || "rangedDefender" === t.role || "guard" === t.role || "ranger" === t.role;
+}
+});
+if (t.hostileCount > 3 * r.length) return U.info("Creep ".concat(e.name, " retreating: heavily outnumbered (").concat(t.hostileCount, " hostiles vs ").concat(r.length, " defenders)"), {
+subsystem: "Defense",
+room: e.room.name,
+creep: e.name
+}), !0;
+var o = e.room.find(FIND_MY_CREEPS, {
+filter: function(e) {
+return "healer" === e.memory.role;
+}
+});
+return e.hits < .3 * e.hitsMax && t.healerCount > 0 && 0 === o.length ? (U.info("Creep ".concat(e.name, " retreating: damaged (").concat(e.hits, "/").concat(e.hitsMax, ") facing ").concat(t.healerCount, " enemy healers without friendly healer support"), {
+subsystem: "Defense",
+room: e.room.name,
+creep: e.name
+}), !0) : t.boostedCount > 0 && r.length < 2 * t.boostedCount && (U.info("Creep ".concat(e.name, " retreating: facing ").concat(t.boostedCount, " boosted hostiles without sufficient support"), {
+subsystem: "Defense",
+room: e.room.name,
+creep: e.name
+}), !0);
+}(e, Kr(e.room)) && (function(e) {
+var t, r, o, n, c = e.room.find(FIND_MY_SPAWNS)[0];
+if (c) {
+var u = e.moveTo(c, {
+range: 3,
+visualizePathStyle: {
+stroke: "#ffaa00"
+}
+});
+if (u === OK || u === ERR_TIRED) return;
+}
+var l = Game.map.describeExits(e.room.name);
+if (l) {
+var m = ((t = {})[TOP] = FIND_EXIT_TOP, t[BOTTOM] = FIND_EXIT_BOTTOM, t[LEFT] = FIND_EXIT_LEFT,
+t[RIGHT] = FIND_EXIT_RIGHT, t), d = [];
+try {
+for (var p = a(Object.entries(l)), f = p.next(); !f.done; f = p.next()) {
+var y = i(f.value, 2), v = y[0], g = y[1], h = Number(v), R = Game.rooms[g];
+if (null === (n = null == R ? void 0 : R.controller) || void 0 === n ? void 0 : n.my) {
+var E = m[h];
+if (E) {
+var T = e.room.find(E);
+T.length > 0 && d.push.apply(d, s([], i(T), !1));
+}
+}
+}
+} catch (e) {
+r = {
+error: e
+};
+} finally {
+try {
+f && !f.done && (o = p.return) && o.call(p);
+} finally {
+if (r) throw r.error;
+}
+}
+if (d.length > 0) {
+var C = e.pos.findClosestByPath(d);
+if (C) return void e.moveTo(C, {
+visualizePathStyle: {
+stroke: "#ffaa00"
+}
+});
+}
+}
+var S = e.pos.findClosestByPath(FIND_EXIT);
+S && e.moveTo(S, {
+visualizePathStyle: {
+stroke: "#ff0000"
+}
+});
+}(e), !0);
+}
+
+!function(e) {
+e[e.NONE = 0] = "NONE", e[e.LOW = 1] = "LOW", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
+e[e.CRITICAL = 4] = "CRITICAL";
+}(pa || (pa = {}));
+
+var Ra = function() {
+function e() {
+this.emergencyStates = new Map;
+}
+return e.prototype.assess = function(e, t) {
+var r, o, n = this.emergencyStates.get(e.name), a = this.calculateEmergencyLevel(e, t);
+if (a === pa.NONE && !n) return {
+level: pa.NONE,
+startedAt: Game.time,
+assistanceRequested: !1,
+boostsAllocated: !1,
+lastEscalation: 0
+};
+var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : pa.NONE;
+return n ? (o = n).level = a : (o = {
+level: a,
+startedAt: Game.time,
+assistanceRequested: !1,
+boostsAllocated: !1,
+lastEscalation: 0
+}, this.emergencyStates.set(e.name, o)), a === pa.NONE ? (n && (U.info("Emergency resolved in ".concat(e.name), {
+subsystem: "Defense"
+}), this.emergencyStates.delete(e.name)), o) : (n && a > i && (U.warn("Emergency escalated in ".concat(e.name, ": Level ").concat(i, " → ").concat(a), {
+subsystem: "Defense"
+}), o.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, o), o);
+}, e.prototype.calculateEmergencyLevel = function(e, t) {
+var r = j(e);
+if (0 === t.danger && 0 === r.length) return pa.NONE;
+var o = vr(e), n = hr(e), a = Kr(e);
+if (e.find(FIND_MY_STRUCTURES, {
+filter: function(e) {
+return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
+}
+}).length > 0) return pa.CRITICAL;
+var i = r.filter(function(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && e.boost;
+});
+}), s = Math.max(0, o.guards - n.guards) + Math.max(0, o.rangers - n.rangers) + Math.max(0, o.healers - n.healers);
+return i.length > 0 && s >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers || a.dangerLevel >= 2 && s >= 2 ? pa.HIGH : (t.danger >= 2 || a.dangerLevel >= 2) && s >= 1 ? pa.MEDIUM : t.danger >= 1 || r.length > 0 ? pa.LOW : pa.NONE;
+}, e.prototype.executeEmergencyResponse = function(e, t, r) {
+r.level >= pa.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
+r.level >= pa.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
+r.boostsAllocated = !0), this.updateDefensePosture(e, t, r);
+}, e.prototype.requestDefenseAssistance = function(e, t) {
+var r;
+if (!Rr(e, t)) return !1;
+var o = Er(e, t);
+if (!o) return !1;
+var n = Memory, a = null !== (r = n.defenseRequests) && void 0 !== r ? r : [], c = a.find(function(t) {
+return t.roomName === e.name && Game.time - t.createdAt < 500;
+}), u = a.filter(function(t) {
+return t.roomName !== e.name && Game.time - t.createdAt < 500;
+});
+return c && !this.shouldRefreshDefenseRequest(c, o) ? (n.defenseRequests = s(s([], i(u), !1), [ c ], !1),
+!0) : (n.defenseRequests = s(s([], i(u), !1), [ o ], !1), U.warn("Defense assistance requested for ".concat(e.name, ": ") + "".concat(o.guardsNeeded, " guards, ").concat(o.rangersNeeded, " rangers, ").concat(o.healersNeeded, " healers - ").concat(o.threat), {
+subsystem: "Defense"
+}), !0);
+}, e.prototype.shouldRefreshDefenseRequest = function(e, t) {
+return t.urgency !== e.urgency || t.guardsNeeded !== e.guardsNeeded || t.rangersNeeded !== e.rangersNeeded || t.healersNeeded !== e.healersNeeded || t.threat !== e.threat;
+}, e.prototype.allocateBoostsForDefense = function(e, t) {
+var r, o = Memory, n = null !== (r = o.boostDefensePriority) && void 0 !== r ? r : {};
+n[e.name] = !0, o.boostDefensePriority = n, U.info("Allocated boost priority for defenders in ".concat(e.name), {
+subsystem: "Defense"
+});
+}, e.prototype.updateDefensePosture = function(e, t, r) {
+switch (r.level) {
+case pa.CRITICAL:
+"evacuate" !== t.posture && (t.posture = "war", t.pheromones.war = 100, t.pheromones.defense = 100,
+U.warn("".concat(e.name, " posture: CRITICAL DEFENSE"), {
+subsystem: "Defense"
+}));
+break;
+
+case pa.HIGH:
+"war" !== t.posture && "evacuate" !== t.posture && (t.posture = "defensive", t.pheromones.defense = 80,
+t.pheromones.war = 40, U.info("".concat(e.name, " posture: HIGH DEFENSE"), {
+subsystem: "Defense"
+}));
+break;
+
+case pa.MEDIUM:
+"eco" !== t.posture && "expand" !== t.posture || (t.posture = "defensive", t.pheromones.defense = 60,
+U.info("".concat(e.name, " posture: MEDIUM DEFENSE"), {
+subsystem: "Defense"
+}));
+break;
+
+case pa.LOW:
+"eco" !== t.posture && "expand" !== t.posture || (t.pheromones.defense = 30, U.debug("".concat(e.name, ": LOW DEFENSE alert"), {
+subsystem: "Defense"
+}));
+}
+}, e.prototype.getDefenseRequests = function() {
+var e, t = Memory, r = null !== (e = t.defenseRequests) && void 0 !== e ? e : [], o = r.filter(function(e) {
+return Game.time - e.createdAt < 500;
+});
+return o.length !== r.length && (t.defenseRequests = o), o;
+}, e.prototype.clearDefenseRequest = function(e) {
+var t, r = Memory, o = (null !== (t = r.defenseRequests) && void 0 !== t ? t : []).filter(function(t) {
+return t.roomName !== e;
+});
+r.defenseRequests = o;
+}, e.prototype.getEmergencyState = function(e) {
+return this.emergencyStates.get(e);
+}, e.prototype.hasEmergency = function(e) {
+var t = this.emergencyStates.get(e);
+return void 0 !== t && t.level > pa.NONE;
+}, e.prototype.getActiveEmergencies = function() {
+var e, t, r = [];
+try {
+for (var o = a(this.emergencyStates.entries()), n = o.next(); !n.done; n = o.next()) {
+var s = i(n.value, 2), c = s[0], u = s[1];
+u.level > pa.NONE && r.push({
+roomName: c,
+state: u
+});
+}
+} catch (t) {
+e = {
+error: t
+};
+} finally {
+try {
+n && !n.done && (t = o.return) && t.call(o);
+} finally {
+if (e) throw e.error;
+}
+}
+return r.sort(function(e, t) {
+return t.state.level - e.state.level;
+});
+}, e;
+}(), Ea = new Ra;
+
+function Ta(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === HEAL || e.type === WORK || e.type === CLAIM);
+});
+}
+
+function Ca(e, t) {
+return e.body.filter(function(e) {
+return e.hits > 0 && e.type === t;
+}).length;
+}
+
+function Sa(e) {
+return !!e.body.some(function(e) {
+return e.hits > 0 && e.boost;
+}) || Ca(e, WORK) >= 5 || Ca(e, HEAL) >= 3;
+}
+
+var wa, xa = function() {
+function e() {}
+return e.prototype.checkSafeMode = function(e, t) {
+var r, o, n, a, i;
+if (!(null === (r = e.controller) || void 0 === r ? void 0 : r.safeMode) && !(null === (o = e.controller) || void 0 === o ? void 0 : o.safeModeCooldown) && 0 !== (null !== (a = null === (n = e.controller) || void 0 === n ? void 0 : n.safeModeAvailable) && void 0 !== a ? a : 0) && this.shouldTriggerSafeMode(e, t)) {
+var s = null === (i = e.controller) || void 0 === i ? void 0 : i.activateSafeMode();
+if (s === OK) U.warn("SAFE MODE ACTIVATED in ".concat(e.name), {
+subsystem: "Defense"
+}); else {
+var c = void 0 !== s ? String(s) : "undefined";
+U.error("Failed to activate safe mode in ".concat(e.name, ": ").concat(c), {
+subsystem: "Defense"
+});
+}
+}
+}, e.prototype.shouldTriggerSafeMode = function(e, t) {
+var r, o;
+if (t.danger < 2) return !1;
+var n = j(e), i = n.filter(Ta), s = function() {
+var e;
+return !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.safeModeDangerousHostilesOnly);
+}(), c = s ? i : n;
+if (s && 0 === i.length) return !1;
+var u = e.find(FIND_MY_SPAWNS);
+try {
+for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
+var d = m.value;
+if (d.hits < .2 * d.hitsMax) return U.warn("Spawn ".concat(d.name, " critical: ").concat(d.hits, "/").concat(d.hitsMax), {
+subsystem: "Defense"
+}), !0;
+}
+} catch (e) {
+r = {
+error: e
+};
+} finally {
+try {
+m && !m.done && (o = l.return) && o.call(l);
+} finally {
+if (r) throw r.error;
+}
+}
+if (e.storage && e.storage.hits < .2 * e.storage.hitsMax) return U.warn("Storage critical: ".concat(e.storage.hits, "/").concat(e.storage.hitsMax), {
+subsystem: "Defense"
+}), !0;
+if (e.terminal && e.terminal.hits < .2 * e.terminal.hitsMax) return U.warn("Terminal critical: ".concat(e.terminal.hits, "/").concat(e.terminal.hitsMax), {
+subsystem: "Defense"
+}), !0;
+var p = e.find(FIND_MY_CREEPS, {
+filter: function(e) {
+var t = e.memory.role;
+return "guard" === t || "ranger" === t || "soldier" === t;
+}
+});
+if (c.length > 3 * p.length) return U.warn("Overwhelmed: ".concat(c.length, " safe-mode-relevant hostiles vs ").concat(p.length, " defenders"), {
+subsystem: "Defense"
+}), !0;
+var f = c.filter(Sa);
+return f.length > 0 && p.length < 2 * f.length && (U.warn("High-impact siege hostiles detected: ".concat(f.length), {
+subsystem: "Defense"
+}), !0);
+}, e;
+}(), ba = new xa;
+
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(qn || (qn = {}));
+}(wa || (wa = {}));
 
-var ya, va = new (function() {
+var Oa, ka = new (function() {
 function e() {
-this.level = qn.INFO;
+this.level = wa.INFO;
 }
 return e.prototype.setLevel = function(e) {
 this.level = e;
 }, e.prototype.debug = function(e, t) {
-this.level <= qn.DEBUG && console.log(JSON.stringify(o({
+this.level <= wa.DEBUG && console.log(JSON.stringify(o({
 level: "DEBUG",
 message: e,
 tick: Game.time
 }, t)));
 }, e.prototype.info = function(e, t) {
-this.level <= qn.INFO && console.log(JSON.stringify(o({
+this.level <= wa.INFO && console.log(JSON.stringify(o({
 level: "INFO",
 message: e,
 tick: Game.time
 }, t)));
 }, e.prototype.warn = function(e, t) {
-this.level <= qn.WARN && console.log(JSON.stringify(o({
+this.level <= wa.WARN && console.log(JSON.stringify(o({
 level: "WARN",
 message: e,
 tick: Game.time
 }, t)));
 }, e.prototype.error = function(e, t) {
-this.level <= qn.ERROR && console.log(JSON.stringify(o({
+this.level <= wa.ERROR && console.log(JSON.stringify(o({
 level: "ERROR",
 message: e,
 tick: Game.time
 }, t)));
 }, e;
-}()), ga = {
+}()), Aa = {
 maxEventsPerTick: 50,
 maxQueueSize: 200,
 lowBucketThreshold: 2e3,
@@ -10553,32 +10865,32 @@ enableEventCoalescing: !0
 !function(e) {
 e[e.CRITICAL = 100] = "CRITICAL", e[e.HIGH = 75] = "HIGH", e[e.NORMAL = 50] = "NORMAL",
 e[e.LOW = 25] = "LOW", e[e.BACKGROUND = 10] = "BACKGROUND";
-}(ya || (ya = {}));
+}(Oa || (Oa = {}));
 
-var ha, Ra = {
-"hostile.detected": ya.CRITICAL,
-"nuke.detected": ya.CRITICAL,
-"safemode.activated": ya.CRITICAL,
-"structure.destroyed": ya.HIGH,
-"hostile.cleared": ya.HIGH,
-"creep.died": ya.HIGH,
-"energy.critical": ya.HIGH,
-"spawn.emergency": ya.HIGH,
-"posture.change": ya.HIGH,
-"spawn.completed": ya.NORMAL,
-"rcl.upgrade": ya.NORMAL,
-"construction.complete": ya.NORMAL,
-"remote.lost": ya.NORMAL,
-"squad.formed": ya.NORMAL,
-"squad.dissolved": ya.NORMAL,
-"market.transaction": ya.LOW,
-"pheromone.update": ya.LOW,
-"cluster.update": ya.LOW,
-"expansion.candidate": ya.LOW,
-"powerbank.discovered": ya.LOW,
-"cpu.spike": ya.BACKGROUND,
-"bucket.modeChange": ya.BACKGROUND
-}, Ea = function() {
+var Ma, Ua = {
+"hostile.detected": Oa.CRITICAL,
+"nuke.detected": Oa.CRITICAL,
+"safemode.activated": Oa.CRITICAL,
+"structure.destroyed": Oa.HIGH,
+"hostile.cleared": Oa.HIGH,
+"creep.died": Oa.HIGH,
+"energy.critical": Oa.HIGH,
+"spawn.emergency": Oa.HIGH,
+"posture.change": Oa.HIGH,
+"spawn.completed": Oa.NORMAL,
+"rcl.upgrade": Oa.NORMAL,
+"construction.complete": Oa.NORMAL,
+"remote.lost": Oa.NORMAL,
+"squad.formed": Oa.NORMAL,
+"squad.dissolved": Oa.NORMAL,
+"market.transaction": Oa.LOW,
+"pheromone.update": Oa.LOW,
+"cluster.update": Oa.LOW,
+"expansion.candidate": Oa.LOW,
+"powerbank.discovered": Oa.LOW,
+"cpu.spike": Oa.BACKGROUND,
+"bucket.modeChange": Oa.BACKGROUND
+}, _a = function() {
 function e(e) {
 void 0 === e && (e = {}), this.handlers = new Map, this.eventQueue = [], this.coalescedQueueMap = new Map,
 this.handlerIdCounter = 0, this.stats = {
@@ -10588,21 +10900,21 @@ eventsDeferred: 0,
 eventsDropped: 0,
 eventsCoalesced: 0,
 handlersInvoked: 0
-}, this.config = o(o({}, ga), e);
+}, this.config = o(o({}, Aa), e);
 }
 return e.prototype.on = function(e, t, r) {
 var o, n, a, i, s = this;
 void 0 === r && (r = {});
 var c = {
 handler: t,
-priority: null !== (o = r.priority) && void 0 !== o ? o : ya.NORMAL,
+priority: null !== (o = r.priority) && void 0 !== o ? o : Oa.NORMAL,
 minBucket: null !== (n = r.minBucket) && void 0 !== n ? n : 0,
 once: null !== (a = r.once) && void 0 !== a && a,
 id: "handler_".concat(++this.handlerIdCounter)
 }, u = null !== (i = this.handlers.get(e)) && void 0 !== i ? i : [];
 return u.push(c), u.sort(function(e, t) {
 return t.priority - e.priority;
-}), this.handlers.set(e, u), this.config.enableLogging && va.debug('EventBus: Registered handler for "'.concat(e, '" (id: ').concat(c.id, ")"), {
+}), this.handlers.set(e, u), this.config.enableLogging && ka.debug('EventBus: Registered handler for "'.concat(e, '" (id: ').concat(c.id, ")"), {
 subsystem: "EventBus"
 }), function() {
 return s.off(e, c.id);
@@ -10617,12 +10929,12 @@ if (r) {
 var o = r.findIndex(function(e) {
 return e.id === t;
 });
--1 !== o && (r.splice(o, 1), this.config.enableLogging && va.debug('EventBus: Unregistered handler "'.concat(t, '" from "').concat(e, '"'), {
+-1 !== o && (r.splice(o, 1), this.config.enableLogging && ka.debug('EventBus: Unregistered handler "'.concat(t, '" from "').concat(e, '"'), {
 subsystem: "EventBus"
 }));
 }
 }, e.prototype.offAll = function(e) {
-this.handlers.delete(e), this.config.enableLogging && va.debug('EventBus: Removed all handlers for "'.concat(e, '"'), {
+this.handlers.delete(e), this.config.enableLogging && ka.debug('EventBus: Removed all handlers for "'.concat(e, '"'), {
 subsystem: "EventBus"
 });
 }, e.prototype.emit = function(e, t, r) {
@@ -10630,13 +10942,13 @@ var n, a, i;
 void 0 === r && (r = {});
 var s = o(o({}, t), {
 tick: Game.time
-}), c = null !== (a = null !== (n = r.priority) && void 0 !== n ? n : Ra[e]) && void 0 !== a ? a : ya.NORMAL, u = null !== (i = r.immediate) && void 0 !== i ? i : c >= ya.CRITICAL;
-this.stats.eventsEmitted++, this.config.enableLogging && va.debug('EventBus: Emitting "'.concat(e, '" (priority: ').concat(c, ", immediate: ").concat(String(u), ")"), {
+}), c = null !== (a = null !== (n = r.priority) && void 0 !== n ? n : Ua[e]) && void 0 !== a ? a : Oa.NORMAL, u = null !== (i = r.immediate) && void 0 !== i ? i : c >= Oa.CRITICAL;
+this.stats.eventsEmitted++, this.config.enableLogging && ka.debug('EventBus: Emitting "'.concat(e, '" (priority: ').concat(c, ", immediate: ").concat(String(u), ")"), {
 subsystem: "EventBus"
 });
 var l = Game.cpu.bucket;
-u || l >= this.config.lowBucketThreshold ? this.processEvent(e, s) : l >= this.config.criticalBucketThreshold ? this.queueEvent(e, s, c) : c >= ya.CRITICAL ? this.processEvent(e, s) : (this.stats.eventsDropped++,
-this.config.enableLogging && va.warn('EventBus: Dropped event "'.concat(e, '" due to critical bucket'), {
+u || l >= this.config.lowBucketThreshold ? this.processEvent(e, s) : l >= this.config.criticalBucketThreshold ? this.queueEvent(e, s, c) : c >= Oa.CRITICAL ? this.processEvent(e, s) : (this.stats.eventsDropped++,
+this.config.enableLogging && ka.warn('EventBus: Dropped event "'.concat(e, '" due to critical bucket'), {
 subsystem: "EventBus"
 }));
 }, e.prototype.getCoalescingKey = function(e, t, r) {
@@ -10683,7 +10995,7 @@ if (!(c < d.minBucket)) try {
 d.handler(t), this.stats.handlersInvoked++, d.once && u.push(d.id);
 } catch (t) {
 var p = t instanceof Error ? t.message : String(t);
-va.error('EventBus: Handler error for "'.concat(e, '": ').concat(p), {
+ka.error('EventBus: Handler error for "'.concat(e, '": ').concat(p), {
 subsystem: "EventBus"
 });
 }
@@ -10730,7 +11042,7 @@ event: e,
 index: t
 };
 }).filter(function(e) {
-return e.event.priority < ya.HIGH;
+return e.event.priority < Oa.HIGH;
 }).sort(function(e, t) {
 return e.event.queuedAt - t.event.queuedAt;
 })[0];
@@ -10816,12 +11128,12 @@ return this.getHandlerCount(e) > 0;
 }, e.prototype.logStats = function() {
 if (Game.time % this.config.statsLogInterval === 0) {
 var e = this.getStats();
-va.debug("EventBus stats: ".concat(e.eventsEmitted, " emitted, ").concat(e.eventsProcessed, " processed, ") + "".concat(e.eventsDeferred, " deferred, ").concat(e.eventsDropped, " dropped, ") + "".concat(e.eventsCoalesced, " coalesced, ").concat(e.queueSize, " queued, ") + "".concat(e.handlerCount, " handlers"), {
+ka.debug("EventBus stats: ".concat(e.eventsEmitted, " emitted, ").concat(e.eventsProcessed, " processed, ") + "".concat(e.eventsDeferred, " deferred, ").concat(e.eventsDropped, " dropped, ") + "".concat(e.eventsCoalesced, " coalesced, ").concat(e.queueSize, " queued, ") + "".concat(e.handlerCount, " handlers"), {
 subsystem: "EventBus"
 });
 }
 }, e;
-}(), Ta = new Ea, Ca = o({}, {
+}(), Na = new _a, Pa = o({}, {
 enableAdaptiveBudgets: !0,
 cpu: {
 bucketThresholds: {
@@ -10847,7 +11159,7 @@ ecoRoom: .1,
 warRoom: .25,
 overmind: 1
 }
-}), Sa = {
+}), Ia = {
 baseFrequencyBudgets: {
 high: .25,
 medium: .06,
@@ -10874,8 +11186,8 @@ responsiveness: .3
 }
 };
 
-function wa(e, t, r, o, n) {
-void 0 === o && (o = Sa), void 0 === n && (n = {});
+function Ga(e, t, r, o, n) {
+void 0 === o && (o = Ia), void 0 === n && (n = {});
 var a = o.baseFrequencyBudgets[e], i = function(e, t) {
 var r = t.roomScaling, o = r.minRooms, n = r.scaleFactor, a = r.maxMultiplier, i = Math.max(e, o), s = 1 + Math.log(i / o) / Math.log(n);
 return Math.max(1, Math.min(a, s));
@@ -10893,9 +11205,9 @@ return Math.max(.01, Math.min(1, c));
 !function(e) {
 e[e.CRITICAL = 100] = "CRITICAL", e[e.HIGH = 75] = "HIGH", e[e.MEDIUM = 50] = "MEDIUM",
 e[e.LOW = 25] = "LOW", e[e.IDLE = 10] = "IDLE";
-}(ha || (ha = {}));
+}(Ma || (Ma = {}));
 
-var xa = {
+var La = {
 targetCpuUsage: .98,
 reservedCpuFraction: .02,
 enableStats: !0,
@@ -10903,13 +11215,13 @@ statsLogInterval: 100,
 budgetWarningThreshold: 1.5,
 budgetWarningInterval: 500,
 enableAdaptiveBudgets: !0,
-adaptiveBudgetConfig: Sa,
+adaptiveBudgetConfig: Ia,
 enablePriorityDecay: !0,
 priorityDecayRate: 1,
 maxPriorityBoost: 50
 };
 
-function ba(e) {
+function Da(e) {
 var t, r, n = e.bucketThresholds.highMode, a = e.bucketThresholds.lowMode, i = function(e) {
 return Math.max(0, Math.floor(e / 2));
 }(a), s = (t = e.taskFrequencies, {
@@ -10925,7 +11237,7 @@ high: (r = e.budgets).rooms,
 medium: r.strategic,
 low: Math.max(r.market, r.visualization)
 };
-return o(o({}, xa), {
+return o(o({}, La), {
 lowBucketThreshold: a,
 highBucketThreshold: n,
 criticalBucketThreshold: i,
@@ -10935,7 +11247,7 @@ frequencyCpuBudgets: u
 });
 }
 
-var Oa = function() {
+var Fa = function() {
 function e(e) {
 this.processes = new Map, this.bucketMode = "normal", this.tickCpuUsed = 0, this.initialized = !1,
 this.lastExecutedProcessId = null, this.lastExecutedIndex = -1, this.processQueue = [],
@@ -10953,17 +11265,17 @@ this.frequencyDefaults = this.buildFrequencyDefaults();
 return e.prototype.registerProcess = function(e) {
 var t, r, n, a, i, s = null !== (t = e.frequency) && void 0 !== t ? t : "medium", c = this.frequencyDefaults[s];
 if (void 0 !== e.tickModulo) {
-if (e.tickModulo < 0) throw va.error('Kernel: Cannot register process "'.concat(e.name, '" - tickModulo must be non-negative (got ').concat(e.tickModulo, ")"), {
+if (e.tickModulo < 0) throw ka.error('Kernel: Cannot register process "'.concat(e.name, '" - tickModulo must be non-negative (got ').concat(e.tickModulo, ")"), {
 subsystem: "Kernel"
 }), new Error("Invalid tickModulo: ".concat(e.tickModulo, " (must be >= 0)"));
-if (e.tickModulo > 0 && void 0 !== e.tickOffset && e.tickOffset >= e.tickModulo) throw va.error('Kernel: Cannot register process "'.concat(e.name, '" - tickOffset (').concat(e.tickOffset, ") must be less than tickModulo (").concat(e.tickModulo, ")"), {
+if (e.tickModulo > 0 && void 0 !== e.tickOffset && e.tickOffset >= e.tickModulo) throw ka.error('Kernel: Cannot register process "'.concat(e.name, '" - tickOffset (').concat(e.tickOffset, ") must be less than tickModulo (").concat(e.tickModulo, ")"), {
 subsystem: "Kernel"
 }), new Error("Invalid tickOffset: ".concat(e.tickOffset, " (must be < tickModulo ").concat(e.tickModulo, ")"));
 }
 var u = null !== (r = e.interval) && void 0 !== r ? r : c.interval, l = void 0 === e.tickModulo && u > 1 && u <= 20 ? this.resolveIntervalJitterOffset(u, e.id) : void 0, m = {
 id: e.id,
 name: e.name,
-priority: null !== (n = e.priority) && void 0 !== n ? n : ha.MEDIUM,
+priority: null !== (n = e.priority) && void 0 !== n ? n : Ma.MEDIUM,
 frequency: s,
 minBucket: null !== (a = e.minBucket) && void 0 !== a ? a : c.minBucket,
 cpuBudget: null !== (i = e.cpuBudget) && void 0 !== i ? i : c.cpuBudget,
@@ -10990,12 +11302,12 @@ suspensionReason: null,
 consecutiveCpuSkips: 0
 }
 };
-this.processes.set(e.id, m), this.queueDirty = !0, va.debug('Kernel: Registered process "'.concat(m.name, '" (').concat(m.id, ")"), {
+this.processes.set(e.id, m), this.queueDirty = !0, ka.debug('Kernel: Registered process "'.concat(m.name, '" (').concat(m.id, ")"), {
 subsystem: "Kernel"
 });
 }, e.prototype.unregisterProcess = function(e) {
 var t = this.processes.delete(e);
-return t && (this.queueDirty = !0, va.debug("Kernel: Unregistered process ".concat(e), {
+return t && (this.queueDirty = !0, ka.debug("Kernel: Unregistered process ".concat(e), {
 subsystem: "Kernel"
 })), t;
 }, e.prototype.getProcess = function(e) {
@@ -11070,24 +11382,24 @@ byState: C
 }
 };
 }, e.prototype.initialize = function() {
-this.initialized || (va.info("Kernel initialized with ".concat(this.processes.size, " processes"), {
+this.initialized || (ka.info("Kernel initialized with ".concat(this.processes.size, " processes"), {
 subsystem: "Kernel"
 }), this.initialized = !0);
 }, e.prototype.updateBucketMode = function() {
 var e, t = Game.cpu.bucket;
-if ((e = t < this.config.criticalBucketThreshold ? "critical" : t < this.config.lowBucketThreshold ? "low" : t > this.config.highBucketThreshold ? "high" : "normal") !== this.bucketMode && (va.info("Kernel: Bucket mode changed from ".concat(this.bucketMode, " to ").concat(e, " (bucket: ").concat(t, ")"), {
+if ((e = t < this.config.criticalBucketThreshold ? "critical" : t < this.config.lowBucketThreshold ? "low" : t > this.config.highBucketThreshold ? "high" : "normal") !== this.bucketMode && (ka.info("Kernel: Bucket mode changed from ".concat(this.bucketMode, " to ").concat(e, " (bucket: ").concat(t, ")"), {
 subsystem: "Kernel"
 }), this.bucketMode = e), Game.time % 100 == 0 && ("low" === this.bucketMode || "critical" === this.bucketMode)) {
 var r = this.processes.size;
-va.info("Bucket ".concat(this.bucketMode.toUpperCase(), " mode: ").concat(t, "/10000 bucket. ") + "Core work remains enabled; optional processes below their minBucket are deferred. " + "".concat(r, " processes registered."), {
+ka.info("Bucket ".concat(this.bucketMode.toUpperCase(), " mode: ").concat(t, "/10000 bucket. ") + "Core work remains enabled; optional processes below their minBucket are deferred. " + "".concat(r, " processes registered."), {
 subsystem: "Kernel"
 });
 }
 }, e.prototype.validateConfig = function() {
-this.config.criticalBucketThreshold >= this.config.lowBucketThreshold && (va.warn("Kernel: Adjusting critical bucket threshold ".concat(this.config.criticalBucketThreshold, " to stay below low threshold ").concat(this.config.lowBucketThreshold), {
+this.config.criticalBucketThreshold >= this.config.lowBucketThreshold && (ka.warn("Kernel: Adjusting critical bucket threshold ".concat(this.config.criticalBucketThreshold, " to stay below low threshold ").concat(this.config.lowBucketThreshold), {
 subsystem: "Kernel"
 }), this.config.criticalBucketThreshold = Math.max(0, this.config.lowBucketThreshold - 1)),
-this.config.lowBucketThreshold >= this.config.highBucketThreshold && (va.warn("Kernel: Adjusting high bucket threshold ".concat(this.config.highBucketThreshold, " to stay above low threshold ").concat(this.config.lowBucketThreshold), {
+this.config.lowBucketThreshold >= this.config.highBucketThreshold && (ka.warn("Kernel: Adjusting high bucket threshold ".concat(this.config.highBucketThreshold, " to stay above low threshold ").concat(this.config.lowBucketThreshold), {
 subsystem: "Kernel"
 }), this.config.highBucketThreshold = this.config.lowBucketThreshold + 1);
 }, e.prototype.buildFrequencyDefaults = function() {
@@ -11148,11 +11460,11 @@ return "".concat(r >= 0 ? "+" : "-").concat(Math.abs(r).toFixed(3));
 }, e.prototype.updateAdaptiveBudgets = function() {
 if (this.config.enableAdaptiveBudgets) {
 var e = o({}, this.config.frequencyCpuBudgets), t = function(e, t) {
-return void 0 === e && (e = Sa), void 0 === t && (t = {}), function(e, t, r, o) {
-return void 0 === r && (r = Sa), void 0 === o && (o = {}), {
-high: wa("high", e, t, r, o),
-medium: wa("medium", e, t, r, o),
-low: wa("low", e, t, r, o)
+return void 0 === e && (e = Ia), void 0 === t && (t = {}), function(e, t, r, o) {
+return void 0 === r && (r = Ia), void 0 === o && (o = {}), {
+high: Ga("high", e, t, r, o),
+medium: Ga("medium", e, t, r, o),
+low: Ga("low", e, t, r, o)
 };
 }((r = Object.keys(Game.rooms).length, Math.max(1, r)), Game.cpu.bucket, e, t);
 var r;
@@ -11160,7 +11472,7 @@ var r;
 if (this.config.frequencyCpuBudgets = t, this.frequencyDefaults = this.buildFrequencyDefaults(),
 Game.time % 500 == 0) {
 var r = Object.keys(Game.rooms).length, n = Game.cpu.bucket, a = this.formatFrequencyUtilization(this.frequencyUtilization);
-va.info("Adaptive budgets updated: rooms=".concat(r, ", bucket=").concat(n, ", ") + "high=".concat(t.high.toFixed(3), " (").concat(this.formatBudgetDelta(e.high, t.high), "), ") + "medium=".concat(t.medium.toFixed(3), " (").concat(this.formatBudgetDelta(e.medium, t.medium), "), ") + "low=".concat(t.low.toFixed(3), " (").concat(this.formatBudgetDelta(e.low, t.low), "), ") + "util=".concat(a), {
+ka.info("Adaptive budgets updated: rooms=".concat(r, ", bucket=").concat(n, ", ") + "high=".concat(t.high.toFixed(3), " (").concat(this.formatBudgetDelta(e.high, t.high), "), ") + "medium=".concat(t.medium.toFixed(3), " (").concat(this.formatBudgetDelta(e.medium, t.medium), "), ") + "low=".concat(t.low.toFixed(3), " (").concat(this.formatBudgetDelta(e.low, t.low), "), ") + "util=".concat(a), {
 subsystem: "Kernel"
 });
 }
@@ -11225,9 +11537,9 @@ if (!S) break;
 }
 if (T.size > 0) {
 try {
-for (var O = a(T), A = O.next(); !A.done; A = O.next()) {
-var k = A.value;
-E.push(k);
+for (var O = a(T), k = O.next(); !k.done; k = O.next()) {
+var A = k.value;
+E.push(A);
 }
 } catch (e) {
 c = {
@@ -11235,16 +11547,16 @@ error: e
 };
 } finally {
 try {
-A && !A.done && (u = O.return) && u.call(O);
+k && !k.done && (u = O.return) && u.call(O);
 } finally {
 if (c) throw c.error;
 }
 }
-y.size > 0 && va.warn("Kernel: Dependency cycle detected, falling back to priority-only execution for ".concat(T.size, " process(es)."), {
+y.size > 0 && ka.warn("Kernel: Dependency cycle detected, falling back to priority-only execution for ".concat(T.size, " process(es)."), {
 subsystem: "Kernel"
 });
 }
-return f.size > 0 && va.warn("Kernel: Some process dependencies were invalid and ignored for: ".concat(Array.from(f).join(", ")), {
+return f.size > 0 && ka.warn("Kernel: Some process dependencies were invalid and ignored for: ".concat(Array.from(f).join(", ")), {
 subsystem: "Kernel"
 }), E;
 }, e.prototype.resolveIntervalJitterOffset = function(e, t) {
@@ -11293,7 +11605,7 @@ var r = Math.max(1, e.interval + (null !== (t = e.intervalJitterOffset) && void 
 return Game.time - e.stats.lastRunTick >= r;
 }, e.prototype.shouldRunProcess = function(e) {
 var t, r;
-if (Game.cpu.bucket < e.minBucket) return Game.time % 100 == 0 && va.debug('Kernel: Process "'.concat(e.name, '" skipped (bucket: ').concat(Game.cpu.bucket, "/").concat(e.minBucket, ")"), {
+if (Game.cpu.bucket < e.minBucket) return Game.time % 100 == 0 && ka.debug('Kernel: Process "'.concat(e.name, '" skipped (bucket: ').concat(Game.cpu.bucket, "/").concat(e.minBucket, ")"), {
 subsystem: "Kernel"
 }), !1;
 if ("suspended" === e.state) {
@@ -11301,7 +11613,7 @@ if (null === e.stats.suspendedUntil) return !1;
 if (Game.time >= e.stats.suspendedUntil) {
 e.state = "idle", e.stats.suspendedUntil = null;
 var o = e.stats.suspensionReason;
-return e.stats.suspensionReason = null, va.info('Kernel: Process "'.concat(e.name, '" automatically resumed after suspension. ') + "Previous reason: ".concat(o, ". Consecutive errors: ").concat(e.stats.consecutiveErrors), {
+return e.stats.suspensionReason = null, ka.info('Kernel: Process "'.concat(e.name, '" automatically resumed after suspension. ') + "Previous reason: ".concat(o, ". Consecutive errors: ").concat(e.stats.consecutiveErrors), {
 subsystem: "Kernel",
 processId: e.id
 }), this.emit("process.recovered", {
@@ -11315,7 +11627,7 @@ priority: 50
 }
 if (Game.time % 100 == 0) {
 var n = e.stats.suspendedUntil - Game.time;
-va.debug('Kernel: Process "'.concat(e.name, '" suspended (').concat(n, " ticks remaining)"), {
+ka.debug('Kernel: Process "'.concat(e.name, '" suspended (').concat(n, " ticks remaining)"), {
 subsystem: "Kernel"
 });
 }
@@ -11326,9 +11638,9 @@ var a = null !== (t = e.tickOffset) && void 0 !== t ? t : 0;
 if ((Game.time + a) % e.tickModulo !== 0) return !1;
 }
 if (!this.isIntervalReady(e)) {
-if (e.stats.runCount > 0 && Game.time % 100 == 0 && e.priority >= ha.HIGH) {
+if (e.stats.runCount > 0 && Game.time % 100 == 0 && e.priority >= Ma.HIGH) {
 var i = Game.time - e.stats.lastRunTick, s = Math.max(1, e.interval + (null !== (r = e.intervalJitterOffset) && void 0 !== r ? r : 0));
-va.debug('Kernel: Process "'.concat(e.name, '" skipped (interval: ').concat(i, "/").concat(s, " ticks)"), {
+ka.debug('Kernel: Process "'.concat(e.name, '" skipped (interval: ').concat(i, "/").concat(s, " ticks)"), {
 subsystem: "Kernel"
 });
 }
@@ -11349,14 +11661,14 @@ e.stats.lastSuccessfulRunTick = Game.time;
 } catch (t) {
 e.state = "error", e.stats.errorCount++, e.stats.consecutiveErrors++;
 var r = t instanceof Error ? t.message : String(t);
-va.error('Kernel: Process "'.concat(e.name, '" error: ').concat(r), {
+ka.error('Kernel: Process "'.concat(e.name, '" error: ').concat(r), {
 subsystem: "Kernel"
-}), t instanceof Error && t.stack && va.error(t.stack, {
+}), t instanceof Error && t.stack && ka.error(t.stack, {
 subsystem: "Kernel"
 });
 var o = e.stats.consecutiveErrors;
 if (o >= 10) e.stats.suspendedUntil = Number.MAX_SAFE_INTEGER, e.stats.suspensionReason = "Circuit breaker: ".concat(o, " consecutive failures (permanent)"),
-e.state = "suspended", va.error('Kernel: Process "'.concat(e.name, '" permanently suspended after ').concat(o, " consecutive failures"), {
+e.state = "suspended", ka.error('Kernel: Process "'.concat(e.name, '" permanently suspended after ').concat(o, " consecutive failures"), {
 subsystem: "Kernel",
 processId: e.id
 }), this.emit("process.suspended", {
@@ -11371,7 +11683,7 @@ priority: 100
 }); else if (o >= 3) {
 var n = Math.min(1e3, Math.pow(2, o));
 e.stats.suspendedUntil = Game.time + n, e.stats.suspensionReason = "".concat(o, " consecutive failures (auto-resume in ").concat(n, " ticks)"),
-e.state = "suspended", va.warn('Kernel: Process "'.concat(e.name, '" suspended for ').concat(n, " ticks after ").concat(o, " consecutive failures"), {
+e.state = "suspended", ka.warn('Kernel: Process "'.concat(e.name, '" suspended for ').concat(n, " ticks after ").concat(o, " consecutive failures"), {
 subsystem: "Kernel",
 processId: e.id,
 meta: {
@@ -11396,16 +11708,16 @@ this.config.enableStats && (e.stats.totalCpu += a, e.stats.runCount++, e.stats.a
 e.stats.maxCpu = Math.max(e.stats.maxCpu, a), e.stats.lastRunTick = Game.time, e.stats.healthScore = this.calculateHealthScore(e.stats)),
 this.tickCpuUsed += a, this.tickFrequencyCpuUsed[e.frequency] += a, this.tickFrequencyRunCount[e.frequency] += 1;
 var i = this.getCpuLimit() * e.cpuBudget, s = a / i;
-s > this.config.budgetWarningThreshold && Game.time % this.config.budgetWarningInterval === 0 && va.warn('Kernel: Process "'.concat(e.name, '" exceeded CPU budget: ').concat(a.toFixed(3), " > ").concat(i.toFixed(3), " (").concat((100 * s).toFixed(0), "%)"), {
+s > this.config.budgetWarningThreshold && Game.time % this.config.budgetWarningInterval === 0 && ka.warn('Kernel: Process "'.concat(e.name, '" exceeded CPU budget: ').concat(a.toFixed(3), " > ").concat(i.toFixed(3), " (").concat((100 * s).toFixed(0), "%)"), {
 subsystem: "Kernel"
 });
 }, e.prototype.run = function() {
 if (this.updateBucketMode(), this.updateAdaptiveBudgets(), this.tickCpuUsed = 0,
-this.skippedProcessesThisTick = 0, this.resetFrequencyTracking(), Ta.processQueue(),
-this.queueDirty && (this.rebuildProcessQueue(), va.info("Kernel: Rebuilt process queue with ".concat(this.processQueue.length, " processes"), {
+this.skippedProcessesThisTick = 0, this.resetFrequencyTracking(), Na.processQueue(),
+this.queueDirty && (this.rebuildProcessQueue(), ka.info("Kernel: Rebuilt process queue with ".concat(this.processQueue.length, " processes"), {
 subsystem: "Kernel"
 })), 0 !== this.processQueue.length) {
-Game.time % 10 == 0 && va.info("Kernel: Running ".concat(this.processQueue.length, " registered processes"), {
+Game.time % 10 == 0 && ka.info("Kernel: Running ".concat(this.processQueue.length, " registered processes"), {
 subsystem: "Kernel"
 });
 for (var e = 0, t = 0, r = 0, o = 0, n = (this.lastExecutedIndex + 1) % this.processQueue.length, a = 0; a < this.processQueue.length; a++) {
@@ -11416,7 +11728,7 @@ if (this.config.enablePriorityDecay) for (var c = a; c < this.processQueue.lengt
 var u = (n + c) % this.processQueue.length, l = this.processQueue[u];
 this.shouldRunProcess(l) && l.stats.consecutiveCpuSkips++;
 }
-r = this.processQueue.length - e - t, va.warn("Kernel: CPU budget exhausted after ".concat(e, " processes. ").concat(r, " processes deferred to next tick. Used: ").concat(Game.cpu.getUsed().toFixed(2), "/").concat(this.getCpuLimit().toFixed(2)), {
+r = this.processQueue.length - e - t, ka.warn("Kernel: CPU budget exhausted after ".concat(e, " processes. ").concat(r, " processes deferred to next tick. Used: ").concat(Game.cpu.getUsed().toFixed(2), "/").concat(this.getCpuLimit().toFixed(2)), {
 subsystem: "Kernel"
 }), this.config.enablePriorityDecay && r > 0 && (this.queueDirty = !0);
 break;
@@ -11426,13 +11738,13 @@ this.executeProcess(s), e++, this.lastExecutedProcessId = s.id, this.lastExecute
 s.stats.runCount > 0 && !this.isIntervalReady(s) && o++;
 }
 this.collectFrequencyUtilization(), this.config.enableStats && Game.time % this.config.statsLogInterval === 0 && (this.logStats(e, t, o, r),
-Ta.logStats());
-} else va.warn("Kernel: No processes registered in queue", {
+Na.logStats());
+} else ka.warn("Kernel: No processes registered in queue", {
 subsystem: "Kernel"
 });
 }, e.prototype.logStats = function(e, t, r, o) {
 var n = this, a = Game.cpu.bucket, i = (a / 1e4 * 100).toFixed(1), s = Game.cpu.getUsed(), c = this.getCpuLimit();
-if (va.info("Kernel: ".concat(e, " ran, ").concat(t, " skipped (interval: ").concat(r, ", CPU: ").concat(o, "), ") + "CPU: ".concat(s.toFixed(2), "/").concat(c.toFixed(2), " (").concat((s / c * 100).toFixed(1), "%), bucket: ").concat(a, "/10000 (").concat(i, "%), mode: ").concat(this.bucketMode), {
+if (ka.info("Kernel: ".concat(e, " ran, ").concat(t, " skipped (interval: ").concat(r, ", CPU: ").concat(o, "), ") + "CPU: ".concat(s.toFixed(2), "/").concat(c.toFixed(2), " (").concat((s / c * 100).toFixed(1), "%), bucket: ").concat(a, "/10000 (").concat(i, "%), mode: ").concat(this.bucketMode), {
 subsystem: "Kernel"
 }), this.config.enablePriorityDecay && o > 0) {
 var u = this.processQueue.filter(function(e) {
@@ -11440,7 +11752,7 @@ return e.stats.consecutiveCpuSkips >= 5;
 }).sort(function(e, t) {
 return t.stats.consecutiveCpuSkips - e.stats.consecutiveCpuSkips;
 }).slice(0, 3);
-u.length > 0 && va.info("Kernel: Priority decay active: ".concat(u.map(function(e) {
+u.length > 0 && ka.info("Kernel: Priority decay active: ".concat(u.map(function(e) {
 return "".concat(e.name, "(base:").concat(e.priority, ", boost:+").concat(n.calculatePriorityBoost(e.stats.consecutiveCpuSkips), ", skips:").concat(e.stats.consecutiveCpuSkips, ")");
 }).join(", ")), {
 subsystem: "Kernel"
@@ -11452,7 +11764,7 @@ return e.stats.skippedCount > 100;
 }).sort(function(e, t) {
 return t.stats.skippedCount - e.stats.skippedCount;
 }).slice(0, 5);
-l.length > 0 && va.warn("Kernel: Top skipped processes: ".concat(l.map(function(e) {
+l.length > 0 && ka.warn("Kernel: Top skipped processes: ".concat(l.map(function(e) {
 return "".concat(e.name, "(").concat(e.stats.skippedCount, ", interval:").concat(e.interval, ")");
 }).join(", ")), {
 subsystem: "Kernel"
@@ -11464,7 +11776,7 @@ return this.tickCpuUsed;
 return this.skippedProcessesThisTick;
 }, e.prototype.suspendProcess = function(e) {
 var t = this.processes.get(e);
-return !!t && (t.state = "suspended", va.info('Kernel: Suspended process "'.concat(t.name, '"'), {
+return !!t && (t.state = "suspended", ka.info('Kernel: Suspended process "'.concat(t.name, '"'), {
 subsystem: "Kernel"
 }), !0);
 }, e.prototype.resumeProcess = function(e) {
@@ -11472,7 +11784,7 @@ var t = this.processes.get(e);
 if (t && "suspended" === t.state) {
 t.state = "idle", t.stats.suspendedUntil = null;
 var r = t.stats.suspensionReason;
-return t.stats.suspensionReason = null, va.info('Kernel: Manually resumed process "'.concat(t.name, '". ') + "Previous reason: ".concat(r, ". Consecutive errors: ").concat(t.stats.consecutiveErrors), {
+return t.stats.suspensionReason = null, ka.info('Kernel: Manually resumed process "'.concat(t.name, '". ') + "Previous reason: ".concat(r, ". Consecutive errors: ").concat(t.stats.consecutiveErrors), {
 subsystem: "Kernel",
 processId: e
 }), this.emit("process.recovered", {
@@ -11552,7 +11864,7 @@ o && !o.done && (t = r.return) && t.call(r);
 if (e) throw e.error;
 }
 }
-va.info("Kernel: Reset all process statistics", {
+ka.info("Kernel: Reset all process statistics", {
 subsystem: "Kernel"
 });
 }, e.prototype.getDistributionStats = function() {
@@ -11596,691 +11908,72 @@ return o({}, this.frequencyDefaults[e]);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e), this.validateConfig(), this.frequencyDefaults = this.buildFrequencyDefaults();
 }, e.prototype.updateFromCpuConfig = function(e) {
-this.updateConfig(ba(e));
+this.updateConfig(Da(e));
 }, e.prototype.on = function(e, t, r) {
-return void 0 === r && (r = {}), Ta.on(e, t, r);
+return void 0 === r && (r = {}), Na.on(e, t, r);
 }, e.prototype.once = function(e, t, r) {
-return void 0 === r && (r = {}), Ta.once(e, t, r);
+return void 0 === r && (r = {}), Na.once(e, t, r);
 }, e.prototype.emit = function(e, t, r) {
-void 0 === r && (r = {}), Ta.emit(e, t, r);
+void 0 === r && (r = {}), Na.emit(e, t, r);
 }, e.prototype.offAll = function(e) {
-Ta.offAll(e);
+Na.offAll(e);
 }, e.prototype.processEvents = function() {
-Ta.processQueue();
+Na.processQueue();
 }, e.prototype.getEventStats = function() {
-return Ta.getStats();
+return Na.getStats();
 }, e.prototype.hasEventHandlers = function(e) {
-return Ta.hasHandlers(e);
+return Na.hasHandlers(e);
 }, e.prototype.getEventBus = function() {
-return Ta;
+return Na;
 }, e;
 }();
 
-new Oa(ba(o({}, Ca).cpu));
+new Fa(Da(o({}, Pa).cpu));
 
-var Aa, ka = new Set;
+var Ba, Wa = new Set;
 
-function Ma(e, t, r) {
+function Ka(e, t, r) {
 return o({
 id: e,
 name: t,
-priority: ha.MEDIUM,
+priority: Ma.MEDIUM,
 frequency: "medium",
 cpuBudget: .15,
 interval: 5
 }, r), function(e, t, r) {};
 }
 
-function Ua(e, t, r) {
+function Ha(e, t, r) {
 return o({
 id: e,
 name: t,
-priority: ha.LOW,
+priority: Ma.LOW,
 frequency: "low",
 cpuBudget: .1,
 interval: 20
 }, r), function(e, t, r) {};
 }
 
-function _a() {
+function Ya() {
 return function(e) {
-return ka.add(e), e;
+return Wa.add(e), e;
 };
 }
 
 !function(e) {
 e.RUNNING = "running", e.DEAD = "dead", e.SUSPENDED = "suspended";
-}(Aa || (Aa = {}));
+}(Ba || (Ba = {}));
 
-var Na = function() {
-function e() {
-this.assignments = new Map;
-}
-return e.prototype.getDefenseRequestsFromMemory = function() {
-var e;
-return null !== (e = Memory.defenseRequests) && void 0 !== e ? e : [];
-}, e.prototype.setDefenseRequestsInMemory = function(e) {
-Memory.defenseRequests = e;
-}, e.prototype.run = function() {
-var e, t, r = this.getDefenseRequestsFromMemory();
-this.cleanupAssignments();
-try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
-var i = n.value;
-this.processDefenseRequest(i);
-}
-} catch (t) {
-e = {
-error: t
-};
-} finally {
-try {
-n && !n.done && (t = o.return) && t.call(o);
-} finally {
-if (e) throw e.error;
-}
-}
-}, e.prototype.processDefenseRequest = function(e) {
-var t = Game.rooms[e.roomName];
-if (t) {
-var r = Hr(t), o = Math.max(e.urgency, r.dangerLevel, r.assistanceRequired ? 3 : 0), n = this.getAssignedDefenders(e.roomName, "guard"), a = this.getAssignedDefenders(e.roomName, "ranger"), i = r.assistanceRequired ? Math.max(0, Math.ceil(r.totalHostileDPS / 300) - n.length) : 0, s = r.assistanceRequired ? Math.max(0, Math.ceil(r.totalHostileDPS / 300) - a.length) : 0, c = Math.max(0, e.guardsNeeded - n.length, i), u = Math.max(0, e.rangersNeeded - a.length, s);
-0 === c && 0 === u || (c > 0 && this.assignDefenders(e.roomName, "guard", c, o),
-u > 0 && this.assignDefenders(e.roomName, "ranger", u, o));
-}
-}, e.prototype.assignDefenders = function(e, t, r, o) {
-var n, i, s = this, c = this.findHelperRooms(e, o), u = 0;
-try {
-for (var l = a(c), m = l.next(); !m.done; m = l.next()) {
-var d = m.value;
-if (u >= r) break;
-for (var p = d.find(FIND_MY_CREEPS, {
-filter: function(e) {
-var r = e.memory;
-return r.role === t && !r.assistTarget && !s.assignments.has(e.name);
-}
-}), f = Math.min(p.length, 2, r - u), y = 0; y < f; y++) {
-var v = p[y];
-if (v) {
-var g = Game.map.getRoomLinearDistance(d.name, e), h = Game.time + 50 * g, R = {
-creepName: v.name,
-targetRoom: e,
-assignedAt: Game.time,
-eta: h
-};
-this.assignments.set(v.name, R), v.memory.assistTarget = e, u++, U.info("Assigned ".concat(t, " ").concat(v.name, " from ").concat(d.name, " to assist ").concat(e, " (ETA: ").concat(h - Game.time, " ticks)"), {
-subsystem: "Defense"
-});
-}
-}
-}
-} catch (e) {
-n = {
-error: e
-};
-} finally {
-try {
-m && !m.done && (i = l.return) && i.call(l);
-} finally {
-if (n) throw n.error;
-}
-}
-u > 0 && U.info("Defense coordination: Assigned ".concat(u, "/").concat(r, " ").concat(t, "s to ").concat(e), {
-subsystem: "Defense"
-});
-}, e.prototype.findHelperRooms = function(e, t) {
-var r = Object.values(Game.rooms).filter(function(t) {
-var r;
-return (null === (r = t.controller) || void 0 === r ? void 0 : r.my) && t.name !== e;
-});
-return r.map(function(r) {
-var o = 0;
-o -= 10 * Game.map.getRoomLinearDistance(e, r.name), o += 20 * r.find(FIND_MY_CREEPS, {
-filter: function(e) {
-var t = e.memory, r = t.role;
-return ("guard" === r || "ranger" === r) && !t.assistTarget;
-}
-}).length;
-var n = j(r);
-return o -= 30 * n.length, n.length > 0 && t < 3 && (o -= 1e3), {
-room: r,
-score: o
-};
-}).filter(function(e) {
-return e.score > -500;
-}).sort(function(e, t) {
-return t.score - e.score;
-}).map(function(e) {
-return e.room;
-});
-}, e.prototype.getAssignedDefenders = function(e, t) {
-var r, o, n = [];
-try {
-for (var s = a(this.assignments.entries()), c = s.next(); !c.done; c = s.next()) {
-var u = i(c.value, 2), l = u[0], m = u[1];
-if (m.targetRoom === e) {
-var d = Game.creeps[l];
-if (d) {
-if (t && d.memory.role !== t) continue;
-n.push(m);
-}
-}
-}
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-c && !c.done && (o = s.return) && o.call(s);
-} finally {
-if (r) throw r.error;
-}
-}
-return n;
-}, e.prototype.cleanupAssignments = function() {
-var e, t, r, o, n = [];
-try {
-for (var s = a(this.assignments.entries()), c = s.next(); !c.done; c = s.next()) {
-var u = i(c.value, 2), l = u[0], m = u[1], d = Game.creeps[l];
-d ? (d.room.name === m.targetRoom && 0 === j(d.room).length && (delete d.memory.assistTarget,
-n.push(l), U.debug("Released ".concat(l, " from defense assistance (no hostiles in ").concat(m.targetRoom, ")"), {
-subsystem: "Defense"
-})), Game.time - m.assignedAt > 1e3 && (delete d.memory.assistTarget, n.push(l),
-U.debug("Removed stale defense assignment for ".concat(l), {
-subsystem: "Defense"
-}))) : n.push(l);
-}
-} catch (t) {
-e = {
-error: t
-};
-} finally {
-try {
-c && !c.done && (t = s.return) && t.call(s);
-} finally {
-if (e) throw e.error;
-}
-}
-try {
-for (var p = a(n), f = p.next(); !f.done; f = p.next()) l = f.value, this.assignments.delete(l);
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-f && !f.done && (o = p.return) && o.call(p);
-} finally {
-if (r) throw r.error;
-}
-}
-}, e.prototype.getAssignmentsForRoom = function(e) {
-return this.getAssignedDefenders(e);
-}, e.prototype.getAllAssignments = function() {
-return Array.from(this.assignments.values());
-}, e.prototype.cancelAssignment = function(e) {
-if (this.assignments.get(e)) {
-var t = Game.creeps[e];
-t && delete t.memory.assistTarget, this.assignments.delete(e), U.info("Cancelled defense assignment for ".concat(e), {
-subsystem: "Defense"
-});
-}
-}, n([ Ma("cluster:defense", "Defense Coordinator", {
-priority: ha.HIGH,
-interval: 3,
-minBucket: 0,
-cpuBudget: .05
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Pa = new Na;
-
-function Ia(e) {
-return !!function(e, t) {
-if ("retreat" === t.recommendedResponse || "safemode" === t.recommendedResponse) return !0;
-var r = e.room.find(FIND_MY_CREEPS, {
-filter: function(e) {
-var t = e.memory;
-return "defender" === t.role || "rangedDefender" === t.role || "guard" === t.role || "ranger" === t.role;
-}
-});
-if (t.hostileCount > 3 * r.length) return U.info("Creep ".concat(e.name, " retreating: heavily outnumbered (").concat(t.hostileCount, " hostiles vs ").concat(r.length, " defenders)"), {
-subsystem: "Defense",
-room: e.room.name,
-creep: e.name
-}), !0;
-var o = e.room.find(FIND_MY_CREEPS, {
-filter: function(e) {
-return "healer" === e.memory.role;
-}
-});
-return e.hits < .3 * e.hitsMax && t.healerCount > 0 && 0 === o.length ? (U.info("Creep ".concat(e.name, " retreating: damaged (").concat(e.hits, "/").concat(e.hitsMax, ") facing ").concat(t.healerCount, " enemy healers without friendly healer support"), {
-subsystem: "Defense",
-room: e.room.name,
-creep: e.name
-}), !0) : t.boostedCount > 0 && r.length < 2 * t.boostedCount && (U.info("Creep ".concat(e.name, " retreating: facing ").concat(t.boostedCount, " boosted hostiles without sufficient support"), {
-subsystem: "Defense",
-room: e.room.name,
-creep: e.name
-}), !0);
-}(e, Hr(e.room)) && (function(e) {
-var t, r, o, n, c = e.room.find(FIND_MY_SPAWNS)[0];
-if (c) {
-var u = e.moveTo(c, {
-range: 3,
-visualizePathStyle: {
-stroke: "#ffaa00"
-}
-});
-if (u === OK || u === ERR_TIRED) return;
-}
-var l = Game.map.describeExits(e.room.name);
-if (l) {
-var m = ((t = {})[TOP] = FIND_EXIT_TOP, t[BOTTOM] = FIND_EXIT_BOTTOM, t[LEFT] = FIND_EXIT_LEFT,
-t[RIGHT] = FIND_EXIT_RIGHT, t), d = [];
-try {
-for (var p = a(Object.entries(l)), f = p.next(); !f.done; f = p.next()) {
-var y = i(f.value, 2), v = y[0], g = y[1], h = Number(v), R = Game.rooms[g];
-if (null === (n = null == R ? void 0 : R.controller) || void 0 === n ? void 0 : n.my) {
-var E = m[h];
-if (E) {
-var T = e.room.find(E);
-T.length > 0 && d.push.apply(d, s([], i(T), !1));
-}
-}
-}
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-f && !f.done && (o = p.return) && o.call(p);
-} finally {
-if (r) throw r.error;
-}
-}
-if (d.length > 0) {
-var C = e.pos.findClosestByPath(d);
-if (C) return void e.moveTo(C, {
-visualizePathStyle: {
-stroke: "#ffaa00"
-}
-});
-}
-}
-var S = e.pos.findClosestByPath(FIND_EXIT);
-S && e.moveTo(S, {
-visualizePathStyle: {
-stroke: "#ff0000"
-}
-});
-}(e), !0);
-}
-
-var Ga, La = function() {
-function e() {}
-return e.prototype.coordinateDefense = function(e) {
-var t, r, o, n, i = function(e) {
-var t = mr.getCluster(e);
-return t ? t.memberRooms : [];
-}(e);
-if (0 !== i.length) {
-var s = [];
-try {
-for (var c = a(i), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = Game.rooms[l];
-if (m) {
-var d = Hr(m);
-s.push(d), d.dangerLevel >= 2 && Jr(d);
-}
-}
-} catch (e) {
-t = {
-error: e
-};
-} finally {
-try {
-u && !u.done && (r = c.return) && r.call(c);
-} finally {
-if (t) throw t.error;
-}
-}
-var p = s.filter(function(e) {
-return e.assistanceRequired;
-}).sort(function(e, t) {
-return t.assistancePriority - e.assistancePriority;
-});
-try {
-for (var f = a(p), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = this.findAvailableDefenders(i, v.roomName);
-g.length > 0 && (this.sendDefenders(g, v.roomName), U.info("Cluster Defense: Sending ".concat(g.length, " defenders to ").concat(v.roomName), {
-subsystem: "Defense",
-room: v.roomName,
-meta: {
-cluster: e,
-targetRoom: v.roomName,
-threatScore: v.threatScore,
-priority: v.assistancePriority
-}
-}));
-}
-} catch (e) {
-o = {
-error: e
-};
-} finally {
-try {
-y && !y.done && (n = f.return) && n.call(f);
-} finally {
-if (o) throw o.error;
-}
-}
-this.coordinateSafeMode(s);
-}
-}, e.prototype.findAvailableDefenders = function(e, t) {
-var r, o, n = [];
-try {
-for (var c = a(e), u = c.next(); !u.done; u = c.next()) {
-var l = u.value;
-if (l !== t) {
-var m = Game.rooms[l];
-if (m && 0 === Hr(m).dangerLevel) {
-var d = m.find(FIND_MY_CREEPS, {
-filter: function(e) {
-var t = e.memory;
-return ("defender" === t.role || "rangedDefender" === t.role || "guard" === t.role || "ranger" === t.role) && !t.assistTarget;
-}
-});
-n.push.apply(n, s([], i(d), !1));
-}
-}
-}
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-u && !u.done && (o = c.return) && o.call(c);
-} finally {
-if (r) throw r.error;
-}
-}
-return n;
-}, e.prototype.sendDefenders = function(e, t) {
-var r, o;
-try {
-for (var n = a(e), i = n.next(); !i.done; i = n.next()) i.value.memory.assistTarget = t;
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-i && !i.done && (o = n.return) && o.call(n);
-} finally {
-if (r) throw r.error;
-}
-}
-}, e.prototype.coordinateSafeMode = function(e) {
-var t, r = e.filter(function(e) {
-return "safemode" === e.recommendedResponse;
-});
-if (0 !== r.length) {
-var o = r.reduce(function(e, t) {
-return t.threatScore > e.threatScore ? t : e;
-}), n = Game.rooms[o.roomName];
-if ((null === (t = null == n ? void 0 : n.controller) || void 0 === t ? void 0 : t.my) && n.controller.safeModeAvailable > 0 && !n.controller.safeMode && !n.controller.safeModeCooldown) {
-var a = n.controller.activateSafeMode();
-a === OK ? U.warn("Activated safe mode in ".concat(o.roomName), {
-subsystem: "Defense",
-room: o.roomName,
-meta: {
-threatScore: o.threatScore,
-hostiles: o.hostileCount,
-dangerLevel: o.dangerLevel
-}
-}) : U.error("Failed to activate safe mode in ".concat(o.roomName, ": ").concat(a), {
-subsystem: "Defense",
-room: o.roomName,
-meta: {
-errorCode: a
-}
-});
-}
-}
-}, e;
-}(), Da = new La;
-
-!function(e) {
-e[e.NONE = 0] = "NONE", e[e.LOW = 1] = "LOW", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
-e[e.CRITICAL = 4] = "CRITICAL";
-}(Ga || (Ga = {}));
-
-var Fa = function() {
-function e() {
-this.emergencyStates = new Map;
-}
-return e.prototype.assess = function(e, t) {
-var r, o, n = this.emergencyStates.get(e.name), a = this.calculateEmergencyLevel(e, t);
-if (a === Ga.NONE && !n) return {
-level: Ga.NONE,
-startedAt: Game.time,
-assistanceRequested: !1,
-boostsAllocated: !1,
-lastEscalation: 0
-};
-var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : Ga.NONE;
-return n ? (o = n).level = a : (o = {
-level: a,
-startedAt: Game.time,
-assistanceRequested: !1,
-boostsAllocated: !1,
-lastEscalation: 0
-}, this.emergencyStates.set(e.name, o)), a === Ga.NONE ? (n && (U.info("Emergency resolved in ".concat(e.name), {
-subsystem: "Defense"
-}), this.emergencyStates.delete(e.name)), o) : (n && a > i && (U.warn("Emergency escalated in ".concat(e.name, ": Level ").concat(i, " → ").concat(a), {
-subsystem: "Defense"
-}), o.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, o), o);
-}, e.prototype.calculateEmergencyLevel = function(e, t) {
-var r = j(e);
-if (0 === t.danger && 0 === r.length) return Ga.NONE;
-var o = vr(e), n = hr(e), a = Hr(e);
-if (e.find(FIND_MY_STRUCTURES, {
-filter: function(e) {
-return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
-}
-}).length > 0) return Ga.CRITICAL;
-var i = r.filter(function(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && e.boost;
-});
-}), s = Math.max(0, o.guards - n.guards) + Math.max(0, o.rangers - n.rangers) + Math.max(0, o.healers - n.healers);
-return i.length > 0 && s >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers || a.dangerLevel >= 2 && s >= 2 ? Ga.HIGH : (t.danger >= 2 || a.dangerLevel >= 2) && s >= 1 ? Ga.MEDIUM : t.danger >= 1 || r.length > 0 ? Ga.LOW : Ga.NONE;
-}, e.prototype.executeEmergencyResponse = function(e, t, r) {
-r.level >= Ga.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
-r.level >= Ga.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
-r.boostsAllocated = !0), this.updateDefensePosture(e, t, r);
-}, e.prototype.requestDefenseAssistance = function(e, t) {
-var r;
-if (!Rr(e, t)) return !1;
-var o = Er(e, t);
-if (!o) return !1;
-var n = Memory, a = null !== (r = n.defenseRequests) && void 0 !== r ? r : [], c = a.find(function(t) {
-return t.roomName === e.name && Game.time - t.createdAt < 500;
-}), u = a.filter(function(t) {
-return t.roomName !== e.name && Game.time - t.createdAt < 500;
-});
-return c && !this.shouldRefreshDefenseRequest(c, o) ? (n.defenseRequests = s(s([], i(u), !1), [ c ], !1),
-!0) : (n.defenseRequests = s(s([], i(u), !1), [ o ], !1), U.warn("Defense assistance requested for ".concat(e.name, ": ") + "".concat(o.guardsNeeded, " guards, ").concat(o.rangersNeeded, " rangers, ").concat(o.healersNeeded, " healers - ").concat(o.threat), {
-subsystem: "Defense"
-}), !0);
-}, e.prototype.shouldRefreshDefenseRequest = function(e, t) {
-return t.urgency !== e.urgency || t.guardsNeeded !== e.guardsNeeded || t.rangersNeeded !== e.rangersNeeded || t.healersNeeded !== e.healersNeeded || t.threat !== e.threat;
-}, e.prototype.allocateBoostsForDefense = function(e, t) {
-var r, o = Memory, n = null !== (r = o.boostDefensePriority) && void 0 !== r ? r : {};
-n[e.name] = !0, o.boostDefensePriority = n, U.info("Allocated boost priority for defenders in ".concat(e.name), {
-subsystem: "Defense"
-});
-}, e.prototype.updateDefensePosture = function(e, t, r) {
-switch (r.level) {
-case Ga.CRITICAL:
-"evacuate" !== t.posture && (t.posture = "war", t.pheromones.war = 100, t.pheromones.defense = 100,
-U.warn("".concat(e.name, " posture: CRITICAL DEFENSE"), {
-subsystem: "Defense"
-}));
-break;
-
-case Ga.HIGH:
-"war" !== t.posture && "evacuate" !== t.posture && (t.posture = "defensive", t.pheromones.defense = 80,
-t.pheromones.war = 40, U.info("".concat(e.name, " posture: HIGH DEFENSE"), {
-subsystem: "Defense"
-}));
-break;
-
-case Ga.MEDIUM:
-"eco" !== t.posture && "expand" !== t.posture || (t.posture = "defensive", t.pheromones.defense = 60,
-U.info("".concat(e.name, " posture: MEDIUM DEFENSE"), {
-subsystem: "Defense"
-}));
-break;
-
-case Ga.LOW:
-"eco" !== t.posture && "expand" !== t.posture || (t.pheromones.defense = 30, U.debug("".concat(e.name, ": LOW DEFENSE alert"), {
-subsystem: "Defense"
-}));
-}
-}, e.prototype.getDefenseRequests = function() {
-var e, t = Memory, r = null !== (e = t.defenseRequests) && void 0 !== e ? e : [], o = r.filter(function(e) {
-return Game.time - e.createdAt < 500;
-});
-return o.length !== r.length && (t.defenseRequests = o), o;
-}, e.prototype.clearDefenseRequest = function(e) {
-var t, r = Memory, o = (null !== (t = r.defenseRequests) && void 0 !== t ? t : []).filter(function(t) {
-return t.roomName !== e;
-});
-r.defenseRequests = o;
-}, e.prototype.getEmergencyState = function(e) {
-return this.emergencyStates.get(e);
-}, e.prototype.hasEmergency = function(e) {
-var t = this.emergencyStates.get(e);
-return void 0 !== t && t.level > Ga.NONE;
-}, e.prototype.getActiveEmergencies = function() {
-var e, t, r = [];
-try {
-for (var o = a(this.emergencyStates.entries()), n = o.next(); !n.done; n = o.next()) {
-var s = i(n.value, 2), c = s[0], u = s[1];
-u.level > Ga.NONE && r.push({
-roomName: c,
-state: u
-});
-}
-} catch (t) {
-e = {
-error: t
-};
-} finally {
-try {
-n && !n.done && (t = o.return) && t.call(o);
-} finally {
-if (e) throw e.error;
-}
-}
-return r.sort(function(e, t) {
-return t.state.level - e.state.level;
-});
-}, e;
-}(), Ba = new Fa;
-
-function Wa(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === HEAL || e.type === WORK || e.type === CLAIM);
-});
-}
-
-function Ha(e, t) {
-return e.body.filter(function(e) {
-return e.hits > 0 && e.type === t;
-}).length;
-}
-
-function Ka(e) {
-return !!e.body.some(function(e) {
-return e.hits > 0 && e.boost;
-}) || Ha(e, WORK) >= 5 || Ha(e, HEAL) >= 3;
-}
-
-var Ya = function() {
-function e() {}
-return e.prototype.checkSafeMode = function(e, t) {
-var r, o, n, a, i;
-if (!(null === (r = e.controller) || void 0 === r ? void 0 : r.safeMode) && !(null === (o = e.controller) || void 0 === o ? void 0 : o.safeModeCooldown) && 0 !== (null !== (a = null === (n = e.controller) || void 0 === n ? void 0 : n.safeModeAvailable) && void 0 !== a ? a : 0) && this.shouldTriggerSafeMode(e, t)) {
-var s = null === (i = e.controller) || void 0 === i ? void 0 : i.activateSafeMode();
-if (s === OK) U.warn("SAFE MODE ACTIVATED in ".concat(e.name), {
-subsystem: "Defense"
-}); else {
-var c = void 0 !== s ? String(s) : "undefined";
-U.error("Failed to activate safe mode in ".concat(e.name, ": ").concat(c), {
-subsystem: "Defense"
-});
-}
-}
-}, e.prototype.shouldTriggerSafeMode = function(e, t) {
-var r, o;
-if (t.danger < 2) return !1;
-var n = j(e), i = n.filter(Wa), s = function() {
-var e;
-return !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.safeModeDangerousHostilesOnly);
-}(), c = s ? i : n;
-if (s && 0 === i.length) return !1;
-var u = e.find(FIND_MY_SPAWNS);
-try {
-for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value;
-if (d.hits < .2 * d.hitsMax) return U.warn("Spawn ".concat(d.name, " critical: ").concat(d.hits, "/").concat(d.hitsMax), {
-subsystem: "Defense"
-}), !0;
-}
-} catch (e) {
-r = {
-error: e
-};
-} finally {
-try {
-m && !m.done && (o = l.return) && o.call(l);
-} finally {
-if (r) throw r.error;
-}
-}
-if (e.storage && e.storage.hits < .2 * e.storage.hitsMax) return U.warn("Storage critical: ".concat(e.storage.hits, "/").concat(e.storage.hitsMax), {
-subsystem: "Defense"
-}), !0;
-if (e.terminal && e.terminal.hits < .2 * e.terminal.hitsMax) return U.warn("Terminal critical: ".concat(e.terminal.hits, "/").concat(e.terminal.hitsMax), {
-subsystem: "Defense"
-}), !0;
-var p = e.find(FIND_MY_CREEPS, {
-filter: function(e) {
-var t = e.memory.role;
-return "guard" === t || "ranger" === t || "soldier" === t;
-}
-});
-if (c.length > 3 * p.length) return U.warn("Overwhelmed: ".concat(c.length, " safe-mode-relevant hostiles vs ").concat(p.length, " defenders"), {
-subsystem: "Defense"
-}), !0;
-var f = c.filter(Ka);
-return f.length > 0 && p.length < 2 * f.length && (U.warn("High-impact siege hostiles detected: ".concat(f.length), {
-subsystem: "Defense"
-}), !0);
-}, e;
-}(), Va = new Ya, qa = {
+var Va = {
 triggerDangerLevel: 3,
 nukeEvacuationLeadTime: 5e3,
 minStorageEnergy: 5e4,
 priorityResources: [ RESOURCE_ENERGY, RESOURCE_POWER, RESOURCE_GHODIUM, RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ACID, RESOURCE_CATALYZED_ZYNTHIUM_ACID, RESOURCE_OPS ],
 maxTransfersPerTick: 2
-}, ja = function() {
+}, qa = function() {
 function e(e) {
 void 0 === e && (e = {}), this.evacuations = new Map, this.lastTransferTick = 0,
-this.transfersThisTick = 0, this.config = o(o({}, qa), e);
+this.transfersThisTick = 0, this.config = o(o({}, Va), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o;
@@ -12536,15 +12229,15 @@ return void 0 !== t && !t.complete;
 return Array.from(this.evacuations.values()).filter(function(e) {
 return !e.complete;
 });
-}, n([ Ma("cluster:evacuation", "Evacuation Manager", {
-priority: ha.HIGH,
+}, n([ Ka("cluster:evacuation", "Evacuation Manager", {
+priority: Ma.HIGH,
 interval: 5,
 minBucket: 0,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), za = new ja;
+}) ], e.prototype, "run", null), n([ Ya() ], e);
+}(), ja = new qa;
 
-function Qa(e) {
+function za(e) {
 var t = Math.floor(e.bucketThresholds.lowMode / 2), r = {
 high: 1,
 medium: Math.max(1, Math.min(e.taskFrequencies.clusterLogic, e.taskFrequencies.pheromoneUpdate)),
@@ -12572,45 +12265,45 @@ frequencyCpuBudgets: o,
 budgetWarningThreshold: 1.5,
 budgetWarningInterval: 100,
 enableAdaptiveBudgets: !0,
-adaptiveBudgetConfig: Sa,
+adaptiveBudgetConfig: Ia,
 enablePriorityDecay: !0,
 priorityDecayRate: 1,
 maxPriorityBoost: 50
 };
 }
 
-var Xa, Za = null, Ja = new Proxy({}, {
+var Qa, Xa = null, Za = new Proxy({}, {
 get: function(e, t) {
-return Za || (Za = new Oa(Qa(Ue().cpu))), Za[t];
+return Xa || (Xa = new Fa(za(Ue().cpu))), Xa[t];
 },
 set: function(e, t, r) {
-return Za || (Za = new Oa(Qa(Ue().cpu))), Za[t] = r, !0;
+return Xa || (Xa = new Fa(za(Ue().cpu))), Xa[t] = r, !0;
 }
 });
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(Xa || (Xa = {}));
+}(Qa || (Qa = {}));
 
-var $a = {
-level: Xa.INFO,
+var Ja = {
+level: Qa.INFO,
 cpuLogging: !1,
 enableBatching: !0,
 maxBatchSize: 50,
 debugSampleRate: 1,
 maxEntriesPerSubsystemPerTick: 0,
 maxEntriesPerTick: 0
-}, ei = o({}, $a), ti = [], ri = {
+}, $a = o({}, Ja), ei = [], ti = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
 debugSampleCounter: 0
 };
 
-function oi() {
+function ri() {
 var e = "undefined" != typeof Game && "number" == typeof Game.time ? Game.time : 0;
-ri.tick !== e && (ri = {
+ti.tick !== e && (ti = {
 tick: e,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -12618,47 +12311,47 @@ debugSampleCounter: 0
 });
 }
 
-function ni(e, t) {
+function oi(e, t) {
 return !!function(e) {
-if (e !== Xa.DEBUG) return !0;
-oi();
-var t, r = (t = ei.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
+if (e !== Qa.DEBUG) return !0;
+ri();
+var t, r = (t = $a.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
 if (r >= 1) return !0;
 if (r <= 0) return !1;
-ri.debugSampleCounter += 1;
+ti.debugSampleCounter += 1;
 var o = Math.max(1, Math.ceil(1 / r));
-return ri.debugSampleCounter % o === 0;
+return ti.debugSampleCounter % o === 0;
 }(e) && function(e) {
-var t, r, o = ai(ei.maxEntriesPerTick), n = ai(ei.maxEntriesPerSubsystemPerTick);
+var t, r, o = ni($a.maxEntriesPerTick), n = ni($a.maxEntriesPerSubsystemPerTick);
 if (0 === o && 0 === n) return !0;
-if (oi(), o > 0 && ri.totalCount >= o) return !1;
+if (ri(), o > 0 && ti.totalCount >= o) return !1;
 if (n > 0) {
 var a = null != e ? e : "global";
-if ((null !== (t = ri.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
+if ((null !== (t = ti.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
 }
-ri.totalCount += 1;
+ti.totalCount += 1;
 var i = null != e ? e : "global";
-return ri.perSubsystemCounts.set(i, (null !== (r = ri.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
+return ti.perSubsystemCounts.set(i, (null !== (r = ti.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
 !0;
 }(null == t ? void 0 : t.subsystem);
 }
 
-function ai(e) {
+function ni(e) {
 return Number.isFinite(e) && e > 0 ? Math.floor(e) : 0;
 }
 
-function ii(e) {
-ti.length > 0 && ui();
-var t = ei;
-ei = o(o(o({}, $a), e), {
+function ai(e) {
+ei.length > 0 && ci();
+var t = $a;
+$a = o(o(o({}, Ja), e), {
 level: "level" in e ? e.level : t.level,
 cpuLogging: "cpuLogging" in e ? e.cpuLogging : t.cpuLogging,
 enableBatching: "enableBatching" in e ? e.enableBatching : t.enableBatching,
 maxBatchSize: "maxBatchSize" in e ? e.maxBatchSize : t.maxBatchSize,
 debugSampleRate: "debugSampleRate" in e ? e.debugSampleRate : t.debugSampleRate,
-maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : $a.maxEntriesPerSubsystemPerTick,
-maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : $a.maxEntriesPerTick
-}), ti = [], ri = {
+maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Ja.maxEntriesPerSubsystemPerTick,
+maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Ja.maxEntriesPerTick
+}), ei = [], ti = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -12666,21 +12359,21 @@ debugSampleCounter: 0
 };
 }
 
-function si() {
-return o({}, ei);
+function ii() {
+return o({}, $a);
 }
 
-function ci(e) {
-ei.enableBatching ? (ti.push(e), ti.length >= ei.maxBatchSize && ui()) : console.log(e);
+function si(e) {
+$a.enableBatching ? (ei.push(e), ei.length >= $a.maxBatchSize && ci()) : console.log(e);
 }
 
-function ui() {
-0 !== ti.length && (console.log(ti.join("\n")), ti = []);
+function ci() {
+0 !== ei.length && (console.log(ei.join("\n")), ei = []);
 }
 
-var li = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
+var ui = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
 
-function mi(e) {
+function li(e) {
 return JSON.stringify(e, (t = new WeakSet, function(e, r) {
 return "bigint" == typeof r ? r.toString() : "object" != typeof r || null === r ? r : t.has(r) ? "[Circular]" : (t.add(r),
 r);
@@ -12688,7 +12381,7 @@ r);
 var t;
 }
 
-function di(e, t, r, o) {
+function mi(e, t, r, o) {
 void 0 === o && (o = "log");
 var n = {
 type: o,
@@ -12699,35 +12392,35 @@ shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (r.shard && (n.shard = r.shard), r.subsystem && (n.subsystem = r.subsystem),
 r.room && (n.room = r.room), r.creep && (n.creep = r.creep), r.processId && (n.processId = r.processId),
-r.meta)) for (var a in r.meta) li.has(a) || (n[a] = r.meta[a]);
-return mi(n);
+r.meta)) for (var a in r.meta) ui.has(a) || (n[a] = r.meta[a]);
+return li(n);
+}
+
+function di(e, t) {
+$a.level <= Qa.DEBUG && oi(Qa.DEBUG, t) && si(mi("DEBUG", e, t));
 }
 
 function pi(e, t) {
-ei.level <= Xa.DEBUG && ni(Xa.DEBUG, t) && ci(di("DEBUG", e, t));
+$a.level <= Qa.INFO && oi(Qa.INFO, t) && si(mi("INFO", e, t));
 }
 
 function fi(e, t) {
-ei.level <= Xa.INFO && ni(Xa.INFO, t) && ci(di("INFO", e, t));
+$a.level <= Qa.WARN && oi(Qa.WARN, t) && si(mi("WARN", e, t));
 }
 
 function yi(e, t) {
-ei.level <= Xa.WARN && ni(Xa.WARN, t) && ci(di("WARN", e, t));
+$a.level <= Qa.ERROR && oi(Qa.ERROR, t) && si(mi("ERROR", e, t));
 }
 
-function vi(e, t) {
-ei.level <= Xa.ERROR && ni(Xa.ERROR, t) && ci(di("ERROR", e, t));
-}
-
-function gi(e, t, r) {
-if (!ei.cpuLogging) return t();
+function vi(e, t, r) {
+if (!$a.cpuLogging) return t();
 var o = Game.cpu.getUsed(), n = t(), a = Game.cpu.getUsed() - o;
-return pi("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
+return di("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 }
 
-var hi = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
+var gi = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function Ri(e, t, r, o) {
+function hi(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -12736,14 +12429,14 @@ tick: "undefined" != typeof Game ? Game.time : 0,
 shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (n.unit = r), o && (o.shard && (n.shard = o.shard), o.subsystem && (n.subsystem = o.subsystem),
-o.room && (n.room = o.room), o.meta)) for (var a in o.meta) hi.has(a) || (n[a] = o.meta[a]);
-ni(Xa.INFO, o) && ci(mi(n));
+o.room && (n.room = o.room), o.meta)) for (var a in o.meta) gi.has(a) || (n[a] = o.meta[a]);
+oi(Qa.INFO, o) && si(li(n));
 }
 
-function Ei(e) {
+function Ri(e) {
 return {
 debug: function(t, r) {
-pi(t, "string" == typeof r ? {
+di(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -12751,7 +12444,7 @@ subsystem: e
 }, r));
 },
 info: function(t, r) {
-fi(t, "string" == typeof r ? {
+pi(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -12759,7 +12452,7 @@ subsystem: e
 }, r));
 },
 warn: function(t, r) {
-yi(t, "string" == typeof r ? {
+fi(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -12767,7 +12460,7 @@ subsystem: e
 }, r));
 },
 error: function(t, r) {
-vi(t, "string" == typeof r ? {
+yi(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -12775,7 +12468,7 @@ subsystem: e
 }, r));
 },
 stat: function(t, r, n, a) {
-Ri(t, r, n, "string" == typeof a ? {
+hi(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -12783,7 +12476,7 @@ subsystem: e
 }, a));
 },
 measureCpu: function(t, r, n) {
-return gi(t, r, "string" == typeof n ? {
+return vi(t, r, "string" == typeof n ? {
 subsystem: e,
 room: n
 } : o({
@@ -12793,22 +12486,22 @@ subsystem: e
 };
 }
 
-var Ti, Ci = {
-debug: pi,
-info: fi,
-warn: yi,
-error: vi,
-stat: Ri,
-measureCpu: gi,
-configure: ii,
-getConfig: si,
-createLogger: Ei,
-flush: ui
-}, Si = [], wi = new Set;
+var Ei, Ti = {
+debug: di,
+info: pi,
+warn: fi,
+error: yi,
+stat: hi,
+measureCpu: vi,
+configure: ai,
+getConfig: ii,
+createLogger: Ri,
+flush: ci
+}, Ci = [], Si = new Set;
 
-function xi(e) {
+function wi(e) {
 return function(t, r, o) {
-Si.push({
+Ci.push({
 options: e,
 methodName: String(r),
 target: t
@@ -12816,33 +12509,33 @@ target: t
 };
 }
 
-function bi(e, t, r) {
-return xi(o({
+function xi(e, t, r) {
+return wi(o({
 id: e,
 name: t,
-priority: ha.MEDIUM,
+priority: Ma.MEDIUM,
 frequency: "medium",
 cpuBudget: .15,
 interval: 5
 }, r));
 }
 
-function Oi(e, t, r) {
-return xi(o({
+function bi(e, t, r) {
+return wi(o({
 id: e,
 name: t,
-priority: ha.LOW,
+priority: Ma.LOW,
 frequency: "low",
 cpuBudget: .1,
 interval: 20
 }, r));
 }
 
-function Ai(e, t, r) {
-return xi(o({
+function Oi(e, t, r) {
+return wi(o({
 id: e,
 name: t,
-priority: ha.IDLE,
+priority: Ma.IDLE,
 frequency: "low",
 cpuBudget: .05,
 interval: 100
@@ -12851,11 +12544,11 @@ interval: 100
 
 function ki() {
 return function(e) {
-return wi.add(e), e;
+return Si.add(e), e;
 };
 }
 
-function Mi(e) {
+function Ai(e) {
 var t = Math.floor(.1 * e), r = Math.floor(Math.random() * (2 * t + 1)) - t;
 return {
 interval: Math.max(1, e + r),
@@ -12863,25 +12556,25 @@ jitter: r
 };
 }
 
-function Ui(e) {
+function Mi(e) {
 var t, r, o, n, i, s = Object.getPrototypeOf(e);
 try {
-for (var c = a(Si), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(Ci), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.target === s || Object.getPrototypeOf(l.target) === s || l.target === Object.getPrototypeOf(s)) {
 var m = e[l.methodName];
 if ("function" == typeof m) {
-var d = m.bind(e), p = null !== (o = l.options.interval) && void 0 !== o ? o : 5, f = Mi(p), y = f.interval, v = f.jitter;
-Ja.registerProcess({
+var d = m.bind(e), p = null !== (o = l.options.interval) && void 0 !== o ? o : 5, f = Ai(p), y = f.interval, v = f.jitter;
+Za.registerProcess({
 id: l.options.id,
 name: l.options.name,
-priority: null !== (n = l.options.priority) && void 0 !== n ? n : ha.MEDIUM,
+priority: null !== (n = l.options.priority) && void 0 !== n ? n : Ma.MEDIUM,
 frequency: null !== (i = l.options.frequency) && void 0 !== i ? i : "medium",
 minBucket: l.options.minBucket,
 cpuBudget: l.options.cpuBudget,
 interval: y,
 execute: d
-}), Ci.debug('Registered decorated process "'.concat(l.options.name, '" (').concat(l.options.id, ") with interval ").concat(y, " (base: ").concat(p, ", jitter: ").concat(v > 0 ? "+" : "").concat(v, ")"), {
+}), Ti.debug('Registered decorated process "'.concat(l.options.name, '" (').concat(l.options.id, ") with interval ").concat(y, " (base: ").concat(p, ", jitter: ").concat(v > 0 ? "+" : "").concat(v, ")"), {
 subsystem: "ProcessDecorators"
 });
 }
@@ -12900,7 +12593,7 @@ if (t) throw t.error;
 }
 }
 
-var _i, Ni, Pi = {
+var Ui, _i, Ni = {
 updateInterval: 200,
 minBucket: 0,
 minCreditsForPixels: 5e5,
@@ -12912,11 +12605,11 @@ targetPixelPrice: 2e3,
 maxPixelsPerTransaction: 10,
 purchaseCooldown: 1e3,
 minBaseMineralReserve: 1e4,
-criticalResourceThresholds: (Ti = {}, Ti[RESOURCE_GHODIUM] = 5e3, Ti),
+criticalResourceThresholds: (Ei = {}, Ei[RESOURCE_GHODIUM] = 5e3, Ei),
 enabled: !0
-}, Ii = function() {
+}, Pi = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Pi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ni), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13092,15 +12785,15 @@ this.config.enabled = !1, U.info("Pixel buying disabled", {
 subsystem: "PixelBuying"
 });
 }, e;
-}(), Gi = {
+}(), Ii = {
 enabled: !0,
 fullBucketTicksRequired: 25,
 bucketMax: 1e4,
 cpuCostPerPixel: 1e4,
 minBucketAfterGeneration: 0
-}, Li = function() {
+}, Gi = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, Gi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.config = o(o({}, Ii), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13162,7 +12855,7 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), Di = function(e) {
+}(), Li = function(e) {
 var t = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.map(function(e) {
@@ -13192,28 +12885,28 @@ for (var o = [], n = 1; n < arguments.length; n++) o[n - 1] = arguments[n];
 return console.log.apply(console, s([ "[".concat(e, "] ERROR:"), r ], i(t.apply(void 0, s([], i(o), !1))), !1));
 }
 };
-}("stats"), Fi = function(e) {
+}("stats"), Di = function(e) {
 var t, r, o;
 return (null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.swarm) || (null === (o = Memory.swarm) || void 0 === o ? void 0 : o[e]) || {};
 };
 
 !function(e) {
 e.ACTIVE = "active", e.DECAY = "decay", e.INACTIVE = "inactive";
-}(_i || (_i = {})), function(e) {
+}(Ui || (Ui = {})), function(e) {
 e.PHEROMONES = "pheromones", e.PATHS = "paths", e.TARGETS = "targets", e.DEBUG = "debug";
-}(Ni || (Ni = {}));
+}(_i || (_i = {}));
 
-function Bi(e, t) {
+function Fi(e, t) {
 var r = t.roomScaling, o = r.minRooms, n = r.scaleFactor, a = r.maxMultiplier, i = Math.max(1, o), s = n > 1 ? n : 100, c = a >= 1 ? a : 1, u = Math.max(e, i), l = 1 + Math.log(u / i) / Math.log(s);
 return Math.max(1, Math.min(c, l));
 }
 
-function Wi(e, t) {
+function Bi(e, t) {
 var r = t.bucketMultipliers, o = r.highThreshold, n = r.lowThreshold, a = r.criticalThreshold, i = r.highMultiplier, s = r.lowMultiplier, c = r.criticalMultiplier;
 return e >= o ? i : e < a ? c : e < n ? s : 1;
 }
 
-var Hi = new (function() {
+var Wi = new (function() {
 function e() {
 this.metrics = {
 totalCalls: 0,
@@ -13270,15 +12963,15 @@ return t.percentUsed - e.percentUsed;
 var r, n, a = "room:".concat(e.target), i = null === (r = t.processes) || void 0 === r ? void 0 : r[a], s = null !== (n = null == i ? void 0 : i.tickModulo) && void 0 !== n ? n : 1, c = s > 1 ? " [runs every ".concat(s, " ticks]") : "", u = "".concat((100 * e.percentUsed).toFixed(1), "%");
 return o ? "".concat(e.target, ": ").concat(u, " (").concat(e.cpuUsed.toFixed(3), "/").concat(e.budgetLimit.toFixed(3), " CPU)").concat(c) : "".concat(e.target, ": ").concat(u).concat(c);
 });
-return Yi(n, e.length);
+return Hi(n, e.length);
 }
 
-function Yi(e, t) {
+function Hi(e, t) {
 var r = t - e.length;
 return r > 0 && e.push("... ".concat(r, " more omitted")), e.join(", ");
 }
 
-var Vi = {
+var Yi = {
 enabled: !0,
 smoothingFactor: .1,
 trackNativeCalls: !0,
@@ -13300,9 +12993,9 @@ enabled: !0,
 spikeThreshold: 2,
 minSamples: 10
 }
-}, qi = 1e-9, ji = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
+}, Vi = 1e-9, qi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
 
-function zi() {
+function ji() {
 return {
 tasks: 0,
 openTasks: 0,
@@ -13314,28 +13007,28 @@ remainingAmount: 0
 };
 }
 
-function Qi(e) {
+function zi(e) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, e) : 0;
 }
 
-function Xi(e) {
+function Qi(e) {
 var t;
 return Object.values(null !== (t = e.reservations) && void 0 !== t ? t : {}).reduce(function(e, t) {
-return e + Qi(null == t ? void 0 : t.amount);
+return e + zi(null == t ? void 0 : t.amount);
 }, 0);
 }
 
-var Zi = function() {
+var Xi = function() {
 function e(e) {
 void 0 === e && (e = {}), this.subsystemMeasurements = new Map, this.cpuDetailMeasurements = new Map,
 this.roomMeasurements = new Map, this.lastSegmentUpdate = 0, this.lastBudgetAlertLogTick = -1 / 0,
 this.lastAnomalyLogTick = -1 / 0, this.segmentRequested = !1, this.skippedProcessesThisTick = 0,
-this.spawnIdleTickState = new Map, this.config = o(o({}, Vi), e), this.currentSnapshot = this.createEmptySnapshot(),
+this.spawnIdleTickState = new Map, this.config = o(o({}, Yi), e), this.currentSnapshot = this.createEmptySnapshot(),
 this.nativeCallsThisTick = this.createEmptyNativeCalls();
 }
 return e.prototype.initialize = function() {
 void 0 === RawMemory.segments[this.config.segmentId] && (RawMemory.setActiveSegments([ this.config.segmentId ]),
-this.segmentRequested = !0), this.installCpuProfilerGlobal(), Di.info("Unified stats system initialized", {
+this.segmentRequested = !0), this.installCpuProfilerGlobal(), Li.info("Unified stats system initialized", {
 subsystem: "Stats"
 });
 }, e.prototype.preserveRoomStats = function() {
@@ -13371,7 +13064,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-Hi.reset();
+Wi.reset();
 }
 }, e.prototype.publishIdleTick = function() {
 this.startTick(), this.finalizeTick();
@@ -13407,19 +13100,19 @@ return "critical" === e.severity;
 }), C = R.alerts.filter(function(e) {
 return "warning" === e.severity;
 });
-T.length > 0 && Di.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Ki(T, {
+T.length > 0 && Li.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Ki(T, {
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
-}), C.length > 0 && Di.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Ki(C, {
+}), C.length > 0 && Li.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Ki(C, {
 includeCpuUsage: !1,
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
 }), this.lastBudgetAlertLogTick = Game.time;
 }
-E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Di.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
-return Yi(s([], i(e), !1).sort(function(e, t) {
+E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Li.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
+return Hi(s([], i(e), !1).sort(function(e, t) {
 return t.multiplier - e.multiplier;
 }).slice(0, 5).map(function(e) {
 return "".concat(e.target, " (").concat(e.type, "): ").concat(e.current.toFixed(3), " CPU (").concat(e.multiplier.toFixed(1), "x baseline)").concat(e.context ? " - ".concat(e.context) : "");
@@ -13519,7 +13212,7 @@ v.staleReservations = null !== (s = null === (i = y.stats) || void 0 === i ? voi
 v.blockedReservations = null !== (u = null === (c = y.stats) || void 0 === c ? void 0 : c.blockedReservations) && void 0 !== u ? u : 0;
 try {
 for (var g = a(Object.values(null !== (l = y.tasks) && void 0 !== l ? l : {})), h = g.next(); !h.done; h = g.next()) {
-var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : zi(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = Qi(R.amount), w = Xi(R), x = Math.max(0, S - w), b = ji.has(E);
+var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : ji(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = zi(R.amount), w = Qi(R), x = Math.max(0, S - w), b = qi.has(E);
 v.tasks++, v.reservations += C, v.amount += S, v.reservedAmount += w, v.remainingAmount += x,
 T.tasks++, T.reservations += C, T.amount += S, T.reservedAmount += w, T.remainingAmount += x,
 "open" === R.status ? (v.openTasks++, T.openTasks++) : "assigned" === R.status && (v.assignedTasks++,
@@ -13548,10 +13241,10 @@ return "string" == typeof e;
 }) : [], h = this.getMyUsername(), R = null !== (i = null === (n = Memory.empire) || void 0 === n ? void 0 : n.knownRooms) && void 0 !== i ? i : {}, E = 0, T = 0, C = 0, S = 1 / 0, w = 0;
 try {
 for (var x = a(g), b = x.next(); !b.done; b = x.next()) {
-var O = b.value, A = Game.rooms[O], k = R[O];
-A && E++;
-var M = null !== (u = null === (c = null === (s = null == A ? void 0 : A.controller) || void 0 === s ? void 0 : s.owner) || void 0 === c ? void 0 : c.username) && void 0 !== u ? u : null == k ? void 0 : k.owner, U = null !== (d = null === (m = null === (l = null == A ? void 0 : A.controller) || void 0 === l ? void 0 : l.reservation) || void 0 === m ? void 0 : m.username) && void 0 !== d ? d : null == k ? void 0 : k.reserver, _ = null === (f = null === (p = null == A ? void 0 : A.controller) || void 0 === p ? void 0 : p.reservation) || void 0 === f ? void 0 : f.ticksToEnd;
-U === h ? (T++, "number" == typeof _ && (S = Math.min(S, _))) : U && C++, (M && M !== h || U && U !== h || (null !== (y = null == k ? void 0 : k.threatLevel) && void 0 !== y ? y : 0) >= 2) && w++;
+var O = b.value, k = Game.rooms[O], A = R[O];
+k && E++;
+var M = null !== (u = null === (c = null === (s = null == k ? void 0 : k.controller) || void 0 === s ? void 0 : s.owner) || void 0 === c ? void 0 : c.username) && void 0 !== u ? u : null == A ? void 0 : A.owner, U = null !== (d = null === (m = null === (l = null == k ? void 0 : k.controller) || void 0 === l ? void 0 : l.reservation) || void 0 === m ? void 0 : m.username) && void 0 !== d ? d : null == A ? void 0 : A.reserver, _ = null === (f = null === (p = null == k ? void 0 : k.controller) || void 0 === p ? void 0 : p.reservation) || void 0 === f ? void 0 : f.ticksToEnd;
+U === h ? (T++, "number" == typeof _ && (S = Math.min(S, _))) : U && C++, (M && M !== h || U && U !== h || (null !== (y = null == A ? void 0 : A.threatLevel) && void 0 !== y ? y : 0) >= 2) && w++;
 }
 } catch (e) {
 r = {
@@ -13649,8 +13342,8 @@ return e + t.cpuBudget * Game.cpu.limit;
 this.currentSnapshot.kernelBudgets = {
 adaptiveBudgetsEnabled: !0,
 roomCount: r,
-roomMultiplier: Bi(r, t.adaptiveBudgetConfig),
-bucketMultiplier: Wi(o, t.adaptiveBudgetConfig),
+roomMultiplier: Fi(r, t.adaptiveBudgetConfig),
+bucketMultiplier: Bi(o, t.adaptiveBudgetConfig),
 budgets: {
 high: t.frequencyCpuBudgets.high || 0,
 medium: t.frequencyCpuBudgets.medium || 0,
@@ -13733,11 +13426,11 @@ idleSpawnTicks: n.idleSpawnTicks
 }
 }
 }, e.prototype.recordRoom = function(e, t) {
-var r, o, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, A;
+var r, o, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, k;
 if (this.config.enabled) {
-var k = Fi(e.name), M = Object.values(Game.creeps).filter(function(t) {
+var A = Di(e.name), M = Object.values(Game.creeps).filter(function(t) {
 return t.room.name === e.name;
-}).length, U = j(e), _ = this.getRoomTaskBoardStats(e.name), N = this.getRemoteStats(e.name, k), P = this.getDefenseStats(e, U, k), I = this.getControllerDowngradeStats(e), G = this.currentSnapshot.rooms[e.name];
+}).length, U = j(e), _ = this.getRoomTaskBoardStats(e.name), N = this.getRemoteStats(e.name, A), P = this.getDefenseStats(e, U, A), I = this.getControllerDowngradeStats(e), G = this.currentSnapshot.rooms[e.name];
 G || (G = {
 name: e.name,
 rcl: null !== (s = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== s ? s : 0,
@@ -13757,9 +13450,9 @@ downgradeRisk: I.downgradeRisk
 creeps: M,
 hostiles: U.length,
 brain: {
-danger: null !== (v = null == k ? void 0 : k.danger) && void 0 !== v ? v : 0,
-postureCode: this.postureToCode(null !== (g = null == k ? void 0 : k.posture) && void 0 !== g ? g : "eco"),
-colonyLevelCode: this.colonyLevelToCode(null !== (h = null == k ? void 0 : k.colonyLevel) && void 0 !== h ? h : "seedNest")
+danger: null !== (v = null == A ? void 0 : A.danger) && void 0 !== v ? v : 0,
+postureCode: this.postureToCode(null !== (g = null == A ? void 0 : A.posture) && void 0 !== g ? g : "eco"),
+colonyLevelCode: this.colonyLevelToCode(null !== (h = null == A ? void 0 : A.colonyLevel) && void 0 !== h ? h : "seedNest")
 },
 pheromones: {},
 metrics: {
@@ -13789,14 +13482,14 @@ var L = this.getProfilerMemory().rooms[e.name], D = null !== (E = null === (R = 
 if (G.taskBoard = _, G.remote = N, G.defense = P, G.rcl = null !== (w = null === (S = e.controller) || void 0 === S ? void 0 : S.level) && void 0 !== w ? w : 0,
 G.energy.available = e.energyAvailable, G.energy.capacity = e.energyCapacityAvailable,
 G.energy.storage = F, G.energy.terminal = null !== (b = null === (x = e.terminal) || void 0 === x ? void 0 : x.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== b ? b : 0,
-G.controller.progress = D, G.controller.progressTotal = null !== (A = null === (O = e.controller) || void 0 === O ? void 0 : O.progressTotal) && void 0 !== A ? A : 1,
+G.controller.progress = D, G.controller.progressTotal = null !== (k = null === (O = e.controller) || void 0 === O ? void 0 : O.progressTotal) && void 0 !== k ? k : 1,
 G.controller.ticksToDowngrade = I.ticksToDowngrade, G.controller.downgradeRisk = I.downgradeRisk,
 G.creeps = M, G.hostiles = U.length, G.controller.progressPercent = G.controller.progressTotal > 0 ? G.controller.progress / G.controller.progressTotal * 100 : 0,
-k) {
-if (k.pheromones && "object" == typeof k.pheromones) try {
-for (var B = a(Object.entries(k.pheromones)), W = B.next(); !W.done; W = B.next()) {
-var H = i(W.value, 2), K = H[0], Y = H[1];
-G.pheromones[K] = Y;
+A) {
+if (A.pheromones && "object" == typeof A.pheromones) try {
+for (var B = a(Object.entries(A.pheromones)), W = B.next(); !W.done; W = B.next()) {
+var K = i(W.value, 2), H = K[0], Y = K[1];
+G.pheromones[H] = Y;
 }
 } catch (e) {
 r = {
@@ -13809,19 +13502,19 @@ W && !W.done && (o = B.return) && o.call(B);
 if (r) throw r.error;
 }
 }
-k.metrics && "object" == typeof k.metrics && (G.metrics = {
-energyHarvested: k.metrics.energyHarvested,
-energySpawning: k.metrics.energySpawning,
-energyConstruction: k.metrics.energyConstruction,
-energyRepair: k.metrics.energyRepair,
-energyTower: k.metrics.energyTower,
-energyAvailableForSharing: k.metrics.energyAvailable,
-energyCapacityTotal: k.metrics.energyCapacity,
-energyNeed: k.metrics.energyNeed,
-controllerProgress: k.metrics.controllerProgress,
-hostileCount: k.metrics.hostileCount,
-damageReceived: k.metrics.damageReceived,
-constructionSites: k.metrics.constructionSites
+A.metrics && "object" == typeof A.metrics && (G.metrics = {
+energyHarvested: A.metrics.energyHarvested,
+energySpawning: A.metrics.energySpawning,
+energyConstruction: A.metrics.energyConstruction,
+energyRepair: A.metrics.energyRepair,
+energyTower: A.metrics.energyTower,
+energyAvailableForSharing: A.metrics.energyAvailable,
+energyCapacityTotal: A.metrics.energyCapacity,
+energyNeed: A.metrics.energyNeed,
+controllerProgress: A.metrics.controllerProgress,
+hostileCount: A.metrics.hostileCount,
+damageReceived: A.metrics.damageReceived,
+constructionSites: A.metrics.constructionSites
 });
 }
 var V = void 0 !== (null == L ? void 0 : L.controllerProgress) ? Math.max(0, D - L.controllerProgress) : 0, q = void 0 !== (null == L ? void 0 : L.storageEnergy) ? Math.max(0, F - L.storageEnergy) : 0;
@@ -13839,7 +13532,7 @@ storageEnergy: F
 };
 }
 }, e.prototype.isWarRoom = function(e) {
-var t = Fi(e);
+var t = Di(e);
 return !!t && ("war" === t.posture || "siege" === t.posture || t.danger >= 2);
 }, e.prototype.validateBudgets = function() {
 var e, t, r, o = {
@@ -13854,8 +13547,8 @@ try {
 for (var n = a(Object.entries(this.currentSnapshot.rooms)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
 o.roomsEvaluated++;
-var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= qi ? h : Math.abs(v - g) <= qi ? g : v;
-v + qi >= h ? (o.roomsOverBudget++, o.alerts.push({
+var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Vi ? h : Math.abs(v - g) <= Vi ? g : v;
+v + Vi >= h ? (o.roomsOverBudget++, o.alerts.push({
 severity: "critical",
 target: u,
 targetType: "room",
@@ -13863,7 +13556,7 @@ cpuUsed: y,
 budgetLimit: f,
 percentUsed: R,
 tick: Game.time
-})) : v + qi >= g ? (o.alerts.push({
+})) : v + Vi >= g ? (o.alerts.push({
 severity: "warning",
 target: u,
 targetType: "room",
@@ -13897,7 +13590,7 @@ var v = null !== (n = this.roomMeasurements.get(f)) && void 0 !== n ? n : 0;
 if (!((x = y.profiler.avgCpu) < .01)) {
 var g = v / x;
 if (g >= this.config.anomalyDetection.spikeThreshold) {
-var h = Fi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
+var h = Di(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
 l.push({
 type: "spike",
 target: f,
@@ -14160,8 +13853,8 @@ return e.memory.role === v;
 }), h = g.length, R = 0, E = 0, T = 0, C = 0, S = 0;
 try {
 for (var w = (i = void 0, a(g)), x = w.next(); !x.done; x = w.next()) {
-var b = x.value, O = b.memory, A = null !== (o = null === (r = O.state) || void 0 === r ? void 0 : r.action) && void 0 !== o ? o : "idle", k = null !== (n = O.working) && void 0 !== n ? n : "idle" !== A;
-S += b.body.length, C += null !== (s = b.ticksToLive) && void 0 !== s ? s : 0, b.spawning ? R++ : k && "idle" !== A ? T++ : E++;
+var b = x.value, O = b.memory, k = null !== (o = null === (r = O.state) || void 0 === r ? void 0 : r.action) && void 0 !== o ? o : "idle", A = null !== (n = O.working) && void 0 !== n ? n : "idle" !== k;
+S += b.body.length, C += null !== (s = b.ticksToLive) && void 0 !== s ? s : 0, b.spawning ? R++ : A && "idle" !== k ? T++ : E++;
 }
 } catch (e) {
 i = {
@@ -14325,7 +14018,7 @@ evictions: 0
 }
 };
 }, e.prototype.finalizePathfindingStats = function() {
-this.currentSnapshot.pathfinding = Hi.getMetrics();
+this.currentSnapshot.pathfinding = Wi.getMetrics();
 }, e.prototype.formatCpuDetailsForMemory = function() {
 var e, t, r, n, s = this.getCpuDetailsConfig(), c = {};
 try {
@@ -14593,18 +14286,18 @@ if (r) throw r.error;
 }
 try {
 for (var b = a(Object.entries(f.roles)), O = b.next(); !O.done; O = b.next()) {
-var A = i(O.value, 2), k = (w = A[0], A[1]);
+var k = i(O.value, 2), A = (w = k[0], k[1]);
 p.stats.roles[w] = {
-count: k.count,
-avg_cpu: k.avgCpu,
-peak_cpu: k.peakCpu,
-calls: k.calls,
-samples: k.samples,
-spawning_count: k.spawningCount,
-idle_count: k.idleCount,
-active_count: k.activeCount,
-avg_ticks_to_live: k.avgTicksToLive,
-total_body_parts: k.totalBodyParts
+count: A.count,
+avg_cpu: A.avgCpu,
+peak_cpu: A.peakCpu,
+calls: A.calls,
+samples: A.samples,
+spawning_count: A.spawningCount,
+idle_count: A.idleCount,
+active_count: A.activeCount,
+avg_ticks_to_live: A.avgTicksToLive,
+total_body_parts: A.totalBodyParts
 };
 }
 } catch (e) {
@@ -14687,24 +14380,24 @@ var o = JSON.parse(r);
 Array.isArray(o) && (t = o);
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Di.error("Failed to parse stats segment: ".concat(n), {
+Li.error("Failed to parse stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
 t.push(this.currentSnapshot), t.length > this.config.maxHistoryPoints && (t = t.slice(-this.config.maxHistoryPoints));
 var a = JSON.stringify(t);
 if (a.length > e) {
-for (Di.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
+for (Li.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
 subsystem: "Stats"
 }); a.length > e && t.length > 1; ) t.shift(), a = JSON.stringify(t);
-if (a.length > e) return void Di.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
+if (a.length > e) return void Li.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
 subsystem: "Stats"
 });
 }
 try {
 RawMemory.segments[this.config.segmentId] = a;
 } catch (e) {
-n = e instanceof Error ? e.message : String(e), Di.error("Failed to save stats segment: ".concat(n), {
+n = e instanceof Error ? e.message : String(e), Li.error("Failed to save stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
@@ -14721,17 +14414,17 @@ lastUpdate: 0
 }), e.stats.profiler;
 }, e.prototype.logSummary = function() {
 var e, t, r, o, n, i, s, c, u, l, m = this.currentSnapshot;
-Di.info("=== Unified Stats Summary ==="), Di.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
-Di.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
+Li.info("=== Unified Stats Summary ==="), Li.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
+Li.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
 var d = Object.values(m.subsystems).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (d.length > 0) {
-Di.info("Top Subsystems:");
+Li.info("Top Subsystems:");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Di.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
+Li.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
 }
 } catch (t) {
 e = {
@@ -14749,11 +14442,11 @@ var v = Object.values(m.roles).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (v.length > 0) {
-Di.info("Top Roles:");
+Li.info("Top Roles:");
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Di.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
+Li.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
 }
 } catch (e) {
 r = {
@@ -14771,11 +14464,11 @@ var E = Object.values(m.processes).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (E.length > 0) {
-Di.info("Top Processes:");
+Li.info("Top Processes:");
 try {
 for (var T = a(E), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-Di.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
+Li.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
 }
 } catch (e) {
 n = {
@@ -14793,11 +14486,11 @@ var w = Object.values(m.rooms).sort(function(e, t) {
 return t.profiler.avgCpu - e.profiler.avgCpu;
 }).slice(0, 5);
 if (w.length > 0) {
-Di.info("Top Rooms by CPU:");
+Li.info("Top Rooms by CPU:");
 try {
 for (var x = a(w), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Di.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
+Li.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
 }
 } catch (e) {
 s = {
@@ -14811,15 +14504,15 @@ if (s) throw s.error;
 }
 }
 }
-var A = Object.values(m.creeps).sort(function(e, t) {
+var k = Object.values(m.creeps).sort(function(e, t) {
 return t.cpu - e.cpu;
 }).slice(0, 5);
-if (A.length > 0) {
-Di.info("Top Creeps by CPU:");
+if (k.length > 0) {
+Li.info("Top Creeps by CPU:");
 try {
-for (var k = a(A), M = k.next(); !M.done; M = k.next()) {
+for (var A = a(k), M = A.next(); !M.done; M = A.next()) {
 var U = M.value;
-Di.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
+Li.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
 }
 } catch (e) {
 u = {
@@ -14827,13 +14520,13 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (l = k.return) && l.call(k);
+M && !M.done && (l = A.return) && l.call(A);
 } finally {
 if (u) throw u.error;
 }
 }
 }
-this.config.trackNativeCalls && Di.info("Native calls: ".concat(m.native.total, " total"));
+this.config.trackNativeCalls && Li.info("Native calls: ".concat(m.native.total, " total"));
 }, e.prototype.postureToCode = function(e) {
 var t;
 return null !== (t = {
@@ -14879,16 +14572,16 @@ lastUpdate: 0
 return o({}, this.currentSnapshot);
 }, e.POSTURE_NAMES = [ "eco", "expand", "defensive", "war", "siege", "evacuate", "nukePrep" ],
 e;
-}(), Ji = new Zi, $i = {
+}(), Zi = new Xi, Ji = {
 primarySegment: 90,
 backupSegment: 91,
 retentionPeriod: 1e4,
 updateInterval: 50,
 maxDataPoints: 1e3
-}, es = function() {
+}, $i = function() {
 function e(e) {
 void 0 === e && (e = {}), this.statsData = null, this.segmentRequested = !1, this.lastUpdate = 0,
-this.config = o(o({}, $i), e);
+this.config = o(o({}, Ji), e);
 }
 return e.prototype.initialize = function() {
 RawMemory.setActiveSegments([ this.config.primarySegment ]), this.segmentRequested = !0;
@@ -14899,12 +14592,12 @@ this.lastUpdate = Game.time);
 }, e.prototype.loadFromSegment = function() {
 var e = RawMemory.segments[this.config.primarySegment];
 if (e && 0 !== e.length) try {
-this.statsData = JSON.parse(e), Di.debug("Loaded stats from segment", {
+this.statsData = JSON.parse(e), Li.debug("Loaded stats from segment", {
 subsystem: "Stats"
 });
 } catch (e) {
 var t = e instanceof Error ? e.message : String(e);
-Di.error("Failed to parse stats segment: ".concat(t), {
+Li.error("Failed to parse stats segment: ".concat(t), {
 subsystem: "Stats"
 }), this.statsData = this.createDefaultStatsData();
 } else this.statsData = this.createDefaultStatsData();
@@ -14956,7 +14649,7 @@ c["".concat(p, ".energy.capacity")] = d.energyCapacity, c["".concat(p, ".storage
 c["".concat(p, ".terminal.energy")] = d.terminalEnergy, c["".concat(p, ".creeps")] = d.creepCount,
 c["".concat(p, ".controller.progress")] = d.controllerProgress, c["".concat(p, ".controller.progress_total")] = d.controllerProgressTotal,
 c["".concat(p, ".controller.progress_percent")] = d.controllerProgressTotal > 0 ? d.controllerProgress / d.controllerProgressTotal * 100 : 0;
-var f = Fi(d.roomName);
+var f = Di(d.roomName);
 if (f) {
 if (c["".concat(p, ".brain.danger")] = f.danger, c["".concat(p, ".brain.posture_code")] = this.postureToCode(f.posture),
 c["".concat(p, ".brain.colony_level_code")] = this.colonyLevelToCode(f.colonyLevel),
@@ -15071,7 +14764,7 @@ try {
 this.statsData.lastUpdate = Game.time;
 var i = JSON.stringify(this.statsData);
 if (i.length > n) {
-for (Di.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
+for (Li.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
 subsystem: "Stats"
 }); i.length > n && this.statsData.history.length > 10; ) this.statsData.history.shift(),
 i = JSON.stringify(this.statsData);
@@ -15090,7 +14783,7 @@ if (e) throw e.error;
 }
 }
 if (i.length > n) {
-Di.warn("Stats data still exceeds limit after trimming, clearing history", {
+Li.warn("Stats data still exceeds limit after trimming, clearing history", {
 subsystem: "Stats"
 }), this.statsData.history = this.statsData.history.slice(-5);
 try {
@@ -15113,7 +14806,7 @@ i = JSON.stringify(this.statsData);
 RawMemory.segments[this.config.primarySegment] = i;
 } catch (e) {
 var p = e instanceof Error ? e.message : String(e);
-Di.error("Failed to save stats segment: ".concat(p), {
+Li.error("Failed to save stats segment: ".concat(p), {
 subsystem: "Stats"
 });
 }
@@ -15217,9 +14910,9 @@ fortifiedHive: 4,
 empireDominance: 5
 }[e]) && void 0 !== t ? t : 0;
 }, e;
-}(), ts = new es;
+}(), es = new $i;
 
-function rs(e) {
+function ts(e) {
 e._metrics || (e._metrics = {
 tasksCompleted: 0,
 energyTransferred: 0,
@@ -15232,15 +14925,15 @@ healingDone: 0
 });
 }
 
-function os(e) {
-return rs(e), e._metrics;
+function rs(e) {
+return ts(e), e._metrics;
 }
 
-function ns(e, t) {
-os(e).damageDealt += t;
+function os(e, t) {
+rs(e).damageDealt += t;
 }
 
-var as, is = {
+var ns, as = {
 minBucket: 0,
 minSourceLinkEnergy: 400,
 controllerLinkMaxEnergy: 700,
@@ -15252,11 +14945,11 @@ storageEnergyReserveForSpawnLink: 1e4
 !function(e) {
 e.SOURCE = "source", e.CONTROLLER = "controller", e.STORAGE = "storage", e.SPAWN = "spawn",
 e.UNKNOWN = "unknown";
-}(as || (as = {}));
+}(ns || (ns = {}));
 
-var ss, cs, us = function() {
+var is, ss, cs = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, is), e);
+void 0 === e && (e = {}), this.config = o(o({}, as), e);
 }
 return e.prototype.run = function() {
 var e, t;
@@ -15290,13 +14983,13 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (!(t.length < 2)) {
 var r = this.classifyLinks(e, t), o = r.filter(function(e) {
-return e.role === as.SOURCE;
+return e.role === ns.SOURCE;
 }), n = r.filter(function(e) {
-return e.role === as.CONTROLLER;
+return e.role === ns.CONTROLLER;
 }), a = r.filter(function(e) {
-return e.role === as.STORAGE;
+return e.role === ns.STORAGE;
 }), i = r.filter(function(e) {
-return e.role === as.SPAWN;
+return e.role === ns.SPAWN;
 });
 this.executeTransfers(e, o, n, a, i);
 }
@@ -15333,11 +15026,11 @@ try {
 for (var R = (l = void 0, a(f)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.link.store.getFreeCapacity(RESOURCE_ENERGY) < this.config.transferThreshold)) {
-if (T.role === as.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
+if (T.role === ns.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
 h = T;
 break;
 }
-if (T.role !== as.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
+if (T.role !== ns.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
 h = T;
 break;
 }
@@ -15417,25 +15110,25 @@ i.transferEnergy(m, l));
 var t = e.room, r = t.controller, o = t.storage, n = t.find(FIND_SOURCES), a = t.find(FIND_MY_SPAWNS);
 return this.classifyLinkRole(e, r, o, n, a);
 }, e.prototype.classifyLinkRole = function(e, t, r, o, n) {
-return t && e.pos.getRangeTo(t) <= 2 ? as.CONTROLLER : o.some(function(t) {
+return t && e.pos.getRangeTo(t) <= 2 ? ns.CONTROLLER : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 1;
-}) ? as.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? as.STORAGE : n.some(function(t) {
+}) ? ns.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? ns.STORAGE : n.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? as.SPAWN : o.some(function(t) {
+}) ? ns.SPAWN : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? as.SOURCE : as.UNKNOWN;
+}) ? ns.SOURCE : ns.UNKNOWN;
 }, e.prototype.getRolePriority = function(e) {
 switch (e) {
-case as.CONTROLLER:
+case ns.CONTROLLER:
 return 100;
 
-case as.SPAWN:
+case ns.SPAWN:
 return 75;
 
-case as.STORAGE:
+case ns.STORAGE:
 return 50;
 
-case as.SOURCE:
+case ns.SOURCE:
 return 10;
 
 default:
@@ -15451,34 +15144,34 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (r.length < 2) return !1;
 var o = this.classifyLinks(e, r), n = o.some(function(e) {
-return e.role === as.SOURCE;
+return e.role === ns.SOURCE;
 }), a = o.some(function(e) {
-return e.role === as.CONTROLLER || e.role === as.STORAGE;
+return e.role === ns.CONTROLLER || e.role === ns.STORAGE;
 });
 return n && a;
-}, n([ Ma("link:manager", "Link Manager", {
-priority: ha.MEDIUM,
+}, n([ Ka("link:manager", "Link Manager", {
+priority: Ma.MEDIUM,
 interval: 5,
 minBucket: 0,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), ls = new us;
+}) ], e.prototype, "run", null), n([ Ya() ], e);
+}(), us = new cs;
 
-function ms(e) {
+function ls(e) {
 return "string" == typeof e.roomName && e.roomName.length > 0;
 }
 
-function ds(e) {
+function ms(e) {
 var t, r;
 return Math.max(0, null !== (r = null !== (t = e.remainingAmount) && void 0 !== t ? t : e.amount) && void 0 !== r ? r : 0);
 }
 
-function ps(e, t) {
+function ds(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var fs, ys, vs, gs, hs, Rs, Es, Ts, Cs, Ss, ws, xs, bs = {
+var ps, fs, ys, vs, gs, hs, Rs, Es, Ts, Cs, Ss, ws, xs = {
 updateInterval: 100,
 priceUpdateInterval: 500,
 minBucket: 2e3,
@@ -15496,14 +15189,14 @@ highPriceMultiplier: 1.1,
 trendChangeThreshold: .05,
 buyOpportunityAdjustment: 1.02,
 sellOpportunityAdjustment: .98,
-sellThresholds: (ss = {}, ss[RESOURCE_ENERGY] = 5e5, ss[RESOURCE_HYDROGEN] = 2e4,
-ss[RESOURCE_OXYGEN] = 2e4, ss[RESOURCE_UTRIUM] = 2e4, ss[RESOURCE_LEMERGIUM] = 2e4,
-ss[RESOURCE_KEANIUM] = 2e4, ss[RESOURCE_ZYNTHIUM] = 2e4, ss[RESOURCE_CATALYST] = 2e4,
+sellThresholds: (is = {}, is[RESOURCE_ENERGY] = 5e5, is[RESOURCE_HYDROGEN] = 2e4,
+is[RESOURCE_OXYGEN] = 2e4, is[RESOURCE_UTRIUM] = 2e4, is[RESOURCE_LEMERGIUM] = 2e4,
+is[RESOURCE_KEANIUM] = 2e4, is[RESOURCE_ZYNTHIUM] = 2e4, is[RESOURCE_CATALYST] = 2e4,
+is),
+buyThresholds: (ss = {}, ss[RESOURCE_ENERGY] = 1e5, ss[RESOURCE_HYDROGEN] = 5e3,
+ss[RESOURCE_OXYGEN] = 5e3, ss[RESOURCE_UTRIUM] = 5e3, ss[RESOURCE_LEMERGIUM] = 5e3,
+ss[RESOURCE_KEANIUM] = 5e3, ss[RESOURCE_ZYNTHIUM] = 5e3, ss[RESOURCE_CATALYST] = 5e3,
 ss),
-buyThresholds: (cs = {}, cs[RESOURCE_ENERGY] = 1e5, cs[RESOURCE_HYDROGEN] = 5e3,
-cs[RESOURCE_OXYGEN] = 5e3, cs[RESOURCE_UTRIUM] = 5e3, cs[RESOURCE_LEMERGIUM] = 5e3,
-cs[RESOURCE_KEANIUM] = 5e3, cs[RESOURCE_ZYNTHIUM] = 5e3, cs[RESOURCE_CATALYST] = 5e3,
-cs),
 trackedResources: [ RESOURCE_ENERGY, RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_UTRIUM, RESOURCE_LEMERGIUM, RESOURCE_KEANIUM, RESOURCE_ZYNTHIUM, RESOURCE_CATALYST, RESOURCE_GHODIUM, RESOURCE_POWER ],
 criticalResources: [ RESOURCE_ENERGY, RESOURCE_GHODIUM ],
 emergencyBuyThreshold: 5e3,
@@ -15521,39 +15214,39 @@ minArbitrageMargin: .05,
 energyOverflowStorageEnter: 8e5,
 energyOverflowStorageExit: 5e5,
 minOverflowEnergySellAmount: 1e3
-}, Os = function() {
+}, bs = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedEmpireTick = -1, this.cachedEmpire = null,
-this.config = o(o({}, bs), e);
+this.config = o(o({}, xs), e);
 }
 return e.prototype.run = function() {
 var e = this;
 this.lastRun = Game.time, this.cachedEmpireTick = -1, this.cachedEmpire = null,
-ps("market.ensureMemory", function() {
+ds("market.ensureMemory", function() {
 return e.ensureMarketMemory();
-}), Game.time % this.config.priceUpdateInterval === 0 && ps("market.updatePriceTracking", function() {
+}), Game.time % this.config.priceUpdateInterval === 0 && ds("market.updatePriceTracking", function() {
 return e.updatePriceTracking();
-}), ps("market.updateOrderStats", function() {
+}), ds("market.updateOrderStats", function() {
 return e.updateOrderStats();
-}), ps("market.reconcilePendingArbitrage", function() {
+}), ds("market.reconcilePendingArbitrage", function() {
 return e.reconcilePendingArbitrage();
-}), ps("market.handleEmergencyBuying", function() {
+}), ds("market.handleEmergencyBuying", function() {
 return e.handleEmergencyBuying();
-}), ps("market.cancelOldOrders", function() {
+}), ds("market.cancelOldOrders", function() {
 return e.cancelOldOrders();
-}), ps("market.manageExistingOrders", function() {
+}), ds("market.manageExistingOrders", function() {
 return e.manageExistingOrders();
-}), this.canRunActiveTrading() && (ps("market.updateBuyOrders", function() {
+}), this.canRunActiveTrading() && (ds("market.updateBuyOrders", function() {
 return e.updateBuyOrders();
-}), ps("market.handleEnergyOverflowSales", function() {
+}), ds("market.handleEnergyOverflowSales", function() {
 return e.handleEnergyOverflowSales();
-}), ps("market.updateSellOrders", function() {
+}), ds("market.updateSellOrders", function() {
 return e.updateSellOrders();
-}), ps("market.checkArbitrageOpportunities", function() {
+}), ds("market.checkArbitrageOpportunities", function() {
 return e.checkArbitrageOpportunities();
-}), ps("market.executeDeal", function() {
+}), ds("market.executeDeal", function() {
 return e.executeDeal();
-}), Game.time % 200 == 0 && ps("market.balanceResourcesAcrossRooms", function() {
+}), Game.time % 200 == 0 && ds("market.balanceResourcesAcrossRooms", function() {
 return e.balanceResourcesAcrossRooms();
 }));
 }, e.prototype.canRunActiveTrading = function() {
@@ -15844,8 +15537,8 @@ var b = Math.min(t, E.remainingAmount, this.config.maxActiveBuyAmount, x);
 if (!(b <= 0)) {
 var O = Game.market.calcTransactionCost(b, S.name, E.roomName);
 if (!(w.store.getUsedCapacity(RESOURCE_ENERGY) - O < this.config.terminalEnergyReserve)) {
-var A = E.price * b;
-if (!(Game.market.credits - A < this.config.minCredits) && Game.market.deal(E.id, b, S.name) === OK) return U.info("Bought ".concat(b, " ").concat(e, " at ").concat(E.price.toFixed(3), " credits/unit"), {
+var k = E.price * b;
+if (!(Game.market.credits - k < this.config.minCredits) && Game.market.deal(E.id, b, S.name) === OK) return U.info("Bought ".concat(b, " ").concat(e, " at ").concat(E.price.toFixed(3), " credits/unit"), {
 subsystem: "Market"
 }), !0;
 }
@@ -15940,8 +15633,8 @@ energyCreditValue: this.config.energyCreditValue,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}, u.orders.filter(ms).map(function(e) {
-var t = Math.min(u.requestedAmount, ds(e), u.maxDealAmount);
+}, u.orders.filter(ls).map(function(e) {
+var t = Math.min(u.requestedAmount, ms(e), u.maxDealAmount);
 if (!(t <= 0)) {
 var r = u.calcTransactionCost(t, u.sourceRoomName, e.roomName), o = e.price * t - r * u.energyCreditValue;
 return {
@@ -16147,8 +15840,8 @@ maxDealAmount: this.config.maxActiveBuyAmount,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}).orders.filter(ms).map(function(e) {
-var t = Math.min(ds(e), m.maxDealAmount, m.requestedAmount);
+}).orders.filter(ls).map(function(e) {
+var t = Math.min(ms(e), m.maxDealAmount, m.requestedAmount);
 if (!(t <= 0)) {
 var r = m.calcTransactionCost(t, e.roomName, m.destinationRoomName);
 return {
@@ -16307,10 +16000,10 @@ try {
 for (var R = (t = void 0, a(c)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = T.terminal;
 if (!((null !== (o = C.store.getFreeCapacity(e)) && void 0 !== o ? o : 0) < h)) {
-var S = Game.market.calcTransactionCost(h, T.name, v.roomName) + Game.market.calcTransactionCost(h, T.name, y.roomName), w = S * d.config.energyCreditValue, x = (y.price - v.price) * h - w, b = v.price * h, O = b > 0 ? x / b : 0, A = b > 0 ? w / b : 1 / 0;
-if (!(x < d.config.minArbitrageProfit || O < d.config.minArbitrageMargin || A > d.config.maxTransportCostRatio || C.store.getUsedCapacity(RESOURCE_ENERGY) - S < d.config.terminalEnergyReserve)) {
-var k = v.price * h;
-if (!(Game.market.credits - k < d.config.minCredits) && Game.market.deal(v.id, h, T.name) === OK) {
+var S = Game.market.calcTransactionCost(h, T.name, v.roomName) + Game.market.calcTransactionCost(h, T.name, y.roomName), w = S * d.config.energyCreditValue, x = (y.price - v.price) * h - w, b = v.price * h, O = b > 0 ? x / b : 0, k = b > 0 ? w / b : 1 / 0;
+if (!(x < d.config.minArbitrageProfit || O < d.config.minArbitrageMargin || k > d.config.maxTransportCostRatio || C.store.getUsedCapacity(RESOURCE_ENERGY) - S < d.config.terminalEnergyReserve)) {
+var A = v.price * h;
+if (!(Game.market.credits - A < d.config.minCredits) && Game.market.deal(v.id, h, T.name) === OK) {
 var M = {
 id: "".concat(e, "-").concat(Game.time, "-").concat(v.id),
 resource: e,
@@ -16418,13 +16111,13 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-}, n([ Ua("empire:market", "Market Manager", {
-priority: ha.LOW,
+}, n([ Ha("empire:market", "Market Manager", {
+priority: Ma.LOW,
 interval: 100,
 minBucket: 2e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), As = new Os, ks = function() {
+}) ], e.prototype, "run", null), n([ Ya() ], e);
+}(), Os = new bs, ks = function() {
 function e() {
 this.costCache = new Map, this.COST_CACHE_TTL = 100, this.MAX_HOPS = 3;
 }
@@ -16491,8 +16184,8 @@ if (i) throw i.error;
 if (!C || S === 1 / 0) break;
 if (C === t) break;
 if (h.delete(C), !(this.getPathLength(C, g) >= this.MAX_HOPS)) try {
-for (var A = (c = void 0, a(y)), k = A.next(); !k.done; k = A.next()) {
-var M = k.value;
+for (var k = (c = void 0, a(y)), A = k.next(); !A.done; A = k.next()) {
+var M = A.value;
 if (h.has(M.roomName) && M.roomName !== C) {
 var _ = this.calculateTransferCost(r, C, M.roomName), N = (null !== (m = v.get(C)) && void 0 !== m ? m : 1 / 0) + _;
 N < (null !== (d = v.get(M.roomName)) && void 0 !== d ? d : 1 / 0) && (v.set(M.roomName, N),
@@ -16505,7 +16198,7 @@ error: e
 };
 } finally {
 try {
-k && !k.done && (u = A.return) && u.call(A);
+A && !A.done && (u = k.return) && u.call(k);
 } finally {
 if (c) throw c.error;
 }
@@ -16551,7 +16244,7 @@ if (e) throw e.error;
 var r = e.path.indexOf(t);
 return -1 === r || r === e.path.length - 1 ? null : e.path[r + 1] || null;
 }, e;
-}(), Ms = new ks, Us = {
+}(), As = new ks, Ms = {
 minBucket: 0,
 minStorageEnergy: 5e4,
 terminalEnergyTarget: 2e4,
@@ -16566,9 +16259,9 @@ emergencyDangerThreshold: 2,
 emergencyEnergyAmount: 2e4,
 energySurplusThreshold: 5e4,
 mineralSurplusThreshold: 5e3
-}, _s = function() {
+}, Us = function() {
 function e(e) {
-void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, Us), e);
+void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, Ms), e);
 }
 return e.prototype.requestTransfer = function(e, t, r, o, n) {
 if (void 0 === n && (n = 3), this.transferQueue.some(function(o) {
@@ -16594,7 +16287,7 @@ var e = Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.terminal && e.terminal.my && e.terminal.isActive();
 });
-0 !== e.length && (Ms.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
+0 !== e.length && (As.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
 e.length < 2 || (this.checkEmergencyTransfers(e), this.balanceEnergy(e), this.balanceMinerals(e),
 this.executeTransfers(e)));
 }
@@ -16622,7 +16315,7 @@ var l = u[0];
 if (!c.transferQueue.some(function(e) {
 return e.toRoom === t.name && e.resourceType === RESOURCE_ENERGY && e.isEmergency;
 })) {
-var m = Ms.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
+var m = As.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
 m && (c.transferQueue.push({
 fromRoom: l.name,
 toRoom: t.name,
@@ -16713,7 +16406,7 @@ var w = C - S;
 if (u && u !== e.name) {
 var x = null === (c = Game.rooms[u]) || void 0 === c ? void 0 : c.terminal;
 if (x && x.store.getFreeCapacity() > w) {
-var b = Ms.findOptimalRoute(e.name, u, w);
+var b = As.findOptimalRoute(e.name, u, w);
 if (b) {
 this.transferQueue.push({
 fromRoom: e.name,
@@ -16729,7 +16422,7 @@ continue;
 }
 }
 }
-Game.time % 10 == 0 && As.sellSurplusFromTerminal(e.name, T, w) && U.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
+Game.time % 10 == 0 && Os.sellSurplusFromTerminal(e.name, T, w) && U.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
 subsystem: "Terminal"
 });
 }
@@ -16774,7 +16467,7 @@ return r.fromRoom === t.room.name && r.toRoom === e.room.name && r.resourceType 
 })) return "continue";
 var r = Math.min(Math.floor((t.totalEnergy - u.config.energySendThreshold) / 2), u.config.energyRequestThreshold - e.totalEnergy, t.terminal.store.getUsedCapacity(RESOURCE_ENERGY));
 if (r < u.config.minTransferAmount) return "continue";
-var o = Ms.findOptimalRoute(t.room.name, e.room.name, r);
+var o = As.findOptimalRoute(t.room.name, e.room.name, r);
 if (!o) return "continue";
 var n = o.cost / r;
 if (n > u.config.maxTransferCostRatio) return U.debug("Skipping terminal transfer from ".concat(t.room.name, " to ").concat(e.room.name, ": cost ratio ").concat(n.toFixed(2), " too high"), {
@@ -16909,7 +16602,7 @@ var a = r.terminal;
 if (a.cooldown > 0) return "continue";
 var i = t.toRoom;
 if (t.route && !t.route.isDirect) {
-var c = Ms.getNextHop(t.route, t.fromRoom);
+var c = As.getNextHop(t.route, t.fromRoom);
 c && (i = c);
 }
 var u = null === (o = Game.rooms[i]) || void 0 === o ? void 0 : o.terminal;
@@ -17067,31 +16760,31 @@ S && !S.done && (u = C.return) && u.call(C);
 if (c) throw c.error;
 }
 }
-}, n([ Ma("terminal:manager", "Terminal Manager", {
-priority: ha.MEDIUM,
+}, n([ Ka("terminal:manager", "Terminal Manager", {
+priority: Ma.MEDIUM,
 interval: 20,
 minBucket: 0,
 cpuBudget: .1
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Ns = new _s, Ps = {
+}) ], e.prototype, "run", null), n([ Ya() ], e);
+}(), _s = new Us, Ns = {
 minBucket: 0,
 minStorageEnergy: 8e4,
 inputBufferAmount: 2e3,
 outputBufferAmount: 5e3
-}, Is = ((fs = {})[RESOURCE_UTRIUM_BAR] = ((ys = {})[RESOURCE_UTRIUM] = 500, ys[RESOURCE_ENERGY] = 200,
-ys), fs[RESOURCE_LEMERGIUM_BAR] = ((vs = {})[RESOURCE_LEMERGIUM] = 500, vs[RESOURCE_ENERGY] = 200,
-vs), fs[RESOURCE_ZYNTHIUM_BAR] = ((gs = {})[RESOURCE_ZYNTHIUM] = 500, gs[RESOURCE_ENERGY] = 200,
-gs), fs[RESOURCE_KEANIUM_BAR] = ((hs = {})[RESOURCE_KEANIUM] = 500, hs[RESOURCE_ENERGY] = 200,
-hs), fs[RESOURCE_GHODIUM_MELT] = ((Rs = {})[RESOURCE_GHODIUM] = 500, Rs[RESOURCE_ENERGY] = 200,
-Rs), fs[RESOURCE_OXIDANT] = ((Es = {})[RESOURCE_OXYGEN] = 500, Es[RESOURCE_ENERGY] = 200,
-Es), fs[RESOURCE_REDUCTANT] = ((Ts = {})[RESOURCE_HYDROGEN] = 500, Ts[RESOURCE_ENERGY] = 200,
-Ts), fs[RESOURCE_PURIFIER] = ((Cs = {})[RESOURCE_CATALYST] = 500, Cs[RESOURCE_ENERGY] = 200,
-Cs), fs[RESOURCE_BATTERY] = ((Ss = {})[RESOURCE_ENERGY] = 600, Ss), fs), Gs = ((ws = {})[RESOURCE_BATTERY] = 10,
-ws[RESOURCE_UTRIUM_BAR] = 5, ws[RESOURCE_LEMERGIUM_BAR] = 5, ws[RESOURCE_ZYNTHIUM_BAR] = 5,
-ws[RESOURCE_KEANIUM_BAR] = 5, ws[RESOURCE_GHODIUM_MELT] = 4, ws[RESOURCE_OXIDANT] = 3,
-ws[RESOURCE_REDUCTANT] = 3, ws[RESOURCE_PURIFIER] = 3, ws), Ls = function() {
+}, Ps = ((ps = {})[RESOURCE_UTRIUM_BAR] = ((fs = {})[RESOURCE_UTRIUM] = 500, fs[RESOURCE_ENERGY] = 200,
+fs), ps[RESOURCE_LEMERGIUM_BAR] = ((ys = {})[RESOURCE_LEMERGIUM] = 500, ys[RESOURCE_ENERGY] = 200,
+ys), ps[RESOURCE_ZYNTHIUM_BAR] = ((vs = {})[RESOURCE_ZYNTHIUM] = 500, vs[RESOURCE_ENERGY] = 200,
+vs), ps[RESOURCE_KEANIUM_BAR] = ((gs = {})[RESOURCE_KEANIUM] = 500, gs[RESOURCE_ENERGY] = 200,
+gs), ps[RESOURCE_GHODIUM_MELT] = ((hs = {})[RESOURCE_GHODIUM] = 500, hs[RESOURCE_ENERGY] = 200,
+hs), ps[RESOURCE_OXIDANT] = ((Rs = {})[RESOURCE_OXYGEN] = 500, Rs[RESOURCE_ENERGY] = 200,
+Rs), ps[RESOURCE_REDUCTANT] = ((Es = {})[RESOURCE_HYDROGEN] = 500, Es[RESOURCE_ENERGY] = 200,
+Es), ps[RESOURCE_PURIFIER] = ((Ts = {})[RESOURCE_CATALYST] = 500, Ts[RESOURCE_ENERGY] = 200,
+Ts), ps[RESOURCE_BATTERY] = ((Cs = {})[RESOURCE_ENERGY] = 600, Cs), ps), Is = ((Ss = {})[RESOURCE_BATTERY] = 10,
+Ss[RESOURCE_UTRIUM_BAR] = 5, Ss[RESOURCE_LEMERGIUM_BAR] = 5, Ss[RESOURCE_ZYNTHIUM_BAR] = 5,
+Ss[RESOURCE_KEANIUM_BAR] = 5, Ss[RESOURCE_GHODIUM_MELT] = 4, Ss[RESOURCE_OXIDANT] = 3,
+Ss[RESOURCE_REDUCTANT] = 3, Ss[RESOURCE_PURIFIER] = 3, Ss), Gs = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Ps), e);
+void 0 === e && (e = {}), this.config = o(o({}, Ns), e);
 }
 return e.prototype.run = function() {
 var e, t;
@@ -17134,7 +16827,7 @@ var s = e.storage;
 if (s && !(s.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.minStorageEnergy)) {
 var c = this.selectProduction(e, n, s);
 if (c) {
-var u = Is[c];
+var u = Ps[c];
 if (u) {
 var l = !0;
 try {
@@ -17172,7 +16865,7 @@ subsystem: "Factory"
 }, e.prototype.selectProduction = function(e, t, r) {
 var o, n, s, c, u, l = [];
 try {
-for (var m = a(Object.entries(Is)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Object.entries(Ps)), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1], v = f, g = !0, h = 0;
 try {
 for (var R = (s = void 0, a(Object.entries(y))), E = R.next(); !E.done; E = R.next()) {
@@ -17197,11 +16890,11 @@ if (s) throw s.error;
 if (g) {
 var b = t.store.getUsedCapacity(v) + r.store.getUsedCapacity(v);
 if (!(b > this.config.outputBufferAmount)) {
-var O = null !== (u = Gs[v]) && void 0 !== u ? u : 1, A = O * h * (1 - b / this.config.outputBufferAmount);
+var O = null !== (u = Is[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
 l.push({
 commodity: v,
 priority: O,
-score: A
+score: k
 });
 }
 }
@@ -17225,7 +16918,7 @@ var r, o, n = t.storage;
 if (!n) return [];
 var s = this.selectProduction(t, e, n);
 if (!s) return [];
-var c = Is[s];
+var c = Ps[s];
 if (!c) return [];
 var u = [];
 try {
@@ -17251,7 +16944,7 @@ return u;
 }, e.prototype.hasOutputsToRemove = function(e) {
 var t, r;
 try {
-for (var o = a(Object.keys(Is)), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Object.keys(Ps)), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 if (e.store.getUsedCapacity(i) > 0) return !0;
 }
@@ -17277,13 +16970,13 @@ return e.structureType === STRUCTURE_LAB;
 return t.filter(function(e) {
 return e.cooldown > 0;
 }).length < t.length / 2 || 0 === t.length;
-}, n([ Ma("factory:manager", "Factory Manager", {
-priority: ha.LOW,
+}, n([ Ka("factory:manager", "Factory Manager", {
+priority: Ma.LOW,
 interval: 30,
 minBucket: 0,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Ds = new Ls, Fs = {
+}) ], e.prototype, "run", null), n([ Ya() ], e);
+}(), Ls = new Gs, Ds = {
 updateInterval: 500,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -17295,7 +16988,7 @@ opportunityConfidenceThreshold: .7
 !function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.supplyDemandCache = new Map, this.opportunities = [],
-this.config = o(o({}, Fs), e);
+this.config = o(o({}, Ds), e);
 }
 e.prototype.run = function() {
 var e, t, r = Game.cpu.getUsed();
@@ -17452,15 +17145,15 @@ return null !== (t = null == r ? void 0 : r.sentiment) && void 0 !== t ? t : 0;
 }, e.prototype.isMarketTight = function(e) {
 var t, r = this.supplyDemandCache.get(e);
 return (null !== (t = null == r ? void 0 : r.tightness) && void 0 !== t ? t : 0) > .7;
-}, n([ Ua("empire:marketTrends", "Market Trend Analyzer", {
-priority: ha.LOW,
+}, n([ Ha("empire:marketTrends", "Market Trend Analyzer", {
+priority: Ma.LOW,
 interval: 500,
 minBucket: 2e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), e = n([ _a() ], e);
+}) ], e.prototype, "run", null), e = n([ Ya() ], e);
 }();
 
-var Bs = {
+var Fs = {
 updateInterval: 500,
 minGhodium: 5e3,
 minEnergy: 3e5,
@@ -17472,18 +17165,18 @@ donorRoomBuffer: 1e3,
 salvoSyncWindow: 10,
 roiThreshold: 2,
 counterNukeWarThreshold: 60
-}, Ws = 1e7, Hs = 5e6, Ks = ((xs = {})[STRUCTURE_SPAWN] = 15e3, xs[STRUCTURE_TOWER] = 5e3,
-xs[STRUCTURE_STORAGE] = 3e4, xs[STRUCTURE_TERMINAL] = 1e5, xs[STRUCTURE_LAB] = 5e4,
-xs[STRUCTURE_NUKER] = 1e5, xs[STRUCTURE_POWER_SPAWN] = 1e5, xs[STRUCTURE_OBSERVER] = 8e3,
-xs[STRUCTURE_EXTENSION] = 3e3, xs[STRUCTURE_LINK] = 5e3, xs);
+}, Bs = 1e7, Ws = 5e6, Ks = ((ws = {})[STRUCTURE_SPAWN] = 15e3, ws[STRUCTURE_TOWER] = 5e3,
+ws[STRUCTURE_STORAGE] = 3e4, ws[STRUCTURE_TERMINAL] = 1e5, ws[STRUCTURE_LAB] = 5e4,
+ws[STRUCTURE_NUKER] = 1e5, ws[STRUCTURE_POWER_SPAWN] = 1e5, ws[STRUCTURE_OBSERVER] = 8e3,
+ws[STRUCTURE_EXTENSION] = 3e3, ws[STRUCTURE_LINK] = 5e3, ws);
 
-function Ys(e) {
+function Hs(e) {
 return !!e.threatenedStructures && e.threatenedStructures.some(function(e) {
 return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
 });
 }
 
-function Vs(e, t) {
+function Ys(e, t) {
 var r = {
 empire: t
 };
@@ -17495,18 +17188,18 @@ return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 });
 }
 
-function qs(e, t) {
+function Vs(e, t) {
 var r, o, n;
 if (!e) return !1;
 var a = null === (r = t.knownRooms) || void 0 === r ? void 0 : r[e], i = Game.rooms[e], s = null == i ? void 0 : i.controller, c = {
 empire: t
 };
 return Y(e, c) || Y(null == a ? void 0 : a.owner, c) || Y(null == a ? void 0 : a.reserver, c) || Y(null === (o = null == s ? void 0 : s.owner) || void 0 === o ? void 0 : o.username, c) || Y(null === (n = null == s ? void 0 : s.reservation) || void 0 === n ? void 0 : n.username, c) || !!i && function(e, t) {
-return Vs(e.find(FIND_CREEPS), t) || Vs(e.find(FIND_POWER_CREEPS), t) || Vs(e.find(FIND_STRUCTURES), t) || Vs(e.find(FIND_CONSTRUCTION_SITES), t);
+return Ys(e.find(FIND_CREEPS), t) || Ys(e.find(FIND_POWER_CREEPS), t) || Ys(e.find(FIND_STRUCTURES), t) || Ys(e.find(FIND_CONSTRUCTION_SITES), t);
 }(i, t);
 }
 
-function js(e, t, r) {
+function qs(e, t, r) {
 t.timeToLand < 5e3 ? (r.posture = "evacuate", U.warn("EVACUATION TRIGGERED for ".concat(e.name, ": Critical structures threatened by nuke!"), {
 subsystem: "Nuke"
 })) : ("war" !== r.posture && "evacuate" !== r.posture && (r.posture = "defensive"),
@@ -17515,7 +17208,7 @@ subsystem: "Nuke"
 })), r.pheromones.defense = 100;
 }
 
-function zs() {
+function js() {
 var e, t = 0, r = 0;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
@@ -17525,14 +17218,14 @@ n.terminal && (t += n.terminal.store.getUsedCapacity(RESOURCE_ENERGY) || 0, r +=
 return t >= 6e5 && r >= 1e4;
 }
 
-function Qs(e, t, r, o) {
+function zs(e, t, r, o) {
 var n = 0, a = [], c = t.knownRooms[e];
 if (!c) return {
 roomName: e,
 score: 0,
 reasons: [ "No intel" ]
 };
-if (qs(e, t)) return {
+if (Vs(e, t)) return {
 roomName: e,
 score: 0,
 reasons: [ "Allied room" ]
@@ -17559,7 +17252,7 @@ return Game.map.getRoomLinearDistance(e, t.name);
 n -= 2 * d, a.push("".concat(d, " rooms away"));
 }
 t.warTargets.includes(e) && (n += 15, a.push("War target"));
-var p = new RoomPosition(25, 25, e), f = Zs(e, p, t);
+var p = new RoomPosition(25, 25, e), f = Xs(e, p, t);
 return f >= r.roiThreshold ? (n += Math.min(20, Math.floor(5 * f)), a.push("ROI: ".concat(f.toFixed(1), "x"))) : (n -= 20,
 a.push("Low ROI: ".concat(f.toFixed(1), "x"))), {
 roomName: e,
@@ -17568,7 +17261,7 @@ reasons: a
 };
 }
 
-function Xs(e, t, r) {
+function Qs(e, t, r) {
 var o, n, i = {
 estimatedDamage: 0,
 estimatedValue: 0,
@@ -17578,16 +17271,16 @@ if (!s) {
 var c = r.knownRooms[e];
 if (c) {
 var u = 5 * (c.towerCount || 0) + 10 * (c.spawnCount || 0) + 5;
-i.estimatedDamage = Ws + Hs * u, i.estimatedValue = .01 * i.estimatedDamage;
+i.estimatedDamage = Bs + Ws * u, i.estimatedValue = .01 * i.estimatedDamage;
 }
 return i;
 }
 var l = s.lookForAtArea(LOOK_STRUCTURES, Math.max(0, t.y - 2), Math.max(0, t.x - 2), Math.min(49, t.y + 2), Math.min(49, t.x + 2), !0);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
-var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Ws : Hs;
+var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Bs : Ws;
 p.hits <= v ? (i.estimatedDamage += p.hits, i.threatenedStructures.push("".concat(p.structureType, "-").concat(p.pos.x, ",").concat(p.pos.y)),
-i.estimatedValue += Js(p)) : i.estimatedDamage += v;
+i.estimatedValue += Zs(p)) : i.estimatedDamage += v;
 }
 } catch (e) {
 o = {
@@ -17603,16 +17296,16 @@ if (o) throw o.error;
 return i;
 }
 
-function Zs(e, t, r) {
-var o = Xs(e, t, r);
+function Xs(e, t, r) {
+var o = Qs(e, t, r);
 return 0 === o.estimatedValue ? 0 : o.estimatedValue / 305e3;
 }
 
-function Js(e) {
+function Zs(e) {
 return Ks[e.structureType] || 1e3;
 }
 
-function $s(e, t, r) {
+function Js(e, t, r) {
 var o, n, i, s = null;
 try {
 for (var c = a(Object.values(t)), u = c.next(); !u.done; u = c.next()) {
@@ -17662,9 +17355,9 @@ subsystem: "Nuke"
 }), !0;
 }
 
-var ec = function() {
+var $s = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Bs), e),
+void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Fs), e),
 this.getEmpire = t.getEmpire, this.getSwarmState = t.getSwarmState, this.getClusters = t.getClusters;
 }
 return e.prototype.run = function() {
@@ -17710,7 +17403,7 @@ try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value.structure, l = Math.abs(u.pos.x - t.x), m = Math.abs(u.pos.y - t.y), d = Math.max(l, m);
 if (d <= 2) {
-var p = 0 === d ? Ws : Hs;
+var p = 0 === d ? Bs : Ws;
 u.hits <= p && n.push("".concat(u.structureType, "-").concat(u.pos.x, ",").concat(u.pos.y));
 }
 }
@@ -17763,7 +17456,7 @@ for (var c = a(e.incomingNukes), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.sourceRoom && !e.warTargets.includes(l.sourceRoom)) {
 var m = e.knownRooms[l.sourceRoom];
-if (m) if (qs(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
+if (m) if (Vs(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
 subsystem: "Nuke"
 }); else if (!(m.controllerLevel < 8)) {
 var d = r(l.roomName);
@@ -17792,7 +17485,7 @@ u && !u.done && (i = c.return) && i.call(c);
 if (n) throw n.error;
 }
 }
-}(t, this.config, this.getSwarmState, zs), function(e, t, r, o) {
+}(t, this.config, this.getSwarmState, js), function(e, t, r, o) {
 var n, a;
 if (e.objectives.warMode) for (var i in Game.rooms) {
 var s = Game.rooms[i];
@@ -17844,10 +17537,10 @@ if (e.nukeCandidates = [], e.objectives.warMode) {
 try {
 for (var i = a(e.warTargets), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (qs(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
+if (Vs(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
 subsystem: "Nuke"
 }); else {
-var u = Qs(c, e, t, r);
+var u = zs(c, e, t, r);
 u.score >= t.minScore && (e.nukeCandidates.push({
 roomName: c,
 score: u.score,
@@ -17891,7 +17584,7 @@ var d = r();
 try {
 for (var p = a(e.nukesInFlight), f = p.next(); !f.done; f = p.next()) {
 var y = f.value, v = y.impactTick - Game.time;
-y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && $s(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
+y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && Js(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
 subsystem: "Nuke"
 });
 }
@@ -18027,14 +17720,14 @@ return e.structureType === STRUCTURE_NUKER;
 if (0 !== c.length) try {
 for (var m = a(e.nukeCandidates), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!p.launched) if (qs(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
+if (!p.launched) if (Vs(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
 subsystem: "Nuke"
 }); else {
 try {
 for (var f = (n = void 0, a(c)), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (!(Game.map.getRoomLinearDistance(v.room.name, p.roomName) > 10)) {
-var g = new RoomPosition(25, 25, p.roomName), h = Xs(p.roomName, g, e), R = Zs(p.roomName, g, e);
+var g = new RoomPosition(25, 25, p.roomName), h = Qs(p.roomName, g, e), R = Xs(p.roomName, g, e);
 if (R < t.roiThreshold) U.warn("Skipping nuke launch on ".concat(p.roomName, ": ROI ").concat(R.toFixed(2), "x below threshold ").concat(t.roiThreshold, "x"), {
 subsystem: "Nuke"
 }); else {
@@ -18120,11 +17813,11 @@ var t, r;
 if (e.incomingNukes) try {
 for (var o = a(e.incomingNukes), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-if (!i.evacuationTriggered && Ys(i)) {
+if (!i.evacuationTriggered && Hs(i)) {
 var s = Game.rooms[i.roomName];
 if (s) {
 var c = this.getSwarmState(i.roomName);
-c && (js(s, i, c), i.evacuationTriggered = !0);
+c && (qs(s, i, c), i.evacuationTriggered = !0);
 }
 }
 }
@@ -18169,13 +17862,13 @@ subsystem: "Nuke"
 }) : U.debug("No donor room found for ".concat(r, " ").concat(t, " to ").concat(e), {
 subsystem: "Nuke"
 });
-}(e, t, r, this.config, Ns);
+}(e, t, r, this.config, _s);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e);
 }, e;
-}(), tc = [ {
+}(), ec = [ {
 carryParts: 4,
 capacity: 200,
 moveParts: 4,
@@ -18197,7 +17890,7 @@ moveParts: 24,
 cost: 2400
 } ];
 
-function rc(e, t, r, o, n) {
+function tc(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = {});
 var c = n.reserved, u = void 0 !== c && c, l = n.pathLength, m = n.terrainFactor, d = void 0 === m ? 1.2 : m, p = n.safetyBuffer, f = void 0 === p ? 1.2 : p, y = function(e, t) {
@@ -18220,9 +17913,9 @@ var r = 50 * e * t;
 return Math.ceil(2 * r);
 }(y, d), g = function(e, t) {
 return e * (t ? 3e3 : 1500) / 300;
-}(r, u), h = tc[0];
+}(r, u), h = ec[0];
 try {
-for (var R = a(tc), E = R.next(); !E.done; E = R.next()) {
+for (var R = a(ec), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.cost <= o)) break;
 h = T;
@@ -18251,7 +17944,7 @@ energyPerTick: g
 };
 }
 
-function oc(e) {
+function rc(e) {
 var t;
 return e ? null !== (t = {
 X: 15,
@@ -18264,12 +17957,12 @@ H: 8
 }[e]) && void 0 !== t ? t : 5 : 0;
 }
 
-function nc(e) {
-var t, r, o = mr.getEmpire(), n = 0, i = lc(e);
+function oc(e) {
+var t, r, o = mr.getEmpire(), n = 0, i = uc(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-l && (l.owner && !mc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
+l && (l.owner && !lc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
 l.towerCount && l.towerCount > 0 && (n += 5 * l.towerCount));
 }
 } catch (e) {
@@ -18286,12 +17979,12 @@ if (t) throw t.error;
 return n;
 }
 
-function ac(e) {
+function nc(e) {
 return "plains" === e ? 15 : "swamp" === e ? -10 : 0;
 }
 
-function ic(e) {
-var t, r, o = lc(e);
+function ac(e) {
+var t, r, o = uc(e);
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (ee(i.value)) return !0;
 } catch (e) {
@@ -18308,7 +18001,7 @@ if (t) throw t.error;
 return !1;
 }
 
-function sc(e) {
+function ic(e) {
 var t = mr.getEmpire(), r = t.knownRooms[e];
 if (null == r ? void 0 : r.hasPortal) return 20;
 var o = function(e, t) {
@@ -18326,34 +18019,34 @@ return null === r || r > 3 ? null : r;
 return null === o ? 0 : o <= 1 ? 10 : o <= 2 ? 6 : o <= 3 ? 3 : 0;
 }
 
-function cc(e, t) {
+function sc(e, t) {
 var r = e < 0 ? "W" : "E", o = t < 0 ? "N" : "S", n = Math.abs(e) - (e < 0 ? 1 : 0), a = Math.abs(t) - (t < 0 ? 1 : 0);
 return "".concat(r).concat(n).concat(o).concat(a);
 }
 
-function uc(e, t, r) {
+function cc(e, t, r) {
 return 0 === t.length ? 0 : r <= 2 ? 25 : r <= 3 ? 15 : r <= 5 ? 5 : 0;
 }
 
-function lc(e) {
+function uc(e) {
 var t = X(e);
 if (!t) return [];
-for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(cc(r + a, o + i));
+for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(sc(r + a, o + i));
 return n;
 }
 
-function mc(e) {
+function lc(e) {
 return Y(e, {
 empire: mr.getEmpire()
 });
 }
 
-function dc(e, t, r, o) {
+function mc(e, t, r, o) {
 var n, a = Game.map.getRoomLinearDistance(t, e);
 if (!Number.isFinite(a) || a <= 0) throw new Error("calculateRemoteProfitability: invalid distance ".concat(a, " between ").concat(t, " and ").concat(e));
 if (r.sources <= 0) throw new Error("calculateRemoteProfitability: intel.sources must be positive, got ".concat(r.sources, " for ").concat(e));
 if (void 0 !== r.threatLevel && null !== r.threatLevel && (r.threatLevel < 0 || r.threatLevel > 3)) throw new Error("calculateRemoteProfitability: intel.threatLevel must be in [0, 3], got ".concat(r.threatLevel, " for ").concat(e));
-var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = rc(t, e, r.sources, 800, {
+var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = tc(t, e, r.sources, 800, {
 reserved: m
 }), f = (650 * r.sources + p.haulerConfig.cost * p.recommendedHaulers) / 1500, y = 5e3 * r.sources + 50 * a * 300, v = y / 5e4, g = d * (null !== (n = [ 0, .1, .3, .6 ][r.threatLevel]) && void 0 !== n ? n : 0), h = d - f - v - g, R = f + v, E = R > 0 ? h / R : 0;
 return {
@@ -18377,9 +18070,9 @@ isProfitable: E > 2 && h > 0
 };
 }
 
-var pc = Ue().cpu.bucketThresholds.highMode + 1e3, fc = {
+var dc = Ue().cpu.bucketThresholds.highMode + 1e3, pc = {
 updateInterval: 500,
-minBucket: pc,
+minBucket: dc,
 maxRemoteDistance: 2,
 maxRemotesPerRoom: 5,
 minRemoteSources: 1,
@@ -18388,10 +18081,10 @@ minRclForClaiming: 1,
 minGclProgressForClaim: 0,
 clusterExpansionDistance: 5,
 minStableRoomPercentage: 0
-}, yc = function() {
+}, fc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedUsername = "", this.usernameLastTick = 0,
-this.config = o(o({}, fc), e);
+this.config = o(o({}, pc), e);
 }
 return e.prototype.run = function() {
 var e = mr.getEmpire();
@@ -18473,7 +18166,7 @@ s > o.config.maxRemoteDistance && (U.info("Removing remote ".concat(e, " - too f
 subsystem: "Expansion"
 }), a = "unreachable");
 }
-return !a || (Ja.emit("remote.lost", {
+return !a || (Za.emit("remote.lost", {
 homeRoom: r,
 remoteRoom: e,
 reason: a,
@@ -18486,7 +18179,7 @@ for (var i in t.knownRooms) if (!r.includes(i) && !this.isRemoteAssignedElsewher
 var s = t.knownRooms[i], c = Game.map.getRoomLinearDistance(e, i);
 if ((s.scouted || !(c > 1)) && !s.owner && !(s.reserver && s.reserver !== a || s.isHighway || s.isSK || s.threatLevel >= 2 || c < 1 || c > this.config.maxRemoteDistance)) if (s.scouted) {
 if (!(s.sources < this.config.minRemoteSources)) {
-var u = dc(i, e, s);
+var u = mc(i, e, s);
 if (u.isProfitable) {
 var l = this.scoreRemoteCandidate(s, c);
 n.push({
@@ -18518,10 +18211,10 @@ return r += 50 * e.sources, r -= 20 * t, r -= 30 * e.threatLevel, "plains" === e
 r;
 }, e.prototype.scoreClaimCandidate = function(e, t, r) {
 var o = 0;
-return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += oc(e.mineralType),
-o -= 5 * t, o -= nc(e.name), o -= 15 * e.threatLevel, o += ac(e.terrain), ic(e.name) && (o += 10),
-o += sc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
-o + uc(e.name, r, t);
+return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += rc(e.mineralType),
+o -= 5 * t, o -= oc(e.name), o -= 15 * e.threatLevel, o += nc(e.terrain), ac(e.name) && (o += 10),
+o += ic(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
+o + cc(e.name, r, t);
 }, e.prototype.isRemoteAssignedElsewhere = function(e, t) {
 var r, o, n, i = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -18869,13 +18562,13 @@ return this.cachedUsername;
 var r, o, n = [], i = function(e) {
 var t = [], r = X(e);
 if (!r) return [];
-for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(cc(o + a, n + i));
+for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(sc(o + a, n + i));
 return t;
 }(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t.knownRooms[u];
-l && (l.owner && !mc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
+l && (l.owner && !lc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
 l.towerCount && l.towerCount > 0 && n.push("".concat(l.towerCount, " towers in ").concat(u)),
 l.spawnCount && l.spawnCount > 0 && n.push("".concat(l.spawnCount, " spawns in ").concat(u)),
 l.threatLevel >= 2 && n.push("Threat level ".concat(l.threatLevel, " in ").concat(u)));
@@ -18892,11 +18585,11 @@ if (r) throw r.error;
 }
 }
 return function(e) {
-var t, r, o = mr.getEmpire(), n = lc(e), i = new Set;
+var t, r, o = mr.getEmpire(), n = uc(e), i = new Set;
 try {
 for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-(null == l ? void 0 : l.owner) && !mc(l.owner) && i.add(l.owner);
+(null == l ? void 0 : l.owner) && !lc(l.owner) && i.add(l.owner);
 }
 } catch (e) {
 t = {
@@ -19008,13 +18701,13 @@ var o = r.remoteAssignments.indexOf(t);
 return -1 !== o && (r.remoteAssignments.splice(o, 1), U.info("Manually removed remote ".concat(t, " from ").concat(e), {
 subsystem: "Expansion"
 }), !0);
-}, n([ bi("expansion:manager", "Expansion Manager", {
-priority: ha.LOW,
+}, n([ xi("expansion:manager", "Expansion Manager", {
+priority: Ma.LOW,
 interval: 500,
-minBucket: pc,
+minBucket: dc,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), vc = new yc, gc = function() {
+}(), yc = new fc, vc = function() {
 function e() {}
 return e.prototype.status = function() {
 var e, t, r, o, n, i, s, c, u, l, m = mr.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
@@ -19052,16 +18745,16 @@ C += "\n";
 }
 if (E > 0) {
 C += "=== Active Expansion Attempts ===\n";
-var A = m.claimQueue.filter(function(e) {
+var k = m.claimQueue.filter(function(e) {
 return e.claimed;
-}), k = function(e) {
+}), A = function(e) {
 var t = Game.time - e.lastEvaluated, r = T.find(function(t) {
 return t.memory.targetRoom === e.roomName;
 }), o = r ? "".concat(r.name, " en route") : "No claimer assigned";
 C += "  ".concat(e.roomName, ": ").concat(o, ", Age ").concat(t, " ticks\n");
 };
 try {
-for (var M = a(A), U = M.next(); !U.done; U = M.next()) k(b = U.value);
+for (var M = a(k), U = M.next(); !U.done; U = M.next()) A(b = U.value);
 } catch (e) {
 r = {
 error: e
@@ -19106,9 +18799,9 @@ return mr.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use ex
 }, e.prototype.resume = function() {
 return mr.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
 }, e.prototype.addRemote = function(e, t) {
-return vc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
+return yc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
 }, e.prototype.removeRemote = function(e, t) {
-return vc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
+return yc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
 }, e.prototype.clearQueue = function() {
 var e = mr.getEmpire(), t = e.claimQueue.length;
 return e.claimQueue = [], "Cleared ".concat(t, " candidates from claim queue. Queue will repopulate on next empire tick.");
@@ -19149,21 +18842,21 @@ usage: "expansion.clearQueue()",
 examples: [ "expansion.clearQueue()" ],
 category: "Empire"
 }) ], e.prototype, "clearQueue", null), e;
-}(), hc = new gc;
+}(), gc = new vc;
 
-function Rc(e) {
+function hc(e) {
 return function(e) {
 return "string" == typeof e && e.trimStart().startsWith("{");
 }(e) ? e.trim() : null;
 }
 
-function Ec(e) {
+function Rc(e) {
 var t;
 if (!e.controller) return null;
 var r = e.controller;
 if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
 var o = function(e) {
-var t = Rc(e);
+var t = hc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19181,12 +18874,12 @@ availableQuests: [ o.id ]
 };
 }
 
-function Tc() {
+function Ec() {
 var e;
 return (null === (e = Memory.tooangel) || void 0 === e ? void 0 : e.npcRooms) || {};
 }
 
-function Cc(e) {
+function Tc(e) {
 var t = Memory;
 t.tooangel || (t.tooangel = {}), t.tooangel.npcRooms || (t.tooangel.npcRooms = {});
 var r = t.tooangel.npcRooms[e.roomName];
@@ -19197,7 +18890,7 @@ e.availableQuests = Array.from(o);
 t.tooangel.npcRooms[e.roomName] = e;
 }
 
-function Sc() {
+function Cc() {
 var e = Memory;
 return e.tooangel || (e.tooangel = {
 enabled: !0,
@@ -19219,14 +18912,14 @@ Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionI
 e.tooangel;
 }
 
-var wc = [ "applied", "active" ];
+var Sc = [ "applied", "active" ];
 
-function xc(e) {
+function wc(e) {
 var t, r;
 return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
 }
 
-function bc(e, t) {
+function xc(e, t) {
 return !!function(e, t) {
 if (e.sender) return "TooAngel" === e.sender.username;
 var r = function(e) {
@@ -19234,7 +18927,7 @@ var t, r, o = new Set(Object.keys(e.npcRooms || {}));
 try {
 for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-wc.includes(s.status) && s.originRoom && o.add(s.originRoom);
+Sc.includes(s.status) && s.originRoom && o.add(s.originRoom);
 }
 } catch (e) {
 t = {
@@ -19248,25 +18941,25 @@ if (t) throw t.error;
 }
 }
 return o;
-}(Sc());
+}(Cc());
 return !!r.has(e.from) && (void 0 === t || r.has(t));
 }(e, t) && !function(e) {
-return Sc().recentTransactionIds.includes(xc(e));
+return Cc().recentTransactionIds.includes(wc(e));
 }(e) && (function(e) {
-var t = Sc(), r = xc(e);
+var t = Cc(), r = wc(e);
 t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
 }(e), !0);
 }
 
-var Oc = {
+var bc = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function Ac(e) {
-var t = Rc(e);
+function Oc(e) {
+var t = hc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19278,23 +18971,23 @@ return null;
 }
 
 function kc() {
-return Sc().activeQuests || {};
+return Cc().activeQuests || {};
 }
 
-function Mc() {
+function Ac() {
 var e = kc();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < Oc.MAX_ACTIVE_QUESTS;
+}).length < bc.MAX_ACTIVE_QUESTS;
 }
 
-function Uc(e) {
-return Oc.SUPPORTED_TYPES.includes(e);
+function Mc(e) {
+return bc.SUPPORTED_TYPES.includes(e);
 }
 
-function _c(e, t, r) {
+function Uc(e, t, r) {
 var o, n;
-if (!Mc()) return U.debug("Cannot accept more quests (at max capacity)", {
+if (!Ac()) return U.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19311,17 +19004,17 @@ if (!n || !n.terminal || !n.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < Oc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Oc.MIN_APPLICATION_ENERGY), {
+if (l < bc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(bc.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, Oc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, bc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (U.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
-}), Sc().activeQuests[e] = {
+}), Cc().activeQuests[e] = {
 id: e,
 type: "buildcs",
 status: "applied",
@@ -19334,8 +19027,8 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Nc(e) {
-var t = Sc(), r = t.activeQuests[e.id];
+function _c(e) {
+var t = Cc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (U.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
 }), r.status = "completed") : (U.warn("Quest ".concat(e.id, " failed"), {
@@ -19345,13 +19038,13 @@ subsystem: "TooAngel"
 });
 }
 
-function Pc() {
+function Nc() {
 var e;
-return (null === (e = Sc().reputation) || void 0 === e ? void 0 : e.value) || 0;
+return (null === (e = Cc().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function Ic(e) {
-var t = Rc(e);
+function Pc(e) {
+var t = hc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19360,8 +19053,8 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function Gc(e) {
-var t, r, o, n = Sc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
+function Ic(e) {
+var t, r, o, n = Cc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return U.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
 }), !1;
@@ -19376,7 +19069,7 @@ if (!o || !o.terminal || !o.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var c = function(e) {
-var t = Tc(), r = null, o = 1 / 0;
+var t = Ec(), r = null, o = 1 / 0;
 for (var n in t) {
 var a = Game.map.getRoomLinearDistance(e, n);
 a < o && (o = a, r = t[n]);
@@ -19400,7 +19093,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Lc(e) {
+function Gc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19542,7 +19235,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Dc, Fc, Bc = Ue().cpu.bucketThresholds.highMode + 1e3, Wc = Bc, Hc = function() {
+var Lc, Dc, Fc = Ue().cpu.bucketThresholds.highMode + 1e3, Bc = Fc, Wc = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19560,19 +19253,19 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, U.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < Wc)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < Bc)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Sc();
+var r = Cc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = Ic(i.description);
-null !== s && bc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
+var s = Pc(i.description);
+null !== s && xc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19599,7 +19292,7 @@ if (e) throw e.error;
 }(), function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Sc();
+var r = Cc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
@@ -19607,12 +19300,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = Ac(i.description);
-if (s && bc(i, s.origin)) {
+var s = Oc(i.description);
+if (s && xc(i, s.origin)) {
 if (U.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-Nc(s);
+_c(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19626,7 +19319,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Uc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
+}, Mc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19663,15 +19356,15 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (U.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Lc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Gc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
 }(), function() {
-var e = Sc().activeQuests || {};
+var e = Cc().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - Oc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - bc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19688,7 +19381,7 @@ subsystem: "TooAngel"
 var e, t, r = function() {
 var e = [];
 for (var t in Game.rooms) {
-var r = Ec(Game.rooms[t]);
+var r = Rc(Game.rooms[t]);
 r && (U.info("Detected TooAngel NPC room: ".concat(t), {
 subsystem: "TooAngel"
 }), e.push(r));
@@ -19696,7 +19389,7 @@ subsystem: "TooAngel"
 return e;
 }();
 try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) Cc(n.value);
+for (var o = a(r), n = o.next(); !n.done; n = o.next()) Tc(n.value);
 } catch (t) {
 e = {
 error: t
@@ -19712,12 +19405,12 @@ r.length > 0 && U.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-Gc();
+Ic();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (Mc()) {
-var r = Tc(), o = kc();
+if (Ac()) {
+var r = Ec(), o = kc();
 for (var n in r) {
 var i = r[n];
 try {
@@ -19725,7 +19418,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return U.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void _c(u, n);
+}), void Uc(u, n);
 }
 } catch (t) {
 e = {
@@ -19742,11 +19435,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return Pc();
+return Nc();
 }, e.prototype.getActiveQuests = function() {
 return kc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return _c(e, t, r);
+return Uc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -19760,12 +19453,12 @@ var i = t[a], s = i.deadline - Game.time;
 n.push("  ".concat(a, ": ").concat(i.type, " in ").concat(i.targetRoom, " (").concat(i.status, ", ").concat(s, " ticks left)"));
 }
 return n.join("\n");
-}, n([ Oi("empire:tooangel", "TooAngel Manager", {
-priority: ha.LOW,
+}, n([ bi("empire:tooangel", "TooAngel Manager", {
+priority: Ma.LOW,
 interval: 100,
-minBucket: Bc
+minBucket: Fc
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Kc = new Hc, Yc = {
+}(), Kc = new Wc, Hc = {
 status: function() {
 return Kc.getStatus();
 },
@@ -19776,11 +19469,11 @@ disable: function() {
 return Kc.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = Pc();
+var e = Nc();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return Gc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return Ic(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
 var e, t = kc(), r = [ "Active Quests:" ];
@@ -19793,7 +19486,7 @@ r.push("    Assigned creeps: ".concat(i));
 return r.join("\n");
 },
 npcs: function() {
-var e = Tc(), t = [ "TooAngel NPC Rooms:" ];
+var e = Ec(), t = [ "TooAngel NPC Rooms:" ];
 if (0 === Object.keys(e).length) t.push("  No NPC rooms discovered"); else for (var r in e) {
 var o = e[r];
 t.push("  ".concat(r, ":")), t.push("    Has terminal: ".concat(o.hasTerminal)),
@@ -19802,12 +19495,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return _c(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return Uc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, Vc = function() {
+}, Yc = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -19829,20 +19522,20 @@ if (r) throw r.error;
 }
 }
 return "".concat(s.join("\n"), "\n");
-}(Ht.checkMemoryUsage(), Ht);
+}(Kt.checkMemoryUsage(), Kt);
 }, e.prototype.analyze = function(e) {
 return void 0 === e && (e = 10), t = {
 topN: e,
-consumers: Ht.getLargestConsumers(e),
+consumers: Kt.getLargestConsumers(e),
 recommendations: nr.getRecommendations()
-}, r = Ht, o = [ "Top ".concat(t.topN, " Memory Consumers:") ], t.consumers.forEach(function(e, t) {
+}, r = Kt, o = [ "Top ".concat(t.topN, " Memory Consumers:") ], t.consumers.forEach(function(e, t) {
 o.push("".concat(t + 1, ". ").concat(e.type, ":").concat(e.name, " - ").concat(r.formatBytes(e.size)));
 }), t.recommendations.length > 0 ? o.push.apply(o, s([ "", "Recommendations:" ], i(t.recommendations.map(function(e) {
 return "- ".concat(e);
 })), !1)) : o.push("", "No recommendations at this time."), "".concat(o.join("\n"), "\n");
 var t, r, o;
 }, e.prototype.prune = function() {
-return e = nr.pruneAll(), t = Ht, [ "Memory Pruning Complete:", "  Dead creeps removed:        ".concat(e.deadCreeps), "  Event log entries removed:  ".concat(e.eventLogs), "  Stale intel removed:        ".concat(e.staleIntel), "  Market history removed:     ".concat(e.marketHistory), "  Total bytes saved:          ".concat(t.formatBytes(e.bytesSaved)), "" ].join("\n");
+return e = nr.pruneAll(), t = Kt, [ "Memory Pruning Complete:", "  Dead creeps removed:        ".concat(e.deadCreeps), "  Event log entries removed:  ".concat(e.eventLogs), "  Stale intel removed:        ".concat(e.staleIntel), "  Market history removed:     ".concat(e.marketHistory), "  Total bytes saved:          ".concat(t.formatBytes(e.bytesSaved)), "" ].join("\n");
 var e, t;
 }, e.prototype.segments = function() {
 return function(e, t) {
@@ -19876,11 +19569,11 @@ if (r) throw r.error;
 return "".concat(n.join("\n"), "\n");
 }({
 activeSegments: Vt.getActiveSegments(),
-allocation: Kt,
+allocation: Ht,
 segmentSize: function(e) {
 return Vt.getSegmentSize(e);
 }
-}, Ht);
+}, Kt);
 }, e.prototype.compress = function(e) {
 var t, r, o = e.split("."), n = Memory;
 try {
@@ -19902,8 +19595,8 @@ if (t) throw t.error;
 }
 if (!n) return "No data at path: ".concat(e);
 var u = tr.getCompressionStats(n), l = "Compression Test for: ".concat(e, "\n");
-return l += "  Original size:    ".concat(Ht.formatBytes(u.originalSize), "\n"),
-l += "  Compressed size:  ".concat(Ht.formatBytes(u.compressedSize), "\n"), l += "  Bytes saved:      ".concat(Ht.formatBytes(u.bytesSaved), "\n"),
+return l += "  Original size:    ".concat(Kt.formatBytes(u.originalSize), "\n"),
+l += "  Compressed size:  ".concat(Kt.formatBytes(u.compressedSize), "\n"), l += "  Bytes saved:      ".concat(Kt.formatBytes(u.bytesSaved), "\n"),
 (l += "  Compression ratio: ".concat((100 * u.ratio).toFixed(1), "%\n")) + "  Worth compressing: ".concat(u.ratio < .9 ? "YES" : "NO", "\n");
 }, e.prototype.migrations = function() {
 return e = {
@@ -19975,16 +19668,16 @@ usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), qc = new Vc, jc = {
+}(), Vc = new Yc, qc = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, zc = function() {
+}, jc = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, jc), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, qc), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
@@ -20342,22 +20035,22 @@ n && !n.done && (t = o.return) && t.call(o);
 if (e) throw e.error;
 }
 }
-}, n([ Oi("empire:powerBank", "Power Bank Harvesting", {
-priority: ha.LOW,
+}, n([ bi("empire:powerBank", "Power Bank Harvesting", {
+priority: Ma.LOW,
 interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Qc = new zc, Xc = {
+}(), zc = new jc, Qc = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, Zc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], Jc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], $c = function() {
+}, Xc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], Zc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], Jc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, Xc), e);
+this.config = o(o({}, Qc), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20511,7 +20204,7 @@ return l.homeRoom = a, l.role = o, U.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? Zc : Jc).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? Xc : Zc).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20649,217 +20342,217 @@ U.info("Power System: GPL ".concat(this.gplState.currentLevel, " ") + "(".concat
 subsystem: "PowerCreep"
 });
 }
-}, n([ Oi("empire:powerCreep", "Power Creep Management", {
-priority: ha.LOW,
+}, n([ bi("empire:powerCreep", "Power Creep Management", {
+priority: Ma.LOW,
 interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), eu = new $c, tu = {
+}(), $c = new Jc, eu = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, ru = ((Dc = {})[RESOURCE_HYDROXIDE] = {
+}, tu = ((Lc = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Dc[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Lc[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Dc[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Lc[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Dc[RESOURCE_GHODIUM] = {
+}, Lc[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Dc[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Lc[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Dc[RESOURCE_UTRIUM_OXIDE] = {
+}, Lc[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Dc[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Lc[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Dc[RESOURCE_KEANIUM_OXIDE] = {
+}, Lc[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Dc[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Lc[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Dc[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Lc[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Dc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Lc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Dc[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Lc[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Dc[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Lc[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Dc[RESOURCE_GHODIUM_OXIDE] = {
+}, Lc[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Dc[RESOURCE_UTRIUM_ACID] = {
+}, Lc[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Lc[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_KEANIUM_ACID] = {
+}, Lc[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Lc[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_LEMERGIUM_ACID] = {
+}, Lc[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Lc[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_ZYNTHIUM_ACID] = {
+}, Lc[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Lc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_GHODIUM_ACID] = {
+}, Lc[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Lc[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Dc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Lc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Lc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Lc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Lc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Lc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Lc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Lc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Lc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Lc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Lc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Dc), ou = ((Fc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Fc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Fc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Fc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Fc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Fc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Fc[RESOURCE_GHODIUM] = 5e3, Fc[RESOURCE_HYDROXIDE] = 5e3, Fc);
+}, Lc), ru = ((Dc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Dc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Dc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Dc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Dc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Dc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Dc[RESOURCE_GHODIUM] = 5e3, Dc[RESOURCE_HYDROXIDE] = 5e3, Dc);
 
-function nu(e, t) {
-var r, o, n, a = null !== (r = ou[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function ou(e, t) {
+var r, o, n, a = null !== (r = ru[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function au(e) {
+function nu(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var iu = function() {
+var au = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : tu;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : eu;
 }
 return e.prototype.getReaction = function(e) {
-return ru[e];
+return tu[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = ru[e];
+var c = tu[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -20881,11 +20574,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = au(t);
+var d = nu(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (ru[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < nu(y, t)) {
+if (tu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < ou(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -20944,18 +20637,18 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = au(t);
+var h = nu(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = ru[T];
+var T = E.value, C = tu[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = nu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = ou(T, t), x = w - S;
 if (x > 0) {
-var b = x / w, O = C.priority * (1 + Math.min(b, .5)), A = {};
+var b = x / w, O = C.priority * (1 + Math.min(b, .5)), k = {};
 try {
-for (var k = (c = void 0, a(Object.entries(g.store))), M = k.next(); !M.done; M = k.next()) {
+for (var A = (c = void 0, a(Object.entries(g.store))), M = A.next(); !M.done; M = A.next()) {
 var U = i(M.value, 2), _ = U[0], N = U[1];
-A[_] = N;
+k[_] = N;
 }
 } catch (e) {
 c = {
@@ -20963,12 +20656,12 @@ error: e
 };
 } finally {
 try {
-M && !M.done && (u = k.return) && u.call(k);
+M && !M.done && (u = A.return) && u.call(A);
 } finally {
 if (c) throw c.error;
 }
 }
-var P = this.calculateReactionChain(T, A);
+var P = this.calculateReactionChain(T, k);
 try {
 for (var I = (l = void 0, a(P)), G = I.next(); !G.done; G = I.next()) {
 var L = G.value;
@@ -21065,7 +20758,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), su = [ {
+}(), iu = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21083,13 +20776,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function cu(e) {
-return su.find(function(t) {
+function su(e) {
+return iu.find(function(t) {
 return t.role === e;
 });
 }
 
-function uu(e, t) {
+function cu(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21106,29 +20799,29 @@ return;
 }
 }
 
-function lu(e, t) {
+function uu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function mu(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : pu(e, t) && pu(e, r) ? "output" : "boost";
+function lu(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : du(e, t) && du(e, r) ? "output" : "boost";
 }
 
-function du(e, t) {
+function mu(e, t) {
 return t.filter(function(t) {
-return e.id !== t.id && pu(e, t);
+return e.id !== t.id && du(e, t);
 }).length;
 }
 
-function pu(e, t) {
+function du(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var fu, yu = function() {
+var pu, fu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : tu;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : eu;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21244,7 +20937,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = uu(s.role, o);
+var s = i.value, c = cu(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21266,13 +20959,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, du(t, e) ];
+return [ t.id, mu(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && pu(e, s) && pu(e, c);
+return t !== a && t !== i && du(e, s) && du(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21285,19 +20978,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(lu)[0];
+return n.sort(uu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: mu(e, t.input1, t.input2)
+role: lu(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, du(r, e));
+return Math.max(t, mu(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21441,17 +21134,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), vu = function() {
+}(), yu = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = cu(o.role);
+var n = su(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = cu(n.role);
+var r, o, n = e.memory, i = su(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21529,7 +21222,7 @@ return 0 === c.length && (n.boosted = !0, U.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = cu(t);
+var r, o, n = su(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21560,7 +21253,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = cu(t);
+var r, o, n = su(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21594,7 +21287,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ cu("soldier"), cu("ranger"), cu("healer"), cu("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ su("soldier"), su("ranger"), su("healer"), su("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21651,7 +21344,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = cu(e);
+var r = su(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21661,7 +21354,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = cu(e);
+var n = su(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21695,7 +21388,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), gu = new vu, hu = {
+}(), vu = new yu, gu = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -21708,10 +21401,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Ru = function() {
+}, hu = function() {
 function e() {
-this.manager = new yu({
-logger: hu
+this.manager = new fu({
+logger: gu
 });
 }
 return e.prototype.initialize = function(e) {
@@ -21781,14 +21474,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), Eu = new Ru, Tu = function() {
+}(), Ru = new hu, Eu = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = Eu.getConfig(e);
+var s = Ru.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = Eu.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = Ru.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -21800,7 +21493,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = Eu.getBoostLabs(e), f = function(e) {
+var p = Ru.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -21831,9 +21524,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = Eu.getConfig(e);
+var c = Ru.getConfig(e);
 if (!c) return [];
-var u = [], l = Eu.getOutputLabs(e);
+var u = [], l = Ru.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -21858,7 +21551,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = Eu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = Ru.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -21894,15 +21587,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = Eu.getConfig(e);
+var r, o, n, i, s = Ru.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = Eu.getInputLabs(e), u = c.input1, l = c.input2;
+var c = Ru.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = Eu.getOutputLabs(e);
+var m = Ru.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -21924,23 +21617,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-Eu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
+Ru.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = Eu.setActiveReaction(e, t, r, o);
+var n = Ru.setActiveReaction(e, t, r, o);
 return n && U.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return Eu.runReactions(e);
+return Ru.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return Eu.getBoostLabs(e).length > 0;
+return Ru.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = Eu.getConfig(e);
+var r, o, n, i, s, c = Ru.getConfig(e);
 if (!c) return null;
-var u = Eu.getBoostLabs(e);
+var u = Ru.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -22044,17 +21737,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = Eu.getConfig(e);
+var t = Ru.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-Eu.loadFromMemory(e), Eu.initialize(e);
+Ru.loadFromMemory(e), Ru.initialize(e);
 }, e.prototype.save = function(e) {
-Eu.saveToMemory(e);
+Ru.saveToMemory(e);
 }, e;
-}(), Cu = new Tu, Su = function() {
+}(), Tu = new Eu, Cu = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = Eu.getConfig(e);
+var t, r, o, n, i, s, c, u, l = Ru.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22077,7 +21770,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = Cu.getLabResourceNeeds(e);
+var h = Tu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22097,7 +21790,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = Cu.getLabOverflow(e);
+var C = Tu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22119,13 +21812,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return Cu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return Tu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return Cu.clearReactions(e), "Cleared active reactions in ".concat(e);
+return Tu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = gu.areBoostLabsReady(n, t), s = gu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = vu.areBoostLabsReady(n, t), s = vu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22171,7 +21864,7 @@ usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), wu = function() {
+}(), Su = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22228,10 +21921,10 @@ usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), xu = function() {
+}(), wu = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = eu.getGPLState();
+var e = $c.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22240,7 +21933,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = eu.getAssignments();
+var e, t, r = $c.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22262,7 +21955,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = Qc.getActiveOperations();
+var e, t, r = zc.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22287,7 +21980,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return eu.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return $c.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22361,11 +22054,11 @@ usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), bu = new Su, Ou = new wu, Au = new xu, ku = function() {
+}(), xu = new Cu, bu = new Su, Ou = new wu, ku = function() {
 function e() {}
 return e.prototype.showConfig = function() {
-var e = Ue(), t = si();
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(Xa[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+var e = Ue(), t = ii();
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(Qa[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
 }, n([ Tt({
 name: "showConfig",
 description: "Show current bot configuration",
@@ -22373,31 +22066,31 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Mu = k("CreepContext"), Uu = ((fu = {})[STRUCTURE_SPAWN] = 100, fu[STRUCTURE_TOWER] = 95,
-fu[STRUCTURE_STORAGE] = 90, fu[STRUCTURE_EXTENSION] = 80, fu[STRUCTURE_TERMINAL] = 75,
-fu[STRUCTURE_LINK] = 70, fu[STRUCTURE_CONTAINER] = 65, fu[STRUCTURE_RAMPART] = 55,
-fu[STRUCTURE_WALL] = 50, fu[STRUCTURE_ROAD] = 30, fu), _u = new Map;
+}(), Au = A("CreepContext"), Mu = ((pu = {})[STRUCTURE_SPAWN] = 100, pu[STRUCTURE_TOWER] = 95,
+pu[STRUCTURE_STORAGE] = 90, pu[STRUCTURE_EXTENSION] = 80, pu[STRUCTURE_TERMINAL] = 75,
+pu[STRUCTURE_LINK] = 70, pu[STRUCTURE_CONTAINER] = 65, pu[STRUCTURE_RAMPART] = 55,
+pu[STRUCTURE_WALL] = 50, pu[STRUCTURE_ROAD] = 30, pu), Uu = new Map;
 
-function Nu(e) {
+function _u(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function Pu(e) {
+function Nu(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-var r, o, n = null !== (r = Uu[e.structureType]) && void 0 !== r ? r : 50;
-return (null !== (o = Uu[t.structureType]) && void 0 !== o ? o : 50) - n;
+var r, o, n = null !== (r = Mu[e.structureType]) && void 0 !== r ? r : 50;
+return (null !== (o = Mu[t.structureType]) && void 0 !== o ? o : 50) - n;
 })), e._prioritizedSites;
 }
 
-function Iu(e) {
-return void 0 === e._repairTargets && (Nu(e), e._repairTargets = e.allStructures.filter(function(e) {
+function Pu(e) {
+return void 0 === e._repairTargets && (_u(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function Gu(e) {
+function Iu(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = _u.get(e.name);
+var t = Uu.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22406,9 +22099,9 @@ hostiles: j(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return _u.set(e.name, r), r;
+return Uu.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Mu.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Au.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -22473,10 +22166,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return Pu(i).length;
+return Nu(i).length;
 },
 get damagedStructureCount() {
-return Iu(i).length;
+return Pu(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -22487,13 +22180,13 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return void 0 === (e = i)._containers && (Nu(e), e._containers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._containers && (_u(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 var e;
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (Nu(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (_u(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -22522,10 +22215,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return Pu(i);
+return Nu(i);
 },
 get repairTargets() {
-return Iu(i);
+return Pu(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -22559,9 +22252,9 @@ var e;
 };
 }
 
-var Lu, Du = {}, Fu = function() {
-if (Lu) return Du;
-Lu = 1, Object.defineProperty(Du, "__esModule", {
+var Gu, Lu = {}, Du = function() {
+if (Gu) return Lu;
+Gu = 1, Object.defineProperty(Lu, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== qt ? qt : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -22605,11 +22298,11 @@ return R.apply(e, arguments);
 };
 }, C = T, S = C({}.toString), w = C("".slice), x = function(e) {
 return w(S(e), 8, -1);
-}, b = n, O = x, A = Object, k = T("".split), M = b(function() {
-return !A("z").propertyIsEnumerable(0);
+}, b = n, O = x, k = Object, A = T("".split), M = b(function() {
+return !k("z").propertyIsEnumerable(0);
 }) ? function(e) {
-return "String" === O(e) ? k(e, "") : A(e);
-} : A, U = function(e) {
+return "String" === O(e) ? A(e, "") : k(e);
+} : k, U = function(e) {
 return null == e;
 }, _ = U, N = TypeError, P = function(e) {
 if (_(e)) throw new N("Can't call method on " + e);
@@ -22622,8 +22315,8 @@ return "function" == typeof e || e === D;
 return "function" == typeof e;
 }, B = F, W = function(e) {
 return "object" == typeof e ? null !== e : B(e);
-}, H = r, K = F, Y = function(e, t) {
-return arguments.length < 2 ? (r = H[e], K(r) ? r : void 0) : H[e] && H[e][t];
+}, K = r, H = F, Y = function(e, t) {
+return arguments.length < 2 ? (r = K[e], H(r) ? r : void 0) : K[e] && K[e][t];
 var r;
 }, V = T({}.isPrototypeOf), q = r.navigator, j = q && q.userAgent, z = r, Q = j ? String(j) : "", X = z.process, Z = z.Deno, J = X && X.versions || Z && Z.version, $ = J && J.v8;
 $ && (y = (f = $.split("."))[0] > 0 && f[0] < 4 ? 1 : +(f[0] + f[1])), !y && Q && (!(f = Q.match(/Edge\/(\d+)/)) || f[1] >= 74) && (f = Q.match(/Chrome\/(\d+)/)) && (y = +f[1]);
@@ -22665,16 +22358,16 @@ copyright: "© 2013–2025 Denis Pushkarev (zloirock.ru), 2025–2026 CoreJS Com
 license: "https://github.com/zloirock/core-js/blob/v3.48.0/LICENSE",
 source: "https://github.com/zloirock/core-js"
 });
-var Ae = Ee.exports, ke = Ae, Me = function(e, t) {
-return ke[e] || (ke[e] = t || {});
+var ke = Ee.exports, Ae = ke, Me = function(e, t) {
+return Ae[e] || (Ae[e] = t || {});
 }, Ue = P, _e = Object, Ne = function(e) {
 return _e(Ue(e));
 }, Pe = Ne, Ie = T({}.hasOwnProperty), Ge = Object.hasOwn || function(e, t) {
 return Ie(Pe(e), t);
 }, Le = T, De = 0, Fe = Math.random(), Be = Le(1.1.toString), We = function(e) {
 return "Symbol(" + (void 0 === e ? "" : e) + ")_" + Be(++De + Fe, 36);
-}, He = Me, Ke = Ge, Ye = We, Ve = oe, qe = ne, je = r.Symbol, ze = He("wks"), Qe = qe ? je.for || je : je && je.withoutSetter || Ye, Xe = function(e) {
-return Ke(ze, e) || (ze[e] = Ve && Ke(je, e) ? je[e] : Qe("Symbol." + e)), ze[e];
+}, Ke = Me, He = Ge, Ye = We, Ve = oe, qe = ne, je = r.Symbol, ze = Ke("wks"), Qe = qe ? je.for || je : je && je.withoutSetter || Ye, Xe = function(e) {
+return He(ze, e) || (ze[e] = Ve && He(je, e) ? je[e] : Qe("Symbol." + e)), ze[e];
 }, Ze = u, Je = W, $e = ue, et = TypeError, tt = Xe("toPrimitive"), rt = ue, ot = function(e) {
 var t = function(e, t) {
 if (!Je(e) || $e(e)) return e;
@@ -22715,9 +22408,9 @@ writable: !1
 }), Tt = W, Ct = String, St = TypeError, wt = function(e) {
 if (Tt(e)) return e;
 throw new St(Ct(e) + " is not an object");
-}, xt = a, bt = ut, Ot = Et, At = wt, kt = ot, Mt = TypeError, Ut = Object.defineProperty, _t = Object.getOwnPropertyDescriptor, Nt = "enumerable", Pt = "configurable", It = "writable";
+}, xt = a, bt = ut, Ot = Et, kt = wt, At = ot, Mt = TypeError, Ut = Object.defineProperty, _t = Object.getOwnPropertyDescriptor, Nt = "enumerable", Pt = "configurable", It = "writable";
 Rt.f = xt ? Ot ? function(e, t, r) {
-if (At(e), t = kt(t), At(r), "function" == typeof e && "prototype" === t && "value" in r && It in r && !r[It]) {
+if (kt(e), t = At(t), kt(r), "function" == typeof e && "prototype" === t && "value" in r && It in r && !r[It]) {
 var o = _t(e, t);
 o && o[It] && (e[t] = r.value, r = {
 configurable: Pt in r ? r[Pt] : o[Pt],
@@ -22727,7 +22420,7 @@ writable: !1
 }
 return Ut(e, t, r);
 } : Ut : function(e, t, r) {
-if (At(e), t = kt(t), At(r), bt) try {
+if (kt(e), t = At(t), kt(r), bt) try {
 return Ut(e, t, r);
 } catch (e) {}
 if ("get" in r || "set" in r) throw new Mt("Accessors not supported");
@@ -22739,15 +22432,15 @@ return Gt.f(e, t, Lt(1, r));
 return e[t] = r, e;
 }, Ft = {
 exports: {}
-}, Bt = a, Wt = Ge, Ht = Function.prototype, Kt = Bt && Object.getOwnPropertyDescriptor, Yt = {
-CONFIGURABLE: Wt(Ht, "name") && (!Bt || Bt && Kt(Ht, "name").configurable)
-}, Vt = F, jt = Ae, zt = T(Function.toString);
+}, Bt = a, Wt = Ge, Kt = Function.prototype, Ht = Bt && Object.getOwnPropertyDescriptor, Yt = {
+CONFIGURABLE: Wt(Kt, "name") && (!Bt || Bt && Ht(Kt, "name").configurable)
+}, Vt = F, jt = ke, zt = T(Function.toString);
 Vt(jt.inspectSource) || (jt.inspectSource = function(e) {
 return zt(e);
 });
 var Qt, Xt, Zt, Jt = jt.inspectSource, $t = F, er = r.WeakMap, tr = $t(er) && /native code/.test(String(er)), rr = We, or = Me("keys"), nr = function(e) {
 return or[e] || (or[e] = rr(e));
-}, ar = {}, ir = tr, sr = r, cr = Dt, ur = Ge, lr = Ae, mr = nr, dr = ar, pr = "Object already initialized", fr = sr.TypeError, yr = sr.WeakMap;
+}, ar = {}, ir = tr, sr = r, cr = Dt, ur = Ge, lr = ke, mr = nr, dr = ar, pr = "Object already initialized", fr = sr.TypeError, yr = sr.WeakMap;
 if (ir || lr.state) {
 var vr = lr.state || (lr.state = new yr);
 vr.get = vr.get, vr.has = vr.has, vr.set = vr.set, Qt = function(e, t) {
@@ -22774,20 +22467,20 @@ get: Xt,
 enforce: function(e) {
 return Zt(e) ? Xt(e) : Qt(e, {});
 }
-}, Rr = T, Er = n, Tr = F, Cr = Ge, Sr = a, wr = Yt.CONFIGURABLE, xr = Jt, br = hr.enforce, Or = hr.get, Ar = String, kr = Object.defineProperty, Mr = Rr("".slice), Ur = Rr("".replace), _r = Rr([].join), Nr = Sr && !Er(function() {
-return 8 !== kr(function() {}, "length", {
+}, Rr = T, Er = n, Tr = F, Cr = Ge, Sr = a, wr = Yt.CONFIGURABLE, xr = Jt, br = hr.enforce, Or = hr.get, kr = String, Ar = Object.defineProperty, Mr = Rr("".slice), Ur = Rr("".replace), _r = Rr([].join), Nr = Sr && !Er(function() {
+return 8 !== Ar(function() {}, "length", {
 value: 8
 }).length;
 }), Pr = String(String).split("String"), Ir = Ft.exports = function(e, t, r) {
-"Symbol(" === Mr(Ar(t), 0, 7) && (t = "[" + Ur(Ar(t), /^Symbol\(([^)]*)\).*$/, "$1") + "]"),
-r && r.getter && (t = "get " + t), r && r.setter && (t = "set " + t), (!Cr(e, "name") || wr && e.name !== t) && (Sr ? kr(e, "name", {
+"Symbol(" === Mr(kr(t), 0, 7) && (t = "[" + Ur(kr(t), /^Symbol\(([^)]*)\).*$/, "$1") + "]"),
+r && r.getter && (t = "get " + t), r && r.setter && (t = "set " + t), (!Cr(e, "name") || wr && e.name !== t) && (Sr ? Ar(e, "name", {
 value: t,
 configurable: !0
-}) : e.name = t), Nr && r && Cr(r, "arity") && e.length !== r.arity && kr(e, "length", {
+}) : e.name = t), Nr && r && Cr(r, "arity") && e.length !== r.arity && Ar(e, "length", {
 value: r.arity
 });
 try {
-r && Cr(r, "constructor") && r.constructor ? Sr && kr(e, "prototype", {
+r && Cr(r, "constructor") && r.constructor ? Sr && Ar(e, "prototype", {
 writable: !1
 }) : e.prototype && (e.prototype = void 0);
 } catch (e) {}
@@ -22797,9 +22490,9 @@ return Cr(o, "source") || (o.source = _r(Pr, "string" == typeof t ? t : "")), e;
 Function.prototype.toString = Ir(function() {
 return Tr(this) && Or(this).source || xr(this);
 }, "toString");
-var Gr = Ft.exports, Lr = F, Dr = Rt, Fr = Gr, Br = Se, Wr = {}, Hr = Math.ceil, Kr = Math.floor, Yr = Math.trunc || function(e) {
+var Gr = Ft.exports, Lr = F, Dr = Rt, Fr = Gr, Br = Se, Wr = {}, Kr = Math.ceil, Hr = Math.floor, Yr = Math.trunc || function(e) {
 var t = +e;
-return (t > 0 ? Kr : Hr)(t);
+return (t > 0 ? Hr : Kr)(t);
 }, Vr = function(e) {
 var t = +e;
 return t != t || 0 === t ? 0 : Yr(t);
@@ -22832,10 +22525,10 @@ var t = po.f(yo(e)), r = fo.f;
 return r ? vo(t, r(e)) : t;
 }, ho = Ge, Ro = go, Eo = o, To = Rt, Co = n, So = F, wo = /#|\.prototype\./, xo = function(e, t) {
 var r = Oo[bo(e)];
-return r === ko || r !== Ao && (So(t) ? Co(t) : !!t);
+return r === Ao || r !== ko && (So(t) ? Co(t) : !!t);
 }, bo = xo.normalize = function(e) {
 return String(e).replace(wo, ".").toLowerCase();
-}, Oo = xo.data = {}, Ao = xo.NATIVE = "N", ko = xo.POLYFILL = "P", Mo = xo, Uo = r, _o = o.f, No = Dt, Po = function(e, t, r, o) {
+}, Oo = xo.data = {}, ko = xo.NATIVE = "N", Ao = xo.POLYFILL = "P", Mo = xo, Uo = r, _o = o.f, No = Dt, Po = function(e, t, r, o) {
 o || (o = {});
 var n = o.enumerable, a = void 0 !== o.name ? o.name : t;
 if (Lr(r) && Fr(r, a, o), o.global) n ? e[t] = r : Br(t, r); else {
@@ -22866,8 +22559,8 @@ Go(a, n);
 }
 }, Fo = x, Bo = Array.isArray || function(e) {
 return "Array" === Fo(e);
-}, Wo = TypeError, Ho = x, Ko = T, Yo = function(e) {
-if ("Function" === Ho(e)) return Ko(e);
+}, Wo = TypeError, Ko = x, Ho = T, Yo = function(e) {
+if ("Function" === Ko(e)) return Ho(e);
 }, Vo = pe, qo = i, jo = Yo(Yo.bind), zo = a, Qo = Rt, Xo = v, Zo = Bo, Jo = Zr, $o = function(e) {
 if (e > 9007199254740991) throw Wo("Maximum allowed index exceeded");
 return e;
@@ -22919,11 +22612,11 @@ var e;
 return Cn(Cn.call) || !Cn(Object) || !Cn(function() {
 e = !0;
 }) || e;
-}) ? Sn : Cn, xn = Bo, bn = wn, On = W, An = Xe("species"), kn = Array, Mn = function(e, t) {
+}) ? Sn : Cn, xn = Bo, bn = wn, On = W, kn = Xe("species"), An = Array, Mn = function(e, t) {
 return new (function(e) {
 var t;
-return xn(e) && (t = e.constructor, (bn(t) && (t === kn || xn(t.prototype)) || On(t) && null === (t = t[An])) && (t = void 0)),
-void 0 === t ? kn : t;
+return xn(e) && (t = e.constructor, (bn(t) && (t === An || xn(t.prototype)) || On(t) && null === (t = t[kn])) && (t = void 0)),
+void 0 === t ? An : t;
 }(e))(0 === t ? 0 : t);
 }, Un = rn, _n = pe, Nn = Ne, Pn = Zr, In = Mn;
 Do({
@@ -22938,10 +22631,10 @@ t;
 });
 var Gn = {}, Ln = io, Dn = so, Fn = Object.keys || function(e) {
 return Ln(e, Dn);
-}, Bn = a, Wn = Et, Hn = Rt, Kn = wt, Yn = L, Vn = Fn;
+}, Bn = a, Wn = Et, Kn = Rt, Hn = wt, Yn = L, Vn = Fn;
 Gn.f = Bn && !Wn ? Object.defineProperties : function(e, t) {
-Kn(e);
-for (var r, o = Yn(t), n = Vn(t), a = n.length, i = 0; a > i; ) Hn.f(e, r = n[i++], o[r]);
+Hn(e);
+for (var r, o = Yn(t), n = Vn(t), a = n.length, i = 0; a > i; ) Kn.f(e, r = n[i++], o[r]);
 return e;
 };
 var qn, jn = Y("document", "documentElement"), zn = wt, Qn = Gn, Xn = so, Zn = ar, Jn = jn, $n = st, ea = "prototype", ta = "script", ra = nr("IE_PROTO"), oa = function() {}, na = function(e) {
@@ -23152,28 +22845,28 @@ if (void 0 !== e) return ba.encode(e);
 deserialize(e) {
 if (void 0 !== e) return ba.decode(e);
 }
-}, Aa = (e, t) => `cg_${e.key}_${t}`, ka = (e, t) => Object.assign(Object.assign({}, e), {
+}, ka = (e, t) => `cg_${e.key}_${t}`, Aa = (e, t) => Object.assign(Object.assign({}, e), {
 get(r) {
 var o;
 const n = e.get(r);
 if (n) try {
-const e = null !== (o = wa.get(Aa(t, n))) && void 0 !== o ? o : t.deserialize(n);
-return void 0 !== e && wa.set(Aa(t, n), e, Game.time + CREEP_LIFE_TIME), e;
+const e = null !== (o = wa.get(ka(t, n))) && void 0 !== o ? o : t.deserialize(n);
+return void 0 !== e && wa.set(ka(t, n), e, Game.time + CREEP_LIFE_TIME), e;
 } catch (o) {
-return e.delete(r), void wa.delete(Aa(t, n));
+return e.delete(r), void wa.delete(ka(t, n));
 }
 },
 set(r, o, n) {
 const a = e.get(r);
-a && wa.delete(Aa(t, a));
+a && wa.delete(ka(t, a));
 const i = t.serialize(o);
-i ? (e.set(r, i, n), wa.set(Aa(t, i), o, Game.time + CREEP_LIFE_TIME)) : e.delete(r);
+i ? (e.set(r, i, n), wa.set(ka(t, i), o, Game.time + CREEP_LIFE_TIME)) : e.delete(r);
 },
 delete(r) {
 const o = e.get(r);
-o && wa.delete(Aa(t, o)), e.delete(r);
+o && wa.delete(ka(t, o)), e.delete(r);
 },
-with: t => ka(e, t)
+with: t => Aa(e, t)
 });
 function Ma() {
 var e, t;
@@ -23197,7 +22890,7 @@ expires: e => Oa.deserialize(Ua()[e]),
 delete(e) {
 delete Ma()[e];
 },
-with: e => ka(_a, e),
+with: e => Aa(_a, e),
 clean() {
 const e = Ua();
 for (const t in e) {
@@ -23238,10 +22931,10 @@ depth: 12
 }), Wa = new xa.Codec({
 depth: 3,
 array: !0
-}), Ha = new xa.Codec({
+}), Ka = new xa.Codec({
 array: !0,
 depth: 16
-}), Ka = [ "WN", "EN", "WS", "ES" ], Ya = e => {
+}), Ha = [ "WN", "EN", "WS", "ES" ], Ya = e => {
 const t = (65280 & e.__packedPos) >> 8, r = 255 & e.__packedPos, o = e.__packedPos >>> 4 & 4294963200 | t << 6 | r;
 return Fa.encode(o);
 }, Va = function(e) {
@@ -23328,11 +23021,11 @@ a = $a(t, r + 1), n = 0;
 }
 return a === e.roomName ? La(e, o, n) : Ga(o, n, a);
 }
-const ni = e => Ha.encode(e.map(e => {
+const ni = e => Ka.encode(e.map(e => {
 const [t, r, o, n, a] = e.split(/([A-Z])([0-9]+)([A-Z])([0-9]+)/);
-return Ka.indexOf(r + n) << 14 | parseInt(o) << 7 | parseInt(a);
-})), ai = e => Ha.decode(e).map(e => {
-const t = e >> 14, r = e >> 7 & 127, o = 127 & e, [n, a] = Ka[t].split("");
+return Ha.indexOf(r + n) << 14 | parseInt(o) << 7 | parseInt(a);
+})), ai = e => Ka.decode(e).map(e => {
+const t = e >> 14, r = e >> 7 & 127, o = 127 & e, [n, a] = Ha[t].split("");
 return `${n}${r}${a}${o}`;
 }), ii = e => ni([ e ]), si = e => ai(e)[0], ci = new xa.Codec({
 array: !1,
@@ -23513,14 +23206,14 @@ return !(o.get(e.x, e.y) === TERRAIN_MASK_WALL || Game.rooms[e.roomName] && e.lo
 let t = e.match(/^[WE]([0-9]+)[NS]([0-9]+)$/);
 if (!t) throw new Error("Invalid room name");
 return Number(t[1]) % 10 == 0 || Number(t[2]) % 10 == 0;
-}, Ai = e => {
+}, ki = e => {
 let t = e.match(/^[WE]([0-9]+)[NS]([0-9]+)$/);
 if (!t) throw new Error("Invalid room name");
 let r = Number(t[1]) % 10, o = Number(t[2]) % 10;
 return !(5 === r && 5 === o) && r >= 4 && r <= 6 && o >= 4 && o <= 6;
-}, ki = (e, t, r) => r ? e.slice(0, t) : e.slice(t + 1), Mi = e => "_ck" + e;
+}, Ai = (e, t, r) => r ? e.slice(0, t) : e.slice(t + 1), Mi = e => "_ck" + e;
 function Ui(e) {
-Ai(e) && !_a.get(Mi(e)) && _a.with(di).set(Mi(e), [ ...Game.rooms[e].find(FIND_SOURCES), ...Game.rooms[e].find(FIND_MINERALS) ].map(e => e.pos));
+ki(e) && !_a.get(Mi(e)) && _a.with(di).set(Mi(e), [ ...Game.rooms[e].find(FIND_SOURCES), ...Game.rooms[e].find(FIND_MINERALS) ].map(e => e.pos));
 }
 class _i extends Map {
 get(e) {
@@ -23582,7 +23275,7 @@ depth: 30
 }), Fi = new Map;
 null !== (Pi = Memory[Li = Ta.MEMORY_PORTAL_PATH]) && void 0 !== Pi || (Memory[Li] = []);
 for (const e of Memory[Ta.MEMORY_PORTAL_PATH]) {
-const t = Hi(e), r = null !== (Ii = Fi.get(t.room1)) && void 0 !== Ii ? Ii : new Map;
+const t = Ki(e), r = null !== (Ii = Fi.get(t.room1)) && void 0 !== Ii ? Ii : new Map;
 r.set(t.room2, t), Fi.set(t.room1, r);
 const o = null !== (Gi = Fi.get(t.room2)) && void 0 !== Gi ? Gi : new Map;
 o.set(t.room1, t), Fi.set(t.room2, o);
@@ -23626,7 +23319,7 @@ let r = "";
 return r += ii(e.room1), r += ii(e.room2), r += Di.encode(null !== (t = e.expires) && void 0 !== t ? t : 0),
 r += za([ ...e.portalMap.entries() ].flat()), r;
 }
-function Hi(e) {
+function Ki(e) {
 const t = si(e.slice(0, 3)), r = si(e.slice(3, 6)), o = Di.decode(e.slice(6, 8)), n = new Ni, a = Qa(e.slice(8));
 for (let e = 0; e < a.length; e += 2) n.set(a[e], a[e + 1]);
 return {
@@ -23636,7 +23329,7 @@ expires: 0 !== o ? o : void 0,
 portalMap: n
 };
 }
-function Ki(e) {
+function Hi(e) {
 var t;
 const r = new Set(Object.values(null !== (t = Game.map.describeExits(e)) && void 0 !== t ? t : {})), o = Fi.get(e);
 if (!o) return [ ...r ];
@@ -23788,7 +23481,7 @@ let p = function(e, t, r) {
 const o = Object.assign(Object.assign({}, Ta.DEFAULT_MOVE_OPTS), r), n = Na((e, t) => e + t, (e, t) => {
 var r;
 const n = null === (r = o.routeCallback) || void 0 === r ? void 0 : r.call(o, e, t);
-return void 0 !== n ? n : Oi(e) ? o.highwayRoomCost : Ai(e) ? o.sourceKeeperRoomCost : o.defaultRoomCost;
+return void 0 !== n ? n : Oi(e) ? o.highwayRoomCost : ki(e) ? o.sourceKeeperRoomCost : o.defaultRoomCost;
 }), a = function(e, t, r, o) {
 var n, a;
 if (t.includes(e)) return [];
@@ -23798,7 +23491,7 @@ const c = new Map, u = new Map;
 c.set(e, e), u.set(e, 0);
 let l = s.take();
 for (;l && !t.includes(l); ) {
-for (const e of Ki(l)) {
+for (const e of Hi(l)) {
 const r = u.get(l) + i(l, e);
 if (r !== 1 / 0 && (!u.has(e) || r < u.get(e))) {
 u.set(e, r);
@@ -24131,7 +23824,7 @@ void 0 === c) return ERR_NOT_FOUND;
 wa.set(qi(e, fs), c);
 let u = Math.max(0, Math.min(s.length - 1, (null == r ? void 0 : r.reverse) ? c - 1 : c + 1));
 if (null == r ? void 0 : r.visualizePathStyle) {
-const t = Object.assign(Object.assign({}, Ta.DEFAULT_VISUALIZE_OPTS), r.visualizePathStyle), o = ki(s, c, null == r ? void 0 : r.reverse);
+const t = Object.assign(Object.assign({}, Ta.DEFAULT_VISUALIZE_OPTS), r.visualizePathStyle), o = Ai(s, c, null == r ? void 0 : r.reverse);
 null === (i = e.room) || void 0 === i || i.visual.poly(o.filter(t => {
 var r;
 return t.roomName === (null === (r = e.room) || void 0 === r ? void 0 : r.name);
@@ -24154,12 +23847,12 @@ deserialize(e) {
 if (void 0 !== e) return JSON.parse(e);
 }
 }, ws = "_cp", xs = "_ct", bs = "_co", Os = [ "avoidCreeps", "avoidObstacleStructures", "flee", "plainCost", "swampCost", "roadCost" ];
-function As(e, t = vi.HeapCache) {
+function ks(e, t = vi.HeapCache) {
 gs(qi(e, ws), {
 cache: t
 }), t.delete(qi(e, xs)), t.delete(qi(e, bs));
 }
-const ks = (e, t, r, o = {
+const As = (e, t, r, o = {
 avoidCreeps: !0
 }) => {
 var n, a, i, s;
@@ -24170,17 +23863,17 @@ let l = Ri(t, c.keepTargetInRoom, c.flee), m = !1, d = u.with(li).get(qi(e, xs))
 for (const {pos: t, range: o} of l) {
 if (!m && t.inRangeTo(e.pos, o) && e.pos.roomName === t.roomName) {
 if (!(null == r ? void 0 : r.flee)) {
-As(e, u);
+ks(e, u);
 const t = zi(c)(e.pos.roomName);
 return ds(e, [ e.pos, ...xi(e.pos, !0).filter(e => l.some(t => t.pos.inRangeTo(e, t.range)) && (!t || 255 !== t.get(e.x, e.y))) ], c.priority),
 OK;
 }
 m = !0;
 }
-d && !d.some(e => e && t.isEqualTo(e.pos) && o === e.range) && (As(e, u), d = void 0);
+d && !d.some(e => e && t.isEqualTo(e.pos) && o === e.range) && (ks(e, u), d = void 0);
 }
 const p = u.with(Ss).get(qi(e, bs));
-p && !Os.some(e => c[e] !== p[e]) || As(e, u);
+p && !Os.some(e => c[e] !== p[e]) || ks(e, u);
 const f = [ null == r ? void 0 : r.roadCost, null == r ? void 0 : r.plainCost, null == r ? void 0 : r.swampCost ].some(e => void 0 !== e);
 "body" in e && !f && (c = Object.assign({
 creepMovementInfo: {
@@ -24193,7 +23886,7 @@ u.with(li).set(qi(e, xs), l, y), u.with(Ss).set(qi(e, bs), Os.reduce((e, t) => (
 e), {}), y);
 const v = vs(qi(e, ws), {
 cache: u
-}), g = wa.get(qi(e, "_cpi")), h = v && ki(v, null != g ? g : 0), R = null !== (i = null === (a = c.avoidTargets) || void 0 === a ? void 0 : a.call(c, e.pos.roomName)) && void 0 !== i ? i : [];
+}), g = wa.get(qi(e, "_cpi")), h = v && Ai(v, null != g ? g : 0), R = null !== (i = null === (a = c.avoidTargets) || void 0 === a ? void 0 : a.call(c, e.pos.roomName)) && void 0 !== i ? i : [];
 if (c.repathIfStuck && v && Cs(e, c.repathIfStuck)) gs(qi(e, ws), {
 cache: u
 }), c = Object.assign(Object.assign({}, c), o); else if ((null == h ? void 0 : h.length) && Rs(h, R)) {
@@ -24231,21 +23924,21 @@ let T = hs(e, qi(e, ws), Object.assign(Object.assign({}, c), {
 reverse: !1,
 cache: u
 }));
-return T === ERR_NOT_FOUND && (As(e, u), ys(qi(e, ws), e.pos, l, Object.assign(Object.assign({}, c), {
+return T === ERR_NOT_FOUND && (ks(e, u), ys(qi(e, ws), e.pos, l, Object.assign(Object.assign({}, c), {
 cache: u
 })), T = hs(e, qi(e, ws), Object.assign(Object.assign({}, c), {
 reverse: !1,
 cache: u
 }))), T;
 }, Ms = "_rsi";
-return Du.CachingStrategies = vi, Du.CoordListSerializer = fi, Du.CoordSerializer = pi,
-Du.Keys = ji, Du.MoveTargetListSerializer = li, Du.MoveTargetSerializer = ui, Du.NumberSerializer = Oa,
-Du.PositionListSerializer = di, Du.PositionSerializer = mi, Du.adjacentWalkablePositions = xi,
-Du.blockSquare = function(e) {
+return Lu.CachingStrategies = vi, Lu.CoordListSerializer = fi, Lu.CoordSerializer = pi,
+Lu.Keys = ji, Lu.MoveTargetListSerializer = li, Lu.MoveTargetSerializer = ui, Lu.NumberSerializer = Oa,
+Lu.PositionListSerializer = di, Lu.PositionSerializer = mi, Lu.adjacentWalkablePositions = xi,
+Lu.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, Du.cachePath = ys, Du.cachedPathKey = ps, Du.calculateAdjacencyMatrix = Ti, Du.calculateAdjacentPositions = Ci,
-Du.calculateNearbyPositions = Si, Du.calculatePositionsAtRange = wi, Du.cleanAllCaches = yi,
-Du.clearCachedPath = As, Du.compressPath = e => {
+}, Lu.cachePath = ys, Lu.cachedPathKey = ps, Lu.calculateAdjacencyMatrix = Ti, Lu.calculateAdjacentPositions = Ci,
+Lu.calculateNearbyPositions = Si, Lu.calculatePositionsAtRange = wi, Lu.cleanAllCaches = yi,
+Lu.clearCachedPath = ks, Lu.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24254,19 +23947,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, Du.config = Ta, Du.decompressPath = e => {
+}, Lu.config = Ta, Lu.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, Du.fastRoomPosition = Ga, Du.fixEdgePosition = Ei, Du.follow = function(e, t) {
+}, Lu.fastRoomPosition = Ga, Lu.fixEdgePosition = Ei, Lu.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, Du.followPath = hs, Du.fromGlobalPosition = ti, Du.generatePath = ts, Du.getCachedPath = vs,
-Du.getMoveIntents = ns, Du.getRangeTo = ri, Du.globalPosition = ei, Du.isExit = hi,
-Du.isPositionWalkable = bi, Du.move = ds, Du.moveByPath = function(e, t, r) {
+}, Lu.followPath = hs, Lu.fromGlobalPosition = ti, Lu.generatePath = ts, Lu.getCachedPath = vs,
+Lu.getMoveIntents = ns, Lu.getRangeTo = ri, Lu.globalPosition = ei, Lu.isExit = hi,
+Lu.isPositionWalkable = bi, Lu.move = ds, Lu.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, Ms));
@@ -24290,14 +23983,14 @@ u = void 0);
 let m = ERR_NOT_FOUND;
 if (void 0 === u && (m = hs(e, t, r)), m !== ERR_NOT_FOUND) {
 const t = wa.get(qi(e, "_cpi"));
-if (!(s && Cs(e, s) || l && Rs(ki(l, null != t ? t : 0, null == r ? void 0 : r.reverse), c))) return m;
+if (!(s && Cs(e, s) || l && Rs(Ai(l, null != t ? t : 0, null == r ? void 0 : r.reverse), c))) return m;
 void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi(e, Ms), u));
 }
 let d = vs(t, r);
-return d ? (void 0 !== u && (d = ki(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : ks(e, d, r)) : ERR_NO_PATH;
-}, Du.moveTo = ks, Du.normalizeTargets = Ri, Du.offsetRoomPosition = Da, Du.packCoord = qa,
-Du.packCoordList = za, Du.packPos = Ya, Du.packPosList = Xa, Du.packRoomName = ii,
-Du.packRoomNames = ni, Du.posAtDirection = oi, Du.preTick = function() {
+return d ? (void 0 !== u && (d = Ai(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : As(e, d, r)) : ERR_NO_PATH;
+}, Lu.moveTo = As, Lu.normalizeTargets = Ri, Lu.offsetRoomPosition = Da, Lu.packCoord = qa,
+Lu.packCoordList = za, Lu.packPos = Ya, Lu.packPosList = Xa, Lu.packRoomName = ii,
+Lu.packRoomNames = ni, Lu.posAtDirection = oi, Lu.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) Ui(e), Bi(e);
 !function() {
@@ -24309,23 +24002,23 @@ n.expires && n.expires < Game.time ? (null === (e = Fi.get(n.room1)) || void 0 =
 null === (t = Fi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, Du.reconcileTraffic = function(e) {
+}, Lu.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 _a.with(Oa).set(cs, Game.time);
-}, Du.reconciledRecently = us, Du.resetCachedPath = gs, Du.roomNameFromCoords = $a,
-Du.roomNameToCoords = Ja, Du.sameRoomPosition = La, Du.unpackCoord = ja, Du.unpackCoordList = Qa,
-Du.unpackPos = Va, Du.unpackPosList = Za, Du.unpackRoomName = si, Du.unpackRoomNames = ai,
-Du;
+}, Lu.reconciledRecently = us, Lu.resetCachedPath = gs, Lu.roomNameFromCoords = $a,
+Lu.roomNameToCoords = Ja, Lu.sameRoomPosition = La, Lu.unpackCoord = ja, Lu.unpackCoordList = Qa,
+Lu.unpackPos = Va, Lu.unpackPosList = Za, Lu.unpackRoomName = si, Lu.unpackRoomNames = ai,
+Lu;
 }();
 
-function Bu(e) {
+function Fu(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var Wu, Hu = 5e5;
+var Bu, Wu = 5e5;
 
 function Ku(e) {
 var t;
@@ -24333,10 +24026,10 @@ if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Hu;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Wu;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Hu), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Wu), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24348,21 +24041,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(Wu || (Wu = {}));
+}(Bu || (Bu = {}));
 
-var Yu = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Vu = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], qu = new Set([ "build", "repair", "upgrade" ]), ju = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Hu = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Yu = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Vu = new Set([ "build", "repair", "upgrade" ]), qu = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function zu(e, t) {
+function ju(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function Qu() {
+function zu() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function Xu() {
+function Qu() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24377,8 +24070,8 @@ rooms: {}
 };
 }
 
-function Zu(e) {
-var t = Xu();
+function Xu(e) {
+var t = Qu();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24397,32 +24090,32 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Ju(e, t, r) {
+function Zu(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function $u(e) {
+function Ju(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
+function $u(e) {
+return Yu.includes(e);
+}
+
 function el(e) {
-return Vu.includes(e);
+return Vu.has(e);
 }
 
 function tl(e) {
-return qu.has(e);
-}
-
-function rl(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY);
 }
 
-function ol(e, t) {
+function rl(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function nl(e, t) {
+function ol(e, t) {
 if (!t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -24430,12 +24123,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return rl(e.creep) > 0;
+return tl(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return rl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return tl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -24454,7 +24147,7 @@ return !1;
 }
 }
 
-function al(e, t) {
+function nl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24471,7 +24164,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function il(e) {
+function al(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24479,36 +24172,36 @@ roomName: e.roomName
 };
 }
 
-function sl(e, t, r, o, n) {
+function il(e, t, r, o, n) {
 return {
-id: Ju(e, t, r.id),
+id: Zu(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: il(r.pos),
+targetPos: al(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: Yu,
+allowedRoles: Hu,
 expiresTick: Game.time + 50
 };
 }
 
-function cl(e, t) {
+function sl(e, t) {
 var r, o, n, i, s, c, u, l, m = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = Qu()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = zu()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < m)) {
 t.lastGeneratedTick = Game.time;
-var d = zu("taskBoard.findMyStructures", function() {
+var d = ju("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y, v = f.value;
-v.structureType !== STRUCTURE_SPAWN ? v.structureType !== STRUCTURE_EXTENSION ? v.structureType === STRUCTURE_TOWER && (y = v.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && al(t, sl(e.name, "refillTower", v, y, Wu.HIGH)) : (y = v.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && al(t, sl(e.name, "refillExtension", v, y, Wu.HIGH)) : (y = v.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && al(t, sl(e.name, "refillSpawn", v, y, Wu.CRITICAL));
+v.structureType !== STRUCTURE_SPAWN ? v.structureType !== STRUCTURE_EXTENSION ? v.structureType === STRUCTURE_TOWER && (y = v.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && nl(t, il(e.name, "refillTower", v, y, Bu.HIGH)) : (y = v.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && nl(t, il(e.name, "refillExtension", v, y, Bu.HIGH)) : (y = v.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && nl(t, il(e.name, "refillSpawn", v, y, Bu.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24522,28 +24215,28 @@ if (r) throw r.error;
 }
 }
 var g = Ku(e);
-g && al(t, sl(e.name, "fillTerminalEnergy", g.terminal, g.amount, Wu.NORMAL));
+g && nl(t, il(e.name, "fillTerminalEnergy", g.terminal, g.amount, Bu.NORMAL));
 var h = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && h > 0) {
 var R = Math.min(h, 1e3);
-al(t, sl(e.name, "storeEnergy", e.storage, R, Wu.LOW));
+nl(t, il(e.name, "storeEnergy", e.storage, R, Bu.LOW));
 }
-var E = zu("taskBoard.findHostiles", function() {
+var E = ju("taskBoard.findHostiles", function() {
 return j(e);
 });
 try {
 for (var T = a(E.slice(0, 5)), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-al(t, {
-id: Ju(e.name, "defend", S.id),
+nl(t, {
+id: Zu(e.name, "defend", S.id),
 roomName: e.name,
 type: "defend",
-priority: Wu.CRITICAL,
+priority: Bu.CRITICAL,
 targetId: S.id,
-targetPos: il(S.pos),
+targetPos: al(S.pos),
 amount: S.hits,
 maxAssignments: 3,
-allowedRoles: ju,
+allowedRoles: qu,
 expiresTick: Game.time + 50
 });
 }
@@ -24558,7 +24251,7 @@ C && !C.done && (i = T.return) && i.call(T);
 if (n) throw n.error;
 }
 }
-var w = zu("taskBoard.findInjuredAllies", function() {
+var w = ju("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -24568,13 +24261,13 @@ return e.hits < e.hitsMax;
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-al(t, {
-id: Ju(e.name, "heal", O.id),
+nl(t, {
+id: Zu(e.name, "heal", O.id),
 roomName: e.name,
 type: "heal",
-priority: Wu.HIGH,
+priority: Bu.HIGH,
 targetId: O.id,
-targetPos: il(O.pos),
+targetPos: al(O.pos),
 amount: O.hitsMax - O.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -24595,17 +24288,17 @@ if (s) throw s.error;
 }
 }
 
-function ul(e) {
+function cl(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function ll(e) {
+function ul(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && V(e));
 }
 
-function ml(e) {
+function ll(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -24630,11 +24323,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !ll(t);
+return !ul(t);
 }
 }
 
-function dl(e, t) {
+function ml(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -24656,7 +24349,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function pl(e, t) {
+function dl(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -24664,7 +24357,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (tl(m.type)) dl(e, m); else {
+if (el(m.type)) ml(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -24681,7 +24374,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-ul(m), Game.time > m.expiresTick || !ml(m) ? dl(e, m) : ($u(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !el(m.type)) && (m.status = "assigned");
+cl(m), Game.time > m.expiresTick || !ll(m) ? ml(e, m) : (Ju(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !$u(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -24699,7 +24392,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function fl(e, t, r) {
+function pl(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -24707,15 +24400,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-ul(t);
+cl(t);
 }
 }
 
-function yl(e, t) {
+function fl(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function vl(e, t, r) {
+function yl(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -24728,39 +24421,39 @@ return e.reservations[t];
 });
 }(e, t.creep.name, t.memory.assignedTaskId);
 if (s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId,
-s && yl(s, r) && ml(s) && nl(t, s)) {
+s && fl(s, r) && ll(s) && ol(t, s)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Wu.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Bu.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var c = gl(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Wu.CRITICAL);
+var c = vl(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Bu.CRITICAL);
 if (!c || u < l || !m) return s;
-fl(0, s, t.creep.name), e.stats.preemptions++;
+pl(0, s, t.creep.name), e.stats.preemptions++;
 }
-var d = gl(e, t, r);
+var d = vl(e, t, r);
 if (!d) return null;
-var p = Math.min(Math.max(1, $u(d)), function(e, t) {
+var p = Math.min(Math.max(1, Ju(d)), function(e, t) {
 return "harvest" === t.type ? function(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
-}(e) : Math.max(1, rl(e));
+}(e) : Math.max(1, tl(e));
 }(t.creep, d));
 return t.memory.assignedTaskId = d.id, d.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: p,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, d.updatedTick = Game.time, ul(d), e.stats.assigned++, d;
+}, d.updatedTick = Game.time, cl(d), e.stats.assigned++, d;
 }
 
-function gl(e, t, r) {
+function vl(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (yl(l, r) && nl(t, l) && ml(l) && !($u(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || el(l.type))) {
-var m = hl(t.creep, l), d = 1e3 * l.priority - m;
+if (fl(l, r) && ol(t, l) && ll(l) && !(Ju(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || $u(l.type))) {
+var m = gl(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -24778,7 +24471,7 @@ if (o) throw o.error;
 return i;
 }
 
-function hl(e, t) {
+function gl(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -24786,7 +24479,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function Rl(e, t) {
+function hl(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -24800,7 +24493,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: ol(e, t.creep.name)
+amount: rl(e, t.creep.name)
 };
 
 case "build":
@@ -24829,7 +24522,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (ll(t)) return null;
+if (ul(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -24848,57 +24541,57 @@ return null;
 }
 }
 
-var El = function() {
+var Rl = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== Xu().enabled;
+return !1 !== Qu().enabled;
 }, e.prototype.setEnabled = function(e) {
-Xu().enabled = e;
+Qu().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !Qu()) return null;
-var r = Zu(e.room.name);
-zu("taskBoard.cleanup", function() {
-return pl(r);
-}), zu("taskBoard.generate", function() {
-return cl(e.room, r);
+if (!this.isEnabled() || !zu()) return null;
+var r = Xu(e.room.name);
+ju("taskBoard.cleanup", function() {
+return dl(r);
+}), ju("taskBoard.generate", function() {
+return sl(e.room, r);
 });
-var o = vl(r, e, {
+var o = yl(r, e, {
 allowedTypes: t
 });
-return o ? Rl(o, e) : null;
+return o ? hl(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !Qu()) return null;
-var t = Zu(e.room.name);
-zu("taskBoard.cleanup", function() {
-return pl(t);
-}), zu("taskBoard.generate", function() {
-return cl(e.room, t);
+if (!this.isEnabled() || !zu()) return null;
+var t = Xu(e.room.name);
+ju("taskBoard.cleanup", function() {
+return dl(t);
+}), ju("taskBoard.generate", function() {
+return sl(e.room, t);
 });
-var r = vl(t, e, {
+var r = yl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: Wu.NORMAL,
+preemptPriority: Bu.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = Rl(r, e);
+var o = hl(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = Qu();
+var r, o = zu();
 if (!this.isEnabled() || !o) return !1;
-var n = Zu(e);
-zu("taskBoard.cleanup", function() {
-return pl(n);
+var n = Xu(e);
+ju("taskBoard.cleanup", function() {
+return dl(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && zu("taskBoard.generate", function() {
-return cl(a, n);
+return a && ju("taskBoard.generate", function() {
+return sl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && ml(e);
+return t.includes(e.type) && ll(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && Qu()) {
+if (this.isEnabled() && zu()) {
 !function(e) {
-var t, r, o, n, s = Xu();
+var t, r, o, n, s = Qu();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -24919,20 +24612,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = Zu(e.name);
-zu("taskBoard.cleanup", function() {
-return pl(t);
-}), zu("taskBoard.generate", function() {
-return cl(e, t);
+var t = Xu(e.name);
+ju("taskBoard.cleanup", function() {
+return dl(t);
+}), ju("taskBoard.generate", function() {
+return sl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = Xu(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = Qu(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) fl(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) pl(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -24959,26 +24652,26 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = Xu(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && el(c.type) && ml(c))) return delete e.memory.assignedTaskId,
+var a = Qu(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && $u(c.type) && ll(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = ol(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = rl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-ul(c), u.amount);
+cl(c), u.amount);
 }, e.prototype.clear = function(e) {
-var t = Xu();
+var t = Qu();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = Qu();
+var t, r = zu();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = Zu(e);
-zu("taskBoard.cleanup", function() {
-return pl(n, !0);
-}), zu("taskBoard.generate", function() {
-return cl(o, n);
+var n = Xu(e);
+ju("taskBoard.cleanup", function() {
+return dl(n, !0);
+}), ju("taskBoard.generate", function() {
+return sl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25003,10 +24696,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = Qu(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = zu(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = Zu(e);
-pl(i, !0), cl(n, i);
+var i = Xu(e);
+dl(i, !0), sl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25028,8 +24721,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = Zu(e);
-pl(s, !0);
+var t, r, o, n, i, s = Xu(e);
+dl(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25064,15 +24757,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), Tl = new El;
+}(), El = new Rl;
 
-function Cl(e) {
+function Tl(e) {
 return e === ERR_NO_PATH;
 }
 
-function Sl(e) {
+function Cl(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && Cl(e.moveResult),
+clearState: void 0 !== e.moveResult && Tl(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25083,11 +24776,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var wl, xl = k("ActionExecutor");
+var Sl, wl = A("ActionExecutor");
 
-function bl(e, t, r) {
+function xl(e, t, r) {
 var o;
-return !!V(r) && (xl.warn("Refusing harmful action against known ally target", {
+return !!V(r) && (wl.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25095,19 +24788,19 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (Fu.clearCachedPath(e.creep), $e(e.creep)),
-Tl.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (Du.clearCachedPath(e.creep), $e(e.creep)),
+El.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function Ol(e, t, r) {
+function bl(e, t, r) {
 var o, n;
-if (!t || !t.type) return xl.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return wl.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && xl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-"idle" === a.type ? xl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : xl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && wl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+"idle" === a.type ? wl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : wl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
@@ -25181,7 +24874,7 @@ return e.upgradeController(a.target);
 break;
 
 case "dismantle":
-if (bl(r, a.type, a.target)) {
+if (xl(r, a.type, a.target)) {
 i = !0;
 break;
 }
@@ -25191,7 +24884,7 @@ return e.dismantle(a.target);
 break;
 
 case "attack":
-if (bl(r, a.type, a.target)) {
+if (xl(r, a.type, a.target)) {
 i = !0;
 break;
 }
@@ -25201,7 +24894,7 @@ return e.attack(a.target);
 break;
 
 case "rangedAttack":
-if (bl(r, a.type, a.target)) {
+if (xl(r, a.type, a.target)) {
 i = !0;
 break;
 }
@@ -25217,7 +24910,7 @@ return e.heal(a.target);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), Cl(Fu.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), Tl(Du.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
@@ -25233,7 +24926,7 @@ return e.reserveController(a.target);
 break;
 
 case "attackController":
-if (bl(r, a.type, a.target)) {
+if (xl(r, a.type, a.target)) {
 i = !0;
 break;
 }
@@ -25243,12 +24936,12 @@ return e.attackController(a.target);
 break;
 
 case "moveTo":
-Cl(Fu.moveTo(e, a.target)) && (i = !0);
+Tl(Du.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-Cl(Fu.moveTo(e, {
+Tl(Du.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25257,11 +24950,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-Cl(Al(e, a.target, a.routeType)) && (i = !0);
+Tl(Ol(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), Cl(Al(e, {
+c = new RoomPosition(25, 25, a.roomName), Tl(Ol(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25276,40 +24969,40 @@ pos: e,
 range: 10
 };
 });
-Cl(Fu.moveTo(e, u, {
+Tl(Du.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (Fu.isExit(e.pos)) {
+if (Du.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-Fu.moveTo(e, l, {
+Du.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || Cl(Fu.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || Tl(Du.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-Cl(Fu.moveTo(e, a.target, {
+Tl(Du.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (Fu.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), Fu.moveTo(e, l, {
+if (Du.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), Du.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = Bu(m.name);
+var d = Fu(m.name);
 if (d && !e.pos.isEqualTo(d)) {
-Cl(Fu.moveTo(e, d, {
+Tl(Du.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25318,7 +25011,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && Fu.moveTo(e, {
+p && Du.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25326,8 +25019,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, Fu.clearCachedPath(e), $e(e), Tl.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || Tl.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, Du.clearCachedPath(e), $e(e), El.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || El.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25335,27 +25028,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function Al(e, t, r, o) {
-if (!wl) return Fu.moveTo(e, t, o);
+function Ol(e, t, r, o) {
+if (!Sl) return Du.moveTo(e, t, o);
 try {
-return wl(e, t, r, o);
+return Sl(e, t, r, o);
 } catch (n) {
-return xl.warn("Remote movement handler failed; falling back to default movement", {
+return wl.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), Fu.moveTo(e, t, o);
+}), Du.moveTo(e, t, o);
 }
 }
 
 function kl(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = Fu.moveTo(e, r);
-return s !== OK && xl.info("Movement attempt returned non-OK result", {
+var s = Du.moveTo(e, r);
+return s !== OK && wl.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25363,49 +25056,49 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), Sl({
+}), Cl({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = Sl({
+var c = Cl({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
 var n, a, i, s, c, u, l, m = e.memory;
-switch (rs(m), t) {
+switch (ts(m), t) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
 var d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length;
-l = 2 * d, os(m).energyHarvested += l;
+l = 2 * d, rs(m).energyHarvested += l;
 break;
 
 case "transfer":
 var p = null !== (n = null == o ? void 0 : o.resourceType) && void 0 !== n ? n : RESOURCE_ENERGY, f = Math.min(null !== (a = null == o ? void 0 : o.amount) && void 0 !== a ? a : e.store.getUsedCapacity(p), e.store.getUsedCapacity(p), null !== (s = null === (i = r.store) || void 0 === i ? void 0 : i.getFreeCapacity(p)) && void 0 !== s ? s : 1 / 0);
 f > 0 && function(e, t) {
-os(e).energyTransferred += t;
+rs(e).energyTransferred += t;
 }(m, f);
 break;
 
 case "build":
 c = m, u = 5 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
-}).length), os(c).buildProgress += u;
+}).length), rs(c).buildProgress += u;
 break;
 
 case "repair":
 !function(e, t) {
-os(e).repairProgress += t;
+rs(e).repairProgress += t;
 }(m, 100 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length));
 break;
 
 case "attack":
-ns(m, g = 30 * e.body.filter(function(e) {
+os(m, g = 30 * e.body.filter(function(e) {
 return e.type === ATTACK && e.hits > 0;
 }).length);
 break;
@@ -25414,7 +25107,7 @@ case "rangedAttack":
 var y = e.body.filter(function(e) {
 return e.type === RANGED_ATTACK && e.hits > 0;
 }).length, v = e.pos.getRangeTo(r), g = 0;
-v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), ns(m, g);
+v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), os(m, g);
 break;
 
 case "heal":
@@ -25423,18 +25116,18 @@ var h = e.body.filter(function(e) {
 return e.type === HEAL && e.hits > 0;
 }).length;
 !function(e, t) {
-os(e).healingDone += t;
+rs(e).healingDone += t;
 }(m, "heal" === t ? 12 * h : 4 * h);
 break;
 
 case "upgrade":
 !function(e, t) {
-os(e).upgradeProgress += t;
+rs(e).upgradeProgress += t;
 }(m, d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (xl.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (wl.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25445,13 +25138,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Ml, Ul = k("StateMachine");
+var Al, Ml = A("StateMachine");
 
-function _l(e) {
+function Ul(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function Nl(e, t, r) {
+function _l(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25473,12 +25166,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== _l(e.amount) ? {
+}, void 0 !== Ul(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), Ul.info(r, {
+}(t), Ml.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25486,13 +25179,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : Ul.info("Behavior returned idle action", {
+})) : Ml.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (Ul.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (Ml.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25503,11 +25196,11 @@ type: "idle"
 });
 }
 
-function Pl(e, t, r) {
+function Nl(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, Nl(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, _l(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -25587,7 +25280,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) Ul.info("State completed, evaluating new action", {
+}(a, e)) Ml.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25637,7 +25330,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = _l(e.data.amount);
+var c = Ul(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -25711,11 +25404,11 @@ return null;
 }(a);
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return c;
-var u = e.memory.assignedTaskId, l = Tl.refreshCreepReservation(e, c);
+var u = e.memory.assignedTaskId, l = El.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-Ul.info("Task-board delivery reservation missing, re-evaluating behavior", {
+Ml.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25725,7 +25418,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-Ul.info("State reconstruction failed, re-evaluating behavior", {
+Ml.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25733,7 +25426,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (Ul.info("State invalid, re-evaluating behavior", {
+} else a && (Ml.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -25742,33 +25435,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return Nl(e, t(e), "Committed new state action");
+return _l(e, t(e), "Committed new state action");
 }
 
-(Ml = {})[FIND_SOURCES] = 5e3, Ml[FIND_MINERALS] = 5e3, Ml[FIND_DEPOSITS] = 100,
-Ml[FIND_STRUCTURES] = 50, Ml[FIND_MY_STRUCTURES] = 50, Ml[FIND_HOSTILE_STRUCTURES] = 20,
-Ml[FIND_MY_SPAWNS] = 100, Ml[FIND_MY_CONSTRUCTION_SITES] = 20, Ml[FIND_CONSTRUCTION_SITES] = 20,
-Ml[FIND_CREEPS] = 5, Ml[FIND_MY_CREEPS] = 5, Ml[FIND_HOSTILE_CREEPS] = 3, Ml[FIND_DROPPED_RESOURCES] = 5,
-Ml[FIND_TOMBSTONES] = 10, Ml[FIND_RUINS] = 10, Ml[FIND_FLAGS] = 50, Ml[FIND_NUKES] = 20,
-Ml[FIND_POWER_CREEPS] = 10, Ml[FIND_MY_POWER_CREEPS] = 10;
+(Al = {})[FIND_SOURCES] = 5e3, Al[FIND_MINERALS] = 5e3, Al[FIND_DEPOSITS] = 100,
+Al[FIND_STRUCTURES] = 50, Al[FIND_MY_STRUCTURES] = 50, Al[FIND_HOSTILE_STRUCTURES] = 20,
+Al[FIND_MY_SPAWNS] = 100, Al[FIND_MY_CONSTRUCTION_SITES] = 20, Al[FIND_CONSTRUCTION_SITES] = 20,
+Al[FIND_CREEPS] = 5, Al[FIND_MY_CREEPS] = 5, Al[FIND_HOSTILE_CREEPS] = 3, Al[FIND_DROPPED_RESOURCES] = 5,
+Al[FIND_TOMBSTONES] = 10, Al[FIND_RUINS] = 10, Al[FIND_FLAGS] = 50, Al[FIND_NUKES] = 20,
+Al[FIND_POWER_CREEPS] = 10, Al[FIND_MY_POWER_CREEPS] = 10;
 
-var Il, Gl, Ll = {}, Dl = {}, Fl = {}, Bl = {};
+var Pl, Il, Gl = {}, Ll = {}, Dl = {}, Fl = {};
 
-function Wl() {
-if (Il) return Bl;
-Il = 1;
+function Bl() {
+if (Pl) return Fl;
+Pl = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Bl.encode = function(t) {
+return Fl.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, Bl;
+}, Fl;
 }
 
-function Hl() {
-if (Gl) return Fl;
-Gl = 1;
-const e = Wl();
-return Fl.encode = function(t) {
+function Wl() {
+if (Il) return Dl;
+Il = 1;
+const e = Bl();
+return Dl.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25776,23 +25469,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Fl;
+}, Dl;
 }
 
-var Kl, Yl, Vl, ql = {}, jl = jt(Object.freeze({
+var Kl, Hl, Yl, Vl = {}, ql = jt(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function zl() {
-return Yl ? Kl : (Yl = 1, Kl = "function" == typeof URL ? URL : jl.URL);
+function jl() {
+return Hl ? Kl : (Hl = 1, Kl = "function" == typeof URL ? URL : ql.URL);
 }
 
-function Ql() {
-if (Vl) return ql;
-Vl = 1;
-const e = zl();
-ql.getArg = function(e, t, r) {
+function zl() {
+if (Yl) return Vl;
+Yl = 1;
+const e = jl();
+Vl.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25812,16 +25505,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-ql.toSetString = t ? r : function(e) {
+Vl.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, ql.fromSetString = t ? r : function(e) {
+}, Vl.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, ql.compareByGeneratedPositionsInflated = function(e, t) {
+}, Vl.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, ql.parseSourceMapInput = function(e) {
+}, Vl.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25875,7 +25568,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return ql.normalize = f, ql.join = y, ql.relative = function(t, r) {
+return Vl.normalize = f, Vl.join = y, Vl.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25887,18 +25580,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, ql.computeSourceURL = function(e, t, r) {
+}, Vl.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, ql;
+}, Vl;
 }
 
-var Xl, Zl = {};
+var Ql, Xl = {};
 
-function Jl() {
-if (Xl) return Zl;
-Xl = 1;
+function Zl() {
+if (Ql) return Xl;
+Ql = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -25931,19 +25624,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Zl.ArraySet = e, Zl;
+return Xl.ArraySet = e, Xl;
 }
 
-var $l, em, tm = {};
+var Jl, $l, em = {};
 
-function rm() {
-if (em) return Dl;
-em = 1;
-const e = Hl(), t = Ql(), r = Jl().ArraySet, o = function() {
-if ($l) return tm;
+function tm() {
+if ($l) return Ll;
 $l = 1;
-const e = Ql();
-return tm.MappingList = class {
+const e = Wl(), t = zl(), r = Zl().ArraySet, o = function() {
+if (Jl) return em;
+Jl = 1;
+const e = zl();
+return em.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -25963,7 +25656,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, tm;
+}, em;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26092,13 +25785,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Dl.SourceMapGenerator = n, Dl;
+return n.prototype._version = 3, Ll.SourceMapGenerator = n, Ll;
 }
 
-var om, nm = {}, am = {};
+var rm, om = {}, nm = {};
 
-function im() {
-return om || (om = 1, function(e) {
+function am() {
+return rm || (rm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26110,36 +25803,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(am)), am;
+}(nm)), nm;
 }
 
-var sm, cm, um, lm, mm = {
+var im, sm, cm, um, lm = {
 exports: {}
 };
 
-function dm() {
-if (sm) return mm.exports;
-sm = 1;
+function mm() {
+if (im) return lm.exports;
+im = 1;
 let e = null;
-return mm.exports = function() {
+return lm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, mm.exports.initialize = t => {
+}, lm.exports.initialize = t => {
 e = t;
-}, mm.exports;
+}, lm.exports;
 }
 
-function pm() {
-if (um) return cm;
-um = 1;
-const e = dm();
+function dm() {
+if (cm) return sm;
+cm = 1;
+const e = mm();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return cm = function() {
+return sm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26206,28 +25899,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, cm;
+}, sm;
 }
 
-var fm, ym, vm, gm, hm = {};
+var pm, fm, ym, vm, gm = {};
 
-function Rm(e, t, r) {
+function hm(e, t, r) {
 return e - t >= r;
 }
 
-function Em(e, t) {
+function Rm(e, t) {
 return e.priority - t.priority;
 }
 
-function Tm(e, t, r, o) {
+function Em(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function Cm(e, t, r, o) {
+function Tm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Sm(e) {
+function Cm(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26245,12 +25938,12 @@ if (t) throw t.error;
 return o;
 }
 
-ym || (ym = 1, Ll.SourceMapGenerator = rm().SourceMapGenerator, Ll.SourceMapConsumer = function() {
-if (lm) return nm;
-lm = 1;
-const e = Ql(), t = im(), r = Jl().ArraySet;
-Hl();
-const o = dm(), n = pm(), a = Symbol("smcInternal");
+fm || (fm = 1, Gl.SourceMapGenerator = tm().SourceMapGenerator, Gl.SourceMapConsumer = function() {
+if (um) return om;
+um = 1;
+const e = zl(), t = am(), r = Zl().ArraySet;
+Wl();
+const o = mm(), n = dm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26287,7 +25980,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, nm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, om.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26477,7 +26170,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, nm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, om.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26586,11 +26279,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return nm.IndexedSourceMapConsumer = c, nm;
-}().SourceMapConsumer, Ll.SourceNode = function() {
-if (fm) return hm;
-fm = 1;
-const e = rm().SourceMapGenerator, t = Ql(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return om.IndexedSourceMapConsumer = c, om;
+}().SourceMapConsumer, Gl.SourceNode = function() {
+if (pm) return gm;
+pm = 1;
+const e = tm().SourceMapGenerator, t = zl(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26729,27 +26422,27 @@ map: o
 };
 }
 }
-return hm.SourceNode = n, hm;
+return gm.SourceNode = n, gm;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(gm || (gm = {}));
+}(vm || (vm = {}));
 
-var wm, xm = [ gm.CRITICAL, gm.HIGH, gm.MEDIUM, gm.LOW ], bm = {
-bucketThresholds: (vm = {}, vm[gm.CRITICAL] = 0, vm[gm.HIGH] = 2e3, vm[gm.MEDIUM] = 5e3,
-vm[gm.LOW] = 8e3, vm),
+var Sm, wm = [ vm.CRITICAL, vm.HIGH, vm.MEDIUM, vm.LOW ], xm = {
+bucketThresholds: (ym = {}, ym[vm.CRITICAL] = 0, ym[vm.HIGH] = 2e3, ym[vm.MEDIUM] = 5e3,
+ym[vm.LOW] = 8e3, ym),
 defaultMaxCpu: 5,
 logExecution: !1
-}, Om = function() {
+}, bm = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Sm(xm),
+tasksByPriority: Cm(wm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, bm), e);
+}, this.config = o(o({}, xm), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26763,13 +26456,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(Em), l = 0;
+var u = Array.from(this.tasks.values()).sort(Rm), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (Rm(Game.time, p.lastRun, p.interval)) if (Tm(p.priority, s, this.config.bucketThresholds, gm.CRITICAL)) this.stats.skippedThisTick++; else {
+if (hm(Game.time, p.lastRun, p.interval)) if (Em(p.priority, s, this.config.bucketThresholds, vm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (Cm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Tm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26817,7 +26510,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Sm(xm);
+var t, r, o = Cm(wm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26834,10 +26527,10 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), Am = ((wm = global)._computationScheduler || (wm._computationScheduler = new Om),
-wm._computationScheduler), km = new Map;
+}(), Om = ((Sm = global)._computationScheduler || (Sm._computationScheduler = new bm),
+Sm._computationScheduler), km = new Map;
 
-function Mm(e) {
+function Am(e) {
 var t = km.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
@@ -26845,11 +26538,11 @@ tick: Game.time
 }, km.set(e, t)), t;
 }
 
-function Um(e, t, r) {
+function Mm(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return _m(e, t[0], r), t[0];
-var i = Mm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Um(e, t[0], r), t[0];
+var i = Am(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26866,32 +26559,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && _m(e, s, r), s;
+return s && Um(e, s, r), s;
 }
 
-function _m(e, t, r) {
-var o = Mm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Um(e, t, r) {
+var o = Am(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var Nm = {
+var _m = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function Pm(e, t, r) {
+function Nm(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(Nm[t], ";") : "";
+var o = t ? "color: ".concat(_m[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function Im(e) {
+function Pm(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Gm = {
+var Im = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26905,7 +26598,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(Im((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(Pm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -26922,44 +26615,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(Im(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(Pm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Lm() {
+function Gm() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Bm() + Wm() + '<div class="module-help">'.concat(e.map(Dm).join(""), "</div>");
+return Fm() + Bm() + '<div class="module-help">'.concat(e.map(Lm).join(""), "</div>");
 }
 
-var Dm = function(e) {
-var t = e.api.map(Fm).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Pm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Pm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Fm = function(e) {
+var Lm = function(e) {
+var t = e.api.map(Dm).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Nm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Nm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Dm = function(e) {
 var t = [];
-e.describe && t.push(Pm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(Pm(e.name, "blue"), ": ").concat(Pm(e.desc, "green"));
+e.describe && t.push(Nm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Nm(e.name, "blue"), ": ").concat(Nm(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return Pm(e.name, "blue");
-}).join(", ") : "", o = Pm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Nm(e.name, "blue");
+}).join(", ") : "", o = Nm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Pm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Bm = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Nm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, Fm = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, Wm = function() {
+}, Bm = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Hm = k("EnergyCollection"), Km = [ "refillSpawn", "refillExtension", "refillTower" ];
+}, Wm = A("EnergyCollection"), Km = [ "refillSpawn", "refillExtension", "refillTower" ];
 
-function Ym(e) {
+function Hm(e) {
 if (e.droppedResources.length > 0) {
 var t = Je(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Hm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -26969,22 +26662,22 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Um(e.creep, r, "energy_container");
-if (o) return Hm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Mm(e.creep, r, "energy_container");
+if (o) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Hm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(r)) return Hm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
+if (Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(r)) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "withdraw",
 target: a,
 resourceType: RESOURCE_ENERGY
 };
 }
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Hm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -26994,35 +26687,35 @@ var n = ze(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (n.length > 0) {
-var a, i = Um(e.creep, n, "energy_source");
-if (i) return Hm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
+var a, i = Mm(e.creep, n, "energy_source");
+if (i) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
-if (Hm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
-a = e.creep.pos.findClosestByRange(n)) return Hm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
+if (Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(n.length, " sources but distribution returned null, falling back to closest")),
+a = e.creep.pos.findClosestByRange(n)) return Wm.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(a.id, " at ").concat(a.pos)),
 {
 type: "harvest",
 target: a
 };
 }
-return Hm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Wm.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Vm(e) {
-var t = Tl.getAssignedAction(e, Km);
+function Ym(e) {
+var t = El.getAssignedAction(e, Km);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function qm(e) {
-return Tl.hasActiveTask(e.room.name, Km);
+function Vm(e) {
+return El.hasActiveTask(e.room.name, Km);
 }
 
-function jm(e, t) {
+function qm(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27049,11 +26742,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function zm(e) {
-var t = Tl.getAssignedDeliveryAction(e);
+function jm(e) {
+var t = El.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!qm(e)) {
-var r = jm(e, "deliver");
+if (!Vm(e)) {
+var r = qm(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27075,9 +26768,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Qm = /^[WE]\d+[NS]\d+$/;
+var zm = /^[WE]\d+[NS]\d+$/;
 
-function Xm(e) {
+function Qm(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27087,28 +26780,28 @@ routeType: "hauler"
 } : null;
 }
 
-function Zm(e) {
-return Qm.test(e);
+function Xm(e) {
+return zm.test(e);
 }
 
-function Jm(e) {
+function Zm(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-if (!n || !Zm(n)) return Xm(e);
+if (!n || !Xm(n)) return Qm(e);
 var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
 return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
-} : null : Xm(e) : null;
+} : null : Qm(e) : null;
 }
 
-function $m(e) {
+function Jm(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = Jm(e);
+var a = Zm(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !Zm(n)) return null;
+if (!n || !Xm(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27121,7 +26814,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function ed(e) {
+function $m(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27130,11 +26823,11 @@ var n = e.memory.working;
 return o !== n && et(e.creep), n;
 }
 
-function td(e) {
+function ed(e) {
 e.memory.working = !1, et(e.creep);
 }
 
-var rd = function() {
+var td = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27229,20 +26922,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), od = new rd, nd = k("LarvaWorkerBehavior");
+}(), rd = new td, od = A("LarvaWorkerBehavior");
 
-function ad(e) {
-var t = ed(e), r = Jm(e);
+function nd(e) {
+var t = $m(e), r = Zm(e);
 if (r) return r;
 if (t) {
-nd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = $m(e);
+od.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = Jm(e);
 if (o) return o;
-var n = zm(e);
-if (n) return nd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = jm(e);
+if (n) return od.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = od.getSwarmState(e.room.name);
+var t, r = rd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27259,7 +26952,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return nd.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return od.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27268,14 +26961,20 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return nd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return od.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-nd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-td(e);
+od.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+ed(e);
 }
-return Ym(e);
+return Hm(e);
+}
+
+function ad(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
 }
 
 function id(e) {
@@ -27285,35 +26984,29 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 }
 
 function sd(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
-}
-
-function cd(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var ud = k("HarvesterBehavior"), ld = k("HaulerBehavior"), md = [ "refillSpawn", "refillExtension" ];
+var cd = A("HarvesterBehavior"), ud = A("HaulerBehavior"), ld = [ "refillSpawn", "refillExtension" ];
 
-function dd(e, t, r) {
+function md(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return _m(e, c, r), c;
+if (c) return Um(e, c, r), c;
 }
-var u = Um(e, t, r);
+var u = Mm(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function pd(e) {
+function dd(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27327,7 +27020,7 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-var fd = {
+var pd = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27337,11 +27030,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, yd = fd, vd = function(e) {
-return yd.getLabResourceNeeds(e);
+}, fd = pd, yd = function(e) {
+return fd.getLabResourceNeeds(e);
 };
 
-function gd(e) {
+function vd(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27363,7 +27056,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = vd(e.room.name);
+var n = yd(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27391,7 +27084,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, yd.getLabOverflow(r));
+var t, r, o = (r = e.room.name, fd.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27406,7 +27099,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = vd(e.room.name);
+var i = yd(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27425,8 +27118,8 @@ type: "idle"
 }(e);
 }
 
-var hd = {
-larvaWorker: ad,
+var gd = {
+larvaWorker: nd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27437,12 +27130,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(id).length > 0) return {
+if (e.hostiles.filter(ad).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (ed(e)) {
+if ($m(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27461,7 +27154,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Ym(e);
+return Hm(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27495,10 +27188,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(sd)) return {
+if (e.hostiles.some(id)) return {
 type: "idle"
 };
-if (ed(e)) {
+if ($m(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27517,10 +27210,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Ym(e);
+return Hm(e);
 },
 harvester: function(e) {
-var t, r = (t = cd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = sd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27569,8 +27262,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), ud.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return ud.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), cd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return cd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -27598,7 +27291,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return ud.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return cd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -27619,20 +27312,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (ud.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (cd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (ud.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (cd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = ed(e), o = "defenseRefuel" === e.memory.task;
-if (ld.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = $m(e), o = "defenseRefuel" === e.memory.task;
+if (ud.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -27645,9 +27338,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = Tl.getAssignedAction(e, md);
+var t = El.getAssignedAction(e, ld);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (Tl.hasActiveTask(e.room.name, md)) return null;
+if (El.hasActiveTask(e.room.name, ld)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27667,13 +27360,13 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = Tl.getAssignedDeliveryAction(e);
+var c = El.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!qm(e)) {
+if (!Vm(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return ld.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+if (u.length > 0 && (p = Je(e.creep, u, "hauler_spawn", 10))) return ud.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
 {
 type: "transfer",
 target: p,
@@ -27726,12 +27419,12 @@ type: "transfer",
 target: p,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return ld.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return ud.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-ld.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-td(e);
+ud.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+ed(e);
 }
 if (o) {
 var y = function(e) {
@@ -27739,7 +27432,7 @@ var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = dd(e.creep, t, "energy_container");
+var r = md(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -27783,16 +27476,16 @@ var R = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (R.length > 0) {
-var E = dd(e.creep, R, "energy_container");
-if (E) return ld.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var E = md(e.creep, R, "energy_container");
+if (E) return ud.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: E,
 resourceType: RESOURCE_ENERGY
 };
-ld.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+ud.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
 var T = e.creep.pos.findClosestByRange(R);
-if (T) return ld.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+if (T) return ud.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
 {
 type: "withdraw",
 target: T,
@@ -27800,7 +27493,7 @@ resourceType: RESOURCE_ENERGY
 };
 }
 if (e.mineralContainers.length > 0) {
-var C = dd(e.creep, e.mineralContainers, "mineral_container");
+var C = md(e.creep, e.mineralContainers, "mineral_container");
 if (C) {
 if (S = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
@@ -27810,11 +27503,11 @@ target: C,
 resourceType: S
 };
 } else {
-ld.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+ud.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var S, w = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (w && (S = Object.keys(w.store).find(function(e) {
 return e !== RESOURCE_ENERGY && w.store.getUsedCapacity(e) > 0;
-}))) return ld.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
+}))) return ud.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
 {
 type: "withdraw",
 target: w,
@@ -27859,31 +27552,31 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (ld.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (ud.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
 {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : (ld.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+}) : (ud.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 }));
 },
 builder: function(e) {
-var t = ed(e), r = Jm(e);
+var t = $m(e), r = Zm(e);
 if (r) return r;
 if (t) {
-var o = $m(e);
+var o = Jm(e);
 if (o) return o;
-var n = Vm(e);
+var n = Ym(e);
 if (n) return n;
-if (!qm(e)) {
-var a = jm(e, "builder");
+if (!Vm(e)) {
+var a = qm(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = cd(e);
+var t = sd(e);
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r) return r;
@@ -27906,15 +27599,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Ym(e);
+return Hm(e);
 },
 upgrader: function(e) {
-if (ed(e)) {
-if (pd(e)) {
-var t = Vm(e);
+if ($m(e)) {
+if (dd(e)) {
+var t = Ym(e);
 if (t) return t;
-if (!qm(e)) {
-var r = jm(e, "upgrader");
+if (!Vm(e)) {
+var r = qm(e, "upgrader");
 if (r) return r;
 }
 }
@@ -27987,7 +27680,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (ed(e)) {
+if ($m(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28011,7 +27704,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : zm(e) || (e.storage ? {
+} : jm(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28131,15 +27824,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : gd(e);
+} : vd(e);
 },
-labSupply: gd,
+labSupply: vd,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (ed(e)) {
+if ($m(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28319,7 +28012,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = ed(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = $m(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28342,9 +28035,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : zm(e) || (e.isEmpty || e.room.name !== o ? {
+} : jm(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (td(e), {
+} : (ed(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28443,16 +28136,16 @@ roomName: o
 }
 };
 
-function Rd(e) {
+function hd(e) {
 var t;
-return (null !== (t = hd[e.memory.role]) && void 0 !== t ? t : ad)(e);
+return (null !== (t = gd[e.memory.role]) && void 0 !== t ? t : nd)(e);
 }
 
-var Ed = new Set([ "build", "repair", "upgrade" ]);
+var Rd = new Set([ "build", "repair", "upgrade" ]);
 
-function Td(e, t) {
+function Ed(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && Zm(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && Xm(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -28461,12 +28154,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : $m(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Jm(e);
 }(e, t);
-return r || (Ed.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || pd(e) ? Vm(e) : null : null);
+return r || (Rd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || dd(e) ? Ym(e) : null : null);
 }
 
-var Cd = "patrol", Sd = [ {
+var Td = "patrol", Cd = [ {
 x: 10,
 y: 5
 }, {
@@ -28502,7 +28195,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], wd = [ {
+} ], Sd = [ {
 x: 10,
 y: 10
 }, {
@@ -28519,7 +28212,7 @@ x: 25,
 y: 25
 } ];
 
-function xd(e) {
+function wd(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28527,7 +28220,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function bd(e) {
+function xd(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28537,9 +28230,9 @@ roomName: e.roomName
 });
 }
 
-function Od(e) {
+function bd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Fe.get(e.name, {
-namespace: Cd
+namespace: Td
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28559,25 +28252,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(Sd), !1), i(wd), !1);
-}(t).map(xd).filter(function(e) {
+}(e)), !1), i(Cd), !1), i(Sd), !1);
+}(t).map(wd).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Fe.set(e.name, {
-waypoints: bd(n),
+waypoints: xd(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: Cd,
+namespace: Td,
 ttl: 1e3
 }), n;
 }
 
-function Ad(e, t) {
+function Od(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28587,88 +28280,87 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var kd = k("MilitaryBehaviors"), Md = "defenseAssist";
+var kd = A("MilitaryBehaviors");
 
-function Ud(e) {
-var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Md ? e.targetRoom : void 0;
-}
-
-function _d(e) {
+function Ad(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === Md && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === fa && (delete e.task,
 delete e.targetRoom);
 }
 
-function Nd(e, t) {
+function Md(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function Pd(e) {
+function Ud(e) {
 return Ir(Mr(e));
 }
 
-function Id(e) {
+function _d(e) {
 return e.creep.room.name === e.homeRoom && j(e.room).length > 0;
 }
 
-function Gd(e) {
+function Nd(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Ld(e, t) {
+function Pd(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Dd(e) {
-return Ld(e, "guard") + Ld(e, "ranger") + Ld(e, "healer");
+function Id(e) {
+return Pd(e, "guard") + Pd(e, "ranger") + Pd(e, "healer");
 }
 
-function Fd(e, t, r) {
+function Gd(e, t, r) {
 var o = e.memory;
-return Ud(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
+return ga(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function Bd(e, t) {
+function Ld(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return Fd(r, e, t);
+return Gd(r, e, t);
 });
 }
 
-function Wd(e, t) {
+function Dd(e, t) {
 return "defenseAssist:".concat(e, ":").concat(t, ":active");
 }
 
-function Hd(e, t, r) {
-return Ld(e, t) > function(e, t) {
+function Fd(e, t, r) {
+return Pd(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
-return !r.spawning && o.role === t && Ud(o) === e;
+return !r.spawning && o.role === t && ga(o) === e;
 }).length;
-}(e.roomName, t) || Dd(e) > 0 && Pd(e.roomName) && function(e, t) {
-return Bd(e, t).length;
+}(e.roomName, t) || Id(e) > 0 && Ud(e.roomName) && function(e, t) {
+return Ld(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Kd(e, t) {
+function Bd(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== Md) return null;
-if (Id(e)) return null;
+if (t.task && t.task !== fa) return null;
+if (_d(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Gd).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Nd).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== j(l).length && Hd(u, t.role, e.homeRoom)) return t.task = Md, t.targetRoom = u.roomName,
-t.assistTarget = u.roomName, t.defenseSquadId = Wd(e.homeRoom, u.roomName), t.defenseSquadSize = Pd(u.roomName) ? Math.max(5, Dd(u)) : Math.max(1, Dd(u)),
-t.defenseSquadCreatedAt = Game.time, u.roomName;
+if (l && 0 !== j(l).length && Fd(u, t.role, e.homeRoom)) return va(e.creep, {
+homeRoom: e.homeRoom,
+targetRoom: u.roomName,
+now: Game.time,
+squadId: Dd(e.homeRoom, u.roomName),
+squadSize: Ud(u.roomName) ? Math.max(5, Id(u)) : Math.max(1, Id(u))
+}), u.roomName;
 }
 } catch (e) {
 r = {
@@ -28684,7 +28376,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Yd(e) {
+function Wd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28692,19 +28384,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Vd(e, t) {
+function Kd(e, t) {
 if (!function(e) {
-return Boolean(Ud(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(ga(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = Ud(t);
+var r = ga(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = Mr(r), n = Ir(o), a = n ? Bd(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = Ud(e);
+var o = Mr(r), n = Ir(o), a = n ? Ld(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = ga(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Fd(e, r, o);
+return e.memory.defenseSquadId === t && Gd(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28718,7 +28410,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return Bd(e, t).reduce(function(e, t) {
+return Ld(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = br(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28740,16 +28432,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return Nd(t, "parity-ready"), null;
-if (c >= u) return Nd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Md(t, "parity-ready"), null;
+if (c >= u) return Md(t, "squad-quorum"), null;
 if (l) {
-if (!n) return Nd(t, "expired-staging"), null;
+if (!n) return Md(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Yd(e) - Yd(t);
+var r = Wd(e) - Wd(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28757,20 +28449,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return Nd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Md(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return Nd(t, "squad-quorum"), null;
-if (l) return Nd(t, "expired-staging"), null;
+if (c >= u) return Md(t, "squad-quorum"), null;
+if (l) return Md(t, "expired-staging"), null;
 }
-var m = Bu(e.room.name);
+var m = Fu(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function qd(e) {
+function Hd(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28802,13 +28494,13 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function jd(e, t) {
+function Yd(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function zd(e, t) {
+function Vd(e, t) {
 if (!e.swarmState) return null;
-var r = Bu(e.room.name);
+var r = Fu(e.room.name);
 return r && e.creep.pos.getRangeTo(r) > 2 ? (kd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
@@ -28816,7 +28508,7 @@ target: r
 }) : null;
 }
 
-function Qd(e) {
+function qd(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28840,7 +28532,7 @@ if (t) throw t.error;
 }
 }
 
-function Xd(e) {
+function jd(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28848,23 +28540,23 @@ return Boolean(e);
 });
 }
 
-function Zd(e) {
+function zd(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Jd(e) {
+function Qd(e) {
 var t, r = e.creep.memory;
-if (Ia(e.creep)) return {
+if (ha(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Qd(e.memory.squadId);
-if (o) return $d(e, o);
+var o = qd(e.memory.squadId);
+if (o) return Xd(e, o);
 }
-var n = null !== (t = Kd(e, r)) && void 0 !== t ? t : Ud(r);
-if (n && !Id(e)) {
-var a = Vd(e, r);
+var n = null !== (t = Bd(e, r)) && void 0 !== t ? t : ga(r);
+if (n && !_d(e)) {
+var a = Kd(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28877,9 +28569,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = qd(e);
+var s = Hd(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = jd(e.creep, RANGED_ATTACK), l = jd(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Yd(e.creep, RANGED_ATTACK), l = Yd(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28891,7 +28583,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = jd(e.creep, RANGED_ATTACK), l = jd(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Yd(e.creep, RANGED_ATTACK), l = Yd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28902,7 +28594,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (_d(r), e.creep.room.name !== e.homeRoom) return {
+} else if (Ad(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28911,8 +28603,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = qd(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = jd(e.creep, RANGED_ATTACK), l = jd(e.creep, ATTACK),
+var m = Hd(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Yd(e.creep, RANGED_ATTACK), l = Yd(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28923,7 +28615,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = Od(e.room), p = Ad(e.creep, d);
+var d = bd(e.room), p = Od(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28937,7 +28629,7 @@ type: "idle"
 };
 }
 
-function $d(e, t) {
+function Xd(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28945,7 +28637,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Zd(t);
+var n = zd(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28953,7 +28645,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Xd(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(jd(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -28976,7 +28668,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Xd(e).filter(function(t) {
+var t, r, o = jd(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29005,7 +28697,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Xd(t).filter(function(t) {
+var r = jd(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29021,7 +28713,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Xd(t).sort(function(e, t) {
+var a = jd(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29058,7 +28750,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Xd(t).filter(function(e) {
+var l = jd(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29075,7 +28767,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Xd(e).find(function(e) {
+return null !== (t = jd(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29086,7 +28778,7 @@ target: m
 type: "idle"
 };
 }
-var d = qd(e);
+var d = Hd(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29098,10 +28790,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : jd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Yd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : jd(e.creep, ATTACK) && p <= 1 ? {
+} : Yd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29117,10 +28809,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : jd(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Yd(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : jd(e.creep, ATTACK) && p <= 1 ? {
+} : Yd(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29136,7 +28828,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Zd(t)
+target: zd(t)
 };
 
 case "dissolving":
@@ -29154,8 +28846,8 @@ type: "idle"
 }
 }
 
-var ep = {
-guard: Jd,
+var Zd = {
+guard: Qd,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29164,8 +28856,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = Od(e.room);
-return (o = Ad(e.creep, r)) ? {
+var r = bd(e.room);
+return (o = Od(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29186,7 +28878,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = Od(e.room), (o = Ad(e.creep, r)) ? {
+} : (r = bd(e.room), (o = Od(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29200,11 +28892,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return jd(e, HEAL);
+return Yd(e, HEAL);
 }), t.filter(function(e) {
-return jd(e, RANGED_ATTACK);
+return Yd(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return jd(e, ATTACK);
+return Yd(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29225,7 +28917,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = jd(e.creep, RANGED_ATTACK), u = jd(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Yd(e.creep, RANGED_ATTACK), u = Yd(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29256,19 +28948,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Qd(e.memory.squadId);
-if (o) return $d(e, o);
+var o = qd(e.memory.squadId);
+if (o) return Xd(e, o);
 }
-var n = null !== (t = Kd(e, r)) && void 0 !== t ? t : Ud(r);
-if (n && !Id(e)) {
-var a = Vd(e, r);
+var n = null !== (t = Bd(e, r)) && void 0 !== t ? t : ga(r);
+if (n && !_d(e)) {
+var a = Kd(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === j(i).length) return _d(r), {
+if (0 === j(i).length) return Ad(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29276,7 +28968,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== Md && !r.assistTarget) {
+if (r.targetRoom && r.task !== fa && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -29336,7 +29028,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || Ud(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || ga(r) === t);
 }(e, t);
 }
 });
@@ -29362,7 +29054,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = Od(e.room), v = Ad(e.creep, y);
+var y = bd(e.room), v = Od(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29373,8 +29065,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Qd(e.memory.squadId);
-if (r) return $d(e, r);
+var r = qd(e.memory.squadId);
+if (r) return Xd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29396,9 +29088,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = qd(e);
+var a = Hd(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = jd(e.creep, RANGED_ATTACK), c = jd(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Yd(e.creep, RANGED_ATTACK), c = Yd(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29417,7 +29109,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = Od(e.room), m = Ad(e.creep, l);
+var l = bd(e.room), m = Od(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29439,8 +29131,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Qd(e.memory.squadId);
-if (r) return $d(e, r);
+var r = qd(e.memory.squadId);
+if (r) return Xd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29501,9 +29193,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = zd(e, "siegeUnit");
+var p = Vd(e, "siegeUnit");
 if (p) return p;
-var f = Od(e.room), y = Ad(e.creep, f);
+var f = bd(e.room), y = Od(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29514,8 +29206,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Qd(e.memory.squadId);
-if (r) return $d(e, r);
+var r = qd(e.memory.squadId);
+if (r) return Xd(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29532,7 +29224,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return zd(e, "harasser (no target)") || {
+if (!t) return Vd(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29574,9 +29266,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = zd(e, "harasser (no targets)");
+var c = Vd(e, "harasser (no targets)");
 if (c) return c;
-var u = Od(e.room), l = Ad(e.creep, u);
+var u = bd(e.room), l = Od(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29586,12 +29278,12 @@ type: "idle"
 },
 ranger: function(e) {
 var t, r, o = e.creep.memory;
-if (Ia(e.creep)) return {
+if (ha(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Qd(e.memory.squadId))) return $d(e, a);
+if (e.memory.squadId && (a = qd(e.memory.squadId))) return Xd(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (Ud(o) && _d(o), e.room.name !== e.homeRoom) return {
+if (ga(o) && Ad(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29605,9 +29297,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Kd(e, o)) && void 0 !== t ? t : Ud(o);
-if (i && !Id(e)) {
-var s = Vd(e, o);
+var a, i = null !== (t = Bd(e, o)) && void 0 !== t ? t : ga(o);
+if (i && !_d(e)) {
+var s = Kd(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29617,14 +29309,14 @@ roomName: i
 var u = j(c), l = z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return _d(o), {
+if (0 === u.length && 0 === l.length) return Ad(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = qd(e);
+var m = Hd(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29644,8 +29336,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Qd(e.memory.squadId))) return $d(e, a);
-var p, f = qd(e);
+if (e.memory.squadId && (a = qd(e.memory.squadId))) return Xd(e, a);
+var p, f = Hd(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29656,7 +29348,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = Od(e.room), v = Ad(e.creep, y);
+var y = bd(e.room), v = Od(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29677,21 +29369,21 @@ type: "idle"
 }
 };
 
-function tp(e) {
+function Jd(e) {
 var t;
-return Tl.getAssignedAction(e) || (null !== (t = ep[e.memory.role]) && void 0 !== t ? t : Jd)(e);
+return El.getAssignedAction(e) || (null !== (t = Zd[e.memory.role]) && void 0 !== t ? t : Qd)(e);
 }
 
-var rp = k("PowerExecutor");
+var $d = A("PowerExecutor");
 
-function op(e, t) {
+function ep(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function np(e) {
+function tp(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29733,8 +29425,8 @@ type: "idle"
 };
 }
 
-var ap = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), ip = {
-powerHarvester: np,
+var rp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), op = {
+powerHarvester: tp,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29806,65 +29498,65 @@ roomName: e.homeRoom
 }
 };
 
-function sp(e) {
+function np(e) {
 var t;
-return (null !== (t = ip[e.memory.role]) && void 0 !== t ? t : np)(e);
+return (null !== (t = op[e.memory.role]) && void 0 !== t ? t : tp)(e);
 }
 
-function cp(e) {
+function ap(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var up = {
+var ip = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, lp = {
+}, sp = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, mp = {
+}, cp = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, dp = {
+}, up = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, pp = {
+}, lp = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, fp = {
+}, mp = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, yp = {
+}, dp = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, vp = {
+}, pp = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function gp(e) {
+function fp(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function hp(e) {
+function yp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29872,7 +29564,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function Rp(e) {
+function vp(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29880,12 +29572,12 @@ y: parseInt(n, 10)
 };
 }
 
-function Ep(e) {
+function gp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = Tp(s);
+o[s.n] = hp(s);
 }
 } catch (e) {
 t = {
@@ -29901,23 +29593,23 @@ if (t) throw t.error;
 return o;
 }
 
-function Tp(e) {
+function hp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = lp[e.r]) && void 0 !== t ? t : "core",
-health: Cp(e.h),
+role: null !== (t = sp[e.r]) && void 0 !== t ? t : "core",
+health: Rp(e.h),
 activeTasks: e.t,
-portals: e.p.map(Sp),
+portals: e.p.map(Ep),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(wp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Tp)
 };
 }
 
-function Cp(e) {
+function Rp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = dp[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = up[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29930,11 +29622,11 @@ lastUpdate: e.u
 };
 }
 
-function Sp(e) {
+function Ep(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: hp(e.sp),
+sourcePos: yp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29944,7 +29636,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function wp(e) {
+function Tp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29953,7 +29645,7 @@ bucketLevel: e.b
 };
 }
 
-function xp(e) {
+function Cp(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -29963,12 +29655,12 @@ isAlly: 1 === e.a
 };
 }
 
-function bp(e) {
+function Sp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Op(u);
+i[u.n] = wp(u);
 }
 } catch (e) {
 t = {
@@ -29991,13 +29683,13 @@ updatedAt: e.u
 };
 }
 
-function Op(e) {
+function wp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: Rp(e.pp),
+portalPos: vp(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30008,46 +29700,46 @@ lastUpdate: e.u
 };
 }
 
-function Ap(e) {
+function xp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = fp[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = mp[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = vp[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = pp[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function kp(e, t) {
+function bp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function Mp(e) {
+function Op(e) {
 var t;
 return {
-c: null !== (t = mp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: kp(e.cpuUsage, 2),
+c: null !== (t = cp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: bp(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: kp(e.avgRCL, 1),
+rl: bp(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function Up(e) {
+function kp(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: gp(e.sourcePos),
+sp: fp(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30056,27 +29748,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function _p(e) {
+function Ap(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: kp(e.cpuUsed, 2),
+u: bp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function Np(e) {
+function Mp(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Pp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Up)
 };
 }
 
-function Pp(e) {
+function Up(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30086,23 +29778,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Ip(e) {
+function _p(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = pp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = lp[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = yp[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = dp[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Gp(e) {
+function Np(e) {
 return {
 name: e,
 role: "core",
@@ -30125,7 +29817,7 @@ cpuLimit: 0
 };
 }
 
-function Lp(e) {
+function Pp(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30135,16 +29827,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = up[t.role]) && void 0 !== r ? r : t.role[0],
-h: Mp(t.health),
+r: null !== (r = ip[t.role]) && void 0 !== r ? r : t.role[0],
+h: Op(t.health),
 t: t.activeTasks,
-p: t.portals.map(Up),
+p: t.portals.map(kp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(_p)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Ap)
 };
 }(t[0], t[1]);
 }),
-g: Np(e.globalTargets),
+g: Mp(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30158,7 +29850,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? gp(t.portalPos) : void 0,
+pp: t.portalPos ? fp(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30170,21 +29862,21 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Ip),
+k: e.tasks.map(_p),
 ls: e.lastSync
 };
 var t;
-}(e), r = cp(JSON.stringify(t));
+}(e), r = ap(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Dp(e) {
+function Ip(e) {
 try {
-var t = JSON.parse(e), r = cp(JSON.stringify(t.d));
-return t.c !== r ? (va.warn("InterShardMemory checksum mismatch", {
+var t = JSON.parse(e), r = ap(JSON.stringify(t.d));
+return t.c !== r ? (ka.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
 expected: r,
@@ -30192,52 +29884,52 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: Ep(a.s),
+shards: gp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(xp)), n),
-footprintOperation: a.o ? bp(a.o) : void 0,
-tasks: a.k.map(Ap),
+o.en && (n.enemies = o.en.map(Cp)), n),
+footprintOperation: a.o ? Sp(a.o) : void 0,
+tasks: a.k.map(xp),
 lastSync: a.ls,
 checksum: i
 });
 } catch (e) {
-return va.error("Failed to deserialize InterShardMemory: ".concat(String(e)), {
+return ka.error("Failed to deserialize InterShardMemory: ".concat(String(e)), {
 subsystem: "InterShard"
 }), null;
 }
 var o, n, a, i;
 }
 
-var Fp, Bp, Wp = 102400;
+var Gp, Lp, Dp = 102400;
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Fp || (Fp = {})), function(e) {
+}(Gp || (Gp = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(Bp || (Bp = {}));
+}(Lp || (Lp = {}));
 
-var Hp = null != va ? va : {
+var Fp = null != ka ? ka : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Kp = {
+}, Bp = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Yp = {
+}, Wp = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Vp = function() {
+}, Kp = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Kp), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Bp), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30254,19 +29946,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Dp(r);
-o && (this.interShardMemory = o, Hp.debug("Loaded InterShardMemory", {
+var o = Ip(r);
+o && (this.interShardMemory = o, Fp.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Hp.error("Failed to load InterShardMemory: ".concat(n), {
+Fp.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Gp(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Np(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30427,25 +30119,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Hp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Fp.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Hp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Fp.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Hp.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Fp.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Hp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Fp.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30478,7 +30170,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Hp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Fp.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30508,12 +30200,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Hp.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Fp.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Hp.info("War ended, transitioning to ".concat(i), {
+Fp.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Hp.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Fp.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30539,7 +30231,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Yp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Wp[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30591,13 +30283,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Hp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Fp.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Hp.debug("Could not set shard limits: ".concat(S), {
+Fp.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30605,27 +30297,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Hp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Fp.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
 try {
-var t = InterShardMemory.getLocal(), r = t ? Dp(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
+var t = InterShardMemory.getLocal(), r = t ? Ip(t) : null, o = null == r ? void 0 : r.footprintOperation, n = this.interShardMemory.footprintOperation;
 o && (!n || o.updatedAt >= n.updatedAt) && (this.interShardMemory.footprintOperation = o);
 } catch (e) {}
-var a = Lp(this.interShardMemory);
-if (a.length > Wp) {
-Hp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Wp), {
+var a = Pp(this.interShardMemory);
+if (a.length > Dp) {
+Fp.warn("InterShardMemory size exceeds limit: ".concat(a.length, "/").concat(Dp), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var i = Lp(this.interShardMemory);
-return i.length > Wp ? (Hp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Wp), {
+var i = Pp(this.interShardMemory);
+return i.length > Dp ? (Fp.error("InterShardMemory still too large after trim: ".concat(i.length, "/").concat(Dp), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(i);
 }
 InterShardMemory.setLocal(a), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var s = e instanceof Error ? e.message : String(e);
-Hp.error("Failed to sync InterShardMemory: ".concat(s), {
+Fp.error("Failed to sync InterShardMemory: ".concat(s), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30663,7 +30355,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Gp(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Np(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30681,40 +30373,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Hp.info("Repaired InterShardMemory structure", {
+Fp.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Hp.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Fp.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Dp(r);
-if (!o) return void Hp.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Ip(r);
+if (!o) return void Fp.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Hp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Fp.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Hp.warn("InterShardMemory verification failed: ".concat(a), {
+Fp.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Hp.info("Attempting InterShardMemory recovery", {
+Fp.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Dp(r);
-if (o) return this.interShardMemory = o, void Hp.info("Recovered InterShardMemory from storage", {
+var o = Ip(r);
+if (o) return this.interShardMemory = o, void Fp.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30729,12 +30421,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Gp(n), Hp.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Np(n), Fp.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Hp.error("InterShardMemory recovery failed: ".concat(a), {
+Fp.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30744,7 +30436,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Hp.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Fp.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30760,7 +30452,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Hp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Fp.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30776,7 +30468,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Hp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Fp.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30791,7 +30483,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Hp.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Fp.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30810,7 +30502,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Hp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Fp.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30856,11 +30548,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Hp.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Fp.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = Lp(this.interShardMemory).length, o = r / Wp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = Pp(this.interShardMemory).length, o = r / Dp * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30887,11 +30579,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Hp.info("Forcing InterShardMemory sync with validation", {
+Fp.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = Lp(this.interShardMemory).length, n = Lp(o(o({}, this.interShardMemory), {
+var e, t, r = Pp(this.interShardMemory).length, n = Pp(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -30915,8 +30607,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: Wp,
-percent: Math.round(r / Wp * 1e4) / 100,
+limit: Dp,
+percent: Math.round(r / Dp * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -30924,10 +30616,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Fp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Gp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), qp = new Vp, jp = {
+}(), Hp = new Kp, Yp = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -30938,11 +30630,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: Bp.LOW,
-NORMAL: Bp.NORMAL,
-HIGH: Bp.HIGH
+LOW: Lp.LOW,
+NORMAL: Lp.NORMAL,
+HIGH: Lp.HIGH
 }
-}, zp = function() {
+}, Vp = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -30952,7 +30644,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = qp.getActiveTransferTasks();
+var n = Hp.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -30979,7 +30671,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = qp.getOptimalPortalRoute(e.targetShard);
+var t = Hp.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -30996,13 +30688,13 @@ status: "queued",
 assignedCreeps: [],
 transferred: 0
 };
-this.memory.requests[e.id] = o, va.info("Created transfer request: ".concat(e.resourceAmount, " ").concat(e.resourceType, " from ").concat(r, " to ").concat(e.targetShard, "/").concat(e.targetRoom), {
+this.memory.requests[e.id] = o, ka.info("Created transfer request: ".concat(e.resourceAmount, " ").concat(e.resourceType, " from ").concat(r, " to ").concat(e.targetShard, "/").concat(e.targetRoom), {
 subsystem: "CrossShardTransfer"
 });
-} else va.warn("No room with sufficient ".concat(e.resourceType, " for transfer"), {
+} else ka.warn("No room with sufficient ".concat(e.resourceType, " for transfer"), {
 subsystem: "CrossShardTransfer"
 });
-} else va.warn("No portal found to ".concat(e.targetShard, ", cannot create transfer request"), {
+} else ka.warn("No portal found to ".concat(e.targetShard, ", cannot create transfer request"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31047,7 +30739,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-qp.updateTaskProgress(e.taskId, t);
+Hp.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31056,26 +30748,26 @@ return void 0 !== e;
 }), n = o.reduce(function(e, t) {
 return e + t.carryCapacity;
 }, 0);
-if (n >= r) return e.status = "gathering", void va.info("Transfer request ".concat(e.taskId, " moving to gathering phase"), {
+if (n >= r) return e.status = "gathering", void ka.info("Transfer request ".concat(e.taskId, " moving to gathering phase"), {
 subsystem: "CrossShardTransfer"
 });
 var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = jp.optimizeBody({
+i = Yp.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
 } catch (e) {
-return void va.error("Failed to optimize body for crossShardCarrier: ".concat(String(e)), {
+return void ka.error("Failed to optimize body for crossShardCarrier: ".concat(String(e)), {
 subsystem: "CrossShardTransfer"
 });
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = jp.spawnPriorities.LOW;
-e.priority >= 80 ? d = jp.spawnPriorities.HIGH : e.priority >= 50 && (d = jp.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Yp.spawnPriorities.LOW;
+e.priority >= 80 ? d = Yp.spawnPriorities.HIGH : e.priority >= 50 && (d = Yp.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31093,14 +30785,14 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-jp.spawnQueue.addRequest(y), va.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Yp.spawnQueue.addRequest(y), ka.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
-va.debug("Transfer request ".concat(e.taskId, " needs ").concat(s, " carry capacity, requested ").concat(m, " carriers"), {
+ka.debug("Transfer request ".concat(e.taskId, " needs ").concat(s, " carry capacity, requested ").concat(m, " carriers"), {
 subsystem: "CrossShardTransfer"
 });
-} else va.warn("Source room ".concat(e.sourceRoom, " not available for spawning carriers"), {
+} else ka.warn("Source room ".concat(e.sourceRoom, " not available for spawning carriers"), {
 subsystem: "CrossShardTransfer"
 });
 }, e.prototype.handleGatheringRequest = function(e) {
@@ -31111,7 +30803,7 @@ return void 0 !== e;
 });
 0 !== t.length ? t.every(function(t) {
 return t.store.getUsedCapacity(e.resourceType) > 0;
-}) && (e.status = "moving", va.info("Transfer request ".concat(e.taskId, " moving to portal"), {
+}) && (e.status = "moving", ka.info("Transfer request ".concat(e.taskId, " moving to portal"), {
 subsystem: "CrossShardTransfer"
 })) : e.status = "queued";
 }, e.prototype.handleMovingRequest = function(e) {
@@ -31120,10 +30812,10 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void qp.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Hp.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
-}).length > 0 && (e.status = "transferring", va.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
+}).length > 0 && (e.status = "transferring", ka.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.handleTransferringRequest = function(e) {
@@ -31132,8 +30824,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, qp.updateTaskProgress(e.taskId, 100, "complete"),
-qp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), va.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Hp.updateTaskProgress(e.taskId, 100, "complete"),
+Hp.recordPortalTraversal(e.portalRoom, e.targetShard, !0), ka.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31149,7 +30841,7 @@ if (r && r.assignedCreeps.includes(e)) return r;
 return null;
 }, e.prototype.assignCreep = function(e, t) {
 var r = this.memory.requests[e];
-r && !r.assignedCreeps.includes(t) && (r.assignedCreeps.push(t), va.info("Assigned creep ".concat(t, " to transfer request ").concat(e), {
+r && !r.assignedCreeps.includes(t) && (r.assignedCreeps.push(t), ka.info("Assigned creep ".concat(t, " to transfer request ").concat(e), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.getActiveRequests = function() {
@@ -31163,12 +30855,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Qp = new zp;
+}(), qp = new Vp;
 
-function Xp(e, t, r) {
+function jp(e, t, r) {
 var o, n, a, i;
 try {
-var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Dp(c)) && void 0 !== a ? a : {
+var s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = InterShardMemory.getLocal(), u = c && null !== (a = Ip(c)) && void 0 !== a ? a : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -31183,11 +30875,11 @@ if (!(null == l ? void 0 : l.targets[s])) return;
 var m = l.targets[s];
 m.status = e, null !== (i = m.arrivedAt) && void 0 !== i || (m.arrivedAt = Game.time),
 m.claimTargetRoom = null != t ? t : m.claimTargetRoom, m.blockedReason = r, m.lastUpdate = Game.time,
-"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(Lp(u));
+"claimed" === e && (m.claimedAt = Game.time), l.updatedAt = Game.time, InterShardMemory.setLocal(Pp(u));
 } catch (e) {}
 }
 
-function Zp(e) {
+function zp(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31215,15 +30907,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Xp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (jp("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || j(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Xp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (jp("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Xp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (jp((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31240,24 +30932,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Xp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, jp("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Xp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (jp("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Jp(e) {
+function Qp(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function $p(e, t) {
+function Xp(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31275,7 +30967,7 @@ var w = R > 2 * E ? "swamp" : E > 2 * R ? "plains" : "mixed", x = e.name.match(/
 filter: function(e) {
 return e.structureType === STRUCTURE_KEEPER_LAIR;
 }
-}).length > 0, A = {
+}).length > 0, k = {
 name: e.name,
 lastSeen: Game.time,
 sources: f.length,
@@ -31286,19 +30978,19 @@ terrain: w,
 isHighway: b,
 isSK: O
 };
-(null === (s = null == v ? void 0 : v.owner) || void 0 === s ? void 0 : s.username) && (A.owner = v.owner.username),
-(null === (c = null == v ? void 0 : v.reservation) || void 0 === c ? void 0 : c.username) && (A.reserver = v.reservation.username),
-(null == y ? void 0 : y.mineralType) && (A.mineralType = y.mineralType), u[e.name] = A;
+(null === (s = null == v ? void 0 : v.owner) || void 0 === s ? void 0 : s.username) && (k.owner = v.owner.username),
+(null === (c = null == v ? void 0 : v.reservation) || void 0 === c ? void 0 : c.username) && (k.reserver = v.reservation.username),
+(null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function ef(e, t) {
+function Zp(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function tf(e) {
-var t = od.getEmpire();
-if (Fu.isExit(e.creep.pos)) return Jp(e.room.name);
+function Jp(e) {
+var t = rd.getEmpire();
+if (Du.isExit(e.creep.pos)) return Qp(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31313,7 +31005,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ ef(t.x, t.y - 1), ef(t.x + 1, t.y), ef(t.x, t.y + 1), ef(t.x - 1, t.y) ] : [];
+return t ? [ Zp(t.x, t.y - 1), Zp(t.x + 1, t.y), Zp(t.x, t.y + 1), Zp(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31376,13 +31068,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? ($p(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Xp(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : ($p(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Xp(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31392,19 +31084,19 @@ type: "idle"
 };
 }
 
-function rf(e) {
+function $p(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function of(e) {
-return e.hostiles.some(rf);
+function ef(e) {
+return e.hostiles.some($p);
 }
 
-function nf(e) {
+function tf(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function af(e) {
+function rf(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31427,8 +31119,8 @@ type: "idle"
 };
 }
 
-var sf = {
-scout: tf,
+var of = {
+scout: Jp,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31462,7 +31154,7 @@ return {
 type: "idle"
 };
 }
-if (Fu.isExit(e.creep.pos)) return Jp(e.room.name);
+if (Du.isExit(e.creep.pos)) return Qp(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31484,8 +31176,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Zp,
-interShardScout: Zp,
+interShardClaimer: zp,
+interShardScout: zp,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31561,8 +31253,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return af(e);
-if (of(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return rf(e);
+if (ef(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31603,7 +31295,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return nf(t) - nf(e);
+return tf(t) - tf(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31623,7 +31315,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : af(e);
+} : rf(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31712,9 +31404,9 @@ type: "idle"
 }
 };
 
-function cf(e, t) {
+function nf(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : of(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : ef(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31722,26 +31414,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function uf(e) {
+function af(e) {
 var t;
-return (null !== (t = sf[e.memory.role]) && void 0 !== t ? t : tf)(e);
+return (null !== (t = of[e.memory.role]) && void 0 !== t ? t : Jp)(e);
 }
 
-function lf(e) {
-var t = Gu(e);
-Ol(e, Pl(t, Rd, {
-interrupt: Td
+function sf(e) {
+var t = Iu(e);
+bl(e, Nl(t, hd, {
+interrupt: Ed
 }), t);
 }
 
-function mf(e) {
-var t = Gu(e);
-Ol(e, Pl(t, uf, {
-interrupt: cf
+function cf(e) {
+var t = Iu(e);
+bl(e, Nl(t, af, {
+interrupt: nf
 }), t);
 }
 
-function df(e) {
+function uf(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31782,8 +31474,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && ap.has(i) && V(s))) {
-rp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && rp.has(i) && V(s))) {
+$d.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31794,16 +31486,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && Fu.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && Du.moveTo(e, t.target);
 break;
 
 case "moveTo":
-Fu.moveTo(e, t.target);
+Du.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-Fu.moveTo(e, {
+Du.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -31812,11 +31504,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && Fu.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && Du.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && Fu.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && Du.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -31848,7 +31540,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !op(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !ep(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31858,7 +31550,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !op(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !ep(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31869,7 +31561,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !op(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !ep(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -31922,7 +31614,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !op(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !ep(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -31964,7 +31656,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !op(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !ep(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -31974,7 +31666,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !op(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !ep(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -31982,7 +31674,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && j(e.room).length > 0) {
 var o = je(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !op(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !ep(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -31994,7 +31686,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !op(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !ep(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32002,12 +31694,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !op(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !ep(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !op(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !ep(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32041,58 +31733,58 @@ roomName: e.homeRoom
 }(t));
 }
 
-function pf(e) {
+function lf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var ff = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), yf = -1, vf = Object.create(null);
+var mf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), df = -1, pf = Object.create(null);
 
-function gf(e) {
+function ff(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var hf = {
-harvester: ha.CRITICAL,
-queenCarrier: ha.CRITICAL,
-hauler: ha.HIGH,
-guard: ha.HIGH,
-healer: ha.HIGH,
-soldier: ha.HIGH,
-ranger: ha.HIGH,
-siegeUnit: ha.HIGH,
-harasser: ha.HIGH,
-powerQueen: ha.HIGH,
-powerWarrior: ha.HIGH,
-larvaWorker: ha.HIGH,
-pioneer: ha.HIGH,
-interShardPioneer: ha.HIGH,
-interShardClaimer: ha.HIGH,
-interShardScout: ha.HIGH,
-builder: ha.MEDIUM,
-upgrader: ha.MEDIUM,
-interRoomCarrier: ha.MEDIUM,
-scout: ha.MEDIUM,
-claimer: ha.MEDIUM,
-engineer: ha.MEDIUM,
-remoteHarvester: ha.MEDIUM,
-powerHarvester: ha.MEDIUM,
-powerCarrier: ha.MEDIUM,
-remoteHauler: ha.LOW,
-remoteWorker: ha.LOW,
-linkManager: ha.LOW,
-terminalManager: ha.LOW,
-mineralHarvester: ha.LOW,
-labTech: ha.IDLE,
-factoryWorker: ha.IDLE
+var yf = {
+harvester: Ma.CRITICAL,
+queenCarrier: Ma.CRITICAL,
+hauler: Ma.HIGH,
+guard: Ma.HIGH,
+healer: Ma.HIGH,
+soldier: Ma.HIGH,
+ranger: Ma.HIGH,
+siegeUnit: Ma.HIGH,
+harasser: Ma.HIGH,
+powerQueen: Ma.HIGH,
+powerWarrior: Ma.HIGH,
+larvaWorker: Ma.HIGH,
+pioneer: Ma.HIGH,
+interShardPioneer: Ma.HIGH,
+interShardClaimer: Ma.HIGH,
+interShardScout: Ma.HIGH,
+builder: Ma.MEDIUM,
+upgrader: Ma.MEDIUM,
+interRoomCarrier: Ma.MEDIUM,
+scout: Ma.MEDIUM,
+claimer: Ma.MEDIUM,
+engineer: Ma.MEDIUM,
+remoteHarvester: Ma.MEDIUM,
+powerHarvester: Ma.MEDIUM,
+powerCarrier: Ma.MEDIUM,
+remoteHauler: Ma.LOW,
+remoteWorker: Ma.LOW,
+linkManager: Ma.LOW,
+terminalManager: Ma.LOW,
+mineralHarvester: Ma.LOW,
+labTech: Ma.IDLE,
+factoryWorker: Ma.IDLE
 };
 
-function Rf(e) {
+function vf(e) {
 var t;
-return null !== (t = hf[e]) && void 0 !== t ? t : ha.MEDIUM;
+return null !== (t = yf[e]) && void 0 !== t ? t : Ma.MEDIUM;
 }
 
-function Ef(e) {
+function gf(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32108,30 +31800,30 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && gf(o) === e && t++;
+o && ff(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (yf !== Game.time && (yf = Game.time, vf = function() {
+}(e) : null !== (r = (df !== Game.time && (df = Game.time, pf = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = gf(o);
+var n = ff(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), vf)[e]) && void 0 !== r ? r : 0;
+}()), pf)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Ue().cpu.disableCreepBootstrapCountCache
 });
-if (o && Game.time % 50 == 0 && Ci.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
+if (o && Game.time % 50 == 0 && Ti.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
 subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!ff.has(t.role)) return !1;
+if (!mf.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32141,7 +31833,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !pf(r)) return !1;
+if (!r || !lf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32155,7 +31847,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !pf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !lf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32163,7 +31855,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !pf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !lf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32171,7 +31863,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !pf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !lf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32179,7 +31871,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && pf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && lf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32195,7 +31887,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !pf(r)) return !1;
+if (!r || !lf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32230,41 +31922,41 @@ var t;
 return null !== (t = e.memory.family) && void 0 !== t ? t : "economy";
 }(e), i = t.role;
 try {
-Ji.measureSubsystem("role:".concat(i), function() {
+Zi.measureSubsystem("role:".concat(i), function() {
 switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = Gu(e);
-Ol(e, Pl(t, Rd, {
-interrupt: Td
+var t = Iu(e);
+bl(e, Nl(t, hd, {
+interrupt: Ed
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = Gu(e);
-Ol(e, Pl(t, tp), t);
+var t = Iu(e);
+bl(e, Nl(t, Jd), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = Gu(e);
-Ol(e, Pl(t, uf), t);
+var t = Iu(e);
+bl(e, Nl(t, af), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = Gu(e);
-Ol(e, Pl(t, sp), t);
+var t = Iu(e);
+bl(e, Nl(t, np), t);
 }(e);
 }
 });
 } catch (t) {
-Ci.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
+Ti.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
 subsystem: "CreepProcessManager",
 creep: e.name,
 meta: {
@@ -32280,7 +31972,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var Tf = function() {
+var hf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32309,7 +32001,7 @@ if (e) throw e.error;
 }
 }
 var d = s < 5;
-(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && Ci.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
+(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && Ti.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
 subsystem: "CreepProcessManager",
 meta: {
 activeCreeps: r.size,
@@ -32321,8 +32013,8 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Rf(r), n = "creep:".concat(e.name);
-Ja.registerProcess({
+var t = e.memory, r = t.role, o = vf(r), n = "creep:".concat(e.name);
+Za.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
 priority: o,
@@ -32337,14 +32029,14 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Ef(t);
+t && !t.spawning && gf(t);
 }
-}), this.registeredCreeps.add(e.name), Ci.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
+}), this.registeredCreeps.add(e.name), Ti.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.unregisterCreepProcess = function(e) {
 var t = "creep:".concat(e);
-Ja.unregisterProcess(t), this.registeredCreeps.delete(e), Ci.info("Unregistered creep process: ".concat(e), {
+Za.unregisterProcess(t), this.registeredCreeps.delete(e), Ti.info("Unregistered creep process: ".concat(e), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.getMinBucketForRole = function(e, t) {
@@ -32353,16 +32045,16 @@ if ("upgrader" === s.role) {
 var c = null !== (r = Game.rooms[s.homeRoom]) && void 0 !== r ? r : e.room;
 if ((null === (o = null == c ? void 0 : c.controller) || void 0 === o ? void 0 : o.my) && c.controller.level <= 2) return 0;
 }
-return t >= ha.HIGH ? 0 : t === ha.MEDIUM || t === ha.LOW ? a : t === ha.IDLE ? i : 0;
+return t >= Ma.HIGH ? 0 : t === Ma.MEDIUM || t === Ma.LOW ? a : t === Ma.IDLE ? i : 0;
 }, e.prototype.getCpuBudgetForPriority = function(e) {
-return e >= ha.CRITICAL ? .012 : e >= ha.HIGH ? .01 : e >= ha.MEDIUM ? .008 : .006;
+return e >= Ma.CRITICAL ? .012 : e >= Ma.HIGH ? .01 : e >= Ma.MEDIUM ? .008 : .006;
 }, e.prototype.getStats = function() {
 var e, t, r, o, n = {};
 try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Rf(u.memory.role), m = null !== (r = ha[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = vf(u.memory.role), m = null !== (r = Ma[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32387,20 +32079,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), Cf = new Tf;
+}(), Rf = new hf;
 
-function Sf(e) {
+function Ef(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, wf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, Tf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function wf(e) {
+function Tf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function xf(e) {
+function Cf(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32413,14 +32105,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function bf(e, t) {
+function Sf(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var Of = {
+var wf = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32448,11 +32140,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function Af(e, t) {
+function xf(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function kf(e) {
+function bf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32462,9 +32154,9 @@ tick: Game.time
 }, a;
 }
 
-var Mf = [ "defense", "war", "expand", "siege" ];
+var Of = [ "defense", "war", "expand", "siege" ];
 
-function Uf(e) {
+function kf(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32477,11 +32169,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function _f(e, t, r) {
-t >= 2 && (e.pheromones.war = Af(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Af(e.pheromones.siege + 20, r));
+function Af(e, t, r) {
+t >= 2 && (e.pheromones.war = xf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = xf(e.pheromones.siege + 20, r));
 }
 
-var Nf = function() {
+var Mf = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32496,27 +32188,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), Pf = function() {
+}(), Uf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Of), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, wf), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new Nf(10),
-energySpawning: new Nf(10),
-energyConstruction: new Nf(10),
-energyRepair: new Nf(10),
-energyTower: new Nf(10),
-controllerProgress: new Nf(10),
-hostileCount: new Nf(5),
-damageReceived: new Nf(5),
-idleWorkers: new Nf(10),
+energyHarvested: new Mf(10),
+energySpawning: new Mf(10),
+energyConstruction: new Mf(10),
+energyRepair: new Mf(10),
+energyTower: new Mf(10),
+controllerProgress: new Mf(10),
+hostileCount: new Mf(5),
+damageReceived: new Mf(5),
+idleWorkers: new Mf(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = kf(e);
+var o = bf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32589,7 +32281,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = Af(e[s] * c, t);
+e[s] = xf(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32605,43 +32297,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = kf(t);
+var o = bf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = Af(e.harvest + n / 3e3 * 10, r);
+e.harvest = xf(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = Af(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = xf(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = Af(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = xf(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = Af(e.defense + 10 * o, r));
+o > 0 && (e.defense = xf(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = Af(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Af(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = xf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = xf(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = Af(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = xf(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = Af(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = xf(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Af(e.pheromones.defense + 5 * t, o), _f(e, r, o),
+e.danger = r, e.pheromones.defense = xf(e.pheromones.defense + 5 * t, o), Af(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32649,7 +32341,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Af(t / 10, o), _f(e, r, o);
+e.danger = r, e.pheromones.defense = xf(t / 10, o), Af(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32662,8 +32354,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = Af(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = Af(f + y, o);
+var p = xf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = xf(f + y, o);
 }
 }
 }
@@ -32682,18 +32374,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = Af(e.pheromones.defense + 5, r), e.pheromones.build = Af(e.pheromones.build + 10, r),
+e.pheromones.defense = xf(e.pheromones.defense + 5, r), e.pheromones.build = xf(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Af(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = xf(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = Af(e.pheromones.siege + 50, t), e.pheromones.defense = Af(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = xf(e.pheromones.siege + 50, t), e.pheromones.defense = xf(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = Af(e.pheromones.expand - 10, t), e.pheromones.defense = Af(e.pheromones.defense + 5, t);
+e.pheromones.expand = xf(e.pheromones.expand - 10, t), e.pheromones.defense = xf(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32703,10 +32395,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Uf(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(kf(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Mf)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(Of)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32760,7 +32452,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = Af(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = xf(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32795,7 +32487,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), If = new Pf, Gf = {
+}(), _f = new Uf, Nf = {
 seedNest: {
 rcl: 1
 },
@@ -32836,7 +32528,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, Lf = {
+}, Pf = {
 eco: {
 economy: .75,
 military: .05,
@@ -32879,7 +32571,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Df = {
+}, If = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -32936,13 +32628,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Ff = function() {
+}, Gf = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Gf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Gf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Gf.fortifiedHive.rcl ? "fortifiedHive" : s >= Gf.matureColony.rcl ? "matureColony" : s >= Gf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Nf.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Nf.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Nf.fortifiedHive.rcl ? "fortifiedHive" : s >= Nf.matureColony.rcl ? "matureColony" : s >= Nf.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Fe.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -32977,7 +32669,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Gf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Nf[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -32990,7 +32682,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Bf = function() {
+}(), Lf = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33003,7 +32695,7 @@ var n = e.posture, a = null != r ? r : e.role;
 return U.info("Posture change: ".concat(n, " -> ").concat(o), {
 room: a,
 subsystem: "Posture"
-}), e.posture = o, Ja.emit("posture.change", {
+}), e.posture = o, Za.emit("posture.change", {
 roomName: a,
 oldPosture: n,
 newPosture: o,
@@ -33012,9 +32704,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return Lf[e];
+return Pf[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return Df[e];
+return If[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33024,15 +32716,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Wf = new Ff, Hf = new Bf;
+}(), Df = new Gf, Ff = new Lf;
 
-function Kf(e) {
+function Bf(e) {
 return !Y(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Yf(e, t, r) {
+function Wf(e, t, r) {
 if (!e) return null;
 var o = mr.getEmpire();
 if (Y(e, {
@@ -33071,11 +32763,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Vf() {
+function Kf() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var qf = new Map, jf = function() {
+var Hf = new Map, Yf = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = j(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33211,7 +32903,7 @@ if (r) throw r.error;
 }(n, c), c;
 var n, c;
 }, e.prototype.getDefensePostureSnapshot = function(e, t, r, o) {
-var n, a = t.clusterId ? mr.getCluster(t.clusterId) : null, i = o.length > 0 ? Hr(e) : void 0, s = Game.time % 10 == 0 ? e.find(FIND_NUKES) : [];
+var n, a = t.clusterId ? mr.getCluster(t.clusterId) : null, i = o.length > 0 ? Kr(e) : void 0, s = Game.time % 10 == 0 ? e.find(FIND_NUKES) : [];
 return {
 roomName: e.name,
 time: Game.time,
@@ -33219,7 +32911,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: qf.get(e.name),
+previousStructures: Hf.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33249,7 +32941,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && qf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Hf.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33258,7 +32950,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Kf(u) && o.add(u.owner.username);
+Bf(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33272,7 +32964,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Yf(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Wf(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33288,7 +32980,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? If.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? If.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && If.onNukeDetected(t);
+"danger" === y.type ? _f.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? _f.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && _f.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33338,7 +33030,7 @@ case "hostile.detected":
 case "hostile.cleared":
 case "structure.destroyed":
 case "nuke.detected":
-Ja.emit(e.type, e.payload);
+Za.emit(e.type, e.payload);
 }
 }, e.prototype.runTowerControl = function(e, t, r) {
 var o, n, i, s;
@@ -33348,16 +33040,16 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Vf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = Kf()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Vf()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = Kf()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
 if (!(O.store.getUsedCapacity(RESOURCE_ENERGY) < 10)) {
-var A = io({
+var k = ao({
 tower: O,
 hostiles: f,
 posture: y,
@@ -33369,10 +33061,10 @@ bucket: C,
 preferWoundedTargets: E,
 allowSiegeHealing: T
 });
-(S || "heal" !== A.type && "repair" !== A.type) && "idle" !== A.type && w.push({
+(S || "heal" !== k.type && "repair" !== k.type) && "idle" !== k.type && w.push({
 tower: O,
-type: A.type,
-target: A.target
+type: k.type,
+target: k.target
 });
 }
 }
@@ -33394,8 +33086,8 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Hf.isCombatPosture(t.posture),
-wallRepairTarget: so(u, t.danger),
+isCombatPosture: Ff.isCombatPosture(t.posture),
+wallRepairTarget: io(u, t.danger),
 bucket: Game.cpu.bucket
 });
 try {
@@ -33418,27 +33110,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), zf = new jf, Qf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Vf = new Yf, qf = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Xf() {
+function jf() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Zf(e, t, r, o) {
+function zf(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Xf()
+selectedAt: jf()
 });
 }
 
-function Jf(e) {
+function Qf(e) {
 return e >= 2 && e <= 3;
 }
 
-function $f(e, t) {
+function Xf(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33451,7 +33143,7 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-function ey(e, t) {
+function Zf(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -33465,10 +33157,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var ty = function() {
+var Jf = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Jf(e) ? 5 : 10;
+return Qf(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33488,15 +33180,15 @@ var n;
 void 0 === r && (r = {});
 var a = Ko(null != t ? t : e.rcl), c = function(e) {
 var t, r, o;
-if (e.anchor) return Qn(e.anchor);
+if (e.anchor) return jn(e.anchor);
 var n = null === (t = e.existingStructures) || void 0 === t ? void 0 : t.find(function(e) {
-return e.structureType === No;
+return e.structureType === _o;
 });
-if (n) return Qn(n);
+if (n) return jn(n);
 var a = null === (r = e.existingStructures) || void 0 === r ? void 0 : r.find(function(e) {
-return e.structureType === Oo;
+return e.structureType === bo;
 });
-if (a) return Qn({
+if (a) return jn({
 x: a.x + 2,
 y: a.y
 });
@@ -33514,7 +33206,7 @@ y: e.y + t.y
 x: 0,
 y: 0
 });
-return Qn({
+return jn({
 x: u.x / c.length,
 y: u.y / c.length
 });
@@ -33531,7 +33223,7 @@ ramparts: [],
 unplaced: [],
 errors: [],
 stamps: [],
-version: jn
+version: Vn
 };
 return {
 facts: o(o({}, e), {
@@ -33539,21 +33231,21 @@ rcl: a
 }),
 plan: u,
 counts: {},
-limits: Yo(a),
-targets: Vo(a),
+limits: Ho(a),
+targets: Yo(a),
 occupied: new Set,
 roadKeys: new Set,
 rampartKeys: new Set
 };
 }(e, t, r);
-ta(c, c.facts.existingStructures, "existing-structure"), ta(c, c.facts.existingConstructionSites, "existing-site");
+$n(c, c.facts.existingStructures, "existing-structure"), $n(c, c.facts.existingConstructionSites, "existing-site");
 var u = [];
 u.push.apply(u, s([], i(function(e) {
 var t, r, o, n = [];
 try {
 for (var c = a(null !== (o = e.facts.sources) && void 0 !== o ? o : []), u = c.next(); !u.done; u = c.next()) {
-var l = sa(e, u.value, e.plan.anchor);
-l && (aa(e, _n, l), ia(e, e.plan.anchor, l, "SOURCE_MINING:path", 1));
+var l = aa(e, u.value, e.plan.anchor);
+l && (oa(e, Un, l), na(e, e.plan.anchor, l, "SOURCE_MINING:path", 1));
 }
 } catch (e) {
 t = {
@@ -33567,17 +33259,17 @@ if (t) throw t.error;
 }
 }
 if (e.facts.controller) {
-var m = sa(e, e.facts.controller, e.plan.anchor);
+var m = aa(e, e.facts.controller, e.plan.anchor);
 if (m) {
-var d = aa(e, Nn, m);
-n.push.apply(n, s([], i(d.missing), !1)), ia(e, e.plan.anchor, m, "CONTROLLER_STAMP:path", 1);
+var d = oa(e, _n, m);
+n.push.apply(n, s([], i(d.missing), !1)), na(e, e.plan.anchor, m, "CONTROLLER_STAMP:path", 1);
 }
 }
-return e.facts.mineral && e.plan.rcl >= 6 && (d = aa(e, Ln, e.facts.mineral), n.push.apply(n, s([], i(d.missing), !1)),
-ia(e, e.plan.anchor, e.facts.mineral, "MINERAL_STAMP:path", 6)), n;
+return e.facts.mineral && e.plan.rcl >= 6 && (d = oa(e, Gn, e.facts.mineral), n.push.apply(n, s([], i(d.missing), !1)),
+na(e, e.plan.anchor, e.facts.mineral, "MINERAL_STAMP:path", 6)), n;
 }(c)), !1)), u.push.apply(u, s([], i(function(e) {
 var t, r, o, n = [];
-n.push.apply(n, s([], i(aa(e, Un, e.plan.anchor).missing), !1));
+n.push.apply(n, s([], i(oa(e, Mn, e.plan.anchor).missing), !1));
 try {
 for (var c = a([ {
 x: (o = e.plan.anchor).x - 6,
@@ -33598,7 +33290,7 @@ y: o.y - 6
 x: o.x + 6,
 y: o.y + 6
 } ]), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = aa(e, Mn, l);
+var l = u.value, m = oa(e, An, l);
 n.push.apply(n, s([], i(m.missing), !1));
 }
 } catch (e) {
@@ -33612,13 +33304,13 @@ u && !u.done && (r = c.return) && r.call(c);
 if (t) throw t.error;
 }
 }
-return n.push.apply(n, s([], i(aa(e, Pn, {
+return n.push.apply(n, s([], i(oa(e, Nn, {
 x: e.plan.anchor.x + 4,
 y: e.plan.anchor.y + 1
-}).missing), !1)), n.push.apply(n, s([], i(aa(e, In, {
+}).missing), !1)), n.push.apply(n, s([], i(oa(e, Pn, {
 x: e.plan.anchor.x + 4,
 y: e.plan.anchor.y - 3
-}).missing), !1)), n.push.apply(n, s([], i(aa(e, Gn, {
+}).missing), !1)), n.push.apply(n, s([], i(oa(e, In, {
 x: e.plan.anchor.x,
 y: e.plan.anchor.y + 4
 }).missing), !1)), n;
@@ -33627,7 +33319,7 @@ var r, o, n, c, u, l = s([], i(t), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 try {
-for (var m = a(l), d = m.next(); !d.done; d = m.next()) oa(e, g = d.value) && ca(e, g);
+for (var m = a(l), d = m.next(); !d.done; d = m.next()) ta(e, g = d.value) && ia(e, g);
 } catch (e) {
 r = {
 error: e
@@ -33640,14 +33332,14 @@ if (r) throw r.error;
 }
 }
 try {
-for (var p = a(Ho), f = p.next(); !f.done; f = p.next()) for (var y = f.value, v = null !== (u = e.targets[y]) && void 0 !== u ? u : 0; Zn(e, y) < v; ) {
+for (var p = a(Wo), f = p.next(); !f.done; f = p.next()) for (var y = f.value, v = null !== (u = e.targets[y]) && void 0 !== u ? u : 0; Qn(e, y) < v; ) {
 var g;
-if (!ca(e, g = {
+if (!ia(e, g = {
 structureType: y,
 priority: 100,
-fallback: ua(y),
+fallback: sa(y),
 reason: "target count not met by preferred stamps",
-localAnchor: y === Go ? e.facts.mineral : e.plan.anchor,
+localAnchor: y === Io ? e.facts.mineral : e.plan.anchor,
 minRcl: e.plan.rcl
 })) {
 e.plan.unplaced.push(g), e.plan.errors.push({
@@ -33672,12 +33364,12 @@ if (n) throw n.error;
 }
 }(c, u);
 var l = function(e, t) {
-var r, o, n, i, s, c, u, l, m, d, p, f = Yo(t.rcl), y = Vo(t.rcl), v = {}, g = [], h = new Set;
+var r, o, n, i, s, c, u, l, m, d, p, f = Ho(t.rcl), y = Yo(t.rcl), v = {}, g = [], h = new Set;
 try {
 for (var R = a(t.structures), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 v[T.structureType] = (null !== (u = v[T.structureType]) && void 0 !== u ? u : 0) + 1,
-Fn(e, T.x, T.y) || g.push({
+Dn(e, T.x, T.y) || g.push({
 type: "TERRAIN_WALL",
 structureType: T.structureType,
 x: T.x,
@@ -33708,11 +33400,11 @@ if (r) throw r.error;
 }
 try {
 for (var S = a(Object.keys(v)), w = S.next(); !w.done; w = S.next()) {
-var x = null !== (l = v[k = w.value]) && void 0 !== l ? l : 0, b = null !== (m = f[k]) && void 0 !== m ? m : 0;
+var x = null !== (l = v[A = w.value]) && void 0 !== l ? l : 0, b = null !== (m = f[A]) && void 0 !== m ? m : 0;
 x > b && g.push({
 type: "RCL_LIMIT_EXCEEDED",
-structureType: k,
-reason: "".concat(k, " count ").concat(x, " exceeds RCL").concat(t.rcl, " limit ").concat(b),
+structureType: A,
+reason: "".concat(A, " count ").concat(x, " exceeds RCL").concat(t.rcl, " limit ").concat(b),
 rcl: t.rcl
 });
 }
@@ -33728,12 +33420,12 @@ if (n) throw n.error;
 }
 }
 try {
-for (var O = a(Object.keys(y)), A = O.next(); !A.done; A = O.next()) {
-var k, M = null !== (d = y[k = A.value]) && void 0 !== d ? d : 0;
-(x = null !== (p = v[k]) && void 0 !== p ? p : 0) < M && g.push({
+for (var O = a(Object.keys(y)), k = O.next(); !k.done; k = O.next()) {
+var A, M = null !== (d = y[A = k.value]) && void 0 !== d ? d : 0;
+(x = null !== (p = v[A]) && void 0 !== p ? p : 0) < M && g.push({
 type: "UNPLACEABLE_STRUCTURE",
-structureType: k,
-reason: "".concat(k, " count ").concat(x, " below RCL").concat(t.rcl, " target ").concat(M),
+structureType: A,
+reason: "".concat(A, " count ").concat(x, " below RCL").concat(t.rcl, " target ").concat(M),
 rcl: t.rcl
 });
 }
@@ -33743,7 +33435,7 @@ error: e
 };
 } finally {
 try {
-A && !A.done && (c = O.return) && c.call(O);
+k && !k.done && (c = O.return) && c.call(O);
 } finally {
 if (s) throw s.error;
 }
@@ -33769,7 +33461,7 @@ var l = e.getTerrain(), m = [], d = [];
 try {
 for (var p = a(e.find(FIND_STRUCTURES)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-la(y.structureType) && m.push({
+ca(y.structureType) && m.push({
 x: y.pos.x,
 y: y.pos.y,
 structureType: y.structureType
@@ -33838,7 +33530,7 @@ y: g.y
 } : {});
 v = new RoomPosition(h.anchor.x, h.anchor.y, e.name);
 var R, E = (R = h, {
-name: "".concat(jn, "-rcl-").concat(R.rcl),
+name: "".concat(Vn, "-rcl-").concat(R.rcl),
 rcl: R.rcl,
 anchor: {
 x: R.anchor.x,
@@ -33866,16 +33558,16 @@ y: e.y - R.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Zf(t, v, E.name, f);
+zf(t, v, E.name, f);
 var T = f >= 3 && (t.danger >= 1 || function(e, t) {
-var r = ey(STRUCTURE_TOWER, t);
-return r > 0 && $f(e, STRUCTURE_TOWER) < r;
+var r = Zf(STRUCTURE_TOWER, t);
+return r > 0 && Xf(e, STRUCTURE_TOWER) < r;
 }(e, f)), C = T ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = ey(STRUCTURE_TOWER, g), R = $f(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Zf(STRUCTURE_TOWER, g), R = Xf(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -33908,7 +33600,7 @@ b && !b.done && (s = x.return) && s.call(x);
 if (i) throw i.error;
 }
 }
-var A = fa(t, {
+var k = da(t, {
 existingStructureKeys: E,
 existingSiteKeys: T,
 currentRcl: g
@@ -33917,21 +33609,21 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_RAMP
 }).sort(function(e, t) {
 return e.structureType === STRUCTURE_TOWER && t.structureType !== STRUCTURE_TOWER ? -1 : t.structureType === STRUCTURE_TOWER && e.structureType !== STRUCTURE_TOWER ? 1 : t.score - e.score;
 });
-if (R < h && !A.some(function(e) {
+if (R < h && !k.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
 })) {
-var k = e.find(FIND_MY_SPAWNS)[0], M = null !== (p = null == k ? void 0 : k.pos) && void 0 !== p ? p : null === (f = e.controller) || void 0 === f ? void 0 : f.pos;
-if (M) for (var U = e.getTerrain(), _ = 1; _ <= 4 && !A.some(function(e) {
+var A = e.find(FIND_MY_SPAWNS)[0], M = null !== (p = null == A ? void 0 : A.pos) && void 0 !== p ? p : null === (f = e.controller) || void 0 === f ? void 0 : f.pos;
+if (M) for (var U = e.getTerrain(), _ = 1; _ <= 4 && !k.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
-}); _++) for (var N = -_; N <= _ && !A.some(function(e) {
+}); _++) for (var N = -_; N <= _ && !k.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
-}); N++) for (var P = -_; P <= _ && !A.some(function(e) {
+}); N++) for (var P = -_; P <= _ && !k.some(function(e) {
 return e.structureType === STRUCTURE_TOWER;
 }); P++) {
 var I = M.x + N, G = M.y + P;
 if (!(I <= 1 || I >= 48 || G <= 1 || G >= 48) && U.get(I, G) !== TERRAIN_MASK_WALL) {
 var L = "".concat(STRUCTURE_TOWER, ":").concat(I, ",").concat(G);
-E.has(L) || T.has(L) || A.unshift({
+E.has(L) || T.has(L) || k.unshift({
 x: I,
 y: G,
 structureType: STRUCTURE_TOWER,
@@ -33945,7 +33637,7 @@ source: "critical-defense-fallback"
 }
 var D = 0;
 try {
-for (var F = a(A), B = F.next(); !B.done; B = F.next()) {
+for (var F = a(k), B = F.next(); !B.done; B = F.next()) {
 var W = B.value;
 if (D >= r || v + D >= y) break;
 e.createConstructionSite(W.x, W.y, W.structureType) === OK && D++;
@@ -33966,22 +33658,22 @@ return D;
 if (c.criticalOnly) t.metrics.constructionSites = p.length + C; else {
 var S = 0;
 f >= 5 && (S = function(e) {
-var t, r, o = Ro(e);
+var t, r, o = ho(e);
 if (0 === o.placements.length) return 0;
-var n = e.find(FIND_MY_CONSTRUCTION_SITES), c = ho(e), u = n.filter(function(e) {
+var n = e.find(FIND_MY_CONSTRUCTION_SITES), c = go(e), u = n.filter(function(e) {
 return e.structureType === STRUCTURE_LINK;
 }), l = c.length + u.length, m = 0, d = function(e, t) {
 return new Set(s(s([], i(e.map(function(e) {
-return vo(e.pos.x, e.pos.y);
+return yo(e.pos.x, e.pos.y);
 })), !1), i(t.map(function(e) {
-return vo(e.pos.x, e.pos.y);
+return yo(e.pos.x, e.pos.y);
 })), !1));
 }(c, u);
 try {
 for (var p = a(o.placements), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
 if (m >= 2 || l >= o.linkLimit) break;
-var v = vo(y.x, y.y);
+var v = yo(y.x, y.y);
 d.has(v) || e.createConstructionSite(y.x, y.y, STRUCTURE_LINK) === OK && (m += 1,
 l += 1, d.add(v));
 }
@@ -34005,7 +33697,7 @@ if (o.length >= 10) return 0;
 var n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f = function(e) {
 var t, r, o;
-return null !== (o = yo(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
+return null !== (o = fo(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
 }(e);
 if (f < 3) return null;
 var y = e.find(FIND_MY_STRUCTURES, {
@@ -34015,16 +33707,16 @@ return e.structureType === STRUCTURE_LAB;
 }), v = e.find(FIND_MY_CONSTRUCTION_SITES), g = v.filter(function(e) {
 return e.structureType === STRUCTURE_LAB;
 }), h = new Set(y.map(function(e) {
-return To(e.pos.x, e.pos.y);
+return Eo(e.pos.x, e.pos.y);
 })), R = new Set(g.map(function(e) {
-return To(e.pos.x, e.pos.y);
+return Eo(e.pos.x, e.pos.y);
 })), E = new Set(s(s([], i(h), !1), i(R), !1));
 if (E.size > f) return null;
 var T = e.find(FIND_STRUCTURES), C = new Set;
 try {
 for (var S = a(T), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-So(x, h) && C.add(To(x.pos.x, x.pos.y));
+Co(x, h) && C.add(Eo(x.pos.x, x.pos.y));
 }
 } catch (e) {
 t = {
@@ -34039,8 +33731,8 @@ if (t) throw t.error;
 }
 try {
 for (var b = a(v), O = b.next(); !O.done; O = b.next()) {
-var A = O.value;
-wo(A, R) && C.add(To(A.pos.x, A.pos.y));
+var k = O.value;
+So(k, R) && C.add(Eo(k.pos.x, k.pos.y));
 }
 } catch (e) {
 o = {
@@ -34053,7 +33745,7 @@ O && !O.done && (n = b.return) && n.call(b);
 if (o) throw o.error;
 }
 }
-var k = function(e) {
+var A = function(e) {
 var t, r, o = e.find(FIND_MY_SPAWNS)[0], n = null !== (r = null !== (t = e.terminal) && void 0 !== t ? t : e.storage) && void 0 !== r ? r : o;
 return n ? {
 x: n.pos.x,
@@ -34081,11 +33773,11 @@ y: e.storage.pos.y
 } : void 0, e.find(FIND_MY_SPAWNS)[0] ? {
 x: e.find(FIND_MY_SPAWNS)[0].pos.x,
 y: e.find(FIND_MY_SPAWNS)[0].pos.y
-} : void 0, k ], !1).filter(function(e) {
+} : void 0, A ], !1).filter(function(e) {
 return void 0 !== e;
 });
 try {
-for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) xo(M, e, P.x + I, P.y + G, k, h, R, C);
+for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) wo(M, e, P.x + I, P.y + G, A, h, R, C);
 } catch (e) {
 c = {
 error: e
@@ -34121,18 +33813,18 @@ return void 0 !== e;
 }), o = s([], i(e.values()), !1).filter(function(e) {
 return !t.has(e.key);
 }).sort(function(e, t) {
-var o = bo(e, r) - bo(t, r);
+var o = xo(e, r) - xo(t, r);
 return 0 !== o ? o : e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
 });
 return s(s([], i(r), !1), i(o), !1).slice(0, 80);
 }(M, E);
 if (B.length < f) return null;
-var W = B.slice(0, 40), H = null, K = function(e) {
+var W = B.slice(0, 40), K = null, H = function(e) {
 var t, r, o = function(t) {
 var r, o, n, c;
 if (e.key === t.key) return "continue";
 var u = B.filter(function(r) {
-return r.key === e.key || r.key === t.key || Co(r, e) <= 2 && Co(r, t) <= 2;
+return r.key === e.key || r.key === t.key || To(r, e) <= 2 && To(r, t) <= 2;
 });
 if (u.length < f) return "continue";
 if (s([], i(E), !1).some(function(e) {
@@ -34188,9 +33880,9 @@ return e.existingLab;
 return e.existingSite;
 }).length - e.reduce(function(e, t) {
 return e + t.distanceToHub;
-}, 0) - 5 * Co(t, r);
+}, 0) - 5 * To(t, r);
 }(T, e, t);
-(!H || C > H.score) && (H = {
+(!K || C > K.score) && (K = {
 positions: T,
 score: C
 });
@@ -34210,7 +33902,7 @@ if (t) throw t.error;
 }
 };
 try {
-for (var Y = a(W), V = Y.next(); !V.done; V = Y.next()) K(V.value);
+for (var Y = a(W), V = Y.next(); !V.done; V = Y.next()) H(V.value);
 } catch (e) {
 d = {
 error: e
@@ -34222,15 +33914,15 @@ V && !V.done && (p = Y.return) && p.call(Y);
 if (d) throw d.error;
 }
 }
-if (!H) return null;
-var q = H.positions.filter(function(e) {
+if (!K) return null;
+var q = K.positions.filter(function(e) {
 return e.existingLab;
-}).length, j = H.positions.filter(function(e) {
+}).length, j = K.positions.filter(function(e) {
 return e.existingSite;
 }).length;
 return {
 desiredCount: f,
-positions: H.positions.map(function(e) {
+positions: K.positions.map(function(e) {
 return {
 x: e.x,
 y: e.y,
@@ -34268,11 +33960,11 @@ if (t) throw t.error;
 return c;
 }(e));
 var x = function(e, t) {
-var r, o, n, i = Vo(t);
+var r, o, n, i = Yo(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && $f(e, u) < l) return !0;
+if (!(l <= 0) && Xf(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34288,8 +33980,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + S + w + C >= 10 && !x) t.metrics.constructionSites = p.length + S + w + C; else {
-if (!Hf.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Xf());
+if (!Ff.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== jf());
 }(t, v)) {
 var b = function(e, t, r, o, n) {
 var i, s;
@@ -34297,7 +33989,7 @@ void 0 === n && (n = []);
 var c = function(e, t, r, o) {
 var n, i, s, c, u, l, m, d, p, f;
 void 0 === o && (o = []);
-var y = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 1, v = on(r, y), g = e.getTerrain(), h = [], R = new Map;
+var y = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 1, v = rn(r, y), g = e.getTerrain(), h = [], R = new Map;
 try {
 for (var E = a(v), T = E.next(); !T.done; T = E.next()) {
 var C = T.value, S = t.x + C.x, w = t.y + C.y;
@@ -34317,24 +34009,24 @@ T && !T.done && (i = E.return) && i.call(E);
 if (n) throw n.error;
 }
 }
-var b = On(e, t, r.roads, o);
+var b = bn(e, t, r.roads, o);
 if (R.set(STRUCTURE_ROAD, b), y >= 6) {
 var O = e.find(FIND_MINERALS);
 if (O.length > 0) {
-var A = O[0], k = new Set;
-k.add("".concat(A.pos.x, ",").concat(A.pos.y)), R.set(STRUCTURE_EXTRACTOR, k);
+var k = O[0], A = new Set;
+A.add("".concat(k.pos.x, ",").concat(k.pos.y)), R.set(STRUCTURE_EXTRACTOR, A);
 }
 }
 var M = function(e) {
 var t, r, o = function(e) {
-return new Set(Ro(e).placements.map(function(e) {
-return vo(e.x, e.y);
+return new Set(ho(e).placements.map(function(e) {
+return yo(e.x, e.y);
 }));
 }(e);
 try {
-for (var n = a(ho(e)), i = n.next(); !i.done; i = n.next()) {
+for (var n = a(go(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Eo(e, s) && o.add(vo(s.pos.x, s.pos.y));
+Ro(e, s) && o.add(yo(s.pos.x, s.pos.y));
 }
 } catch (e) {
 t = {
@@ -34424,7 +34116,7 @@ var O = 1 === b ? "structure" : "structures";
 mr.addRoomEvent(e.name, "structureDestroyed", "".concat(b, " misplaced ").concat(O, " destroyed for blueprint compliance"));
 }
 }
-var A = function(e) {
+var k = function(e) {
 if (e.danger >= 1) return {
 allowPerimeter: !0,
 allowRamparts: !0
@@ -34439,7 +34131,7 @@ rcl: f,
 danger: t.danger,
 hasStorage: Boolean(e.storage),
 remoteAssignments: null !== (d = t.remoteAssignments) && void 0 !== d ? d : []
-}), k = {
+}), A = {
 sitesPlaced: 0,
 wallsRemoved: 0
 };
@@ -34447,17 +34139,17 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Qf.has(e.structureType);
+return qf.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
-allowPerimeter: A.allowPerimeter,
+allowPerimeter: k.allowPerimeter,
 rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = Jf(f) ? 2 : 3;
-(k = function(e, t, r, o, n, c) {
+var M = Qf(f) ? 2 : 3;
+(A = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
 sitesPlaced: 0,
@@ -34466,7 +34158,7 @@ wallsRemoved: 0
 var y = function(e, t, r, o) {
 var n, c, u, l;
 void 0 === o && (o = []);
-var m = On(e, t, r, o), d = function(e) {
+var m = bn(e, t, r, o), d = function(e) {
 var t, r, o, n, c, u, l, m = Game.map.getRoomTerrain(e), d = [], p = [], f = new Set, y = function(e, t, r) {
 if (!(e < 1 || e > 48 || t < 1 || t > 48) && m.get(e, t) !== TERRAIN_MASK_WALL) {
 var o = "".concat(e, ",").concat(t);
@@ -34558,13 +34250,13 @@ try {
 for (var C = a(h), S = C.next(); !S.done; S = C.next()) {
 for (var w = i(S.value, 2), x = w[0], b = s([], i(w[1]), !1).sort(function(e, t) {
 return e.x === t.x ? e.y - t.y : e.x - t.x;
-}), O = [], A = [], k = 0; k < b.length; k++) {
-T = b[k];
-var M = b[k - 1];
-!(M && Math.abs(T.x - M.x) <= 1 && Math.abs(T.y - M.y) <= 1) && A.length > 0 && (O.push(A),
-A = []), A.push(T);
+}), O = [], k = [], A = 0; A < b.length; A++) {
+T = b[A];
+var M = b[A - 1];
+!(M && Math.abs(T.x - M.x) <= 1 && Math.abs(T.y - M.y) <= 1) && k.length > 0 && (O.push(k),
+k = []), k.push(T);
 }
-A.length > 0 && O.push(A);
+k.length > 0 && O.push(k);
 try {
 for (var U = (c = void 0, a(O)), _ = U.next(); !_.done; _ = U.next()) {
 var N, P = (N = _.value)[0], I = N[N.length - 1];
@@ -34589,8 +34281,8 @@ for (L = 1; L <= 1; L++) y(47, P.y - L, x), y(47, I.y + L, x), y(48, P.y - L, x)
 y(48, I.y + L, x);
 }
 var D = Math.floor(N.length / 2);
-for (k = 0; k < N.length; k++) {
-var F = (T = N[k]).x, B = T.y;
+for (A = 0; A < N.length; A++) {
+var F = (T = N[A]).x, B = T.y;
 switch (x) {
 case "top":
 B = 2;
@@ -34607,7 +34299,7 @@ break;
 case "right":
 F = 47;
 }
-N.length >= 4 && k === D ? v(F, B, x) : y(F, B, x);
+N.length >= 4 && A === D ? v(F, B, x) : y(F, B, x);
 }
 }
 } catch (e) {
@@ -34726,7 +34418,7 @@ if (u) throw u.error;
 }
 }
 if (o >= 2 && h < E && T < S) {
-var A = function(t) {
+var k = function(t) {
 if (h >= E) return "break";
 if (T + h >= S) return "break";
 var r = g.some(function(e) {
@@ -34739,14 +34431,14 @@ subsystem: "Defense"
 }));
 };
 try {
-for (var k = a(y.walls), M = k.next(); !M.done && "break" !== A(M.value); M = k.next()) ;
+for (var A = a(y.walls), M = A.next(); !M.done && "break" !== k(M.value); M = A.next()) ;
 } catch (e) {
 m = {
 error: e
 };
 } finally {
 try {
-M && !M.done && (d = k.return) && d.call(k);
+M && !M.done && (d = A.return) && d.call(A);
 } finally {
 if (m) throw m.error;
 }
@@ -34790,7 +34482,7 @@ return {
 sitesPlaced: h,
 wallsRemoved: R
 };
-}(e, v, E.roads, f, M, t.remoteAssignments)).wallsRemoved > 0 && mr.addRoomEvent(e.name, "wallRemoved", "".concat(k.wallsRemoved, " wall(s) removed to allow road passage"));
+}(e, v, E.roads, f, M, t.remoteAssignments)).wallsRemoved > 0 && mr.addRoomEvent(e.name, "wallRemoved", "".concat(A.wallsRemoved, " wall(s) removed to allow road passage"));
 }
 var _ = function(e, t) {
 var r, o, n, i, s, c, u = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, l = "undefined" == typeof Game ? 0 : Object.keys(Game.constructionSites).length;
@@ -34833,7 +34525,7 @@ return {
 structures: i,
 sites: s
 };
-}(e), d = fa(t, {
+}(e), d = da(t, {
 existingStructureKeys: m.structures,
 existingSiteKeys: m.sites,
 currentRcl: null !== (i = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== i ? i : t.rcl
@@ -34862,19 +34554,19 @@ return p;
 }(e, h), N = function(e, t) {
 var r, o, n = e.find(FIND_MY_CONSTRUCTION_SITES);
 if (n.length >= 10) return 0;
-var i = hn(e, t), s = e.getTerrain(), c = function(e) {
+var i = gn(e, t), s = e.getTerrain(), c = function(e) {
 var t = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
 }
 });
 return new Set(t.map(function(e) {
-return dn(e.pos);
+return mn(e.pos);
 }));
 }(e), u = new Set(n.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
 }).map(function(e) {
-return dn(e.pos);
+return mn(e.pos);
 })), l = 0;
 try {
 for (var m = a(i.positions), d = m.next(); !d.done; d = m.next()) {
@@ -34882,7 +34574,7 @@ var p = d.value;
 if (l >= 2) break;
 if (n.length + l >= 10) break;
 if (!c.has(p) && !u.has(p)) {
-var f = pn(p), y = f.x, v = f.y;
+var f = dn(p), y = f.x, v = f.y;
 s.get(y, v) !== TERRAIN_MASK_WALL && e.createConstructionSite(y, v, STRUCTURE_ROAD) === OK && l++;
 }
 }
@@ -34901,7 +34593,7 @@ return l;
 }(e, v), P = {
 placed: 0
 };
-if (A.allowRamparts && f >= 2 && p.length < 9) {
+if (k.allowRamparts && f >= 2 && p.length < 9) {
 var I = t.danger >= 2 ? 3 : 2;
 (P = function(e, t, r, o) {
 var n, i, s, c;
@@ -34914,7 +34606,7 @@ protected: 0
 };
 if (t < 2) return u;
 var l = function(e, t) {
-var r = e.find(FIND_MY_STRUCTURES), o = t < 4 ? uo : co;
+var r = e.find(FIND_MY_STRUCTURES), o = t < 4 ? co : so;
 return r.filter(function(e) {
 return o.includes(e.structureType);
 });
@@ -34926,7 +34618,7 @@ var d = Math.min(o, 10 - m.length), p = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_RAMPART;
 }
-}), f = so(t, r), y = [], v = function(t) {
+}), f = io(t, r), y = [], v = function(t) {
 var o = t.pos, n = o.x, a = o.y;
 if (function(e, t, r) {
 return e.lookForAt(LOOK_STRUCTURES, t, r).some(function(e) {
@@ -34992,7 +34684,7 @@ subsystem: "Defense"
 }), u;
 }(e, f, t.danger, I)).placed > 0 && mr.addRoomEvent(e.name, "rampartPlaced", "".concat(P.placed, " rampart(s) placed on critical structures"));
 }
-t.metrics.constructionSites = p.length + C + _ + S + w + N + k.sitesPlaced + P.placed;
+t.metrics.constructionSites = p.length + C + _ + S + w + N + A.sitesPlaced + P.placed;
 }
 }
 } else {
@@ -35002,38 +34694,38 @@ return e.structureType === STRUCTURE_SPAWN;
 if (!0 === (null === (m = e.controller) || void 0 === m ? void 0 : m.my) && !G) {
 var L = function(e, t) {
 if (t >= 8) {
-var r = rn(e, $o);
+var r = tn(e, Jo);
 if (r) return {
-blueprint: $o,
+blueprint: Jo,
 anchor: r
 };
-if (o = rn(e, Jo)) return {
-blueprint: Jo,
+if (o = tn(e, Zo)) return {
+blueprint: Zo,
 anchor: o
 };
 }
 var o;
-if (t >= 7 && (o = rn(e, Jo))) return {
-blueprint: Jo,
+if (t >= 7 && (o = tn(e, Zo))) return {
+blueprint: Zo,
 anchor: o
 };
 if (t >= 5) {
-var n = rn(e, Zo);
+var n = tn(e, Xo);
 if (n) return {
-blueprint: Zo,
+blueprint: Xo,
 anchor: n
 };
 }
 if (t >= 3) {
-var c = rn(e, Qo);
+var c = tn(e, zo);
 if (c) return {
-blueprint: Qo,
+blueprint: zo,
 anchor: c
 };
 }
-var u = rn(e, jo);
+var u = tn(e, qo);
 if (u) return {
-blueprint: jo,
+blueprint: qo,
 anchor: u
 };
 var l = function(e) {
@@ -35058,7 +34750,7 @@ if (t) throw t.error;
 }
 for (var d = Math.round(s / (n.length + 1)), p = Math.round(c / (n.length + 1)), f = 0; f < 15; f++) for (var y = -f; y <= f; y++) for (var v = -f; v <= f; v++) if (Math.abs(y) === f || Math.abs(v) === f) {
 var g = d + y, h = p + v;
-if (!(g < 3 || g > 46 || h < 3 || h > 46) && en(e, g, h)) {
+if (!(g < 3 || g > 46 || h < 3 || h > 46) && $o(e, g, h)) {
 if (Math.max(Math.abs(g - o.pos.x), Math.abs(h - o.pos.y)) > 20) continue;
 if (i.get(g, h) === TERRAIN_MASK_WALL) continue;
 return new RoomPosition(g, h, e.name);
@@ -35069,14 +34761,14 @@ return null;
 if (l) {
 var m = function(e, t, r) {
 var o, n, c = function(e) {
-return e >= 7 ? Jo : e >= 5 ? Zo : e >= 3 ? Qo : jo;
-}(t), u = s([], i(on(c, t)), !1).sort(function(e, t) {
-var r = nn(t.structureType) - nn(e.structureType);
+return e >= 7 ? Zo : e >= 5 ? Xo : e >= 3 ? zo : qo;
+}(t), u = s([], i(rn(c, t)), !1).sort(function(e, t) {
+var r = on(t.structureType) - on(e.structureType);
 return 0 !== r ? r : t.structureType.localeCompare(e.structureType);
 }), l = new Set, m = [];
 try {
 for (var d = a(u), p = d.next(); !p.done; p = d.next()) {
-var f = p.value, y = r.x + f.x, v = r.y + f.y, g = sn(e, y, v, l);
+var f = p.value, y = r.x + f.x, v = r.y + f.y, g = an(e, y, v, l);
 if (g) {
 var h = g.x - r.x, R = g.y - r.y;
 m.push({
@@ -35104,7 +34796,7 @@ y: e.y
 };
 }).filter(function(t) {
 var o = r.x + t.x, n = r.y + t.y;
-return an(e, o, n) && !l.has("".concat(o, ",").concat(n));
+return nn(e, o, n) && !l.has("".concat(o, ",").concat(n));
 });
 return {
 name: "adaptive-".concat(c.name, "-rcl-").concat(Math.max(1, Math.min(8, Math.floor(t)))),
@@ -35126,19 +34818,19 @@ return e.structureType === STRUCTURE_SPAWN;
 blueprint: m,
 anchor: l
 } : {
-blueprint: jo,
+blueprint: qo,
 anchor: l
 };
 }
 return null;
 }(e, f);
-L && (Zf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
+L && (zf(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), ry = new ty;
+}(), $f = new Jf;
 
-function oy(e) {
+function ey(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35160,7 +34852,7 @@ siege: e.pheromones.siege
 };
 }
 
-var ny = {
+var ty = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35173,10 +34865,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, ay = new (function() {
+}, ry = new (function() {
 function e() {
-this.manager = new iu({
-logger: ny
+this.manager = new au({
+logger: ty
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35186,23 +34878,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = oy(t);
+var r = ey(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = oy(t);
+var r = ey(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), iy = {
-labManager: Cu,
-boostManager: gu,
-chemistryPlanner: ay,
-labConfigManager: Eu,
-logger: Ci
-}, sy = function() {
+}()), oy = {
+labManager: Tu,
+boostManager: vu,
+chemistryPlanner: ry,
+labConfigManager: Ru,
+logger: Ti
+}, ny = function() {
 function e(e) {
-void 0 === e && (e = iy), this.deps = e;
+void 0 === e && (e = oy), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35241,9 +34933,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), cy = new sy, uy = function() {
+}(), ay = new ny, iy = function() {
 function e(e) {
-void 0 === e && (e = cy), this.labWorkflow = e;
+void 0 === e && (e = ay), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35266,30 +34958,30 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), ly = new uy, my = {
+}(), sy = new iy, cy = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, dy = new Map;
+}, uy = new Map;
 
-function py(e) {
+function ly(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function fy(e) {
+function my(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var yy = function() {
+var dy = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, my), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, cy), t);
 }
 return e.prototype.run = function(e) {
-var t, r, o, n = Ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
+var t, r, o, n = Zi.startRoom(this.roomName), i = Game.rooms[this.roomName];
 if (i && (null === (t = i.controller) || void 0 === t ? void 0 : t.my)) {
 var s = Game.cpu.bucket < 6e3;
 s || function(e) {
@@ -35328,7 +35020,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = mr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = dy.get(e.name);
+var t = uy.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35350,38 +35042,38 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return dy.set(e.name, o), o;
+return uy.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && If.updateMetrics(i, c),
-zf.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && _f.updateMetrics(i, c),
+Vf.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Ba.assess(i, c), Va.checkSafeMode(i, c), this.config.enableEvolution && (Wf.updateEvolutionStage(c, i, e),
-s || Wf.updateMissingStructures(c, i)), Hf.updatePosture(c), this.config.enablePheromones && !s && If.updatePheromones(c, i),
-this.config.enableTowers && zf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = ry.getConstructionInterval(l), d = Hf.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), Ea.assess(i, c), ba.checkSafeMode(i, c), this.config.enableEvolution && (Df.updateEvolutionStage(c, i, e),
+s || Df.updateMissingStructures(c, i)), Ff.updatePosture(c), this.config.enablePheromones && !s && _f.updatePheromones(c, i),
+this.config.enableTowers && Vf.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = $f.getConstructionInterval(l), d = Ff.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = py(r), n = fy(e);
+var o = ly(r), n = my(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (ry.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && ($f.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = py(r), n = fy(e);
+var o = ly(r), n = my(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && ly.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && sy.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
 var f = Game.cpu.getUsed() - n;
-Ji.recordRoom(i, f), Ji.endRoom(this.roomName, n);
-} else Ji.endRoom(this.roomName, n);
+Zi.recordRoom(i, f), Zi.endRoom(this.roomName, n);
+} else Zi.endRoom(this.roomName, n);
 }, e;
-}(), vy = function() {
+}(), py = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35395,7 +35087,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new yy(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new dy(v.name));
 }
 } catch (t) {
 e = {
@@ -35431,7 +35123,7 @@ try {
 C.run(p);
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e), w = e instanceof Error && e.stack ? e.stack : void 0;
-Ci.error("Error in room ".concat(C.roomName, ": ").concat(S), {
+Ti.error("Error in room ".concat(C.roomName, ": ").concat(S), {
 subsystem: "RoomManager",
 room: C.roomName,
 meta: {
@@ -35458,7 +35150,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new yy(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new dy(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35469,7 +35161,7 @@ try {
 i.run(r);
 } catch (t) {
 var s = t instanceof Error ? t.message : String(t), c = t instanceof Error && t.stack ? t.stack : void 0;
-Ci.error("Error in room ".concat(e.name, ": ").concat(s), {
+Ti.error("Error in room ".concat(e.name, ": ").concat(s), {
 subsystem: "RoomManager",
 room: e.name,
 meta: {
@@ -35479,38 +35171,38 @@ stack: c
 }
 }
 }, e;
-}(), gy = new vy;
+}(), fy = new py;
 
-function hy(e) {
+function yy(e) {
 var t, r, o;
-if (j(e).length > 0) return ha.CRITICAL;
-if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return ha.HIGH;
+if (j(e).length > 0) return Ma.CRITICAL;
+if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return Ma.HIGH;
 var n = function() {
 var e, t, r, o = null !== (e = Game.spawns) && void 0 !== e ? e : {}, n = Object.values(o)[0];
 return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "";
 }();
-return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? ha.MEDIUM : ha.LOW;
+return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? Ma.MEDIUM : Ma.LOW;
 }
 
-function Ry(e) {
+function vy(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return j(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function Ey(e, t, r) {
+function gy(e, t, r) {
 var o;
-return t === ha.CRITICAL ? {
+return t === Ma.CRITICAL ? {
 tickModulo: void 0,
 tickOffset: void 0
-} : t === ha.HIGH && (null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? {
+} : t === Ma.HIGH && (null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? {
 tickModulo: 5,
 tickOffset: r % 5
-} : t === ha.MEDIUM ? {
+} : t === Ma.MEDIUM ? {
 tickModulo: 10,
 tickOffset: r % 10
-} : t === ha.LOW ? {
+} : t === Ma.LOW ? {
 tickModulo: 20,
 tickOffset: r % 20
 } : {
@@ -35519,7 +35211,7 @@ tickOffset: void 0
 };
 }
 
-var Ty, Cy = function() {
+var hy, Ry = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35535,7 +35227,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ja.getProcess(i), c = hy(n), u = Ry(n);
+var i = "room:".concat(o), s = Za.getProcess(i), c = yy(n), u = vy(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35554,8 +35246,8 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = hy(e), o = Ry(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Ey(e, r, a);
-Ja.registerProcess({
+var t, r = yy(e), o = vy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = gy(e, r, a);
+Za.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
 priority: r,
@@ -35571,16 +35263,16 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && gy.runRoom(t);
+t && fy.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
-Ci.debug("Registered room process: ".concat(e.name, " with priority ").concat(r, " ").concat(s), {
+Ti.debug("Registered room process: ".concat(e.name, " with priority ").concat(r, " ").concat(s), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Ey(e, t, a);
-Ja.unregisterProcess(n), Ja.registerProcess({
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = gy(e, t, a);
+Za.unregisterProcess(n), Za.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
 priority: t,
@@ -35596,29 +35288,29 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && gy.runRoom(t);
+t && fy.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
-Ci.debug("Updated room process: ".concat(e.name, " priority=").concat(t, " budget=").concat(r, " (").concat(s, ")"), {
+Ti.debug("Updated room process: ".concat(e.name, " priority=").concat(t, " budget=").concat(r, " (").concat(s, ")"), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.unregisterRoomProcess = function(e) {
 var t = "room:".concat(e);
-Ja.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
-Ci.debug("Unregistered room process: ".concat(e), {
+Za.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
+Ti.debug("Unregistered room process: ".concat(e), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.getMinBucketForPriority = function(e) {
 var t = Ue().cpu.bucketThresholds.lowMode;
-return e >= ha.HIGH ? 0 : t;
+return e >= Ma.HIGH ? 0 : t;
 }, e.prototype.getStats = function() {
 var e, t, r, o, n, i = {}, s = 0;
 try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = hy(m), p = null !== (r = ha[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = yy(m), p = null !== (r = Ma[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35645,10 +35337,10 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), Sy = new Cy, wy = function() {
+}(), Ey = new Ry, Ty = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
-var e = Ja.getStatsSummary(), t = Ja.getConfig();
+var e = Za.getStatsSummary(), t = Za.getConfig();
 return function(e) {
 var t, r, o, n, i = [ "=== Kernel Stats ===", "Bucket Mode: ".concat(e.bucketMode.toUpperCase()), "CPU Bucket: ".concat(e.cpuBucket), "CPU Limit: ".concat(e.cpuLimit.toFixed(2), " (").concat((100 * e.targetCpuUsage).toFixed(0), "% of ").concat(e.gameCpuLimit, ")"), "Remaining CPU: ".concat(e.remainingCpu.toFixed(2)), "", "Processes: ".concat(e.stats.totalProcesses, " total (").concat(e.stats.activeProcesses, " active, ").concat(e.stats.suspendedProcesses, " suspended)"), "Total CPU Used: ".concat(e.stats.totalCpuUsed.toFixed(3)), "Avg CPU/Process: ".concat(e.stats.avgCpuPerProcess.toFixed(4)), "Avg Health Score: ".concat(e.stats.avgHealthScore.toFixed(1), "/100"), "", "Top CPU Consumers:" ];
 try {
@@ -35686,16 +35378,16 @@ if (o) throw o.error;
 }
 return i.join("\n");
 }({
-bucketMode: Ja.getBucketMode(),
+bucketMode: Za.getBucketMode(),
 cpuBucket: Game.cpu.bucket,
-cpuLimit: Ja.getCpuLimit(),
+cpuLimit: Za.getCpuLimit(),
 targetCpuUsage: t.targetCpuUsage,
 gameCpuLimit: Game.cpu.limit,
-remainingCpu: Ja.getRemainingCpu(),
+remainingCpu: Za.getRemainingCpu(),
 stats: e
 });
 }, e.prototype.listProcesses = function() {
-var e = Ja.getProcesses();
+var e = Za.getProcesses();
 return 0 === e.length ? "No processes registered with kernel." : function(e) {
 var t, r;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -35722,11 +35414,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(xf(e.summary.byLayer)), "Groups: ".concat(xf(e.summary.byGroup)), "States: ".concat(xf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Cf(e.summary.byLayer)), "Groups: ".concat(Cf(e.summary.byGroup)), "States: ".concat(Cf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(bf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(Sf)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(Sf(m));
+c.push(Ef(m));
 }
 } catch (e) {
 t = {
@@ -35763,19 +35455,19 @@ if (o) throw o.error;
 }
 }
 return c.join("\n");
-}(Ja.getProcessTopology());
+}(Za.getProcessTopology());
 }, e.prototype.suspendProcess = function(e) {
-var t = Ja.suspendProcess(e);
+var t = Za.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = Ja.resumeProcess(e);
+var t = Za.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return Ja.resetStats(), "Kernel statistics reset.";
+return Za.resetStats(), "Kernel statistics reset.";
 }, e.prototype.showProcessHealth = function() {
-var e = Ja.getProcesses();
+var e = Za.getProcesses();
 if (0 === e.length) return "No processes registered with kernel.";
-var t = Ja.getStatsSummary();
+var t = Za.getStatsSummary();
 return function(e, t, r) {
 var o, n;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -35802,7 +35494,7 @@ return c.push("", "Average Health: ".concat(r.avgHealthScore.toFixed(1), "/100")
 c.join("\n");
 }(e, Game.time, t);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = Ja.getProcesses().filter(function(e) {
+var e, t, r = Za.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -35810,7 +35502,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Ja.resumeProcess(s.id) && o++;
+Za.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -35825,7 +35517,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = Cf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = Rf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35844,7 +35536,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = Sy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = Ey.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35863,7 +35555,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o = Ja.getProcesses().filter(function(e) {
+var t, r, o = Za.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (o = o.filter(function(t) {
@@ -35892,7 +35584,7 @@ if (t) throw t.error;
 }
 return n + "\nTotal: ".concat(o.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r = Ja.getProcesses().filter(function(e) {
+var e, t, r = Za.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === r.length) return "No room processes registered.";
@@ -35991,25 +35683,25 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), xy = function() {
+}(), Cy = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
-debug: Xa.DEBUG,
-info: Xa.INFO,
-warn: Xa.WARN,
-error: Xa.ERROR,
-none: Xa.NONE
+debug: Qa.DEBUG,
+info: Qa.INFO,
+warn: Qa.WARN,
+error: Qa.ERROR,
+none: Qa.NONE
 }[e.toLowerCase()];
-return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (ii({
+return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (ai({
 level: t
 }), "Log level set to: ".concat(e.toUpperCase()));
 }, e.prototype.toggleDebug = function() {
 var e = !Ue().debug;
 return _e({
 debug: e
-}), ii({
-level: e ? Xa.DEBUG : Xa.INFO
+}), ai({
+level: e ? Qa.DEBUG : Qa.INFO
 }), "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
 }, n([ Tt({
 name: "setLogLevel",
@@ -36024,7 +35716,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), by = function() {
+}(), Sy = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36064,7 +35756,7 @@ hostileCount: null !== (l = null !== (u = null !== (s = this.toNumber(null === (
 var o, n, a, i, s = this.asRecord(null === (o = this.asRecord(e)) || void 0 === o ? void 0 : o.metrics), c = this.asRecord(null == s ? void 0 : s.energy);
 return null !== (i = null !== (a = null !== (n = this.toNumber(null == s ? void 0 : s[t])) && void 0 !== n ? n : this.toNumber(null == c ? void 0 : c[r])) && void 0 !== a ? a : this.toNumber(null == s ? void 0 : s[r])) && void 0 !== i ? i : 0;
 }, e.prototype.showStats = function() {
-var e = ts.getLatestStats();
+var e = es.getLatestStats();
 return e ? "=== SwarmBot Stats (Tick ".concat(e.tick, ") ===\nCPU: ").concat(e.cpuUsed.toFixed(2), "/").concat(e.cpuLimit, " (Bucket: ").concat(e.cpuBucket, ")\nGCL: ").concat(e.gclLevel, " (").concat((100 * e.gclProgress).toFixed(1), "%)\nGPL: ").concat(e.gplLevel, "\nCreeps: ").concat(e.totalCreeps, "\nRooms: ").concat(e.totalRooms, "\n").concat(e.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks.";
@@ -36108,18 +35800,18 @@ return Fe.clear(Ve), "Room.find() cache cleared and statistics reset";
 var e = !Ue().profiling;
 return _e({
 profiling: e
-}), Ji.setEnabled(e), ii({
+}), Zi.setEnabled(e), ai({
 cpuLogging: e
 }), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.enableCpuDetails = function(e, t, r) {
 var o, n, a;
 void 0 === e && (e = 500), void 0 === t && (t = 1);
-var i = Ji.enableCpuDetails(e, t, r);
+var i = Zi.enableCpuDetails(e, t, r);
 return "CPU details enabled until tick ".concat(null !== (o = i.expiresTick) && void 0 !== o ? o : "unknown", " (sampleRate=").concat(null !== (n = i.sampleRate) && void 0 !== n ? n : 1, ", labels=").concat((null !== (a = i.labels) && void 0 !== a ? a : []).join(",") || "all", ")");
 }, e.prototype.disableCpuDetails = function() {
-return Ji.disableCpuDetails(), "CPU details disabled";
+return Zi.disableCpuDetails(), "CPU details disabled";
 }, e.prototype.cpuDetails = function() {
-var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = Ji.getCpuDetailsStatus();
+var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = Zi.getCpuDetailsStatus();
 if (!u) return "CPU details ".concat(l.enabled ? "enabled" : "disabled", "; no samples published yet");
 var m = Object.entries(null !== (o = u.entries) && void 0 !== o ? o : {}), d = Array.isArray(u.labels) ? u.labels.join(",") : "", p = [ "=== CPU Details ===", "Enabled: ".concat(String(u.enabled), " | Expires: ").concat(null !== (n = u.expires_tick) && void 0 !== n ? n : "n/a", " | Sample rate: ").concat(null !== (s = u.sample_rate) && void 0 !== s ? s : 1, " | Labels: ").concat(d || "all") ];
 try {
@@ -36142,7 +35834,7 @@ if (e) throw e.error;
 }
 return 0 === m.length && p.push("  No detail samples this tick"), p.join("\n");
 }, e.prototype.cpuBreakdown = function(e) {
-var t, r, o, n, i, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, A, k, M, U, _ = this, N = Memory.stats;
+var t, r, o, n, i, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, k, A, M, U, _ = this, N = Memory.stats;
 if (!N) return "No stats available. Stats collection may be disabled.";
 var P = !e, I = [ "=== CPU Breakdown ===" ], G = this.asRecord(N.cpu), L = this.toNumberOrZero(null !== (m = null !== (l = this.getStatsValue(G, "used")) && void 0 !== l ? l : this.getStatsValue(G, "getUsed")) && void 0 !== m ? m : this.sumNumericValues(this.asRecord(null == G ? void 0 : G.usage))), D = this.toNumberOrZero(null !== (d = this.getStatsValue(G, "limit")) && void 0 !== d ? d : this.toNumberOrZero(null == G ? void 0 : G.tickLimit)), F = this.toNumberOrZero(null !== (p = this.getStatsValue(N.cpu, "percent")) && void 0 !== p ? p : D > 0 ? L / D * 100 : 0), B = this.toNumberOrZero(this.getStatsValue(N.cpu, "bucket"));
 if (I.push("Tick: ".concat(this.toNumberOrZero(N.tick))), I.push("Total CPU: ".concat(L.toFixed(2), "/").concat(D.toFixed(0), " (").concat(F.toFixed(1), "%)")),
@@ -36150,12 +35842,12 @@ I.push("Bucket: ".concat(B.toFixed(0))), I.push(""), P || "process" === e) {
 var W = Object.values(null !== (f = N.processes) && void 0 !== f ? f : {});
 if (W.length > 0) {
 I.push("=== Process CPU Usage ===");
-var H = W.sort(function(e, t) {
+var K = W.sort(function(e, t) {
 var r, o, n = _.toNumberOrZero(null !== (r = _.getStatsValue(e, "avg_cpu")) && void 0 !== r ? r : _.getStatsValue(e, "avgCpu"));
 return _.toNumberOrZero(null !== (o = _.getStatsValue(t, "avg_cpu")) && void 0 !== o ? o : _.getStatsValue(t, "avgCpu")) - n;
 });
 try {
-for (var K = a(H.slice(0, 10)), Y = K.next(); !Y.done; Y = K.next()) {
+for (var H = a(K.slice(0, 10)), Y = H.next(); !Y.done; Y = H.next()) {
 var V = Y.value, q = this.toNumberOrZero(null !== (y = this.getStatsValue(V, "avg_cpu")) && void 0 !== y ? y : this.getStatsValue(V, "avgCpu")), j = this.toNumberOrZero(null !== (v = this.getStatsValue(V, "max_cpu")) && void 0 !== v ? v : this.getStatsValue(V, "maxCpu")), z = this.toNumberOrZero(null !== (g = V.run_count) && void 0 !== g ? g : V.runCount);
 I.push("  ".concat(String(null !== (h = V.name) && void 0 !== h ? h : "unknown"), ": ").concat(q.toFixed(3), " CPU (runs: ").concat(z.toFixed(0), ", max: ").concat(j.toFixed(3), ")"));
 }
@@ -36165,7 +35857,7 @@ error: e
 };
 } finally {
 try {
-Y && !Y.done && (r = K.return) && r.call(K);
+Y && !Y.done && (r = H.return) && r.call(H);
 } finally {
 if (t) throw t.error;
 }
@@ -36176,12 +35868,12 @@ I.push("");
 if (P || "room" === e) {
 var Q = Object.values(null !== (R = N.rooms) && void 0 !== R ? R : {});
 if (Q.length > 0) {
-I.push("=== Room CPU Usage ==="), H = Q.sort(function(e, t) {
+I.push("=== Room CPU Usage ==="), K = Q.sort(function(e, t) {
 var r, o, n = _.toNumberOrZero(null !== (r = _.getStatsValue(e.profiler, "avg_cpu")) && void 0 !== r ? r : _.getStatsValue(e.profiler, "avgCpu"));
 return _.toNumberOrZero(null !== (o = _.getStatsValue(t.profiler, "avg_cpu")) && void 0 !== o ? o : _.getStatsValue(t.profiler, "avgCpu")) - n;
 });
 try {
-for (var X = a(H), Z = X.next(); !Z.done; Z = X.next()) {
+for (var X = a(K), Z = X.next(); !Z.done; Z = X.next()) {
 var J = Z.value, $ = this.toNumberOrZero(null !== (E = this.getStatsValue(J.profiler, "avg_cpu")) && void 0 !== E ? E : this.getStatsValue(J.profiler, "avgCpu")), ee = this.toNumberOrZero(J.rcl), te = null !== (C = null !== (T = J.name) && void 0 !== T ? T : J.roomName) && void 0 !== C ? C : "unknown";
 I.push("  ".concat(String(te), ": ").concat($.toFixed(3), " CPU (RCL ").concat(ee, ")"));
 }
@@ -36202,12 +35894,12 @@ I.push("");
 if (P || "subsystem" === e) {
 var re = Object.values(null !== (S = N.subsystems) && void 0 !== S ? S : {});
 if (re.length > 0) {
-I.push("=== Subsystem CPU Usage ==="), H = re.sort(function(e, t) {
+I.push("=== Subsystem CPU Usage ==="), K = re.sort(function(e, t) {
 var r, o, n = _.toNumberOrZero(null !== (r = _.getStatsValue(e, "avg_cpu")) && void 0 !== r ? r : _.getStatsValue(e, "avgCpu"));
 return _.toNumberOrZero(null !== (o = _.getStatsValue(t, "avg_cpu")) && void 0 !== o ? o : _.getStatsValue(t, "avgCpu")) - n;
 });
 try {
-for (var oe = a(H.slice(0, 10)), ne = oe.next(); !ne.done; ne = oe.next()) {
+for (var oe = a(K.slice(0, 10)), ne = oe.next(); !ne.done; ne = oe.next()) {
 var ae = ne.value, ie = null !== (w = ae.name) && void 0 !== w ? w : "unknown", se = this.toNumberOrZero(null !== (x = this.getStatsValue(ae, "avg_cpu")) && void 0 !== x ? x : this.getStatsValue(ae, "avgCpu")), ce = this.toNumberOrZero(null !== (b = ae.calls) && void 0 !== b ? b : ae.callCount);
 I.push("  ".concat(String(ie), ": ").concat(se.toFixed(3), " CPU (calls: ").concat(ce.toFixed(0), ")"));
 }
@@ -36228,15 +35920,15 @@ I.push("");
 if (P || "creep" === e) {
 var ue = Object.values(null !== (O = N.creeps) && void 0 !== O ? O : {});
 if (ue.length > 0) {
-I.push("=== Top Creeps by CPU (Top 10) ==="), H = ue.sort(function(e, t) {
+I.push("=== Top Creeps by CPU (Top 10) ==="), K = ue.sort(function(e, t) {
 var r = _.toNumberOrZero(_.getStatsValue(e, "cpu"));
 return _.toNumberOrZero(_.getStatsValue(t, "cpu")) - r;
 });
 try {
-for (var le = a(H.slice(0, 10)), me = le.next(); !me.done; me = le.next()) {
+for (var le = a(K.slice(0, 10)), me = le.next(); !me.done; me = le.next()) {
 var de = me.value, pe = this.toNumberOrZero(this.getStatsValue(de, "cpu"));
 if (pe > 0) {
-var fe = null !== (A = de.role) && void 0 !== A ? A : "unknown", ye = null !== (k = de.name) && void 0 !== k ? k : "".concat(String(fe), "_unknown");
+var fe = null !== (k = de.role) && void 0 !== k ? k : "unknown", ye = null !== (A = de.name) && void 0 !== A ? A : "".concat(String(fe), "_unknown");
 J = null !== (U = null !== (M = de.current_room) && void 0 !== M ? M : de.currentRoom) && void 0 !== U ? U : "unknown",
 I.push("  ".concat(String(ye), " (").concat(String(fe), "): ").concat(pe.toFixed(3), " CPU in ").concat(String(J)));
 }
@@ -36257,7 +35949,7 @@ I.push("");
 }
 return I.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n = Ji.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
+var e, t, r, o, n = Zi.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
 if (i += "Rooms Evaluated: ".concat(n.roomsEvaluated, "\n"), i += "Within Budget: ".concat(n.roomsWithinBudget, "\n"),
 i += "Over Budget: ".concat(n.roomsOverBudget, "\n\n"), 0 === n.alerts.length) i += "OK All rooms within budget!\n"; else {
 i += "Alerts: ".concat(n.alerts.length, "\n");
@@ -36304,7 +35996,7 @@ if (r) throw r.error;
 }
 return i;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n = Ji.detectAnomalies();
+var e, t, r, o, n = Zi.detectAnomalies();
 if (0 === n.length) return "OK No CPU anomalies detected";
 var i = "=== CPU Anomalies Detected: ".concat(n.length, " ===\n\n"), s = n.filter(function(e) {
 return "spike" === e.type;
@@ -36353,7 +36045,7 @@ return i;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n;
 void 0 === e && (e = !1);
-var i = Ji.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
+var i = Zi.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
 s += "Total: ".concat(i.cpu.used.toFixed(2), " / ").concat(i.cpu.limit, " (").concat(i.cpu.percent.toFixed(1), "%)\n"),
 s += "Bucket: ".concat(i.cpu.bucket, "\n"), s += "Heap: ".concat(i.cpu.heapUsed.toFixed(2), " MB\n\n");
 var c = Object.values(i.rooms).sort(function(e, t) {
@@ -36362,7 +36054,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 s += "Top ".concat(u.length, " Rooms by CPU:\n");
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = Ji.postureCodeToName(p);
+var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = Zi.postureCodeToName(p);
 s += "  ".concat(d.name, " (RCL").concat(d.rcl, ", ").concat(f, "): avg ").concat(d.profiler.avgCpu.toFixed(3), " | peak ").concat(d.profiler.peakCpu.toFixed(3), " | samples ").concat(d.profiler.samples, "\n");
 }
 } catch (e) {
@@ -36403,7 +36095,7 @@ return s;
 var t, r, o, n;
 if (!e) return "Error: Room name required. Usage: diagnoseRoom('W16S52')";
 if (!Game.rooms[e]) return "Error: Room ".concat(e, " not visible. Make sure you have vision in this room.");
-var s = Ji.getCurrentSnapshot(), c = s.rooms[e];
+var s = Zi.getCurrentSnapshot(), c = s.rooms[e];
 if (!c) return "Error: No stats available for ".concat(e, ". The room may not have been processed yet.");
 var u = "room:".concat(e), l = s.processes[u], m = mr.getSwarmState(e), d = m && ("war" === m.posture || "siege" === m.posture || m.danger >= 2), p = d ? .25 : .1, f = null !== (o = null == l ? void 0 : l.tickModulo) && void 0 !== o ? o : 1, y = p * f, v = "----------------------------------------------\n";
 v += "  Room Diagnostic: ".concat(e, "\n"), v += "----------------------------------------------\n\n";
@@ -36413,7 +36105,7 @@ energyCapacityTotal: this.getRoomMetricValue(c, "energyCapacityTotal", "capacity
 constructionSites: this.getRoomMetricValue(c, "constructionSites", "construction_sites")
 };
 v += "SUMMARY Basic Info:\n", v += "  RCL: ".concat(c.rcl, "\n"), v += "  Controller Progress: ".concat(c.controller.progressPercent.toFixed(1), "%\n"),
-v += "  Posture: ".concat(Ji.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
+v += "  Posture: ".concat(Zi.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
 v += "  Hostiles: ".concat(g.hostileCount, "\n\n"), v += "CPU CPU Analysis:\n",
 v += "  Average CPU: ".concat(c.profiler.avgCpu.toFixed(3), "\n"), v += "  Peak CPU: ".concat(c.profiler.peakCpu.toFixed(3), "\n"),
 v += "  Samples: ".concat(c.profiler.samples, "\n"), v += "  Budget: ".concat(y.toFixed(3), " (base ").concat(p, ", modulo ").concat(f, ")\n");
@@ -36549,7 +36241,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Oy = function() {
+}(), wy = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Et.generateHelp();
@@ -36568,22 +36260,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), Ay = function() {
+}(), xy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? Tl.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? El.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? Tl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? El.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return Tl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return El.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ Tt({
 name: "tasks",
 description: "Show room creep task queue",
@@ -36603,21 +36295,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), ky = ((Ty = {})[MOVE] = 50, Ty[WORK] = 100, Ty[CARRY] = 50, Ty[ATTACK] = 80,
-Ty[RANGED_ATTACK] = 150, Ty[HEAL] = 250, Ty[CLAIM] = 600, Ty[TOUGH] = 10, Ty);
+}(), by = ((hy = {})[MOVE] = 50, hy[WORK] = 100, hy[CARRY] = 50, hy[ATTACK] = 80,
+hy[RANGED_ATTACK] = 150, hy[HEAL] = 250, hy[CLAIM] = 600, hy[TOUGH] = 10, hy);
 
-function My(e, t) {
+function Oy(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, ky), t);
+var r = o(o({}, by), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : ky[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : by[t]);
 }, 0);
 }
 
-function Uy(e, t) {
+function ky(e, t) {
 void 0 === t && (t = 0);
-var r = My(e);
+var r = Oy(e);
 return {
 parts: e,
 cost: r,
@@ -36625,7 +36317,7 @@ minCapacity: t || r
 };
 }
 
-function _y() {
+function Ay() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36633,11 +36325,11 @@ return Array(o).fill(r);
 });
 }
 
-var Ny, Py, Iy, Gy = {
+var My, Uy, _y, Ny = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Uy([ WORK, CARRY ], 150), Uy([ WORK, CARRY, MOVE ], 200), Uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Uy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Uy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ky([ WORK, CARRY ], 150), ky([ WORK, CARRY, MOVE ], 200), ky([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), ky([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), ky([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36645,7 +36337,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Uy([ WORK, CARRY, MOVE ], 200), Uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Uy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Uy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ky([ WORK, CARRY, MOVE ], 200), ky([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), ky([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), ky([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36653,7 +36345,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Uy([ WORK, CARRY, MOVE, MOVE ], 250), Uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ ky([ WORK, CARRY, MOVE, MOVE ], 250), ky([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36661,7 +36353,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Uy([ WORK, CARRY, MOVE ], 200), Uy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Uy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Uy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ ky([ WORK, CARRY, MOVE ], 200), ky([ WORK, WORK, CARRY, MOVE, MOVE ], 350), ky([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), ky([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), ky([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36669,7 +36361,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Uy([ CARRY, CARRY, MOVE, MOVE ], 200), Uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Uy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ky([ CARRY, CARRY, MOVE, MOVE ], 200), ky([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), ky(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36677,7 +36369,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Uy([ WORK, CARRY, MOVE ], 200), Uy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ ky([ WORK, CARRY, MOVE ], 200), ky([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), ky([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), ky([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36685,7 +36377,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Uy([ WORK, CARRY, MOVE, MOVE ], 250), Uy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ ky([ WORK, CARRY, MOVE, MOVE ], 250), ky([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), ky([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36693,7 +36385,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ ky([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36701,7 +36393,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Uy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ ky([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), ky([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36709,7 +36401,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ ky([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36717,7 +36409,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ ky([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36725,7 +36417,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Uy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Uy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Uy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ ky([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), ky([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), ky([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), ky([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36733,7 +36425,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Uy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ky([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), ky(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36741,7 +36433,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Uy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Uy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ky([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), ky([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36749,16 +36441,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Uy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Uy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Uy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Uy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ky(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), ky(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), ky(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), ky(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Ly = {
+}, Py = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Uy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Uy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Uy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Uy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ ky([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), ky([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), ky([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), ky([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36766,7 +36458,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Uy([ TOUGH, ATTACK, MOVE, MOVE ], 190), Uy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Uy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ ky([ TOUGH, ATTACK, MOVE, MOVE ], 190), ky([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), ky([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36774,7 +36466,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Uy([ HEAL, MOVE, MOVE ], 350), Uy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Uy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Uy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ ky([ HEAL, MOVE, MOVE ], 350), ky([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), ky([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), ky([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36782,7 +36474,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Uy([ ATTACK, ATTACK, MOVE, MOVE ], 260), Uy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Uy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ ky([ ATTACK, ATTACK, MOVE, MOVE ], 260), ky([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), ky([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36790,7 +36482,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Uy([ WORK, WORK, MOVE, MOVE ], 300), Uy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Uy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ ky([ WORK, WORK, MOVE, MOVE ], 300), ky([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), ky([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36798,7 +36490,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Uy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Uy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Uy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Uy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ ky([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), ky([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), ky([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), ky([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36806,16 +36498,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Uy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Uy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Uy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ ky([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), ky([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), ky([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Dy = {
+}, Iy = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Uy(_y([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Uy(_y([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ ky(Ay([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), ky(Ay([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36823,16 +36515,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Uy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Uy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ ky(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), ky(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Fy = {
+}, Gy = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Uy([ MOVE ], 50) ],
+bodies: [ ky([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36840,7 +36532,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Uy([ MOVE ], 50) ],
+bodies: [ ky([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36848,7 +36540,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Uy([ CLAIM, MOVE ], 650) ],
+bodies: [ ky([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36856,7 +36548,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Uy([ CLAIM, MOVE ], 650), Uy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ ky([ CLAIM, MOVE ], 650), ky([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36864,7 +36556,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Uy([ WORK, CARRY, MOVE, MOVE ], 250), Uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ ky([ WORK, CARRY, MOVE, MOVE ], 250), ky([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36872,30 +36564,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Uy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Uy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ ky([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), ky([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, By = o(o(o(o({}, Gy), Ly), Fy), Dy);
+}, Ly = o(o(o(o({}, Ny), Py), Gy), Iy);
 
 try {
-for (var Wy = a(Object.values(By)), Hy = Wy.next(); !Hy.done; Hy = Wy.next()) Hy.value.bodies.sort(function(e, t) {
+for (var Dy = a(Object.values(Ly)), Fy = Dy.next(); !Fy.done; Fy = Dy.next()) Fy.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Ny = {
+My = {
 error: e
 };
 } finally {
 try {
-Hy && !Hy.done && (Py = Wy.return) && Py.call(Wy);
+Fy && !Fy.done && (Uy = Dy.return) && Uy.call(Dy);
 } finally {
-if (Ny) throw Ny.error;
+if (My) throw My.error;
 }
 }
 
-function Ky(e) {
+function By(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -36910,11 +36602,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Yy(o);
+return Wy(o);
 }
 
-function Yy(e) {
-var t = My(e);
+function Wy(e) {
+var t = Oy(e);
 return {
 parts: e,
 cost: t,
@@ -36922,16 +36614,16 @@ minCapacity: t
 };
 }
 
-function Vy(e, t) {
+function Ky(e, t) {
 var r;
-return null !== (r = e.map(Yy).filter(function(e) {
+return null !== (r = e.map(Wy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function qy(e) {
+function Hy(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -36945,7 +36637,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = My(a);
+var s = Oy(a);
 return {
 parts: a,
 cost: s,
@@ -36970,8 +36662,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: My(p),
-minCapacity: My(p)
+cost: Oy(p),
+minCapacity: Oy(p)
 };
 }(e);
 
@@ -36982,7 +36674,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return Ky([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return By([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37003,7 +36695,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return Ky([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return By([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37012,13 +36704,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Yy).filter(function(e) {
+var u = n.map(Wy).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Vy(n, t);
+var l = Ky(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37028,7 +36720,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Vy(n, t);
+var u = Ky(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37037,14 +36729,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Vy(r, t);
+var a = Ky(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function jy(e) {
+function Yy(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37055,9 +36747,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function zy(e, t) {
+function Vy(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: jy(t)
+memory: Yy(t)
 });
 var r;
 }
@@ -37065,9 +36757,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Iy || (Iy = {}));
+}(_y || (_y = {}));
 
-var Qy = function() {
+var qy = function() {
 function e() {
 this.queues = new Map;
 }
@@ -37162,7 +36854,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = zy(m, d);
+var p = Vy(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37182,7 +36874,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Iy.EMERGENCY;
+return e.priority >= _y.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37200,7 +36892,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Iy.EMERGENCY ? n.emergency++ : c.priority >= Iy.HIGH ? n.high++ : c.priority >= Iy.NORMAL ? n.normal++ : n.low++;
+c.priority >= _y.EMERGENCY ? n.emergency++ : c.priority >= _y.HIGH ? n.high++ : c.priority >= _y.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37215,14 +36907,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Xy = new Qy, Zy = {
+}(), jy = new qy, zy = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Jy = {
+}, Qy = {
 predictConsumption: function() {
 return 0;
 },
@@ -37241,7 +36933,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, $y = {
+}, Xy = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37259,44 +36951,44 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, ev = {
+}, Zy = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function tv(e, t, r, o, n) {
-return rc(e, t, r, o, n);
+function Jy(e, t, r, o, n) {
+return tc(e, t, r, o, n);
 }
 
-var rv = new Map, ov = -1, nv = null;
+var $y = new Map, ev = -1, tv = null;
 
-function av() {
-ov === Game.time && nv === Game.creeps || (rv.clear(), ov = Game.time, nv = Game.creeps);
+function rv() {
+ev === Game.time && tv === Game.creeps || ($y.clear(), ev = Game.time, tv = Game.creeps);
 }
 
-function iv(e) {
+function ov(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function sv(e, t) {
+function nv(e, t) {
 var r;
-void 0 === t && (t = !1), av();
-var o = t ? "".concat(e, "_active") : e, n = rv.get(o);
+void 0 === t && (t = !1), rv();
+var o = t ? "".concat(e, "_active") : e, n = $y.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = iv(c);
+var u = ov(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return rv.set(o, a), a;
+return $y.set(o, a), a;
 }
 
-function cv(e, t, r) {
+function av(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37317,22 +37009,22 @@ if (o) throw o.error;
 return i;
 }
 
-function uv(e) {
+function iv(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var lv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var sv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function mv(e) {
-return lv.includes(e);
+function cv(e) {
+return sv.includes(e);
 }
 
-function dv(e) {
+function uv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function pv(e, t, r, o) {
+function lv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37345,10 +37037,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return tv(e, t, ze(r).length, o, {
-reserved: dv(r)
+if (r) return Jy(e, t, ze(r).length, o, {
+reserved: uv(r)
 }).recommendedHaulers;
-var n = tv(e, t, 2, o, {
+var n = Jy(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37359,7 +37051,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: uv
+filter: iv
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37370,7 +37062,7 @@ return 2;
 }
 }
 
-function fv(e, t) {
+function mv(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37380,13 +37072,13 @@ return null;
 }
 }
 
-function yv() {
+function dv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function vv(e) {
-var t = yv(), r = function(e) {
+function pv(e) {
+var t = dv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37398,14 +37090,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function gv(e) {
+function fv(e) {
 var t = mr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = yv();
+var r = dv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function hv(e) {
+function yv(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37413,11 +37105,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function Rv(e) {
+function vv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function Ev() {
+function gv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37427,9 +37119,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var Tv = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var hv = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Cv(e, t) {
+function Rv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37441,8 +37133,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(Ev()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Xy.getPendingRequests(c).some(function(r) {
+for (var i = a(gv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = jy.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37462,7 +37154,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function Sv() {
+function Ev() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -37483,7 +37175,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function wv(e, t) {
+function Tv(e, t) {
 var r, o, n, c, u = mr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37493,15 +37185,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !Cv(e.roomName, "claim");
+return !Rv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || hv(t));
+return !(!r || r.my || r.owner || r.reservation || yv(t));
 }
-return !gv(e);
+return !fv(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37512,11 +37204,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = Sv().filter(function(e) {
-return !Cv(e, "claim");
+var r, o, n = Ev().filter(function(e) {
+return !Rv(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = yv();
+var r, o, n = Game.rooms[e], a = dv();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -37527,7 +37219,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Tv.has(e.type);
+return e.hits > 0 && hv.has(e.type);
 });
 });
 }(n));
@@ -37539,7 +37231,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = fv(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = mv(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -37554,14 +37246,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(Sv()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(Ev()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !Cv(e.roomName, "claim");
+return !e.claimed && !Rv(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -37573,20 +37265,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = yv();
+var l = dv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !Cv(p, "claim")) {
+if (!t.has(p) && !Rv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || vv(y)) continue;
-if (hv(f)) continue;
+if (y.owner || pv(y)) continue;
+if (yv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !Cv(p, "reserve")) return p;
-} else if (!gv(p) && !Cv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !Rv(p, "reserve")) return p;
+} else if (!fv(p) && !Rv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37608,34 +37300,34 @@ task: "reserve"
 } : null;
 }
 
-function xv(e) {
+function Cv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function bv(e) {
-return xv(e) ? Iy.EMERGENCY : Iy.HIGH;
+function Sv(e) {
+return Cv(e) ? _y.EMERGENCY : _y.HIGH;
 }
 
-function Ov(e, t, r) {
+function wv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!Rv(e)) return !1;
+if (!vv(e)) return !1;
 var a = e.name === t ? r : mr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function Av(e, t, r) {
+function xv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return Ov(e, t, r);
+return wv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = fv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = mv(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37643,18 +37335,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function kv(e, t) {
+function bv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !Ov(n, e, t)) return null;
+if (!n || !wv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !Rv(e);
+return !vv(e);
 }).filter(function(e) {
-return !hv(e);
+return !yv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37675,9 +37367,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(Ev()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(gv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Xy.getPendingRequests(d).filter(function(t) {
+i += jy.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37694,12 +37386,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (xv(e) ? 3 : 1);
+}(e.name) < (Cv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = fv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = mv(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37707,10 +37399,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (Av(u.room, e, t) === e) return {
+if (xv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: bv(u.room)
+priority: Sv(u.room)
 };
 }
 } catch (e) {
@@ -37727,10 +37419,10 @@ if (r) throw r.error;
 return null;
 }
 
-function Mv(e, t) {
+function Ov(e, t) {
 if (t <= 0) return null;
 try {
-var r = qy({
+var r = Hy({
 maxEnergy: t,
 role: e
 });
@@ -37740,18 +37432,18 @@ return null;
 }
 }
 
-function Uv(e, t, r) {
-return "healer" === e || "ranger" === e && Ir(r) ? null : Mv(e, t);
+function kv(e, t, r) {
+return "healer" === e || "ranger" === e && Ir(r) ? null : Ov(e, t);
 }
 
-function _v(e) {
+function Av(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Nv(e) {
+function Mv(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37765,7 +37457,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += _v(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Av(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37786,7 +37478,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += _v(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Av(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37802,23 +37494,23 @@ return i;
 }(e)) : r;
 }
 
-var Pv = "defenseAssist", Iv = [ "guard", "ranger", "healer" ];
+var Uv = [ "guard", "ranger", "healer" ];
 
-function Gv(e, t) {
+function _v(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function Lv(e, t, r, o) {
+function Nv(e, t, r, o) {
 void 0 === o && (o = Mr(e.roomName));
-var n = Gv(e, t);
+var n = _v(e, t);
 if (!Br(t)) return n;
 if (!o) return n;
-var i = Wv(e.roomName), s = i[t] + Fr(r, o, {
-guard: Math.max(0, Gv(e, "guard") - i.guard),
-ranger: Math.max(0, Gv(e, "ranger") - i.ranger),
-healer: Math.max(0, Gv(e, "healer") - i.healer)
-}, Kv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = Lv(e.roomName), s = i[t] + Fr(r, o, {
+guard: Math.max(0, _v(e, "guard") - i.guard),
+ranger: Math.max(0, _v(e, "ranger") - i.ranger),
+healer: Math.max(0, _v(e, "healer") - i.healer)
+}, Fv(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Gr(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37833,7 +37525,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && Yv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Bv(u) && Gr(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37851,30 +37543,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function Dv(e) {
+function Pv(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? j(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function Fv(e) {
+function Iv(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === Pv ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === fa ? e.targetRoom : void 0;
 }
 
-function Bv(e, t) {
-var r = Mr(e.roomName), o = Wv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
-guard: Math.max(0, Gv(e, "guard") - o.guard),
-ranger: Math.max(0, Gv(e, "ranger") - o.ranger),
-healer: Math.max(0, Gv(e, "healer") - o.healer)
-}, Kv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function Gv(e, t) {
+var r = Mr(e.roomName), o = Lv(e.roomName), n = Fr(t.energyCapacityAvailable, r, {
+guard: Math.max(0, _v(e, "guard") - o.guard),
+ranger: Math.max(0, _v(e, "ranger") - o.ranger),
+healer: Math.max(0, _v(e, "healer") - o.healer)
+}, Fv(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = Iv.filter(function(o) {
-return !(Lv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
+var i = Uv.filter(function(o) {
+return !(Nv(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Gr(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function Wv(e) {
+function Lv(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37883,7 +37575,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-Br(p) && Fv(d) === e && u[p]++;
+Br(p) && Iv(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -37897,9 +37589,9 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Xy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(jy.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === Pv && g.targetRoom === e) && u[g.role]++;
+Br(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === fa && g.targetRoom === e) && u[g.role]++;
 }
 } catch (e) {
 o = {
@@ -37915,21 +37607,21 @@ if (o) throw o.error;
 return u;
 }
 
-function Hv(e, t, r) {
+function Dv(e, t, r) {
 var o = br(r), n = e[t];
 e[t] = n ? Or(n, o) : o;
 }
 
-function Kv(e) {
+function Fv(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (Br(y) && Fv(f) === e) {
+if (Br(y) && Iv(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && Hv(l, y, v);
+v.length > 0 && Dv(l, y, v);
 }
 }
 } catch (e) {
@@ -37944,9 +37636,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Xy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(jy.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === Pv && E.targetRoom === e) && Hv(l, E.role, E.body.parts);
+Br(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === fa && E.targetRoom === e) && Dv(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -37962,27 +37654,23 @@ if (o) throw o.error;
 return l;
 }
 
-function Yv(e) {
+function Bv(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === j(e).length;
 }
 
-function Vv(e, t, r) {
-return "defenseAssist:".concat(e, ":").concat(t.roomName, ":").concat(r);
-}
-
-function qv(e, t, r, o) {
+function Wv(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && Uv("guard", Nv(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && kv("guard", Mv(r), o) ? 1 : 0;
 }
 
-function jv(e, t) {
+function Kv(e, t) {
 var r;
 if (!function(e) {
 return Br(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !Yv(o)) return null;
+if (!o || !Bv(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38007,7 +37695,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Dv);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(Pv);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -38015,15 +37703,15 @@ return t.roomName !== e;
 var r = Mr(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(Lv(e, t, n, r), qv(e, t, o, r))
+helperNeed: Math.max(Nv(e, t, n, r), Wv(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return Dv(e.request);
+return Pv(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return Br(t) ? Wv(e)[t] : 0;
+return Br(t) ? Lv(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38048,28 +37736,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: Pv,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? Iy.EMERGENCY : Iy.HIGH,
-defenseSquadId: Vv(e, r, n.createdAt),
-defenseSquadSize: Bv(r, t),
+task: fa,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? _y.EMERGENCY : _y.HIGH,
+defenseSquadId: ya(e, r.roomName, n.createdAt),
+defenseSquadSize: Gv(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var zv = "defenseRefuel", Qv = {
+var Hv = "defenseRefuel", Yv = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Xv(e, t) {
+function Vv(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Qv.cost);
-}(n) ? Nv(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || j(e).length > 0 || e.energyCapacityAvailable < Yv.cost);
+}(n) ? Mv(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38106,9 +37794,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Xy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(jy.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === zv && s++;
+"hauler" === p.role && f === Hv && s++;
 }
 } catch (e) {
 o = {
@@ -38123,24 +37811,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: zv,
-priority: Iy.EMERGENCY,
-body: Qv
+task: Hv,
+priority: _y.EMERGENCY,
+body: Yv
 } : null : null;
 }
 
-function Zv(e) {
+function qv(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !vv(t.controller) && !hv(t) : !gv(e);
+return t ? !!t.controller && !pv(t.controller) && !yv(t) : !fv(e);
 }
 
-function Jv(e) {
+function jv(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !vv(t.controller) : !gv(e);
+return (null == t ? void 0 : t.controller) ? !pv(t.controller) : !fv(e);
 }
 
-function $v(e, t, r) {
-var o = By[t];
+function zv(e, t, r) {
+var o = Ly[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller) && 0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
@@ -38152,13 +37840,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function eg(e, t, r) {
+function Qv(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Zv(l) && cv(e, t, l) < pv(e, l, t, Game.rooms[l])) return l;
+if (qv(l) && av(e, t, l) < lv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -38174,10 +37862,10 @@ if (o) throw o.error;
 return null;
 }
 
-function tg(e, t, r, o) {
+function Xv(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = By[t];
+var p = Ly[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -38191,32 +37879,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = By[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = By[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Ly[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Ly[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, sv(e), y)) return !1;
+}(t, nv(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (mv(t)) return !("remoteWorker" === t && function(e, t) {
-av();
-var r = "".concat(e, ":").concat(t), o = rv.get(r);
+if (cv(t)) return !("remoteWorker" === t && function(e, t) {
+rv();
+var r = "".concat(e, ":").concat(t), o = $y.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return rv.set(r, n), n;
-}(e, t) >= $v(e, t, r)) && null !== eg(e, t, r);
+return $y.set(r, n), n;
+}(e, t) >= zv(e, t, r)) && null !== Qv(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Jv(R)) {
+if (jv(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = j(E).filter(function(e) {
@@ -38224,7 +37912,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && cv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && av(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38241,9 +37929,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = sv(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== kv(e, r);
-if (C >= $v(e, t, r)) return !1;
+var C = null !== (u = nv(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== bv(e, r);
+if (C >= zv(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38255,14 +37943,14 @@ var r = mr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = fv(e, o);
+var a = mv(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== wv(e, r);
+if ("claimer" === t) return null !== Tv(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38298,7 +37986,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Zy.getActiveRequests) || void 0 === m ? void 0 : m.call(Zy)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = zy.getActiveRequests) || void 0 === m ? void 0 : m.call(zy)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38326,16 +38014,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function rg(e) {
+function Zv(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function og(e) {
-return 0 === rg(sv(e, !0));
+function Jv(e) {
+return 0 === Zv(nv(e, !0));
 }
 
-function ng(e) {
+function $v(e) {
 var t = ze(e);
 return [ {
 role: "harvester",
@@ -38358,14 +38046,14 @@ minCount: 1
 } ];
 }
 
-function ag(e, t) {
-var r, o, n, i, s = sv(e, !0);
-if (0 === rg(s)) return !0;
+function eg(e, t) {
+var r, o, n, i, s = nv(e, !0);
+if (0 === Zv(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = sv(e, !1), u = ng(t);
+var c = nv(e, !1), u = $v(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38385,57 +38073,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function ig(e) {
+function tg(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function sg(e, t, r) {
-var n = $v(e.name, r.roleName, t);
+function rg(e, t, r) {
+var n = zv(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function cg(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Iy.EMERGENCY;
+function og(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return _y.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Iy.HIGH;
-if (ev.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return _y.HIGH;
+if (Zy.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = vr(e), n = hr(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Iy.EMERGENCY;
-if (a > 0) return Iy.HIGH;
+if (a >= 100) return _y.EMERGENCY;
+if (a > 0) return _y.HIGH;
 }
 return function(e) {
-return e >= 90 ? Iy.HIGH : e >= 60 ? Iy.NORMAL : Iy.LOW;
+return e >= 90 ? _y.HIGH : e >= 60 ? _y.NORMAL : _y.LOW;
 }(o);
 }
 
-function ug(e, t) {
+function ng(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-ig(e);
-var l = sv(e.name), m = og(e.name), d = [];
-if (ag(e.name, e)) {
+tg(e);
+var l = nv(e.name), m = Jv(e.name), d = [];
+if (eg(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === rg(sv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Zv(nv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = sv(e, !1), c = ng(t);
+var s = nv(e, !1), c = $v(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38450,7 +38138,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = tg(e, m.role, r, !0);
+var p = Xv(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38481,17 +38169,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = By[p]) && tg(e.name, p, t, !0) ? (d.push(sg(e, t, {
+return p && (g = Ly[p]) && Xv(e.name, p, t, !0) ? (d.push(rg(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: cg(e, 0, p, g.priority, m),
+priority: og(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(By)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Xv(e.name, p);
+for (var f = a(Object.entries(Ly)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Vv(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38502,7 +38190,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = jv(e.name, p);
+var E = Kv(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38516,8 +38204,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (tg(e.name, p, t, m)) {
-var T = mv(p), C = T ? eg(e.name, p, t) : null, S = "claimer" === p ? wv(e.name, t) : null, w = "pioneer" === p ? kv(e.name, t) : null;
+}); else if (Xv(e.name, p, t, m)) {
+var T = cv(p), C = T ? Qv(e.name, p, t) : null, S = "claimer" === p ? Tv(e.name, t) : null, w = "pioneer" === p ? bv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38527,11 +38215,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(sg(e, t, {
+}) : d.push(rg(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: cg(e, 0, p, g.priority, m),
+priority: og(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38553,7 +38241,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = lg(e, l.value);
+var m = ag(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38574,10 +38262,10 @@ requests: c
 };
 }
 
-function lg(e, t) {
+function ag(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Jy.getMaxAffordableInTicks(e, l), d = Nv(e), p = t.priority >= Iy.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= Iy.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : Uv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Qy.getMaxAffordableInTicks(e, l), d = Mv(e), p = t.priority >= _y.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && Br(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= _y.EMERGENCY, g = t.assistTarget ? Mr(t.assistTarget) : null, h = f ? Gr(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Gr(f, d, g)) && void 0 !== r ? r : kv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38598,7 +38286,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : qy({
+}(t.def, p)) && void 0 !== c ? c : Hy({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38634,44 +38322,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var mg = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), dg = new Set([ "guard", "ranger", "healer" ]);
+var ig = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), sg = new Set([ "guard", "ranger", "healer" ]);
 
-function pg() {
+function cg() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function fg(e) {
+function ug(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function yg(e) {
+function lg(e) {
 var t;
-return e.priority >= Iy.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= _y.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function vg(e) {
+function mg(e) {
 var t;
-return e.priority >= Iy.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= _y.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function gg(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Nv(e), m = r.urgency >= 2 || t.danger >= 3 ? Iy.EMERGENCY : Iy.HIGH, d = kr(j(e)), p = function(e) {
+function dg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Mv(e), m = r.urgency >= 2 || t.danger >= 3 ? _y.EMERGENCY : _y.HIGH, d = Ar(j(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === Iy.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === _y.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Xy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(jy.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || hg(u, e) && ("guard" === u.role && (n.guards++,
-Eg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Eg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Eg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || pg(u, e) && ("guard" === u.role && (n.guards++,
+yg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, yg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, yg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38699,7 +38387,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Eg(n, u, l);
+0 !== l.length && yg(n, u, l);
 }
 }
 }
@@ -38738,26 +38426,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Rg("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) Cg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Rg("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) Cg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Rg("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Cg(e, "healer", "military", Iy.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : fg("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) gg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : fg("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) gg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : fg("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) gg(e, "healer", "military", _y.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < Iy.EMERGENCY || function(e, t) {
+if (!(t < _y.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !dg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !sg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Xy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(jy.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Iy.EMERGENCY || dg.has(c.role) && hg(c, e.name) && c.body.cost <= t && n++;
+c.priority < _y.EMERGENCY || sg.has(c.role) && pg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38774,7 +38462,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = Mv(t, e);
+var r = Ov(t, e);
 return r ? {
 role: t,
 body: r
@@ -38789,45 +38477,45 @@ var r = br(t.body.parts).score - br(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Cg(e, n.role, "military", Iy.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && gg(e, n.role, "military", _y.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function hg(e, t) {
+function pg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Rg(e, t, r) {
+function fg(e, t, r) {
 return r ? Gr(e, t, r) : null;
 }
 
-function Eg(e, t, r) {
+function yg(e, t, r) {
 var o = br(r);
 e[t] = e[t] ? Or(e[t], o) : o;
 }
 
-function Tg(e, t, r) {
-return Xy.getPendingRequests(e).filter(function(e) {
+function vg(e, t, r) {
+return jy.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Cg(e, t, r, o, n, a, i, s, c) {
+function gg(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : qy({
+var u = null != i ? i : Hy({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Xy.addRequest({
+jy.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38845,34 +38533,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Sg(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Iy.HIGH) return !1;
+function hg(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= _y.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Iy.NORMAL) {
-if (Jy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < _y.NORMAL) {
+if (Qy.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Iy.NORMAL && o / e.energyCapacityAvailable < .3 && Jy.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === _y.NORMAL && o / e.energyCapacityAvailable < .3 && Qy.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function wg(e, t) {
+function Rg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-ig(e);
-var s = Xy.getQueueSize(e.name);
+tg(e);
+var s = jy.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = ag(e.name, e), u = og(e.name) && !Xy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
+var c = eg(e.name, e), u = Jv(e.name) && !jy.hasEmergencySpawns(e.name), l = vr(e), m = hr(e);
 if (c) {
-s > 0 && Xy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && gg(e, t, l, m);
+s > 0 && jy.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && dg(e, t, l, m);
 try {
-for (var d = a(ug(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(ng(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Xy.addRequest(f);
+jy.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -38885,8 +38573,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && gg(e, t, l, m), function(e) {
-var t, r, o = $y.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && dg(e, t, l, m), function(e) {
+var t, r, o = Xy.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -38898,17 +38586,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = Iy.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = _y.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Tg(e.name, "powerHarvester", f), g = Tg(e.name, "healer", f), h = Tg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Cg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = vg(e.name, "powerHarvester", f), g = vg(e.name, "healer", f), h = vg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) gg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Cg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) gg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Cg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) gg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -38937,13 +38625,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Xy.getPendingRequests(e.name).map(fg));
+var c = new Set(jy.getPendingRequests(e.name).map(ug));
 try {
-for (var u = a(ug(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Iy.HIGH, p = "claimer" === m.role && pg(), f = yg(m), y = vg(m);
-if (mg.has(m.role) || d || p || f || y) {
-var v = fg(m);
-c.has(v) || (Xy.addRequest(m), c.add(v));
+for (var u = a(ng(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= _y.HIGH, p = "claimer" === m.role && cg(), f = lg(m), y = mg(m);
+if (ig.has(m.role) || d || p || f || y) {
+var v = ug(m);
+c.has(v) || (jy.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -38960,8 +38648,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(ug(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Xy.addRequest(f);
+for (var y = a(ng(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+jy.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -38973,32 +38661,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Xy.getQueueStats(e.name);
+var g = jy.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Xy.clearQueue(e.name);
+} else s > 0 && jy.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Xy.getAvailableSpawns(e.name);
+var t, r, o = jy.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Nv(e);
+var n = 0, i = Mv(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Xy.getNextRequest(e.name, i);
+var u = c.value, l = jy.getNextRequest(e.name, i);
 if (!l) break;
-if (Sg(e, l, i)) {
+if (hg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = zy(u, l);
-m === OK ? (n++, i -= l.body.cost, Xy.markInProgress(e.name, l.id, u.id), Xy.removeRequest(e.name, l.id),
+var m = Vy(u, l);
+m === OK ? (n++, i -= l.body.cost, jy.markInProgress(e.name, l.id, u.id), jy.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Xy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (jy.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -39014,7 +38702,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Xy.getQueueStats(e.name);
+}(e), o = jy.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -39028,7 +38716,7 @@ stats: o
 }(e, t);
 }
 
-var xg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, bg = /^(\d{1,2})\|(.+)$/, Og = k("SS2TerminalComms"), Ag = function() {
+var Eg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, Tg = /^(\d{1,2})\|(.+)$/, Cg = A("SS2TerminalComms"), Sg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -39088,11 +38776,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(xg);
+var t = e.match(Eg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(bg);
+var i = a.match(Tg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -39127,7 +38815,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-Og.warn("Missing packet in multi-packet message", {
+Cg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -39143,7 +38831,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), Og.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), Cg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -39167,7 +38855,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && Og.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && Cg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -39179,7 +38867,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return Og.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return Cg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -39187,14 +38875,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), Og.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), Cg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (Og.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (Cg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -39219,7 +38907,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-Og.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+Cg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -39231,7 +38919,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-Og.info("Completed sending multi-packet message", {
+Cg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -39239,25 +38927,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? Og.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? Cg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (Og.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (Cg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else Og.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else Cg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else Og.warn("Terminal not found for queue item, removing from queue", {
+} else Cg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39291,7 +38979,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && Og.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && Cg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39301,7 +38989,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-Og.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+Cg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39392,7 +39080,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (Og.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (Cg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39414,7 +39102,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return Og.error("Error parsing JSON", {
+return Cg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39425,7 +39113,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), kg = [ {
+}(), wg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39445,7 +39133,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Mg = function() {
+} ], xg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39483,7 +39171,7 @@ return e.clusters || (e.clusters = {}), e.clusters;
 }, e.prototype.getCluster = function(e, t) {
 var r = this.getClusters();
 if (!r[e] && t) {
-r[e] = kt(e, t);
+r[e] = At(e, t);
 var o = this.getEmpire();
 o.clusters.includes(e) || o.clusters.push(e);
 }
@@ -39492,9 +39180,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), Ug = new Mg;
+}(), bg = new xg;
 
-function _g(e) {
+function Og(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39502,19 +39190,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function Ng(e, t) {
+function kg(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Pg(e, t) {
+function Ag(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var Ig = {
+var Mg = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39525,9 +39213,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, Gg = function() {
+}, Ug = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Ig), e);
+void 0 === e && (e = {}), this.config = o(o({}, Mg), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39548,7 +39236,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = Ug.getSwarmState(r.toRoom);
+var o = bg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39561,7 +39249,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = Ug.getSwarmState(c);
+var l = bg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39631,9 +39319,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(Ng), u = n.filter(function(e) {
+}).sort(kg), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Pg), l = [], m = [], d = function(t) {
+}).sort(Ag), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39655,11 +39343,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return _g({
+return Og({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + _g({
+}) + Og({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39758,7 +39446,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), Lg = new Gg, Dg = {
+}(), _g = new Ug, Ng = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39779,14 +39467,14 @@ siegeUnits: 1
 }
 };
 
-function Fg(e) {
+function Pg(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function Bg(e) {
+function Ig(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39809,9 +39497,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function Wg(e) {
+function Gg(e) {
 var t, r, o;
-Bg(e);
+Ig(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39835,20 +39523,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Hg(e) {
+function Lg(e) {
 var t;
-Bg(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Wg(e);
+Ig(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Gg(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function Kg(e) {
-return !!Hg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function Dg(e) {
+return !!Lg(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-Bg(e);
+Ig(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39859,12 +39547,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = Wg(e);
+var d = Gg(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function Yg(e, t) {
+function Fg(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -39885,20 +39573,20 @@ if (r) throw r.error;
 return n;
 }
 
-function Vg(e, t) {
+function Bg(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Dg[r]) && void 0 !== t ? t : Dg[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Ng[r]) && void 0 !== t ? t : Ng[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Yg(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Fg(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: Fg(r),
+targetComposition: Pg(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -39910,7 +39598,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function qg(e) {
+function Wg(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -39930,9 +39618,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function jg(e) {
+function Kg(e) {
 var t = e.members.length;
-Bg(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+Ig(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -39946,7 +39634,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && Kg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && Dg(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -39975,7 +39663,7 @@ subsystem: "Squad"
 }
 }
 
-var zg = {
+var Hg = {
 harassment: {
 composition: {
 harassers: 3,
@@ -40062,7 +39750,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Qg(e, t) {
+function Yg(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -40077,8 +39765,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Xg(e, t) {
-var r, o, n, i = zg[t], s = 0;
+function Vg(e, t) {
+var r, o, n, i = Hg[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -40104,7 +39792,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Zg, Jg, $g, eh = {
+var qg, jg, zg, Qg = {
 move: 50,
 work: 100,
 carry: 50,
@@ -40113,11 +39801,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, th = new Map;
+}, Xg = new Map;
 
-function rh(e, t) {
+function Zg(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (th.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Xg.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -40129,7 +39817,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = zg[p].composition;
+d = Hg[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -40144,19 +39832,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (th.set(m, y), function(e, t, r, o) {
+v ? (Xg.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = zg[s].useBoosts;
+i = Hg[s].useBoosts;
 }
-var c = Iy.NORMAL;
-"siege" === t.type ? c = Iy.HIGH : "defense" === t.type && (c = Iy.EMERGENCY);
+var c = _y.NORMAL;
+"siege" === t.type ? c = _y.HIGH : "defense" === t.type && (c = _y.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = oh(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + eh[t];
-}, 0), m = i ? ah(r) : [], d = {
+var u = Jg(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Qg[t];
+}, 0), m = i ? eh(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -40185,7 +39873,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Xy.addRequest(d), o.spawnRequests.add(d.id);
+jy.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -40199,42 +39887,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function oh(e, t, r) {
+function Jg(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return nh([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return $g([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return nh([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return $g([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return nh([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return $g([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return nh([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return $g([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return nh([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return $g([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return nh([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return $g([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function nh(e, t, r) {
+function $g(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + eh[t];
+return e + Qg[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + eh[t];
+return e + Qg[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function ah(e) {
+function eh(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40265,45 +39953,45 @@ return [];
 }
 }
 
-function ih(e) {
-return th.has(e);
+function th(e) {
+return Xg.has(e);
 }
 
-function sh(e) {
-return Hg(e) || Kg(e);
+function rh(e) {
+return Lg(e) || Dg(e);
 }
 
-(Zg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Zg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Zg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Jg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Jg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Jg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Jg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, ($g = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-$g[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, $g[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-$g[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, $g[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(qg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, qg[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+qg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (jg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+jg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, jg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+jg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (zg = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+zg[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, zg[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+zg[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, zg[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var ch = {
+var oh = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function uh(e, t) {
-var r = ch[t], o = Ug.getClusters();
+function nh(e, t) {
+var r = oh[t], o = bg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function lh(e, t, r) {
+function ah(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = Ug.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = bg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: uh(e, i.danger),
+reservedEnergy: nh(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40393,7 +40081,7 @@ success: !1
 });
 }
 
-var mh = {
+var ih = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40403,7 +40091,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function dh(e, t, r) {
+function sh(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40434,7 +40122,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function ph(e, t, r, o) {
+function ch(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40444,7 +40132,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function fh(e, t) {
+function uh(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40465,19 +40153,19 @@ if (r) throw r.error;
 return n;
 }
 
-function yh() {
-var e = Ug.getEmpire();
+function lh() {
+var e = bg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function vh(e) {
-yh()[e.id] = e;
+function mh(e) {
+lh()[e.id] = e;
 }
 
-function gh(e) {
+function dh(e) {
 e.lastUpdate = Game.time;
-var t = Ug.getCluster(e.clusterId);
-if (!t) return e.state = "failed", vh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = bg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", mh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40487,12 +40175,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (sh(r) || ih(e) || rh(0, r), sh(r));
+return !!r && (rh(r) || th(e) || Zg(0, r), rh(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), vh(e);
+})), mh(e);
 }(e, t);
 break;
 
@@ -40503,7 +40191,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (jg(o), qg(o)) {
+if (Kg(o), Wg(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40532,7 +40220,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = Ug.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = bg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40559,14 +40247,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), vh(e);
+})), mh(e);
 }(e, t);
 }
 }
 
-var hh = "defenseAssist";
-
-function Rh(e, t, r) {
+function ph(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40585,11 +40271,11 @@ score: n.score + o.score
 }
 }
 
-function Eh(e, t, r) {
+function fh(e, t, r) {
 return Gr(e, t, r);
 }
 
-function Th(e, t) {
+function yh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40602,11 +40288,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function Ch(e) {
+function vh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function Sh(e, t, r) {
+function gh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40619,8 +40305,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function wh(e, t, r) {
-var o = Eh(t, e.energyCapacityAvailable, r);
+function hh(e, t, r) {
+var o = fh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40628,16 +40314,16 @@ var a = br(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function xh(e, t, r, o) {
+function Rh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = wh(e, t, o);
-if (s !== wh(n, t, o)) return s ? -1 : 1;
+var a, i, s = hh(e, t, o);
+if (s !== hh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function bh(e, t) {
+function Eh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40721,25 +40407,21 @@ if (r) throw r.error;
 return u;
 }
 
-function Oh(e, t) {
+function Th(e, t) {
 return {
-guard: Math.max(0, Th(e, "guard") - t.counts.guard),
-ranger: Math.max(0, Th(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, Th(e, "healer") - t.counts.healer)
+guard: Math.max(0, yh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, yh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, yh(e, "healer") - t.counts.healer)
 };
 }
 
-function Ah(e, t, r) {
-return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
-}
-
-function kh(e) {
+function Ch(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function Mh(e, t) {
+function Sh(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return kh(e.role);
+return Ch(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40752,12 +40434,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function Uh(e) {
+function wh(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === hh ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === fa ? e.targetRoom : void 0;
 }
 
-function _h(e) {
+function xh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40769,7 +40451,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-kh(m) && Uh(l) === e && !u.spawning && Rh(i, m, u.body.filter(function(e) {
+Ch(m) && wh(l) === e && !u.spawning && ph(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40787,7 +40469,7 @@ if (t) throw t.error;
 return i;
 }
 
-function Nh(e, t, r) {
+function bh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40817,16 +40499,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: Mh(e, r)
+pendingAssist: Sh(e, r)
 };
 }
 }
 
-function Ph(e, t) {
+function Oh(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = Eh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = fh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40847,7 +40529,7 @@ subsystem: "Cluster"
 }
 }
 
-function Ih(e, t, r) {
+function kh(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -40889,20 +40571,20 @@ exitAccess: a
 };
 }
 
-function Gh(e, t) {
+function Ah(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function Lh(e, t, r) {
+function Mh(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function Dh(e) {
+function Uh(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function Fh(e, t) {
+function _h(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -40913,7 +40595,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function Bh(e, t, r) {
+function Nh(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -40924,8 +40606,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = Dh(g);
-h && (g.assistTarget || Fh(v, h) && (t.assignedCreeps.includes(v.name) || Gh(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = Uh(g);
+h && (ga(g) || _h(v, h) && (t.assignedCreeps.includes(v.name) || Ah(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -40962,7 +40644,7 @@ return e.distance - t.distance;
 });
 }
 
-function Wh(e, t) {
+function Ph(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -40987,21 +40669,21 @@ if (r) throw r.error;
 return i;
 }
 
-function Hh(e) {
+function Ih(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var Kh = {
+var Gh = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, Yh = function() {
+}, Lh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Kh), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, Gh), e);
 }
 return e.prototype.run = function() {
-var e = Ug.getClusters();
+var e = bg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -41020,7 +40702,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: kg.map(function(t) {
+steps: wg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -41039,7 +40721,7 @@ focusRoom: e.focusRoom
 }(e);
 }, e.prototype.runCluster = function(e) {
 var t, r, o = this, n = Game.cpu.getUsed(), i = this.getClusterOperationIntent(e), s = function(t) {
-Ji.measureSubsystem(t.statsKey, function() {
+Zi.measureSubsystem(t.statsKey, function() {
 o.executeClusterOperation(t.name, e);
 });
 };
@@ -41068,12 +40750,7 @@ this.updateClusterMetrics(t);
 break;
 
 case "defense":
-this.processDefenseRequests(t), function(e) {
-if (mr.getCluster(e)) Da.coordinateDefense(e); else {
-var t, r = (t = e, mr.getOrInitSwarmState(t).clusterId);
-r && Da.coordinateDefense(r);
-}
-}(t.id);
+this.processDefenseRequests(t);
 break;
 
 case "terminals":
@@ -41081,7 +40758,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-Lg.processCluster(t);
+_g.processCluster(t);
 break;
 
 case "squads":
@@ -41113,7 +40790,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = Ih(e, new RoomPosition(s, c, e.name), "defense");
+var u = kh(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -41162,9 +40839,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = Ug.getSwarmState(i);
+var i = n.value, s = bg.getSwarmState(i);
 if (s) {
-var c = uh(i, s.danger);
+var c = nh(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -41195,7 +40872,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = Ug.getSwarmState(m);
+var m = l.value, d = bg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -41227,7 +40904,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += Hh(l.controller.level));
+}).length, i += Ih(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41344,7 +41021,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-jg(i), "gathering" !== i.state || sh(i) || ih(i.id) || rh(0, i), qg(i) && (i.state = "dissolving");
+Kg(i), "gathering" !== i.state || rh(i) || th(i.id) || Zg(0, i), Wg(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41369,7 +41046,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Vg(e, s);
+var s = i.value, c = Bg(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41386,7 +41063,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(yh()).filter(function(e) {
+var t = (a = e.id, Object.values(lh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41397,22 +41074,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, mh), n), m = [], d = Ug.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, ih), n), m = [], d = bg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = dh(f, y, d);
+var g = sh(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = fh(e, f);
+var h = uh(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = ph(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = ch(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Qg(f, {
+var C = Yg(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41447,29 +41124,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Xg(e, n.doctrine) ? function(e, t, r) {
+Vg(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = Ug.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = bg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = dh(e, o, r);
+var n = sh(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (Ug.getEmpire().knownRooms || {})[t], n = null != r ? r : Qg(t, {
+var o = (bg.getEmpire().knownRooms || {})[t], n = null != r ? r : Yg(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Xg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Vg(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41482,7 +41159,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-vh(i);
+mh(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41496,13 +41173,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Yg(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Fg(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: Fg(n),
+targetComposition: Pg(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41517,8 +41194,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), vh(i), rh(0, c), i.state = "forming", i.lastUpdate = Game.time,
-vh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), mh(i), Zg(0, c), i.state = "forming", i.lastUpdate = Game.time,
+mh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41537,11 +41214,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(th.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Xg.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), th.delete(c));
+}), Xg.delete(c));
 }
 } catch (t) {
 e = {
@@ -41555,10 +41232,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = yh();
-for (var t in e) gh(e[t]);
+var e = lh();
+for (var t in e) dh(e[t]);
 !function() {
-var e = yh();
+var e = lh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41636,14 +41313,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = Ug.getCluster(t, e);
+var t = "cluster_".concat(e), r = bg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = Ug.getCluster(e);
+var o = bg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41672,7 +41349,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && lh(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && ah(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41689,7 +41366,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = Ug.getSwarmState(t);
+var n, a, i = bg.getSwarmState(t);
 if (!i) return "continue";
 if (Rr(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41730,7 +41407,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mr(g), f[g] = _h(g);
+p[g] = Mr(g), f[g] = xh(g);
 }
 } catch (e) {
 r = {
@@ -41746,7 +41423,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = Nh(E, m, t);
+d[E] = bh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41765,31 +41442,31 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Sh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = gh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = bh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = Eh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Fr(T, R, Oh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Fr(T, R, Th(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], A = xh(h, b, g.roomName, R), k = 0; k < O; k++) {
-var M = A.find(function(e) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = Rh(h, b, g.roomName, R), A = 0; A < O; A++) {
+var M = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
 });
 if (!M) break;
 p.set(M.roomName, (null !== (l = p.get(M.roomName)) && void 0 !== l ? l : 0) + 1),
 d.push({
-id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").concat(e.now, "_").concat(k),
+id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").concat(e.now, "_").concat(A),
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: Ch(g.urgency),
+priority: vh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: hh,
-defenseSquadId: Ah(M.roomName, g.roomName, e.now),
+task: fa,
+defenseSquadId: ya(M.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -41829,7 +41506,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) Ph(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) Oh(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41844,7 +41521,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Xy);
+}(e, jy);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41856,18 +41533,20 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = Wh(f, Bh(e, f, t)), v = y.reduce(function(e, t) {
+var y = Ph(f, Nh(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
 }, new Map);
 try {
 for (var g = (n = void 0, a(y)), h = g.next(); !h.done; h = g.next()) {
-var R = h.value, E = R.creep.memory, T = Math.max(1, Math.min(3, null !== (u = v.get(R.room.name)) && void 0 !== u ? u : 1));
-E.assistTarget = f.roomName, E.targetRoom = f.roomName, E.task = "defenseAssist",
-E.defenseSquadId = "defenseAssist:".concat(R.room.name, ":").concat(f.roomName, ":").concat(t.now),
-E.defenseSquadSize = T, E.defenseSquadCreatedAt = t.now, f.assignedCreeps.push(R.creep.name),
-Lh(f, R.role, Gh(f, R.role) - 1), l.push({
+var R = h.value, E = Math.max(1, Math.min(3, null !== (u = v.get(R.room.name)) && void 0 !== u ? u : 1));
+va(R.creep, {
+homeRoom: R.room.name,
+targetRoom: f.roomName,
+now: t.now,
+squadSize: E
+}), f.assignedCreeps.push(R.creep.name), Mh(f, R.role, Ah(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -41928,34 +41607,34 @@ c && !c.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-}, n([ Ma("cluster:manager", "Cluster Manager", {
-priority: ha.MEDIUM,
+}, n([ Ka("cluster:manager", "Cluster Manager", {
+priority: Ma.MEDIUM,
 interval: 10,
 minBucket: 0,
 cpuBudget: .03
-}) ], e.prototype, "run", null), n([ _a() ], e);
-}(), Vh = new Yh, qh = /^([WE])(\d+)([NS])(\d+)$/;
+}) ], e.prototype, "run", null), n([ Ya() ], e);
+}(), Dh = new Lh, Fh = /^([WE])(\d+)([NS])(\d+)$/;
 
-function jh(e) {
-return qh.test(e);
+function Bh(e) {
+return Fh.test(e);
 }
 
-var zh = {
+var Wh = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, Qh = function() {
+}, Kh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, zh), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Wh), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
 var e = InterShardMemory.getLocal();
 if (e) {
-var t = Dp(e);
+var t = Ip(e);
 if (t) {
 this.updateEnemyIntelligence(t);
-var r = Lp(t);
+var r = Pp(t);
 InterShardMemory.setLocal(r);
 }
 }
@@ -41973,7 +41652,7 @@ lastSeen: null !== (r = null == a ? void 0 : a.lastSeen) && void 0 !== r ? r : 0
 }), l = function(e) {
 var t, r, n, c, u, l, m, d, p = new Map, f = new Set, y = new Set, v = new Map;
 try {
-for (var g = a(e.knownRooms), h = g.next(); !h.done; h = g.next()) (k = h.value).owner && v.set(k.roomName, k.owner);
+for (var g = a(e.knownRooms), h = g.next(); !h.done; h = g.next()) (A = h.value).owner && v.set(A.roomName, A.owner);
 } catch (e) {
 t = {
 error: e
@@ -42021,7 +41700,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (jh(x)) {
+if (e.isAlly(x)) f.add(x); else if (Bh(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -42043,10 +41722,10 @@ if (u) throw u.error;
 }
 }
 try {
-for (var O = a(e.knownRooms), A = O.next(); !A.done; A = O.next()) {
-var k;
-(k = A.value).owner && (k.owner.includes("Source Keeper") ? y.add(k.owner) : e.isAlly(k.owner) ? f.add(k.owner) : ((C = R(k.owner)).rooms.includes(k.roomName) || (C.rooms.push(k.roomName),
-C.rooms.sort()), C.lastSeen = Math.max(C.lastSeen, k.lastSeen), C.threatLevel = Math.max(C.threatLevel, k.threatLevel)));
+for (var O = a(e.knownRooms), k = O.next(); !k.done; k = O.next()) {
+var A;
+(A = k.value).owner && (A.owner.includes("Source Keeper") ? y.add(A.owner) : e.isAlly(A.owner) ? f.add(A.owner) : ((C = R(A.owner)).rooms.includes(A.roomName) || (C.rooms.push(A.roomName),
+C.rooms.sort()), C.lastSeen = Math.max(C.lastSeen, A.lastSeen), C.threatLevel = Math.max(C.threatLevel, A.threatLevel)));
 }
 } catch (e) {
 m = {
@@ -42054,7 +41733,7 @@ error: e
 };
 } finally {
 try {
-A && !A.done && (d = O.return) && d.call(O);
+k && !k.done && (d = O.return) && d.call(O);
 } finally {
 if (m) throw m.error;
 }
@@ -42089,15 +41768,15 @@ subsystem: "CrossShardIntel"
 }, e.prototype.getGlobalEnemies = function() {
 var e = InterShardMemory.getLocal();
 if (!e) return [];
-var t = Dp(e);
+var t = Ip(e);
 return t && t.globalTargets.enemies || [];
-}, n([ Oi("empire:crossShardIntel", "Cross-Shard Intel", {
-priority: ha.LOW,
+}, n([ bi("empire:crossShardIntel", "Cross-Shard Intel", {
+priority: Ma.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), Xh = new Qh, Zh = function() {
+}(), Hh = new Kh, Yh = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -42174,9 +41853,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), Jh = new Zh, $h = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), Vh = new Yh, qh = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function eR(e, t) {
+function jh(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -42199,22 +41878,22 @@ if (r) throw r.error;
 return n;
 }
 
-function tR(e) {
+function zh(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function rR(e, t, r) {
-if (!tR(e)) return 0;
-var o = eR(e.name, t);
+function Qh(e, t, r) {
+if (!zh(e)) return 0;
+var o = jh(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
-return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += oc(e.mineralType),
-n -= 5 * o, n -= nc(e.name), n -= 15 * e.threatLevel, n += ac(e.terrain), ic(e.name) && (n += 10),
-n += sc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
-n += uc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
+return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += rc(e.mineralType),
+n -= 5 * o, n -= oc(e.name), n -= 15 * e.threatLevel, n += nc(e.terrain), ac(e.name) && (n += 10),
+n += ic(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
+n += cc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function oR(e, t) {
+function Xh(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -42224,13 +41903,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return j(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && $h.has(e.type);
+return e.hits > 0 && qh.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function nR(e, t, r) {
+function Zh(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -42240,7 +41919,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function aR(e) {
+function Jh(e) {
 return function(e) {
 var t = Z(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42251,8 +41930,8 @@ isSK: J(t.x) && J(t.y)
 }(e);
 }
 
-function iR(e) {
-var t = aR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function $h(e) {
+var t = Jh(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42271,14 +41950,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var sR = {
+var eR = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, cR = function() {
+}, tR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, sR), e);
+void 0 === e && (e = {}), this.config = o(o({}, eR), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42369,7 +42048,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = aR(e);
+var t = Jh(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42381,14 +42060,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return iR(uR(e));
+return $h(rR(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = iR(uR(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = $h(rR(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function uR(e) {
+function rR(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = j(e), c = z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42420,11 +42099,11 @@ swamps: d
 };
 }
 
-var lR = new cR, mR = /^([WE])(\d+)([NS])(\d+)$/, dR = {
+var oR = new tR, nR = /^([WE])(\d+)([NS])(\d+)$/, aR = {
 allies: []
-}, pR = function() {
+}, iR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, dR), e);
+void 0 === e && (e = {}), this.config = o(o({}, aR), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42444,7 +42123,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!mR.test(e)) return !1;
+if (!nR.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42552,7 +42231,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return mR.test(e);
+return nR.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42579,7 +42258,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), fR = new pR, yR = {
+}(), sR = new iR, cR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42592,9 +42271,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, vR = function() {
+}, uR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, yR), e);
+void 0 === e && (e = {}), this.config = o(o({}, cR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = mr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42602,27 +42281,27 @@ if (n < this.config.minBucket) Game.time % 100 == 0 && U.warn("Empire manager sk
 subsystem: "Empire"
 }); else {
 var a = this.getBucketMode(n), i = this.shouldRunDegradedModeWork(a), s = this.shouldRunNormalModeWork(a), c = this.shouldRunFullModeWork(a);
-o.lastUpdate = Game.time, s && (Ji.measureSubsystem("empire:expansion", function() {
+o.lastUpdate = Game.time, s && (Zi.measureSubsystem("empire:expansion", function() {
 t.updateExpansionQueue(o);
-}), Ji.measureSubsystem("empire:powerBanks", function() {
+}), Zi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
-})), Ji.measureSubsystem("empire:warTargets", function() {
-fR.updateWarTargets(o);
-}), Ji.measureSubsystem("empire:objectives", function() {
+})), Zi.measureSubsystem("empire:warTargets", function() {
+sR.updateWarTargets(o);
+}), Zi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
-}), Ji.measureSubsystem("empire:gclTracking", function() {
+}), Zi.measureSubsystem("empire:gclTracking", function() {
 t.trackGCLProgress(o);
-}), s && Ji.measureSubsystem("empire:expansionReadiness", function() {
+}), s && Zi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
-}), i && (Ji.measureSubsystem("empire:intelRefresh", function() {
-lR.refreshRoomIntel(o);
-}), Ji.measureSubsystem("empire:roomDiscovery", function() {
-lR.discoverNearbyRooms(o);
-})), s && Ji.measureSubsystem("empire:nukeCandidates", function() {
+}), i && (Zi.measureSubsystem("empire:intelRefresh", function() {
+oR.refreshRoomIntel(o);
+}), Zi.measureSubsystem("empire:roomDiscovery", function() {
+oR.discoverNearbyRooms(o);
+})), s && Zi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
-}), c && (Ji.measureSubsystem("empire:clusterHealth", function() {
-Jh.monitorClusterHealth();
-}), Ji.measureSubsystem("empire:powerBankProfitability", function() {
+}), c && (Zi.measureSubsystem("empire:clusterHealth", function() {
+Vh.monitorClusterHealth();
+}), Zi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
 var u = Game.cpu.getUsed() - r, l = Game.cpu.limit * this.config.maxCpuBudget;
@@ -42704,22 +42383,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = oR(f, u);
+var y = Boolean(Game.rooms[f]), v = Xh(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = eR(f, t);
+var g = jh(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = nR(h, u, y);
+var h = e.knownRooms[f], R = Zh(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? rR(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? Qh(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42763,10 +42442,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && tR(a)) {
-var i = eR(a.name, t);
+if (a && zh(a)) {
+var i = jh(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = rR(a, t, r);
+var s = Qh(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -42923,14 +42602,14 @@ if (n) throw n.error;
 }
 }
 try {
-for (var A = a(C), k = A.next(); !k.done; k = A.next()) delete S[O = k.value];
+for (var k = a(C), A = k.next(); !A.done; A = k.next()) delete S[O = A.value];
 } catch (e) {
 c = {
 error: e
 };
 } finally {
 try {
-k && !k.done && (u = A.return) && u.call(A);
+A && !A.done && (u = k.return) && u.call(k);
 } finally {
 if (c) throw c.error;
 }
@@ -43080,19 +42759,19 @@ if (t) throw t.error;
 }
 }
 }
-}, n([ Oi("empire:manager", "Empire Manager", {
-priority: ha.MEDIUM,
+}, n([ bi("empire:manager", "Empire Manager", {
+priority: Ma.MEDIUM,
 interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), gR = new vR;
+}(), lR = new uR;
 
-function hR(e) {
+function mR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var RR = {
+var dR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -43100,21 +42779,21 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, ER = function() {
+}, pR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, RR), e);
+this.config = o(o({}, dR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
 this.lastRun = Game.time, 0 === this.scanQueue.length && this.buildScanQueue(),
-Ji.measureSubsystem("intel:scanning", function() {
+Zi.measureSubsystem("intel:scanning", function() {
 e.scanRooms();
-}), Ji.measureSubsystem("intel:enemyTracking", function() {
+}), Zi.measureSubsystem("intel:enemyTracking", function() {
 e.updateEnemyTracking();
-}), Ji.measureSubsystem("intel:threatDetection", function() {
+}), Zi.measureSubsystem("intel:threatDetection", function() {
 e.detectThreats();
-}), Ji.measureSubsystem("intel:threatUpdate", function() {
+}), Zi.measureSubsystem("intel:threatUpdate", function() {
 e.updateRoomThreatLevels();
 });
 var r = Game.cpu.getUsed() - t;
@@ -43247,7 +42926,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, hR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, mR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43269,8 +42948,8 @@ return e.username.localeCompare(t.username);
 };
 }(Game.time, g);
 try {
-for (var A = a(O.enemies), k = A.next(); !k.done; k = A.next()) {
-var M = k.value;
+for (var k = a(O.enemies), A = k.next(); !A.done; A = k.next()) {
+var M = A.value;
 (B = null !== (v = this.enemyPlayers.get(M.username)) && void 0 !== v ? v : {
 username: M.username,
 lastSeen: Game.time,
@@ -43301,7 +42980,7 @@ error: e
 };
 } finally {
 try {
-k && !k.done && (o = A.return) && o.call(A);
+A && !A.done && (o = k.return) && o.call(k);
 } finally {
 if (r) throw r.error;
 }
@@ -43361,7 +43040,7 @@ return Y(e, this.getAllyPolicyOptions(t));
 }, e.prototype.isConfiguredAllyOwned = function(e, t) {
 return function(e, t) {
 return void 0 === t && (t = {}), function(e, t) {
-return void 0 === t && (t = {}), "string" == typeof e && H(t).includes(e);
+return void 0 === t && (t = {}), "string" == typeof e && K(t).includes(e);
 }(B(e), t);
 }(e, this.getAllyPolicyOptions(t));
 }, e.prototype.isConfiguredAllyStructure = function(e, t) {
@@ -43416,15 +43095,15 @@ r.warTargets = s([], i(new Set(c)), !1);
 return this.enemyPlayers.get(e);
 }, e.prototype.getAllEnemies = function() {
 return Array.from(this.enemyPlayers.values());
-}, n([ Oi("empire:intelScanner", "Intel Scanner", {
-priority: ha.MEDIUM,
+}, n([ bi("empire:intelScanner", "Intel Scanner", {
+priority: Ma.MEDIUM,
 interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), TR = new ER, CR = function() {
+}(), fR = new pR, yR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new ec(o(o({}, Bs), e), {
+void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new $s(o(o({}, Fs), e), {
 getEmpire: function() {
 return mr.getEmpire();
 },
@@ -43452,13 +43131,13 @@ return e.structureType === STRUCTURE_NUKER;
 return this.coordinator.getConfig();
 }, e.prototype.updateConfig = function(e) {
 this.coordinator.updateConfig(e);
-}, n([ Oi("empire:nuke", "Nuke Manager", {
-priority: ha.LOW,
+}, n([ bi("empire:nuke", "Nuke Manager", {
+priority: Ma.LOW,
 interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), SR = new CR, wR = function() {
+}(), vR = new yR, gR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = mr.getEmpire();
@@ -43476,36 +43155,36 @@ lastScan: 0
 var e = mr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), xR = new (function(e) {
+}(), hR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new wR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new gR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
-}, n([ Oi("empire:pixelBuying", "Pixel Buying Manager", {
-priority: ha.IDLE,
+}, n([ bi("empire:pixelBuying", "Pixel Buying Manager", {
+priority: Ma.IDLE,
 interval: 200,
 minBucket: 9e3,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Ii));
+}(Pi));
 
-function bR() {
+function RR() {
 return global;
 }
 
-function OR(e) {
+function ER(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function AR(e) {
+function TR(e) {
 return Number(null != e ? e : 0);
 }
 
-var kR = function() {
+var CR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = bR();
+var e = RR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43513,12 +43192,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return bR()._pixelGenerationMemory;
+return RR()._pixelGenerationMemory;
 }, e;
-}(), MR = function(e) {
+}(), SR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new kR) || this;
+var r = e.call(this, t, new CR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43535,7 +43214,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(OR).length : Object.values(null != t ? t : {}).filter(OR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(ER).length : Object.values(null != t ? t : {}).filter(ER).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43546,9 +43225,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (AR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (AR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = AR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = AR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (TR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (TR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = TR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = TR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43564,15 +43243,15 @@ if (e) throw e.error;
 }
 }, t.prototype.run = function() {
 e.prototype.run.call(this);
-}, n([ Oi("empire:pixelGeneration", "Pixel Generation Manager", {
-priority: ha.IDLE,
+}, n([ bi("empire:pixelGeneration", "Pixel Generation Manager", {
+priority: Ma.IDLE,
 interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Li), UR = new MR;
+}(Gi), wR = new SR;
 
-function _R(e, t) {
+function xR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !Y(e.controller.owner.username)) return {
 lost: !0,
@@ -43594,7 +43273,7 @@ lost: !1
 };
 }
 
-function NR(e, t, r) {
+function bR(e, t, r) {
 var o, n = mr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43608,20 +43287,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var PR = Ue().cpu.bucketThresholds.highMode + 1800, IR = {
+var OR = Ue().cpu.bucketThresholds.highMode + 1800, kR = {
 updateInterval: 250,
-minBucket: PR,
+minBucket: OR,
 maxSitesPerRemotePerTick: 2
 };
 
-function GR(e, t) {
+function AR(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var LR = function() {
+var MR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, IR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, kR), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43638,8 +43317,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = _R(l);
-m.lost && m.reason && NR(e, u, m.reason);
+var m = xR(l);
+m.lost && m.reason && bR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43657,10 +43336,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = GR("remoteInfrastructure.intent", function() {
+var i = AR("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-GR("remoteInfrastructure.execute", function() {
+AR("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43780,15 +43459,15 @@ var E = R.value, T = e.visibleRooms[E];
 if (T) {
 var C = new Set(T.roadKeys), S = new Set(T.roadSiteKeys), w = new Set(T.wallKeys), x = null !== (d = f.get(E)) && void 0 !== d ? d : 0, b = 0;
 try {
-for (var O = (u = void 0, a(T.roadPositions)), A = O.next(); !A.done; A = O.next()) {
-var k = A.value;
+for (var O = (u = void 0, a(T.roadPositions)), k = O.next(); !k.done; k = O.next()) {
+var A = k.value;
 if (b >= e.maxRoadSitesPerRoomPerTick) break;
 if (T.constructionSiteCount + x >= e.maxConstructionSitesPerRoom) break;
-var M = "".concat(k.x, ",").concat(k.y);
+var M = "".concat(A.x, ",").concat(A.y);
 C.has(M) || S.has(M) || w.has(M) || (p.push({
 roomName: E,
-x: k.x,
-y: k.y,
+x: A.x,
+y: A.y,
 structureType: STRUCTURE_ROAD
 }), b++, x++);
 }
@@ -43798,7 +43477,7 @@ error: e
 };
 } finally {
 try {
-A && !A.done && (l = O.return) && l.call(O);
+k && !k.done && (l = O.return) && l.call(O);
 } finally {
 if (u) throw u.error;
 }
@@ -43826,13 +43505,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = GR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = AR("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = GR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = AR("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43865,8 +43544,8 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = GR("remoteInfrastructure.calculateRemoteRoads", function() {
-return xn(e, t);
+var n = AR("remoteInfrastructure.calculateRemoteRoads", function() {
+return wn(e, t);
 });
 return this.remoteRoadCache.set(r, {
 expires: Game.time + 1500,
@@ -43894,14 +43573,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = GR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = AR("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? GR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? AR("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -43918,7 +43597,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? GR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? AR("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -43936,7 +43615,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return GR("remoteInfrastructure.findSources", function() {
+return AR("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -44030,25 +43709,25 @@ if (s) throw s.error;
 }, e.prototype.getMyUsername = function() {
 var e = Object.values(Game.spawns);
 return e.length > 0 ? e[0].owner.username : "";
-}, n([ bi("remote:infrastructure", "Remote Infrastructure Manager", {
-priority: ha.LOW,
+}, n([ xi("remote:infrastructure", "Remote Infrastructure Manager", {
+priority: Ma.LOW,
 interval: 1e3,
-minBucket: PR,
+minBucket: OR,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ki() ], e);
-}(), DR = new LR, FR = new (function(e) {
+}(), UR = new MR, _R = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
-}, n([ Oi("empire:shard", "Shard Manager", {
-priority: ha.LOW,
+}, n([ bi("empire:shard", "Shard Manager", {
+priority: Ma.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ki() ], t);
-}(Vp)), BR = function() {
+}(Kp)), NR = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -44064,13 +43743,13 @@ e = JSON.stringify(Memory).length;
 e = 0;
 }
 var o = 2097152, n = e / o * 100;
-n > 90 ? Ci.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+n > 90 ? Ti.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
-}) : n > 75 && Ci.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+}) : n > 75 && Ti.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
 });
 }, e.prototype.updateMemorySegmentStats = function() {
-ts.run();
+es.run();
 }, e.prototype.runPheromoneDiffusion = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44092,7 +43771,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-If.applyDiffusion(o);
+_f.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44101,7 +43780,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Eu.initialize(i.name);
+Ru.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -44114,31 +43793,31 @@ n && !n.done && (t = o.return) && t.call(o);
 if (e) throw e.error;
 }
 }
-}, e.prototype.precacheRoomPaths = function() {}, n([ Oi("core:memoryCleanup", "Memory Cleanup", {
-priority: ha.LOW,
+}, e.prototype.precacheRoomPaths = function() {}, n([ bi("core:memoryCleanup", "Memory Cleanup", {
+priority: Ma.LOW,
 interval: 50,
 cpuBudget: .01
-}) ], e.prototype, "cleanupMemory", null), n([ Ai("core:memorySizeCheck", "Memory Size Check", {
+}) ], e.prototype, "cleanupMemory", null), n([ Oi("core:memorySizeCheck", "Memory Size Check", {
 interval: 100,
 cpuBudget: .005
-}) ], e.prototype, "checkMemorySize", null), n([ Ai("core:memorySegmentStats", "Memory Segment Stats", {
+}) ], e.prototype, "checkMemorySize", null), n([ Oi("core:memorySegmentStats", "Memory Segment Stats", {
 interval: 500,
 minBucket: Ue().cpu.bucketThresholds.highMode,
 cpuBudget: .01
-}) ], e.prototype, "updateMemorySegmentStats", null), n([ bi("cluster:pheromoneDiffusion", "Pheromone Diffusion", {
-priority: ha.LOW,
+}) ], e.prototype, "updateMemorySegmentStats", null), n([ xi("cluster:pheromoneDiffusion", "Pheromone Diffusion", {
+priority: Ma.LOW,
 interval: 50,
 minBucket: Ue().cpu.bucketThresholds.lowMode,
 cpuBudget: .02
-}) ], e.prototype, "runPheromoneDiffusion", null), n([ Oi("room:labConfig", "Lab Config Manager", {
-priority: ha.LOW,
+}) ], e.prototype, "runPheromoneDiffusion", null), n([ bi("room:labConfig", "Lab Config Manager", {
+priority: Ma.LOW,
 interval: 200,
 cpuBudget: .01
-}) ], e.prototype, "initializeLabConfigs", null), n([ Ai("room:pathCachePrecache", "Path Cache Precache (Disabled)", {
+}) ], e.prototype, "initializeLabConfigs", null), n([ Oi("room:pathCachePrecache", "Path Cache Precache (Disabled)", {
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ki() ], e);
-}(), WR = new BR, HR = new (function() {
+}(), PR = new NR, IR = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -44159,18 +43838,18 @@ this.runProcesses(), this.processQueuedEvents();
 this.processesRegistered = !1;
 }, e;
 }())({
-kernel: Ja,
-eventBus: Ta,
+kernel: Za,
+eventBus: Na,
 getCpuConfig: function() {
 return Ue().cpu;
 },
 registerProcesses: function() {
-Ci.info("Registering all processes with kernel...", {
+Ti.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
 }), function() {
 for (var e, t, r = [], o = 0; o < arguments.length; o++) r[o] = arguments[o];
 try {
-for (var n = a(r), i = n.next(); !i.done; i = n.next()) Ui(i.value);
+for (var n = a(r), i = n.next(); !i.done; i = n.next()) Mi(i.value);
 } catch (t) {
 e = {
 error: t
@@ -44182,60 +43861,59 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Ci.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
+Ti.info("Registered decorated processes from ".concat(r.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
-}(WR, Ns, Ds, ls, gR, vc, TR, DR, As, xR, UR, SR, Qc, eu, FR, Xh, Kc, Vh, za, Pa),
-function() {
+}(PR, _s, Ls, us, lR, yc, fR, UR, Os, hR, wR, vR, zc, $c, _R, Hh, Kc, Dh, ja), function() {
 var e, t, r = Ue().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
 name: "Terminal Manager",
-priority: ha.MEDIUM,
+priority: Ma.MEDIUM,
 frequency: "medium",
 interval: 20,
 minBucket: 0,
 cpuBudget: .1,
 execute: function() {
-return Ns.run();
+return _s.run();
 }
 }, {
 id: "factory:manager",
 name: "Factory Manager",
-priority: ha.LOW,
+priority: Ma.LOW,
 frequency: "medium",
 interval: 30,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return Ds.run();
+return Ls.run();
 }
 }, {
 id: "link:manager",
 name: "Link Manager",
-priority: ha.MEDIUM,
+priority: Ma.MEDIUM,
 frequency: "medium",
 interval: 5,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return ls.run();
+return us.run();
 }
 }, {
 id: "empire:market",
 name: "Market Manager",
-priority: ha.LOW,
+priority: Ma.LOW,
 frequency: "low",
 interval: 300,
 minBucket: r,
 cpuBudget: .02,
 execute: function() {
-return As.run();
+return Os.run();
 }
 } ];
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Ja.registerProcess(s);
+Za.registerProcess(s);
 }
 } catch (t) {
 e = {
@@ -44248,13 +43926,13 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-}(), Ci.info("Registered ".concat(Ja.getProcesses().length, " processes with kernel"), {
+}(), Ti.info("Registered ".concat(Za.getProcesses().length, " processes with kernel"), {
 subsystem: "ProcessRegistry"
 });
 }
-}), KR = "_ownedRooms", YR = "_ownedRoomsTick";
+}), GR = "_ownedRooms", LR = "_ownedRoomsTick";
 
-function VR(e) {
+function DR(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44264,20 +43942,20 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var qR = Ei("NativeCallsTracker");
+var FR = Ri("NativeCallsTracker");
 
-function jR(e, t, r) {
+function BR(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) qR.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) FR.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
 }); else try {
 var a = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Ji.recordNativeCall(r), o.apply(this, e);
+return Zi.recordNativeCall(r), o.apply(this, e);
 };
 a.__nativeCallsTrackerWrapped = !0, Object.defineProperty(e, t, {
 value: a,
@@ -44286,7 +43964,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-qR.warn("Failed to wrap method", {
+FR.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44296,30 +43974,30 @@ error: String(e)
 }
 }
 
-var zR, QR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], XR = "shard1", ZR = {
+var WR, KR = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], HR = "shard1", YR = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, JR = {
+}, VR = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, $R = {
+}, qR = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function eE() {
+function jR() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function tE() {
+function zR() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: QR,
+targetShards: KR,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44329,11 +44007,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = QR),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = KR),
 Memory.interShardOperation;
 }
 
-function rE() {
+function QR() {
 var e;
 try {
 if ("undefined" == typeof InterShardMemory) return {
@@ -44348,7 +44026,7 @@ lastSync: 0,
 checksum: 0
 };
 var t = InterShardMemory.getLocal();
-return t && null !== (e = Dp(t)) && void 0 !== e ? e : {
+return t && null !== (e = Ip(t)) && void 0 !== e ? e : {
 version: 1,
 shards: {},
 globalTargets: {
@@ -44374,33 +44052,33 @@ checksum: 0
 }
 }
 
-function oE(e) {
+function XR(e) {
 try {
 if ("undefined" == typeof InterShardMemory) return;
-InterShardMemory.setLocal(Lp(e));
+InterShardMemory.setLocal(Pp(e));
 } catch (e) {}
 }
 
-function nE() {
-var e, t, r, o, n, i, s, c = rE(), u = eE();
+function ZR() {
+var e, t, r, o, n, i, s, c = QR(), u = jR();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: QR,
+targetShards: KR,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : QR,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : KR,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && aE() ? "established" : "unreached",
+status: p === u && JR() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44418,7 +44096,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === XR ? "core" : "frontier",
+role: u === HR ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44435,24 +44113,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), oE(c), c.footprintOperation;
+}), XR(c), c.footprintOperation;
 }
 
-function aE() {
+function JR() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function iE() {
+function $R() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function sE(e, t) {
+function eE(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44471,9 +44149,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(iE()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a($R()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Xy.getPendingRequests(p.name).filter(function(r) {
+s += jy.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44492,7 +44170,7 @@ if (n) throw n.error;
 return s;
 }
 
-function cE(e) {
+function tE(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44536,7 +44214,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = rE().shards[eE()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = QR().shards[jR()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44546,8 +44224,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function uE(e, t) {
-if (!(sE("scout", t) >= 1)) {
+function rE(e, t) {
+if (!(eE("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44585,13 +44263,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Xy.addRequest({
+r && jy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: $R,
-priority: Iy.LOW + 5,
+body: qR,
+priority: _y.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44602,14 +44280,14 @@ task: "interShardPortalScout"
 }
 }
 
-function lE(e, t, r) {
-sE("interShardClaimer", t) >= 1 || Xy.addRequest({
+function oE(e, t, r) {
+eE("interShardClaimer", t) >= 1 || jy.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: ZR,
-priority: Iy.NORMAL + 50,
+body: YR,
+priority: _y.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44622,14 +44300,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function mE(e, t, r) {
-sE("interShardScout", t) >= 1 || Xy.addRequest({
+function nE(e, t, r) {
+eE("interShardScout", t) >= 1 || jy.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: $R,
-priority: Iy.NORMAL,
+body: qR,
+priority: _y.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44642,15 +44320,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function dE(e, t, r) {
+function aE(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (sE("interShardPioneer", t.shard) >= 3 || Xy.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (eE("interShardPioneer", t.shard) >= 3 || jy.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: JR,
-priority: Iy.NORMAL + 25,
+body: VR,
+priority: _y.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44663,19 +44341,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function pE(e) {
+function iE(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = eE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = jR(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : QR), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : KR), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Dp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Ip(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44707,9 +44385,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(iE()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a($R()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Xy.getPendingRequests(l.name).filter(function(e) {
+n += jy.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44728,22 +44406,22 @@ return n;
 }() < o;
 }
 
-(zR = {
-optimizeBody: qy,
+(WR = {
+optimizeBody: Hy,
 spawnQueue: {
 addRequest: function(e) {
-return Xy.addRequest(e);
+return jy.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Iy.LOW,
-NORMAL: Iy.NORMAL,
-HIGH: Iy.HIGH
+LOW: _y.LOW,
+NORMAL: _y.NORMAL,
+HIGH: _y.HIGH
 }
-}).optimizeBody && (jp.optimizeBody = zR.optimizeBody), zR.spawnQueue && (jp.spawnQueue = zR.spawnQueue),
-zR.spawnPriorities && (jp.spawnPriorities = o(o({}, jp.spawnPriorities), zR.spawnPriorities));
+}).optimizeBody && (Yp.optimizeBody = WR.optimizeBody), WR.spawnQueue && (Yp.spawnQueue = WR.spawnQueue),
+WR.spawnPriorities && (Yp.spawnPriorities = o(o({}, Yp.spawnPriorities), WR.spawnPriorities));
 
-var fE, yE = function() {
+var sE, cE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44787,7 +44465,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function vE(e) {
+function uE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44808,7 +44486,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function gE(e, t, r) {
+function lE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44874,16 +44552,16 @@ return u;
 });
 }
 
-function hE(e) {
+function mE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(fE || (fE = {}));
+}(sE || (sE = {}));
 
-var RE = function() {
+var dE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -44921,8 +44599,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = gE(h.pos, T.pos, this.logger);
-if (hE(C)) {
+var T = E.value, C = lE(h.pos, T.pos, this.logger);
+if (mE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -44949,8 +44627,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var A = O.value, k = gE(A, u.pos, this.logger);
-hE(k) && (S = this.pathCache.convertRoomPositionsToPathSteps(k.path), this.cacheRemoteMiningPath(A, u.pos, S, "hauler"),
+var k = O.value, A = lE(k, u.pos, this.logger);
+mE(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -44989,8 +44667,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = gE(e, t, this.logger);
-if (hE(n)) {
+var n = lE(e, t, this.logger);
+if (mE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -45000,7 +44678,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), EE = function() {
+}(), pE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -45010,7 +44688,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = vE(s);
+var c = uE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -45036,7 +44714,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), TE = function() {
+}(), fE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -45085,29 +44763,29 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), CE = {
+}(), yE = {
 debug: function(e, t) {
-return k("RemoteMining").debug(e, t);
+return A("RemoteMining").debug(e, t);
 },
 info: function(e, t) {
-return k("RemoteMining").info(e, t);
+return A("RemoteMining").info(e, t);
 },
 warn: function(e, t) {
-return k("RemoteMining").warn(e, t);
+return A("RemoteMining").warn(e, t);
 },
 error: function(e, t) {
-return k("RemoteMining").error(e, t);
+return A("RemoteMining").error(e, t);
 }
-}, SE = {
+}, vE = {
 getCachedPath: function(e, t) {
-var r = Ke(e, t), o = Fe.get(r, {
-namespace: He
+var r = He(e, t), o = Fe.get(r, {
+namespace: Ke
 });
 if (!o) return null;
 try {
 return Room.deserializePath(o);
 } catch (e) {
-return Fe.invalidate(r, He), null;
+return Fe.invalidate(r, Ke), null;
 }
 },
 cachePath: Ye,
@@ -45125,28 +44803,28 @@ direction: a
 }
 return t;
 }
-}, wE = {
+}, gE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = gm.MEDIUM), Am.register({
+void 0 === o && (o = vm.MEDIUM), Om.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== gm.CRITICAL
+skippable: o !== vm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, xE = new RE(SE, CE), bE = new EE(CE, wE, xE), OE = new TE(CE, SE, xE, Fu.moveTo);
+}, hE = new dE(vE, yE), RE = new pE(yE, gE, hE), EE = new fE(yE, vE, hE, Du.moveTo);
 
-function AE(e, t, r, o) {
-return OE.moveToWithRemoteCache(e, t, r, o);
+function TE(e, t, r, o) {
+return EE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var kE, ME = function() {
+var CE, SE = function() {
 function e() {
-this.logger = k("Pathfinding");
+this.logger = A("Pathfinding");
 }
 return e.prototype.debug = function(e, t) {
 this.logger.debug(e, t);
@@ -45157,17 +44835,17 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), UE = function() {
+}(), wE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 I.on(e, t);
 }, e;
-}(), _E = function() {
+}(), xE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
 var t = e.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), r = new RegExp("^".concat(t, ":|:").concat(t, ":|:").concat(t, "$"));
-Fe.invalidatePattern(r, He);
+Fe.invalidatePattern(r, Ke);
 }(e);
 }, e.prototype.cacheCommonRoutes = function(e) {
 !function(e) {
@@ -45207,28 +44885,28 @@ m.length > 0 && Ye(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), NE = function() {
+}(), bE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return vE(e);
+return uE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-xE.precacheRemoteRoutes(e, t);
+hE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), PE = new yE(new ME, new UE, new _E, new NE), IE = {
+}(), OE = new cE(new SE, new wE, new xE, new bE), kE = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, GE = function() {
+}, AE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, IE), e);
+this.config = o(o({}, kE), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45237,10 +44915,10 @@ lastRun: 0
 }, e.prototype.unregisterTask = function(e) {
 this.tasks.delete(e);
 }, e.prototype.getBucketMode = function() {
-return Ja.getBucketMode();
+return Za.getBucketMode();
 }, e.prototype.updateBucketMode = function() {
 var e = this.getBucketMode();
-e !== this.currentMode && (Ci.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
+e !== this.currentMode && (Ti.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
 subsystem: "Scheduler"
 }), this.currentMode = e);
 }, e.prototype.getCpuLimit = function() {
@@ -45288,13 +44966,13 @@ try {
 i.execute(), i.lastRun = Game.time;
 } catch (e) {
 var c = e instanceof Error ? e.message : String(e);
-Ci.error("Task ".concat(i.name, " failed: ").concat(c), {
+Ti.error("Task ".concat(i.name, " failed: ").concat(c), {
 subsystem: "Scheduler"
 });
 }
 var u = Game.cpu.getUsed() - s;
 if (this.tickCpuUsed += u, !this.hasCpuBudget()) {
-Ci.warn("CPU budget exhausted, skipping remaining tasks", {
+Ti.warn("CPU budget exhausted, skipping remaining tasks", {
 subsystem: "Scheduler"
 });
 break;
@@ -45322,123 +45000,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new GE, (kE = {})[FIND_STRUCTURES] = {
+new AE, (CE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, kE[FIND_MY_STRUCTURES] = {
+}, CE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, kE[FIND_HOSTILE_STRUCTURES] = {
+}, CE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, kE[FIND_SOURCES_ACTIVE] = {
+}, CE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, kE[FIND_SOURCES] = {
+}, CE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, kE[FIND_MINERALS] = {
+}, CE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, kE[FIND_DEPOSITS] = {
+}, CE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, kE[FIND_MY_CONSTRUCTION_SITES] = {
+}, CE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, kE[FIND_CONSTRUCTION_SITES] = {
+}, CE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, kE[FIND_CREEPS] = {
+}, CE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, kE[FIND_MY_CREEPS] = {
+}, CE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, kE[FIND_HOSTILE_CREEPS] = {
+}, CE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, kE[FIND_DROPPED_RESOURCES] = {
+}, CE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, kE[FIND_TOMBSTONES] = {
+}, CE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, kE[FIND_RUINS] = {
+}, CE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, kE[FIND_FLAGS] = {
+}, CE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, kE[FIND_MY_SPAWNS] = {
+}, CE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, kE[FIND_HOSTILE_SPAWNS] = {
+}, CE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, kE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, CE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, kE[FIND_NUKES] = {
+}, CE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, kE[FIND_POWER_CREEPS] = {
+}, CE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, kE[FIND_MY_POWER_CREEPS] = {
+}, CE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, kE[FIND_HOSTILE_POWER_CREEPS] = {
+}, CE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, kE[FIND_EXIT_TOP] = {
+}, CE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, kE[FIND_EXIT_RIGHT] = {
+}, CE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, kE[FIND_EXIT_BOTTOM] = {
+}, CE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, kE[FIND_EXIT_LEFT] = {
+}, CE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, kE[FIND_EXIT] = {
+}, CE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var LE = new le({}, mr), DE = new Ee({}, mr);
+var ME = new le({}, mr), UE = new Ee({}, mr);
 
-function FE(e) {
+function _E(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45446,16 +45124,16 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var BE = !1;
+var NE = !1;
 
-function WE() {
+function PE() {
 var e, t;
-BE || (ii({
-level: (t = Ue()).debug ? Xa.DEBUG : Xa.INFO,
+NE || (ai({
+level: (t = Ue()).debug ? Qa.DEBUG : Qa.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
 maxBatchSize: 50
-}), Ci.info("Bot initialized", {
+}), Ti.info("Bot initialized", {
 subsystem: "SwarmBot",
 meta: {
 debug: t.debug,
@@ -45465,11 +45143,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Zy.getPendingTransfers = function(e) {
+r.getPendingTransfers && (zy.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Zy.needsCarrier = function(e) {
+}), r.needsCarrier && (zy.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Zy.getActiveRequests = function() {
+}), r.getActiveRequests && (zy.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45483,66 +45161,66 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Jy.predictConsumption = function(e) {
+a.predictConsumption && (Qy.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Jy.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Qy.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Jy.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Qy.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Jy.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Qy.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && ($y.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Xy.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && ($y.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Xy.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && ($y.needsCarriers = function(e) {
+}), i.needsCarriers && (Xy.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && ($y.requestSpawns = function(e) {
+}), i.requestSpawns && (Xy.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-ev.getEmergencyState = function(e) {
+Zy.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: bt,
-powerBankHarvestingManager: Qc,
-resourceTransferCoordinator: Qp,
-emergencyResponseManager: Ba,
-kernel: Ja
+powerBankHarvestingManager: zc,
+resourceTransferCoordinator: qp,
+emergencyResponseManager: Ea,
+kernel: Za
 }), function(e) {
 var t, r, o, n;
-yd = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : fd.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : fd.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : fd.getLabOverflow
-} : fd;
+fd = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : pd.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : pd.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : pd.getLabOverflow
+} : pd;
 }({
 getLabResourceNeeds: function(e) {
-return Cu.getLabResourceNeeds(e);
+return Tu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return Cu.getLabResourceNeeds(e);
+return Tu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return Cu.getLabOverflow(e);
+return Tu.getLabOverflow(e);
 }
-}), Ji.initialize(), t.profiling && (function() {
+}), Zi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) qR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) FR.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
 for (var e = [], r = 0; r < arguments.length; r++) e[r] = arguments[r];
-return Ji.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
+return Zi.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
 };
 r.__nativeCallsTrackerWrapped = !0, Object.defineProperty(PathFinder, "search", {
 value: r,
@@ -45551,7 +45229,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-qR.warn("Failed to wrap PathFinder.search", {
+FR.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45559,11 +45237,11 @@ error: String(e)
 }
 }
 }
-}(), jR(e = Creep.prototype, "moveTo", "moveTo"), jR(e, "move", "move"), jR(e, "harvest", "harvest"),
-jR(e, "transfer", "transfer"), jR(e, "withdraw", "withdraw"), jR(e, "build", "build"),
-jR(e, "repair", "repair"), jR(e, "upgradeController", "upgradeController"), jR(e, "attack", "attack"),
-jR(e, "rangedAttack", "rangedAttack"), jR(e, "heal", "heal"), jR(e, "dismantle", "dismantle"),
-jR(e, "say", "say")), function(e, t, r) {
+}(), BR(e = Creep.prototype, "moveTo", "moveTo"), BR(e, "move", "move"), BR(e, "harvest", "harvest"),
+BR(e, "transfer", "transfer"), BR(e, "withdraw", "withdraw"), BR(e, "build", "build"),
+BR(e, "repair", "repair"), BR(e, "upgradeController", "upgradeController"), BR(e, "attack", "attack"),
+BR(e, "rangedAttack", "rangedAttack"), BR(e, "heal", "heal"), BR(e, "dismantle", "dismantle"),
+BR(e, "say", "say")), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
 o && (r.onStructureDestroyed(o, e.structureType), U.debug("Pheromone update: structure destroyed in ".concat(e.roomName), {
@@ -45579,15 +45257,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ja, mr, If), PE.initializePathCacheEvents(), bE.initialize(gm.MEDIUM), wl = AE,
-Ft.initialize(), FR.initialize(), BE = !0), mr.initialize();
-var r = HR.configureForCurrentTick();
-"critical" === r && Game.time % 10 == 0 && Ci.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
+}(Za, mr, _f), OE.initializePathCacheEvents(), RE.initialize(vm.MEDIUM), Sl = TE,
+Ft.initialize(), _R.initialize(), NE = !0), mr.initialize();
+var r = IR.configureForCurrentTick();
+"critical" === r && Game.time % 10 == 0 && Ti.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = tE();
-if (!1 !== r.enabled && (r.lastRun = Game.time, nE(), function() {
-var e, t, r, o, n = rE(), a = n.footprintOperation, i = eE(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = zR();
+if (!1 !== r.enabled && (r.lastRun = Game.time, ZR(), function() {
+var e, t, r, o, n = QR(), a = n.footprintOperation, i = jR(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45600,15 +45278,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, oE(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, XR(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = tE();
+var e, t, r, n, i, s, c = zR();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : QR), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === XR ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : KR), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === HR ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45626,10 +45304,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !aE())) try {
+}(), !JR())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || mf(s), "interShardPioneer" === c && lf(s);
+"interShardClaimer" !== c && "interShardScout" !== c || cf(s), "interShardPioneer" === c && sf(s);
 }
 } catch (t) {
 e = {
@@ -45647,23 +45325,23 @@ var n = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
-if (0 === n) return Game.time % 100 == 0 && Ci.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
+if (0 === n) return Game.time % 100 == 0 && Ti.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), Ji.publishIdleTick(), void Ci.flush();
-Game.time % 10 == 0 && Ci.info("SwarmBot loop executing at tick ".concat(Game.time), {
+}), Zi.publishIdleTick(), void Ti.flush();
+Game.time % 10 == 0 && Ti.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: BE
+systemsInitialized: NE
 }
-}), HR.ensureProcessesRegistered(), Ji.startTick(), _u.clear(), HR.startEventTick();
+}), IR.ensureProcessesRegistered(), Zi.startTick(), Uu.clear(), IR.startEventTick();
 var i = function(e) {
-var t = e.cache[KR], r = e.cache[YR];
+var t = e.cache[GR], r = e.cache[LR];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[KR] = o, e.cache[YR] = e.tick, o;
+return e.cache[GR] = o, e.cache[LR] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45671,7 +45349,7 @@ return Object.values(Game.rooms);
 },
 cache: global
 });
-Ji.measureSubsystem("taskBoard", function() {
+Zi.measureSubsystem("taskBoard", function() {
 var e, t, r = Ue(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
 try {
 for (var n = a(function(e) {
@@ -45685,7 +45363,7 @@ rooms: i,
 interval: o
 })), s = n.next(); !s.done; s = n.next()) {
 var c = s.value;
-Tl.refreshRoom(c);
+El.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -45698,20 +45376,20 @@ s && !s.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-}), Ji.measureSubsystem("spawns", function() {
+}), Zi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = tE();
+var e, t, r, o = zR();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = nE();
+var n = ZR();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : QR), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : KR), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== eE()) try {
+if (d !== jR()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Dp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Ip(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45729,20 +45407,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = iE().sort(function(e, t) {
+var i = $R().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : QR), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : KR), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== eE()) {
+if (u !== jR()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = cE(u);
+var m = tE(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? dE(i, l, m) : pE() ? lE(i, u, m) : (mE(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (uE(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? aE(i, l, m) : iE() ? oE(i, u, m) : (nE(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (rE(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -45759,8 +45437,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = rE();
-d.footprintOperation = n, oE(d);
+var d = QR();
+d.footprintOperation = n, XR(d);
 }
 }
 })(), function() {
@@ -45768,9 +45446,9 @@ var e, t, r, o = Game.cpu.bucket < Ue().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || FE(s))) {
-var c = wg(s, mr.getOrInitSwarmState(s.name));
-Ji.recordSpawnQueue(s.name, c.stats, c.spawned);
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || _E(s))) {
+var c = Rg(s, mr.getOrInitSwarmState(s.name));
+Zi.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
 } catch (t) {
@@ -45785,21 +45463,21 @@ if (e) throw e.error;
 }
 }
 }();
-}), Fu.preTick(), Ji.measureSubsystem("processSync", function() {
-Cf.syncCreepProcesses(), Sy.syncRoomProcesses();
-}), Ji.measureSubsystem("kernel", function() {
-HR.runProcesses();
-}), Ji.measureSubsystem("eventQueue", function() {
-HR.processQueuedEvents();
-}), Ji.measureSubsystem("ss2PacketQueue", function() {
-Ag.processQueue();
-}), Ja.hasCpuBudget() && Ji.measureSubsystem("powerCreeps", function() {
+}), Du.preTick(), Zi.measureSubsystem("processSync", function() {
+Rf.syncCreepProcesses(), Ey.syncRoomProcesses();
+}), Zi.measureSubsystem("kernel", function() {
+IR.runProcesses();
+}), Zi.measureSubsystem("eventQueue", function() {
+IR.processQueuedEvents();
+}), Zi.measureSubsystem("ss2PacketQueue", function() {
+Sg.processQueue();
+}), Za.hasCpuBudget() && Zi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && df(n);
+void 0 !== n.ticksToLive && uf(n);
 }
 } catch (t) {
 e = {
@@ -45813,18 +45491,18 @@ if (e) throw e.error;
 }
 }
 }();
-}), VR({
-hasCpuBudget: Ja.hasCpuBudget(),
+}), DR({
+hasCpuBudget: Za.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && Ji.measureSubsystem("visualizations", function() {
+}) && Zi.measureSubsystem("visualizations", function() {
 var e;
 !function(e, t) {
 var r, o;
 if (Ue().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = LE.getConfig(), s = DE.getConfig();
-LE.setConfig(n.roomVisualizerConfig), n.renderMap && DE.setConfig(n.mapVisualizerConfig);
+var i = ME.getConfig(), s = UE.getConfig();
+ME.setConfig(n.roomVisualizerConfig), n.renderMap && UE.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -45835,10 +45513,10 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-LE.draw(m);
+ME.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
-Ci.error("Visualization error in ".concat(m.name, ": ").concat(d), {
+Ti.error("Visualization error in ".concat(m.name, ": ").concat(d), {
 subsystem: "visualizations",
 room: m.name
 });
@@ -45857,19 +45535,19 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-DE.draw();
+UE.draw();
 } catch (e) {
-d = e instanceof Error ? e.message : String(e), Ci.error("Map visualization error: ".concat(d), {
+d = e instanceof Error ? e.message : String(e), Ti.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-LE.setConfig(i), DE.setConfig(s);
+ME.setConfig(i), UE.setConfig(s);
 }
 }
 }
 }(i, (e = {
-hasCpuBudget: Ja.hasCpuBudget(),
+hasCpuBudget: Za.hasCpuBudget(),
 bucketMode: r,
 bucket: Game.cpu.bucket,
 ownedRoomCount: i.length
@@ -45949,19 +45627,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Fu.reconcileTraffic(), VR({
-hasCpuBudget: Ja.hasCpuBudget(),
+}), Du.reconcileTraffic(), DR({
+hasCpuBudget: Za.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && Ji.measureSubsystem("scheduledTasks", function() {
+}) && Zi.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Am.run(e);
-}), mr.persistHeapCache(), Ji.collectProcessStats(Ja.getProcesses().reduce(function(e, t) {
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Om.run(e);
+}), mr.persistHeapCache(), Zi.collectProcessStats(Za.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
-}, new Map)), Ji.collectKernelBudgetStats(Ja), Ji.setSkippedProcesses(Ja.getSkippedProcessesThisTick()),
-Ji.finalizeTick(), Ci.flush();
+}, new Map)), Zi.collectKernelBudgetStats(Za), Zi.setSkippedProcesses(Za.getSkippedProcessesThisTick()),
+Zi.finalizeTick(), Ti.flush();
 }
 
-var HE = function() {
+var IE = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ue().visualizations;
@@ -45969,25 +45647,25 @@ return _e({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = LE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = ME.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-LE.toggle(o);
-var n = LE.getConfig()[o];
+ME.toggle(o);
+var n = ME.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = DE.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = UE.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-DE.toggle(o);
-var n = DE.getConfig()[o];
+UE.toggle(o);
+var n = UE.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = DE.getConfig();
+var e = UE.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -46110,15 +45788,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), KE = function() {
+}(), GE = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = FR.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = _R.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = FR.getAllShards();
+var e, t, r = _R.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -46140,9 +45818,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (FR.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (_R.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = FR.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = _R.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -46167,19 +45845,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = FR.getOptimalPortalRoute(e, t);
+var r, o = _R.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (FR.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (_R.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (FR.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (_R.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Qp.getActiveRequests();
+var e, t, r = qp.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -46200,7 +45878,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = FR.getCurrentShardState();
+var e, t, r = _R.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -46221,7 +45899,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = FR.getActiveTransferTasks();
+var e, t, r, o = _R.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -46242,16 +45920,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = FR.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Wp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = _R.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Dp, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = FR.getMemoryStats();
+var e = _R.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return FR.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return _R.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = rE().footprintOperation;
+var e, t, r, o = QR().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46357,9 +46035,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), YE = new KE;
+}(), LE = new GE;
 
-function VE(e) {
+function DE(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46389,10 +46067,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? VE(e.metadata.usage) : void 0
+params: e.metadata.usage ? DE(e.metadata.usage) : void 0
 };
 });
-return Lm({
+return Gm({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46443,12 +46121,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Lm.apply(void 0, s([], i(o), !1));
+return Gm.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return Pm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Nm("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Gm.form("spawnCreep", [ {
+return Im.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46482,20 +46160,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return Pm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Nm("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += Pm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += Pm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Gm.button({
+o += '<div style="margin-bottom: 10px;">', o += Nm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Nm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Im.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Gm.button({
+}), o += " ", (o += Im.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Gm.form("configureLogging", [ {
+return Im.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46520,7 +46198,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Gm.form("configureVisualization", [ {
+return Im.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46544,21 +46222,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Gm.button({
+e += Im.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += Gm.button({
+}), e += " ", e += Im.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Gm.button({
+}), e += " ", (e += Im.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += Pm("✓ Success message", "green", !0) + "\n", e += Pm("⚠ Warning message", "yellow", !0) + "\n",
-e += Pm("✗ Error message", "red", !0) + "\n", e += Pm("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + Pm("colored text", "green") + " normal text\n") + "Bold text: " + Pm("important", null, !0) + "\n";
+return e += Nm("✓ Success message", "green", !0) + "\n", e += Nm("⚠ Warning message", "yellow", !0) + "\n",
+e += Nm("✗ Error message", "red", !0) + "\n", e += Nm("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Nm("colored text", "green") + " normal text\n") + "Bold text: " + Nm("important", null, !0) + "\n";
 }, n([ Tt({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46604,39 +46282,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var qE = new xy, jE = new HE, zE = new by, QE = new ku, XE = new wy, ZE = new Oy, JE = new Ay, $E = "__screepsGlobalRuntimeDiagnostics";
+var FE = new Cy, BE = new IE, WE = new Sy, KE = new ku, HE = new Ty, YE = new wy, VE = new xy, qE = "__screepsGlobalRuntimeDiagnostics";
 
-function eT() {
+function jE() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function tT(e, t) {
+function zE(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function rT(e, t) {
+function QE(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function oT(e) {
+function XE(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function nT(e) {
+function ZE(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: tT(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: tT(n.switchCount, 0),
-lastTick: rT(n.lastTick, Game.time),
-lastResetTick: rT(n.lastResetTick, Game.time),
-lastSwitchTick: oT(n.lastSwitchTick),
-lastSwitchPreviousTick: oT(n.lastSwitchPreviousTick),
-lastWarningTick: oT(n.lastWarningTick)
+resetCount: zE(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: zE(n.switchCount, 0),
+lastTick: QE(n.lastTick, Game.time),
+lastResetTick: QE(n.lastResetTick, Game.time),
+lastSwitchTick: XE(n.lastSwitchTick),
+lastSwitchPreviousTick: XE(n.lastSwitchPreviousTick),
+lastWarningTick: XE(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46650,19 +46328,19 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var aT = Ei("Main");
+var JE = Ri("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Et.initialize(), Ct(qE), Ct(jE), Ct(zE), Ct(QE), Ct(XE), Ct(ZE), Ct(JE), Ct(bu),
-Ct(Ou), Ct(Au), Ct(YE), Ct(At), Ct(hc), Ct(qc), global.tooangel = Yc;
+Et.initialize(), Ct(FE), Ct(BE), Ct(WE), Ct(KE), Ct(HE), Ct(YE), Ct(VE), Ct(xu),
+Ct(bu), Ct(Ou), Ct(LE), Ct(kt), Ct(gc), Ct(Vc), global.tooangel = Hc;
 var e = global;
 e.botConfig = {
 getConfig: Ue,
 updateConfig: _e
 }, e.botLogger = {
-configureLogger: ii
+configureLogger: ai
 }, e.botVisualizationManager = f, e.botCacheManager = Fe, Et.exposeToGlobal();
 };
 e ? (Et.initialize(), Et.enableLazyLoading(t), Et.exposeToGlobal()) : t();
@@ -46671,12 +46349,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : eT, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[$E];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : jE, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[qE];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[$E] = s, function(e, t) {
-var r, o = nT(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[qE] = s, function(e, t) {
+var r, o = ZE(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46694,7 +46372,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = nT(e.heapId);
+var n, a = ZE(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46715,14 +46393,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = nT(s.heapId);
+var u = ZE(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: aT
-}), WE();
+logger: JE
+}), PE();
 } catch (e) {
-throw aT.error("Critical error in main loop: ".concat(String(e)), {
+throw JE.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-bot/src/core/processRegistry.ts
+++ b/packages/screeps-bot/src/core/processRegistry.ts
@@ -25,13 +25,12 @@
  * - CrossShardIntelCoordinator (empire:crossShardIntel)
  * - TooAngelManager (empire:tooangel)
  * - EvacuationManager (cluster:evacuation)
- * - DefenseCoordinator (cluster:defense)
  *
  * Addresses Issues: #5, #26, #30
  */
 
 import { clusterManager } from "@ralphschuler/screeps-clusters";
-import { defenseCoordinator, evacuationManager } from "@ralphschuler/screeps-defense";
+import { evacuationManager } from "@ralphschuler/screeps-defense";
 import { factoryManager, linkManager, marketManager, terminalManager } from "@ralphschuler/screeps-economy";
 import { getConfig } from "../config";
 import { crossShardIntelCoordinator } from "../empire/crossShardIntel";
@@ -151,8 +150,7 @@ export function registerAllProcesses(): void {
     // Cluster processes
     clusterManager,
     // Defense processes
-    evacuationManager,
-    defenseCoordinator
+    evacuationManager
   );
 
   registerFrameworkEconomyProcesses();

--- a/packages/screeps-bot/test/unit/processRegistry.test.ts
+++ b/packages/screeps-bot/test/unit/processRegistry.test.ts
@@ -26,7 +26,7 @@ describe("process registry", () => {
     unregisterAllProcesses();
   });
 
-  it("registers framework-decorated economy processes on the bot kernel", () => {
+  it("registers framework-decorated economy processes on the bot kernel without the legacy defense dispatcher", () => {
     registerAllProcesses();
 
     const processIds = kernel.getProcesses().map(process => process.id);
@@ -35,6 +35,7 @@ describe("process registry", () => {
     assert.include(processIds, "terminal:manager");
     assert.include(processIds, "factory:manager");
     assert.include(processIds, "empire:market");
+    assert.notInclude(processIds, "cluster:defense");
   });
 
   it("defers high-cost optional work until bucket exits low mode", () => {

--- a/packages/screeps-defense/src/coordination/clusterDefense.ts
+++ b/packages/screeps-defense/src/coordination/clusterDefense.ts
@@ -15,6 +15,7 @@
 import { logger } from "@ralphschuler/screeps-core";
 import { memoryManager } from "@ralphschuler/screeps-memory";
 import { type ThreatAnalysis, assessThreat, logThreatAnalysis } from "../threat/threatAssessment";
+import { getDefenseAssistTargetRoom, stageDefenseAssistCreep } from "./defenseAssistStaging";
 
 /**
  * Find cluster for a room
@@ -128,16 +129,18 @@ export class ClusterDefenseCoordinator {
         // Room is safe, can spare defenders
         const roomDefenders = room.find(FIND_MY_CREEPS, {
           filter: c => {
-            const memory = c.memory as unknown as { 
-              role?: string; 
+            const memory = c.memory as unknown as {
+              role?: string;
               assistTarget?: string;
+              targetRoom?: string;
+              task?: string;
             };
             return (
-              (memory.role === "defender" || 
-               memory.role === "rangedDefender" || 
-               memory.role === "guard" || 
+              (memory.role === "defender" ||
+               memory.role === "rangedDefender" ||
+               memory.role === "guard" ||
                memory.role === "ranger") &&
-              !memory.assistTarget
+              !getDefenseAssistTargetRoom(memory)
             );
           }
         });
@@ -155,9 +158,18 @@ export class ClusterDefenseCoordinator {
    * @param targetRoom - Room to defend
    */
   private sendDefenders(defenders: Creep[], targetRoom: string): void {
+    const defendersByRoom = defenders.reduce((counts, defender) => {
+      counts.set(defender.room.name, (counts.get(defender.room.name) ?? 0) + 1);
+      return counts;
+    }, new Map<string, number>());
+
     for (const defender of defenders) {
-      const memory = defender.memory as unknown as { assistTarget?: string };
-      memory.assistTarget = targetRoom;
+      stageDefenseAssistCreep(defender, {
+        homeRoom: defender.room.name,
+        targetRoom,
+        now: Game.time,
+        squadSize: defendersByRoom.get(defender.room.name) ?? 1
+      });
     }
   }
 

--- a/packages/screeps-defense/src/coordination/defenseAssistStaging.ts
+++ b/packages/screeps-defense/src/coordination/defenseAssistStaging.ts
@@ -1,0 +1,61 @@
+import type { SwarmCreepMemory } from "@ralphschuler/screeps-memory";
+
+export const DEFENSE_ASSIST_TASK = "defenseAssist" as const;
+
+export type DefenseAssistStagingMemory = Pick<
+  SwarmCreepMemory,
+  | "assistTarget"
+  | "targetRoom"
+  | "task"
+  | "defenseSquadId"
+  | "defenseSquadSize"
+  | "defenseSquadCreatedAt"
+  | "defenseAssistReleasedAt"
+  | "defenseAssistReleaseReason"
+>;
+
+export interface DefenseAssistStagingOptions {
+  homeRoom: string;
+  targetRoom: string;
+  now: number;
+  squadSize: number;
+  squadId?: string;
+  createdAt?: number;
+}
+
+export function createDefenseAssistSquadId(homeRoom: string, targetRoom: string, createdAt: number): string {
+  return `defenseAssist:${homeRoom}:${targetRoom}:${createdAt}`;
+}
+
+export function createDefenseAssistMemory(options: DefenseAssistStagingOptions): DefenseAssistStagingMemory {
+  const createdAt = options.createdAt ?? options.now;
+  return {
+    assistTarget: options.targetRoom,
+    targetRoom: options.targetRoom,
+    task: DEFENSE_ASSIST_TASK,
+    defenseSquadId: options.squadId ?? createDefenseAssistSquadId(options.homeRoom, options.targetRoom, createdAt),
+    defenseSquadSize: Math.max(1, options.squadSize),
+    defenseSquadCreatedAt: createdAt
+  };
+}
+
+export function stageDefenseAssistCreep(creep: Pick<Creep, "memory">, options: DefenseAssistStagingOptions): void {
+  Object.assign(creep.memory as unknown as DefenseAssistStagingMemory, createDefenseAssistMemory(options));
+}
+
+export function getDefenseAssistTargetRoom(memory: Partial<DefenseAssistStagingMemory>): string | undefined {
+  return memory.assistTarget ?? (memory.task === DEFENSE_ASSIST_TASK ? memory.targetRoom : undefined);
+}
+
+export function clearDefenseAssistMemory(memory: Partial<DefenseAssistStagingMemory>): void {
+  delete memory.assistTarget;
+  delete memory.defenseSquadId;
+  delete memory.defenseSquadSize;
+  delete memory.defenseSquadCreatedAt;
+  delete memory.defenseAssistReleasedAt;
+  delete memory.defenseAssistReleaseReason;
+  if (memory.task === DEFENSE_ASSIST_TASK) {
+    delete memory.task;
+    delete memory.targetRoom;
+  }
+}

--- a/packages/screeps-defense/src/coordination/defenseCoordinator.ts
+++ b/packages/screeps-defense/src/coordination/defenseCoordinator.ts
@@ -21,10 +21,15 @@
  */
 
 import { logger } from "@ralphschuler/screeps-core";
-import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 import type { DefenseRequest } from "../analysis/defenderNeeds";
 import { assessThreat } from "../threat/threatAssessment";
 import { getActualHostileCreeps } from "../alliance/nonAggressionPact";
+import {
+  clearDefenseAssistMemory,
+  getDefenseAssistTargetRoom,
+  stageDefenseAssistCreep,
+  type DefenseAssistStagingMemory
+} from "./defenseAssistStaging";
 
 /**
  * Defense assistance assignment
@@ -43,7 +48,6 @@ export interface DefenseAssignment {
 /**
  * Defense Coordinator
  */
-@ProcessClass()
 export class DefenseCoordinator {
   private assignments: Map<string, DefenseAssignment> = new Map();
 
@@ -56,23 +60,9 @@ export class DefenseCoordinator {
   }
 
   /**
-   * Set defense requests in memory
+   * Legacy compatibility loop for direct defense requests.
+   * Runtime dispatch is owned by the cluster manager; this method is intentionally not decorator-registered.
    */
-  private setDefenseRequestsInMemory(requests: DefenseRequest[]): void {
-    const mem = Memory as unknown as Record<string, unknown>;
-    mem.defenseRequests = requests;
-  }
-
-  /**
-   * Main coordination loop - process defense requests and assign helpers
-   * Registered as kernel process via decorator
-   */
-  @MediumFrequencyProcess("cluster:defense", "Defense Coordinator", {
-    priority: ProcessPriority.HIGH,
-    interval: 3,
-    minBucket: 0, // Removed bucket requirement - aligns with kernel defaults
-    cpuBudget: 0.05
-  })
   public run(): void {
     // Get active defense requests
     const requests = this.getDefenseRequestsFromMemory();
@@ -163,13 +153,13 @@ export class DefenseCoordinator {
       // Find available defenders in this room
       const defenders = helperRoom.find(FIND_MY_CREEPS, {
         filter: c => {
-          const memory = c.memory as unknown as { role?: string; assistTarget?: string };
+          const memory = c.memory as unknown as { role?: string; assistTarget?: string; targetRoom?: string; task?: string };
           
           // Must be the right role
           if (memory.role !== role) return false;
           
           // Must not already have an assignment
-          if (memory.assistTarget) return false;
+          if (getDefenseAssistTargetRoom(memory)) return false;
           
           // Must not already be assigned by coordinator
           if (this.assignments.has(c.name)) return false;
@@ -199,9 +189,13 @@ export class DefenseCoordinator {
 
         this.assignments.set(defender.name, assignment);
 
-        // Set creep memory for role behavior
-        const memory = defender.memory as unknown as { assistTarget?: string };
-        memory.assistTarget = targetRoom;
+        // Set staged creep memory for role behavior.
+        stageDefenseAssistCreep(defender, {
+          homeRoom: helperRoom.name,
+          targetRoom,
+          now: Game.time,
+          squadSize: toAssign
+        });
 
         assigned++;
 
@@ -240,9 +234,9 @@ export class DefenseCoordinator {
         // Prefer rooms with idle defenders
         const defenders = room.find(FIND_MY_CREEPS, {
           filter: c => {
-            const memory = c.memory as unknown as { role?: string; assistTarget?: string };
+            const memory = c.memory as unknown as { role?: string; assistTarget?: string; targetRoom?: string; task?: string };
             const role = memory.role;
-            return (role === "guard" || role === "ranger") && !memory.assistTarget;
+            return (role === "guard" || role === "ranger") && !getDefenseAssistTargetRoom(memory);
           }
         });
         score += defenders.length * 20;
@@ -264,11 +258,39 @@ export class DefenseCoordinator {
     return candidates.map(c => c.room);
   }
 
+  private getMemoryBackedAssignments(targetRoom?: string, role?: string, seen = new Set<string>()): DefenseAssignment[] {
+    const assignments: DefenseAssignment[] = [];
+
+    for (const creep of Object.values(Game.creeps)) {
+      if (seen.has(creep.name)) continue;
+      const memory = creep.memory as unknown as {
+        role?: string;
+        assistTarget?: string;
+        targetRoom?: string;
+        task?: string;
+        defenseSquadCreatedAt?: number;
+      };
+      const assignedTargetRoom = getDefenseAssistTargetRoom(memory);
+      if (!assignedTargetRoom) continue;
+      if (targetRoom && assignedTargetRoom !== targetRoom) continue;
+      if (role && memory.role !== role) continue;
+      assignments.push({
+        creepName: creep.name,
+        targetRoom: assignedTargetRoom,
+        assignedAt: memory.defenseSquadCreatedAt ?? Game.time,
+        eta: Game.time
+      });
+    }
+
+    return assignments;
+  }
+
   /**
    * Get defenders already assigned to a room
    */
   private getAssignedDefenders(targetRoom: string, role?: string): DefenseAssignment[] {
     const assigned: DefenseAssignment[] = [];
+    const seen = new Set<string>();
 
     for (const [creepName, assignment] of this.assignments.entries()) {
       if (assignment.targetRoom !== targetRoom) continue;
@@ -282,9 +304,10 @@ export class DefenseCoordinator {
       }
 
       assigned.push(assignment);
+      seen.add(creepName);
     }
 
-    return assigned;
+    return [...assigned, ...this.getMemoryBackedAssignments(targetRoom, role, seen)];
   }
 
   /**
@@ -307,8 +330,7 @@ export class DefenseCoordinator {
         const hostiles = getActualHostileCreeps(creep.room);
         if (hostiles.length === 0) {
           // No more hostiles, release creep
-          const memory = creep.memory as unknown as { assistTarget?: string };
-          delete memory.assistTarget;
+          clearDefenseAssistMemory(creep.memory as Partial<DefenseAssistStagingMemory>);
           toRemove.push(creepName);
           
           logger.debug(
@@ -320,8 +342,7 @@ export class DefenseCoordinator {
 
       // Remove stale assignments (older than 1000 ticks)
       if (Game.time - assignment.assignedAt > 1000) {
-        const memory = creep.memory as unknown as { assistTarget?: string };
-        delete memory.assistTarget;
+        clearDefenseAssistMemory(creep.memory as Partial<DefenseAssistStagingMemory>);
         toRemove.push(creepName);
         
         logger.debug(
@@ -348,7 +369,9 @@ export class DefenseCoordinator {
    * Get all active defense assignments
    */
   public getAllAssignments(): DefenseAssignment[] {
-    return Array.from(this.assignments.values());
+    const assignments = Array.from(this.assignments.values()).filter(assignment => Game.creeps[assignment.creepName]);
+    const seen = new Set(assignments.map(assignment => assignment.creepName));
+    return [...assignments, ...this.getMemoryBackedAssignments(undefined, undefined, seen)];
   }
 
   /**
@@ -356,19 +379,20 @@ export class DefenseCoordinator {
    */
   public cancelAssignment(creepName: string): void {
     const assignment = this.assignments.get(creepName);
-    if (assignment) {
-      const creep = Game.creeps[creepName];
-      if (creep) {
-        const memory = creep.memory as unknown as { assistTarget?: string };
-        delete memory.assistTarget;
-      }
-      this.assignments.delete(creepName);
-      
-      logger.info(
-        `Cancelled defense assignment for ${creepName}`,
-        { subsystem: "Defense" }
-      );
+    const creep = Game.creeps[creepName];
+    const memory = creep?.memory as Partial<DefenseAssistStagingMemory> | undefined;
+    const hasStagedAssignment = memory ? Boolean(getDefenseAssistTargetRoom(memory)) : false;
+    if (!assignment && !hasStagedAssignment) return;
+
+    if (memory) {
+      clearDefenseAssistMemory(memory);
     }
+    this.assignments.delete(creepName);
+
+    logger.info(
+      `Cancelled defense assignment for ${creepName}`,
+      { subsystem: "Defense" }
+    );
   }
 }
 

--- a/packages/screeps-defense/src/index.ts
+++ b/packages/screeps-defense/src/index.ts
@@ -132,6 +132,17 @@ export {
   coordinateClusterDefense,
 } from "./coordination/clusterDefense";
 
+export {
+  DEFENSE_ASSIST_TASK,
+  clearDefenseAssistMemory,
+  createDefenseAssistMemory,
+  createDefenseAssistSquadId,
+  getDefenseAssistTargetRoom,
+  stageDefenseAssistCreep,
+  type DefenseAssistStagingMemory,
+  type DefenseAssistStagingOptions,
+} from "./coordination/defenseAssistStaging";
+
 // Emergency Response
 export {
   emergencyResponseManager,

--- a/packages/screeps-defense/test/clusterDefenseCoordination.test.ts
+++ b/packages/screeps-defense/test/clusterDefenseCoordination.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { memoryManager } from "@ralphschuler/screeps-memory";
 import { coordinateClusterDefense } from "../src/coordination/clusterDefense";
+import { DefenseCoordinator } from "../src/coordination/defenseCoordinator";
 
 function installScreepsConstants(): void {
   Object.assign(globalThis, {
@@ -129,9 +130,50 @@ describe("cluster defense coordination", () => {
     memoryManager.getHeapCache().clear();
   });
 
-  it("accepts a cluster id and assigns an idle helper-room defender", () => {
+  it("accepts a cluster id and assigns an idle helper-room defender with staged assist memory", () => {
     coordinateClusterDefense("cluster_W1N1");
 
-    expect(Game.creeps.guard1.memory.assistTarget).to.equal("W1N1");
+    expect(Game.creeps.guard1.memory).to.include({
+      assistTarget: "W1N1",
+      targetRoom: "W1N1",
+      task: "defenseAssist",
+      defenseSquadId: "defenseAssist:W2N1:W1N1:20",
+      defenseSquadSize: 1,
+      defenseSquadCreatedAt: 20
+    });
+  });
+
+  it("recovers staged defense-assist assignments after coordinator heap state resets", () => {
+    Game.creeps.guard1.memory = {
+      role: "guard",
+      family: "military",
+      homeRoom: "W2N1",
+      assistTarget: "W1N1",
+      targetRoom: "W1N1",
+      task: "defenseAssist",
+      defenseSquadId: "defenseAssist:W2N1:W1N1:10",
+      defenseSquadSize: 1,
+      defenseSquadCreatedAt: 10
+    } as CreepMemory;
+
+    const freshCoordinator = new DefenseCoordinator();
+
+    const expectedAssignment = {
+      creepName: "guard1",
+      targetRoom: "W1N1",
+      assignedAt: 10,
+      eta: Game.time
+    };
+
+    expect(freshCoordinator.getAssignmentsForRoom("W1N1")).to.deep.equal([expectedAssignment]);
+    expect(freshCoordinator.getAllAssignments()).to.deep.equal([expectedAssignment]);
+
+    freshCoordinator.cancelAssignment("guard1");
+
+    expect(Game.creeps.guard1.memory).to.not.have.property("assistTarget");
+    expect(Game.creeps.guard1.memory).to.not.have.property("targetRoom");
+    expect(Game.creeps.guard1.memory).to.not.have.property("task");
+    expect(Game.creeps.guard1.memory).to.not.have.property("defenseSquadId");
+    expect(freshCoordinator.getAllAssignments()).to.deep.equal([]);
   });
 });

--- a/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
@@ -11,6 +11,8 @@ import {
   calculateAggregateDefenseResponsePlan,
   calculateCombatPower,
   calculateDefenseAssistSquadSize,
+  createDefenseAssistSquadId,
+  DEFENSE_ASSIST_TASK,
   getActualHostileCreeps,
   getVisibleDefenseAssistThreatProfile,
   isDefenseAssistMilitaryRole,
@@ -24,7 +26,6 @@ import { spawnQueue, SpawnPriority } from "../spawnQueue";
 
 const DEFENSE_ASSIST_REQUEST_TTL = 500;
 const DEFENSE_ASSIST_WAVE_TTL = 1200;
-const DEFENSE_ASSIST_TASK = "defenseAssist";
 const DEFENSE_ASSIST_ROLES = ["guard", "ranger", "healer"] as const;
 
 export interface DefenseAssistSpawnAssignment {
@@ -248,10 +249,6 @@ function canSpawnDefenseAssistFrom(room: Room): boolean {
   return getActualHostileCreeps(room).length === 0;
 }
 
-function createDefenseAssistSquadId(homeRoom: string, request: DefenseAssistRequestMemory, waveCreatedAt: number): string {
-  return `defenseAssist:${homeRoom}:${request.roomName}:${waveCreatedAt}`;
-}
-
 function createDefenseAssistSpawnAssignment(
   homeRoom: string,
   home: Room,
@@ -262,7 +259,7 @@ function createDefenseAssistSpawnAssignment(
     targetRoom: request.roomName,
     task: DEFENSE_ASSIST_TASK,
     priority: (request.urgency ?? 1) >= 2 ? SpawnPriority.EMERGENCY : SpawnPriority.HIGH,
-    defenseSquadId: createDefenseAssistSquadId(homeRoom, request, wave.createdAt),
+    defenseSquadId: createDefenseAssistSquadId(homeRoom, request.roomName, wave.createdAt),
     defenseSquadSize: getDefenseAssistSquadSizeForHelper(request, home),
     defenseSquadCreatedAt: wave.createdAt
   };


### PR DESCRIPTION
## Summary
- Centralizes defense-assist staging memory in `@ralphschuler/screeps-defense`.
- Removes the duplicate bot/kernel defense dispatcher path from runtime registration and cluster defense ticks.
- Routes cluster, legacy coordinator, role auto-acquire, and spawn reinforcement paths through the staged `defenseAssist` contract.

## Linked issue
Closes #3222

## Changes
- Added shared `defenseAssistStaging` helpers for task/target/squad metadata.
- Converted legacy direct `assistTarget` writers to staged memory helpers.
- Restored memory-backed assignment discovery after coordinator heap resets.
- Updated cluster/process registry tests for staged assignment and duplicate dispatcher removal.
- Rebuilt `packages/screeps-bot/dist/main.js`.

## Validation
- PASS (Node 24.18.0): `npm run check-versions`
- PASS (Node 24.18.0): `npm run sync:deps:check`
- PASS (Node 24.18.0): `npm run build`
- PASS (Node 24.18.0): `npm run typecheck`
- PASS (Node 24.18.0): `npm run lint:all`
- PASS (Node 24.18.0): `npm run test:defense` (82 passing)
- PASS (Node 24.18.0): `npm run test:clusters` (59 passing)
- PASS (Node 24.18.0): `npm run test:roles` (153 passing)
- PASS (Node 24.18.0): `npm run test:spawn` (146 passing)
- PASS (Node 24.18.0): `npm run check:alliance-safety`
- PASS (Node 24.18.0): `npm run test:server:smoke` (49/49 screepsmod-testing assertions, 109 ticks advanced)

## Deployment impact
- Runtime defense dispatch change; deploy updates Screeps bot bundle only.
- No Memory migration required; legacy `assistTarget` is still read, and new staged writes include `task`, `targetRoom`, `defenseSquadId`, `defenseSquadSize`, and `defenseSquadCreatedAt`.

## Scope notes
- No new GitHub issues created.
- Private-server smoke artifact: `packages/screeps-server/artifacts/smoke/summary.md`.
