### PR TITLE
[codex] Skip wiki publish when unavailable

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/wiki-publish.yml'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -28,8 +31,23 @@ jobs:
       
       - name: Build documentation
         run: npm run build:docs
+
+      - name: Check wiki repository availability
+        id: wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WIKI_REPOSITORY: ${{ github.repository }}.wiki
+        run: |
+          if git ls-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${WIKI_REPOSITORY}.git" HEAD >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub wiki repository ${WIKI_REPOSITORY} is available for publishing." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub wiki repository ${WIKI_REPOSITORY} is unavailable or inaccessible; skipping optional wiki publish." >> "$GITHUB_STEP_SUMMARY"
+          fi
       
       - name: Checkout wiki repository
+        if: steps.wiki.outputs.available == 'true'
         uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}.wiki
@@ -37,6 +55,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Copy documentation to wiki
+        if: steps.wiki.outputs.available == 'true'
         run: |
           # Remove old wiki files (except .git)
           find wiki-repo -type f ! -path 'wiki-repo/.git/*' -delete
@@ -45,6 +64,7 @@ jobs:
           cp -r wiki/*.md wiki-repo/
       
       - name: Commit and push to wiki
+        if: steps.wiki.outputs.available == 'true'
         run: |
           cd wiki-repo
           git config user.name "github-actions[bot]"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,9 @@ This directory is the entry point for maintained documentation. Legacy reports a
 npm run build:docs
 ```
 
-The build aggregates docs into `wiki/` for GitHub wiki publishing. `wiki/` is generated output and should not be hand-edited.
+The build aggregates docs into `wiki/` for optional GitHub wiki publishing. `wiki/` is generated output and should not be hand-edited.
+
+GitHub Pages is the canonical automated documentation publication path (`.github/workflows/docs.yml`). The wiki publish workflow (`.github/workflows/wiki-publish.yml`) is best-effort: it builds docs, checks whether the repository wiki is available to `GITHUB_TOKEN`, and skips the wiki upload with a clear workflow summary when `${owner}/${repo}.wiki` is absent or inaccessible.
 
 ## Writing rules
 


### PR DESCRIPTION
## Summary
- Make the optional GitHub wiki publish workflow preflight `${owner}/${repo}.wiki` before checkout.
- Skip wiki checkout/copy/push steps with a clear workflow summary when the wiki repo is absent or inaccessible.
- Document GitHub Pages as the canonical docs publication path and wiki publishing as best-effort.

## Linked issue
Closes #3131

## Changes
- Code changes: updated `.github/workflows/wiki-publish.yml` with wiki availability output and guarded publish steps.
- Test changes: none; workflow/docs-only change.
- Docs changes: updated `docs/README.md` documentation build/publish notes.

## Validation
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run check-versions`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run sync:deps:check`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run build:docs`
- ✅ `source ~/.nvm/nvm.sh && nvm use && npm run build`
- ✅ `node - <<'NODE' ... YAML.parse(.github/workflows/wiki-publish.yml) ... NODE`
- ✅ local wiki preflight probe returned `available=false` for `ralphschuler/screeps.wiki` without failing
- ✅ reviewer subagent found no must-fix findings

## Deployment impact
- No bot runtime behavior changes.
- Screeps deploy path still builds; deployment can proceed after merge per repository workflow.

## Scope notes
- Current GitHub Pages deploy failure returned `Deployment failed, try again later`; this PR only addresses the existing wiki checkout failure tracked by #3131.
