### PR TITLE
[codex] Lint all workspace packages

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,41 +30,54 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Framework packages
-          - package-name: screeps-kernel
-            workspace: "@ralphschuler/screeps-kernel"
-            lint-script: "lint:kernel"
-          - package-name: screeps-roles
-            workspace: "@ralphschuler/screeps-roles"
-            lint-script: "lint:roles"
-          - package-name: screeps-pathfinding
-            workspace: "@ralphschuler/screeps-pathfinding"
-            lint-script: "lint:pathfinding"
-          - package-name: screeps-remote-mining
-            workspace: "@ralphschuler/screeps-remote-mining"
-            lint-script: "lint:remote-mining"
-          - package-name: screeps-spawn
-            workspace: "@ralphschuler/screeps-spawn"
-            lint-script: "lint:spawn"
-          - package-name: screeps-economy
-            workspace: "@ralphschuler/screeps-economy"
-            lint-script: "lint:economy"
-          - package-name: screeps-defense
-            workspace: "@ralphschuler/screeps-defense"
-            lint-script: "lint:defense"
+          # Framework packages with a lint script. Keep synchronized via scripts/test/lint-workspace-coverage.test.mjs.
+          - package-name: screeps-cache
+            workspace: "@ralphschuler/screeps-cache"
           - package-name: screeps-chemistry
             workspace: "@ralphschuler/screeps-chemistry"
-            lint-script: "lint:chemistry"
-          - package-name: screeps-utils
-            workspace: "@ralphschuler/screeps-utils"
-            lint-script: "lint:utils"
+          - package-name: screeps-clusters
+            workspace: "@ralphschuler/screeps-clusters"
+          - package-name: screeps-console
+            workspace: "@ralphschuler/screeps-console"
+          - package-name: screeps-core
+            workspace: "@ralphschuler/screeps-core"
+          - package-name: screeps-defense
+            workspace: "@ralphschuler/screeps-defense"
+          - package-name: screeps-economy
+            workspace: "@ralphschuler/screeps-economy"
+          - package-name: screeps-empire
+            workspace: "@ralphschuler/screeps-empire"
+          - package-name: screeps-intershard
+            workspace: "@ralphschuler/screeps-intershard"
+          - package-name: screeps-kernel
+            workspace: "@ralphschuler/screeps-kernel"
+          - package-name: screeps-layouts
+            workspace: "@ralphschuler/screeps-layouts"
+          - package-name: screeps-memory
+            workspace: "@ralphschuler/screeps-memory"
+          - package-name: screeps-pathfinding
+            workspace: "@ralphschuler/screeps-pathfinding"
+          - package-name: screeps-pheromones
+            workspace: "@ralphschuler/screeps-pheromones"
           - package-name: screeps-posis
             workspace: "@ralphschuler/screeps-posis"
-            lint-script: "lint:posis"
-          # Main bot (already has linting in ci.yml but included for completeness)
+          - package-name: screeps-remote-mining
+            workspace: "@ralphschuler/screeps-remote-mining"
+          - package-name: screeps-roles
+            workspace: "@ralphschuler/screeps-roles"
+          - package-name: screeps-spawn
+            workspace: "@ralphschuler/screeps-spawn"
+          - package-name: screeps-standards
+            workspace: "@ralphschuler/screeps-standards"
+          - package-name: screeps-stats
+            workspace: "@ralphschuler/screeps-stats"
+          - package-name: screeps-utils
+            workspace: "@ralphschuler/screeps-utils"
+          - package-name: screeps-visuals
+            workspace: "@ralphschuler/screeps-visuals"
+          # Main bot workspace
           - package-name: screeps-bot
             workspace: "screeps-typescript-starter"
-            lint-script: "lint"
 
     steps:
       - name: Checkout
@@ -81,7 +94,7 @@ jobs:
 
       - name: Lint ${{ matrix.package-name }}
         id: lint-step
-        run: npm run ${{ matrix.lint-script }}
+        run: npm run lint -w "${{ matrix.workspace }}" -- --max-warnings=0
 
       - name: Lint Summary
         if: always()
