### PR TITLE
[codex] Gate production deploy upload on smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,8 +70,45 @@ jobs:
       - name: Deploy preflight
         run: npm run deploy:preflight
 
+      - name: Set up Docker Buildx for production smoke
+        if: ${{ matrix.target.required == true }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run production private-server smoke
+        if: ${{ matrix.target.required == true }}
+        working-directory: packages/screeps-server
+        run: node scripts/run-private-server-test.js --mode=smoke --durationMinutes=15 --maxTicks=3000 --project=screeps-deploy-smoke-${{ github.run_id }}
+        timeout-minutes: 45
+
+      - name: Upload production smoke summary
+        if: ${{ always() && matrix.target.required == true }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: screeps-deploy-smoke-summary
+          path: |
+            packages/screeps-server/artifacts/smoke/summary.json
+            packages/screeps-server/artifacts/smoke/summary.md
+            packages/screeps-server/artifacts/smoke/harness.log
+            packages/screeps-server/artifacts/smoke/scenario-*.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload production smoke raw logs
+        if: ${{ always() && matrix.target.required == true }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: screeps-deploy-smoke-raw-logs
+          path: packages/screeps-server/artifacts/smoke/docker.log
+          retention-days: 3
+          if-no-files-found: ignore
+
+      - name: Cleanup production smoke Docker
+        if: ${{ always() && matrix.target.required == true }}
+        working-directory: packages/screeps-server
+        run: docker compose -f docker-compose.ci.yml -p screeps-deploy-smoke-${{ github.run_id }} down -v --remove-orphans || true
+
       # Keep deploy credentials scoped to the upload step so dependency installation,
-      # validation, and package lifecycle scripts cannot read Screeps secrets.
+      # validation, private-server smoke, and package lifecycle scripts cannot read Screeps secrets.
       - name: Push to Screeps
         env:
           SCREEPS_PASS: ${{ secrets.SCREEPS_PASS }}

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -44,7 +44,7 @@ The deploy path is `npm run push` / `npm run deploy`. Build-only validation is `
 
 Workflow: `.github/workflows/deploy.yml`.
 
-Deploy can run from `workflow_dispatch` or after the release workflow succeeds. It uses GitHub environments for server-specific variables/secrets. Every deploy job runs `npm run deploy:preflight` before the secret-scoped Screeps upload step.
+Deploy can run from `workflow_dispatch` or after the release workflow succeeds. It uses GitHub environments for server-specific variables/secrets. Every deploy job runs `npm run deploy:preflight` before the secret-scoped Screeps upload step. The required production `screeps.com` target also runs the private-server smoke test before upload; optional community/simulation targets skip that smoke gate and remain non-blocking.
 
 Required environment variables/secrets:
 

--- a/scripts/test/deploy-workflow.test.mjs
+++ b/scripts/test/deploy-workflow.test.mjs
@@ -56,6 +56,44 @@ test("deploy workflow runs preflight before secret-scoped upload", () => {
   assert.match(push, /run: npm run push/, "upload step should still run the Screeps push command");
 });
 
+test("deploy workflow gates production upload on private-server smoke without secrets", () => {
+  assert.ok(
+    stepIndex("Set up Docker Buildx for production smoke") > stepIndex("Deploy preflight"),
+    "Docker Buildx setup should run after preflight",
+  );
+  assert.ok(
+    stepIndex("Run production private-server smoke") > stepIndex("Set up Docker Buildx for production smoke"),
+    "production smoke should run after Docker setup",
+  );
+  assert.ok(
+    stepIndex("Push to Screeps") > stepIndex("Cleanup production smoke Docker"),
+    "Screeps upload should run only after smoke cleanup",
+  );
+
+  const dockerSetup = stepBlock("Set up Docker Buildx for production smoke");
+  assert.match(dockerSetup, /if:\s*\$\{\{\s*matrix\.target\.required\s*==\s*true\s*\}\}/, "Docker setup should run only for required production deploys");
+  assert.doesNotMatch(dockerSetup, /SCREEPS_(PASS|TOKEN)/, "Docker setup must not receive Screeps upload secrets");
+
+  const smoke = stepBlock("Run production private-server smoke");
+  assert.match(smoke, /if:\s*\$\{\{\s*matrix\.target\.required\s*==\s*true\s*\}\}/, "smoke should run only for required production deploys");
+  assert.match(smoke, /working-directory:\s*packages\/screeps-server/, "smoke should run from the server package");
+  assert.match(smoke, /run:\s*node scripts\/run-private-server-test\.js --mode=smoke/, "smoke should use the private-server smoke runner");
+  assert.doesNotMatch(smoke, /SCREEPS_(PASS|TOKEN)/, "smoke must not receive Screeps upload secrets");
+
+  const uploadSummary = stepBlock("Upload production smoke summary");
+  assert.match(uploadSummary, /if:\s*\$\{\{\s*always\(\)\s*&&\s*matrix\.target\.required\s*==\s*true\s*\}\}/, "smoke artifacts should upload for required production deploys even after failure");
+  assert.ok(
+    stepIndex("Upload production smoke summary") > stepIndex("Run production private-server smoke"),
+    "smoke summary upload should run after smoke",
+  );
+  assert.doesNotMatch(uploadSummary, /SCREEPS_(PASS|TOKEN)/, "artifact upload must not receive Screeps upload secrets");
+
+  const cleanup = stepBlock("Cleanup production smoke Docker");
+  assert.match(cleanup, /if:\s*\$\{\{\s*always\(\)\s*&&\s*matrix\.target\.required\s*==\s*true\s*\}\}/, "smoke Docker cleanup should run for required production deploys even after failure");
+  assert.match(cleanup, /docker compose .* down -v --remove-orphans \|\| true/, "cleanup should tear down the smoke project");
+  assert.doesNotMatch(cleanup, /SCREEPS_(PASS|TOKEN)/, "cleanup must not receive Screeps upload secrets");
+});
+
 test("deploy workflow keeps screeps.com required and marks optional targets non-blocking", () => {
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- Require the required production `screeps.com` deploy matrix target to run private-server smoke before upload.
- Keep optional deploy targets non-blocking and smoke-free.
- Keep Screeps upload credentials scoped only to the `Push to Screeps` step.

## Linked issue
Refs #3067

## Changes
- Added production-only Docker Buildx, private-server smoke, artifact upload, and cleanup steps before `npm run push`.
- Added deploy workflow tests for smoke ordering, production gating, artifact/cleanup behavior, and secret scoping.
- Updated deployment docs to describe the production smoke gate.

## Validation
- PASS: `npm run deploy:preflight`
- PASS: `npm run test:scripts`
- PASS: `npm run test:server:smoke`
- PASS: `npm run lint:all`
- PASS: `git diff --check`

## Deployment impact
- Affects GitHub Actions deploy only: production `screeps.com` uploads now wait for private-server smoke to pass.
- Runtime bot code is unchanged.

## Scope notes
- Does not close #3067 because production environment approval/explicit-dispatch policy remains a later stage in the same issue.
- No new issues created.