@@ -92,7 +105,7 @@ jobs:
           else
             echo "❌ Lint warnings or errors found" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Run \`npm run ${{ matrix.lint-script }}\` locally to see details." >> $GITHUB_STEP_SUMMARY
+            echo "Run \`npm run lint -w \"${{ matrix.workspace }}\" -- --max-warnings=0\` locally to see details." >> $GITHUB_STEP_SUMMARY
           fi
 
   # ============================================================================

--- a/BRANCH_PROTECTION.md
+++ b/BRANCH_PROTECTION.md
@@ -39,17 +39,33 @@ Under "Require status checks to pass before merging", search for and add the cur
 - `Check Alliance Safety` - Guards against hostile behavior toward configured allies (`quality.yml`).
 
 #### Package Lint Matrix (Required)
-- `Lint screeps-kernel`
-- `Lint screeps-roles`
-- `Lint screeps-pathfinding`
-- `Lint screeps-remote-mining`
-- `Lint screeps-spawn`
-- `Lint screeps-economy`
-- `Lint screeps-defense`
+- `Lint screeps-cache`
 - `Lint screeps-chemistry`
-- `Lint screeps-utils`
+- `Lint screeps-clusters`
+- `Lint screeps-console`
+- `Lint screeps-core`
+- `Lint screeps-defense`
+- `Lint screeps-economy`
+- `Lint screeps-empire`
+- `Lint screeps-intershard`
+- `Lint screeps-kernel`
+- `Lint screeps-layouts`
+- `Lint screeps-memory`
+- `Lint screeps-pathfinding`
+- `Lint screeps-pheromones`
 - `Lint screeps-posis`
+- `Lint screeps-remote-mining`
+- `Lint screeps-roles`
+- `Lint screeps-spawn`
+- `Lint screeps-standards`
+- `Lint screeps-stats`
+- `Lint screeps-utils`
+- `Lint screeps-visuals`
 - `Lint screeps-bot`
+
+The lint matrix covers every workspace with a `lint` script and enforces `--max-warnings=0`. Workspaces intentionally outside this matrix because they do not currently expose standalone lint scripts:
+- `@ralphschuler/screeps-server` — private-server harness/integration package covered by typecheck and server test workflows.
+- `screepsmod-testing` — local test mod package covered by its TypeScript build path.
 
 #### Runtime Checks (Required for runtime-changing PRs)
 - `Real private-server smoke` - Private-server smoke test (`integration-tests.yml`).
@@ -59,7 +75,7 @@ Under "Require status checks to pass before merging", search for and add the cur
 - `Check Code Duplication` - Transitional informational quality gate.
 - `Check Code Complexity` - Transitional informational quality gate.
 
-**Total Required Checks**: 15 when all modular workflows apply (4 core + 11 lint), plus runtime checks for path-matched PRs.
+**Total Required Checks**: 27 when all modular workflows apply (4 core + 23 lint), plus runtime checks for path-matched PRs.
 
 ### Step 4: Additional Recommended Settings
 
@@ -163,12 +179,14 @@ When adding a new package with tests:
    ```yaml
    - package-name: new-package
      workspace: "@ralphschuler/new-package"
-     lint-script: "lint:new-package"
    ```
+   Keep local coverage synchronized through `npm run lint:all` and `scripts/test/lint-workspace-coverage.test.mjs`.
 
-4. **Update `integration-tests.yml` path filters** if the package affects runtime behavior and should trigger private-server smoke tests.
+4. **Document any workspace without a lint script** in the package-lint exclusion note above, or add a lint script before merging.
 
-5. **Update branch protection** if new job names are added. The shared `Build and Typecheck` job usually covers new packages without adding per-package required checks; add targeted test jobs only when needed.
+5. **Update `integration-tests.yml` path filters** if the package affects runtime behavior and should trigger private-server smoke tests.
+
+6. **Update branch protection** if new job names are added. The shared `Build and Typecheck` job usually covers new packages without adding per-package required checks; add targeted test jobs only when needed.
 
 ### Removing Packages
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "lint:chemistry": "npm run lint -w @ralphschuler/screeps-chemistry",
     "lint:utils": "npm run lint -w @ralphschuler/screeps-utils",
     "lint:posis": "npm run lint -w @ralphschuler/screeps-posis",
-    "lint:all": "npm run lint && npm run lint:kernel && npm run lint:roles && npm run lint:pathfinding && npm run lint:remote-mining && npm run lint:pheromones && npm run lint:spawn && npm run lint:economy && npm run lint:defense && npm run lint:chemistry && npm run lint:utils && npm run lint:posis",
+    "lint:all": "npm run lint --workspaces --if-present -- --max-warnings=0",
     "deploy": "npm run push",
     "push": "DEPLOY=true npm run push -w screeps-typescript-starter",
     "watch": "npm run watch -w screeps-typescript-starter",

--- a/packages/@ralphschuler/screeps-intershard/src/stubs.ts
+++ b/packages/@ralphschuler/screeps-intershard/src/stubs.ts
@@ -6,7 +6,6 @@
 
 // Stub for ProcessClass decorator
 export function ProcessClass() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function <T extends new (...args: any[]) => object>(constructor: T) {
     return constructor;
   };

--- a/scripts/test/lint-workspace-coverage.test.mjs
+++ b/scripts/test/lint-workspace-coverage.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = new URL("../..", import.meta.url);
+const rootPackage = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
+const qualityWorkflow = readFileSync(new URL("../../.github/workflows/quality.yml", import.meta.url), "utf8");
+const branchProtectionDocs = readFileSync(new URL("../../BRANCH_PROTECTION.md", import.meta.url), "utf8");
+
+function workspacePackageJsonPaths() {
+  const paths = [];
+
+  for (const pattern of rootPackage.workspaces ?? []) {
+    assert.match(pattern, /^packages\/(?:\*|@ralphschuler\/\*)$/, `unsupported workspace pattern ${pattern}`);
+    const base = pattern.endsWith("/@ralphschuler/*") ? "packages/@ralphschuler" : "packages";
+    const basePath = path.resolve(root.pathname, base);
+
+    for (const entry of readdirSync(basePath, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const packageJson = path.join(basePath, entry.name, "package.json");
+      if (existsSync(packageJson)) paths.push(packageJson);
+    }
+  }
+
+  return paths.sort();
+}
+
+function workspacePackages() {
+  return workspacePackageJsonPaths().map(packageJson => JSON.parse(readFileSync(packageJson, "utf8")));
+}
+
+function lintableWorkspaces() {
+  return workspacePackages()
+    .filter(packageJson => packageJson.scripts?.lint)
+    .map(packageJson => packageJson.name)
+    .sort();
+}
+
+function noLintWorkspaces() {
+  return workspacePackages()
+    .filter(packageJson => !packageJson.scripts?.lint)
+    .map(packageJson => packageJson.name)
+    .sort();
+}
+
+function workflowLintWorkspaces() {
+  return [...qualityWorkflow.matchAll(/^\s{12}workspace: "?(?<workspace>[^"\n]+)"?$/gm)]
+    .map(match => match.groups.workspace)
+    .sort();
+}
+
+test("root lint:all runs every lintable workspace", () => {
+  assert.equal(
+    rootPackage.scripts["lint:all"],
+    "npm run lint --workspaces --if-present -- --max-warnings=0",
+    "lint:all should use npm workspace discovery and preserve the zero-warning lint gate",
+  );
+});
+
+test("quality workflow lint matrix covers every lintable workspace", () => {
+  assert.deepEqual(
+    workflowLintWorkspaces(),
+    lintableWorkspaces(),
+    "quality.yml lint matrix should match every workspace package with a lint script",
+  );
+
+  assert.match(
+    qualityWorkflow,
+    /run: npm run lint -w "\$\{\{ matrix\.workspace \}\}" -- --max-warnings=0/,
+    "quality workflow should lint the selected workspace directly with the zero-warning gate",
+  );
+});
+
+test("workspaces without lint scripts are documented as excluded", () => {
+  const excludedWorkspaces = noLintWorkspaces();
+  assert.deepEqual(
+    excludedWorkspaces,
+    ["@ralphschuler/screeps-server", "screepsmod-testing"],
+    "unexpected no-lint workspace set should force an explicit lint coverage decision",
+  );
+
+  for (const workspace of excludedWorkspaces) {
+    assert.ok(
+      branchProtectionDocs.includes(`\`${workspace}\``),
+      `${workspace} should be documented as intentionally outside the lint matrix`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Expands the Code Quality lint matrix to every workspace that exposes a `lint` script.
- Changes root `lint:all` to use npm workspace discovery with `--max-warnings=0` so local and CI coverage stay aligned.
- Adds a script test that inventories lintable workspaces, validates the workflow matrix, and documents no-lint workspace exclusions.

## Linked issue
Closes #3069

## Changes
- Code/CI changes
  - `.github/workflows/quality.yml` now lints all 23 lintable workspaces directly with `npm run lint -w <workspace> -- --max-warnings=0`.
  - `package.json` `lint:all` now runs `npm run lint --workspaces --if-present -- --max-warnings=0`.
  - Removed one stale `eslint-disable` in `@ralphschuler/screeps-intershard` exposed by full lint coverage.
- Test changes
  - Added `scripts/test/lint-workspace-coverage.test.mjs` to keep local lint, CI matrix, and documented no-lint exclusions synchronized.
- Docs changes
  - Updated `BRANCH_PROTECTION.md` with the full lint matrix and documented `@ralphschuler/screeps-server` / `screepsmod-testing` as current no-lint workspaces.

## Validation
- PASS `node --test scripts/test/lint-workspace-coverage.test.mjs`
- PASS `npm run lint:all` (Node emits existing MODULE_TYPELESS_PACKAGE_JSON warnings for ESM eslint configs; ESLint exits cleanly with `--max-warnings=0`)
- PASS `npm run test:scripts`
- PASS `npm run sync:deps:check`
- PASS `npm run build:intershard`
- PASS `npm run check:alliance-safety`

## Deployment impact
- CI/documentation lint coverage only; no Screeps runtime behavior or deploy configuration changes.
- No screeps.com deploy required unless this PR is merged into main as part of the standard workflow.

## Scope notes
- Scoped to existing issue #3069. No new GitHub issues created.
- Existing Node module-type warnings from package-level `eslint.config.js` files remain visible; this PR does not change package module semantics.
