### PR TITLE
[codex] Reserve refill work while haulers collect

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
@@ -151,7 +151,7 @@ export function hauler(ctx: CreepContext): CreepAction {
   // Collects all resource types, not just energy
   if (ctx.droppedResources.length > 0) {
     const closest = findCachedClosest(ctx.creep, ctx.droppedResources, "hauler_drop", 5);
-    if (closest) return { type: "pickup", target: closest };
+    if (closest) return reserveForEnergyCollection(ctx, { type: "pickup", target: closest });
   }
 
   // 2. Tombstones (use cached - transient targets)
@@ -166,7 +166,7 @@ export function hauler(ctx: CreepContext): CreepAction {
     if (tombstone) {
       // Prioritize energy first, then other resources
       if (tombstone.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
-        return { type: "withdraw", target: tombstone, resourceType: RESOURCE_ENERGY };
+        return reserveForEnergyCollection(ctx, { type: "withdraw", target: tombstone, resourceType: RESOURCE_ENERGY });
       }
       // If no energy, pick up any other resource type
       const resourceTypes = Object.keys(tombstone.store) as ResourceConstant[];
@@ -187,14 +187,14 @@ export function hauler(ctx: CreepContext): CreepAction {
     const distributed = getCachedDistributedTarget(ctx.creep, containersWithEnergy, "energy_container");
     if (distributed) {
       logger.debug(`${ctx.creep.name} hauler withdrawing from container ${distributed.id} with ${distributed.store.getUsedCapacity(RESOURCE_ENERGY)} energy`);
-      return { type: "withdraw", target: distributed, resourceType: RESOURCE_ENERGY };
+      return reserveForEnergyCollection(ctx, { type: "withdraw", target: distributed, resourceType: RESOURCE_ENERGY });
     } else {
       // BUGFIX: If distribution returns null (shouldn't happen but defensive), fall back to closest container
       logger.warn(`${ctx.creep.name} hauler found ${containersWithEnergy.length} containers but distribution returned null, falling back to closest`);
       const fallback = ctx.creep.pos.findClosestByRange(containersWithEnergy);
       if (fallback) {
         logger.debug(`${ctx.creep.name} hauler using fallback container ${fallback.id}`);
-        return { type: "withdraw", target: fallback, resourceType: RESOURCE_ENERGY };
+        return reserveForEnergyCollection(ctx, { type: "withdraw", target: fallback, resourceType: RESOURCE_ENERGY });
       }
     }
   }
@@ -230,16 +230,26 @@ export function hauler(ctx: CreepContext): CreepAction {
   }
 
   const terminalSupplyAction = collectTerminalBufferFromStorage(ctx);
-  if (terminalSupplyAction) return terminalSupplyAction;
+  if (terminalSupplyAction) return reserveForEnergyCollection(ctx, terminalSupplyAction);
 
   // 5. Storage (single target, no distribution needed)
   if (ctx.storage && ctx.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
     logger.debug(`${ctx.creep.name} hauler withdrawing from storage`);
-    return { type: "withdraw", target: ctx.storage, resourceType: RESOURCE_ENERGY };
+    return reserveForEnergyCollection(ctx, { type: "withdraw", target: ctx.storage, resourceType: RESOURCE_ENERGY });
   }
 
   logger.warn(`${ctx.creep.name} hauler idle (no energy sources found)`);
   return { type: "idle" };
+}
+
+function reserveForEnergyCollection(ctx: CreepContext, action: CreepAction): CreepAction {
+  if (action.type === "withdraw" && action.resourceType === RESOURCE_ENERGY) {
+    taskBoard.reserveDeliveryWork(ctx);
+  }
+  if (action.type === "pickup" && action.target.resourceType === RESOURCE_ENERGY) {
+    taskBoard.reserveDeliveryWork(ctx);
+  }
+  return action;
 }
 
 function findDefenseRefuelDelivery(ctx: CreepContext): CreepAction | null {

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/stateMachine.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/stateMachine.ts
@@ -497,6 +497,13 @@ function commitNewAction(ctx: CreepContext, newAction: CreepAction, logMessage: 
  * @param behaviorFn Behavior function to call when evaluating new action
  * @returns Action to execute
  */
+function isEnergyCollectionAction(action: CreepAction): boolean {
+  return (
+    (action.type === "withdraw" && action.resourceType === RESOURCE_ENERGY) ||
+    (action.type === "pickup" && action.target.resourceType === RESOURCE_ENERGY)
+  );
+}
+
 export function evaluateWithStateMachine(
   ctx: CreepContext,
   behaviorFn: (ctx: CreepContext) => CreepAction,
@@ -542,6 +549,9 @@ export function evaluateWithStateMachine(
             return { ...action, amount: reservationAmount };
           }
         } else {
+          if (ctx.memory.assignedTaskId && isEnergyCollectionAction(action)) {
+            taskBoard.refreshAssignedDeliveryReservation(ctx);
+          }
           return action;
         }
       }

--- a/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
+++ b/packages/@ralphschuler/screeps-roles/src/tasks/taskBoard.ts
@@ -45,6 +45,11 @@ interface MemoryWithTaskBoard extends Memory {
   creepTaskBoard?: TaskBoardMemory;
 }
 
+interface InternalTaskAssignmentOptions extends TaskAssignmentOptions {
+  /** Reserve delivery work before the creep has collected energy. */
+  reserveEmptyEnergyDelivery?: boolean;
+}
+
 function getRuntimeGame(): typeof Game | null {
   const game = (globalThis as unknown as { Game?: typeof Game }).Game;
   return game && typeof game === "object" ? game : null;
@@ -123,9 +128,13 @@ function getCreepEnergyCapacity(creep: Creep): number {
   return Math.max(0, creep.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function getAssignmentAmount(creep: Creep, task: CreepTask): number {
+function getAssignmentAmount(creep: Creep, task: CreepTask, options: InternalTaskAssignmentOptions = {}): number {
   if (task.type === "harvest") return getCreepEnergyCapacity(creep);
-  return Math.max(1, getCreepEnergy(creep));
+  const energy = getCreepEnergy(creep);
+  if (options.reserveEmptyEnergyDelivery && isEnergyDeliveryTaskType(task.type)) {
+    return getCreepEnergyCapacity(creep);
+  }
+  return Math.max(1, energy);
 }
 
 function getReservationAmount(task: CreepTask, creepName: string): number | undefined {
@@ -133,7 +142,7 @@ function getReservationAmount(task: CreepTask, creepName: string): number | unde
   return typeof amount === "number" && Number.isFinite(amount) && amount > 0 ? amount : undefined;
 }
 
-function canPerformTask(ctx: CreepContext, task: CreepTask): boolean {
+function canPerformTask(ctx: CreepContext, task: CreepTask, options: InternalTaskAssignmentOptions = {}): boolean {
   if (!task.allowedRoles.includes(ctx.memory.role)) return false;
 
   switch (task.type) {
@@ -142,7 +151,7 @@ function canPerformTask(ctx: CreepContext, task: CreepTask): boolean {
     case "refillTower":
     case "fillTerminalEnergy":
     case "storeEnergy":
-      return getCreepEnergy(ctx.creep) > 0;
+      return getCreepEnergy(ctx.creep) > 0 || (options.reserveEmptyEnergyDelivery === true && getCreepEnergyCapacity(ctx.creep) > 0);
     case "build":
     case "repair":
     case "upgrade":
@@ -436,14 +445,14 @@ function isAllowedTaskType(task: CreepTask, options: TaskAssignmentOptions): boo
   return !options.allowedTypes || options.allowedTypes.includes(task.type);
 }
 
-function assignTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: TaskAssignmentOptions = {}): CreepTask | null {
+function assignTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: InternalTaskAssignmentOptions = {}): CreepTask | null {
   const current = getCurrentAssignedTask(board, ctx.creep.name, ctx.memory.assignedTaskId);
   if (current && ctx.memory.assignedTaskId !== current.id) {
     ctx.memory.assignedTaskId = current.id;
   } else if (!current && ctx.memory.assignedTaskId) {
     delete ctx.memory.assignedTaskId;
   }
-  if (current && isAllowedTaskType(current, options) && isTargetStillValid(current) && canPerformTask(ctx, current)) {
+  if (current && isAllowedTaskType(current, options) && isTargetStillValid(current) && canPerformTask(ctx, current, options)) {
     if (!shouldCheckForPreemption(ctx, current)) {
       return current;
     }
@@ -462,7 +471,10 @@ function assignTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: Task
   const task = findBestTask(board, ctx, options);
   if (!task) return null;
 
-  const amount = Math.min(Math.max(1, remainingAmount(task)), getAssignmentAmount(ctx.creep, task));
+  const assignmentAmount = getAssignmentAmount(ctx.creep, task, options);
+  if (assignmentAmount <= 0) return null;
+
+  const amount = Math.min(Math.max(1, remainingAmount(task)), assignmentAmount);
   ctx.memory.assignedTaskId = task.id;
   task.reservations[ctx.creep.name] = {
     creepName: ctx.creep.name,
@@ -476,13 +488,13 @@ function assignTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: Task
   return task;
 }
 
-function findBestTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: TaskAssignmentOptions = {}): CreepTask | null {
+function findBestTask(board: RoomTaskBoardMemory, ctx: CreepContext, options: InternalTaskAssignmentOptions = {}): CreepTask | null {
   let best: CreepTask | null = null;
   let bestScore = -Infinity;
 
   for (const task of Object.values(board.tasks)) {
     if (!isAllowedTaskType(task, options)) continue;
-    if (!canPerformTask(ctx, task)) continue;
+    if (!canPerformTask(ctx, task, options)) continue;
     if (!isTargetStillValid(task)) continue;
     if (remainingAmount(task) <= 0) continue;
     if (task.assignedCreeps.length >= task.maxAssignments && !isEnergyDeliveryTaskType(task.type)) continue;
@@ -591,6 +603,20 @@ export class TaskBoard {
     return null;
   }
 
+  public reserveDeliveryWork(ctx: CreepContext): boolean {
+    if (!this.isEnabled() || !getRuntimeGame()) return false;
+    const board = getRoomBoard(ctx.room.name);
+    measureCpuDetail("taskBoard.cleanup", () => cleanupBoard(board));
+    measureCpuDetail("taskBoard.generate", () => generateTasks(ctx.room, board));
+
+    return Boolean(assignTask(board, ctx, {
+      allowedTypes: ["refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy"],
+      preemptPriority: TaskPriority.NORMAL,
+      priorityStickinessDelta: 25,
+      reserveEmptyEnergyDelivery: true
+    }));
+  }
+
   public hasActiveTask(roomName: string, allowedTypes: TaskType[]): boolean {
     const game = getRuntimeGame();
     if (!this.isEnabled() || !game) return false;
@@ -658,6 +684,34 @@ export class TaskBoard {
     task.updatedTick = Game.time;
     recomputeReservationTotals(task);
     return reservation.amount;
+  }
+
+  public refreshAssignedDeliveryReservation(ctx: CreepContext): boolean {
+    const assignedTaskId = ctx.memory.assignedTaskId;
+    if (!assignedTaskId) return false;
+
+    const memory = getTaskMemory();
+    const assignedRoomName = assignedTaskId.split(":", 1)[0];
+    const board = memory.rooms[assignedRoomName] ?? memory.rooms[ctx.room.name];
+    const task = board?.tasks[assignedTaskId];
+    const reservation = task?.reservations[ctx.creep.name];
+
+    if (!board || !task || !reservation || !isEnergyDeliveryTaskType(task.type) || !isTargetStillValid(task)) {
+      delete ctx.memory.assignedTaskId;
+      return false;
+    }
+
+    const assignmentAmount = getAssignmentAmount(ctx.creep, task, { reserveEmptyEnergyDelivery: true });
+    if (assignmentAmount <= 0) {
+      delete ctx.memory.assignedTaskId;
+      return false;
+    }
+
+    reservation.amount = Math.min(Math.max(1, remainingAmount(task) + reservation.amount), assignmentAmount);
+    reservation.expiresTick = Game.time + DEFAULT_RESERVATION_TTL;
+    task.updatedTick = Game.time;
+    recomputeReservationTotals(task);
+    return true;
   }
 
   public clear(roomName?: string): void {

--- a/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/taskBoard.test.ts
@@ -1141,6 +1141,135 @@ describe("TaskBoard", () => {
     expect(taskBoard.describeAssignments(room.name)).to.not.contain("remoteHauler2 -> refillExtension");
   });
 
+  it("reserves refill work for an empty hauler before collecting energy", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const room = createMockRoom("W1N1");
+    const container = {
+      id: "container1" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      room,
+      pos: { x: 10, y: 10, roomName: room.name },
+      store: makeStore(500, 2000)
+    } as unknown as StructureContainer;
+    (room as any).find = (type: number) => {
+      if (type === FIND_MY_STRUCTURES) return [extension];
+      if (type === FIND_MY_CONSTRUCTION_SITES) return [];
+      if (type === FIND_STRUCTURES) return [];
+      if (type === FIND_MY_CREEPS) return [];
+      return [];
+    };
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : id === container.id ? container : null;
+
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1, working: false },
+      store: makeStore(0, 50),
+      pos: { x: 25, y: 25, roomName: room.name, getRangeTo: () => 10, isNearTo: () => false, findInRange: () => [] }
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const collectContext = makeContext(creep, room);
+    collectContext.containers = [container];
+    const collectAction = evaluateEconomyBehavior(collectContext);
+
+    expect(collectAction.type).to.equal("withdraw");
+    expect((collectAction as Extract<CreepAction, { type: "withdraw" }>).target).to.equal(container);
+    expect(taskBoard.describeAssignments(room.name)).to.contain("hauler1 -> refillExtension");
+
+    (creep as unknown as { store: StoreDefinition }).store = makeStore(50, 50);
+    creep.memory.working = true;
+    const deliverAction = evaluateEconomyBehavior(makeContext(creep, room));
+
+    expect(deliverAction.type).to.equal("transfer");
+    expect((deliverAction as Extract<CreepAction, { type: "transfer" }>).target).to.equal(extension);
+  });
+
+  it("does not reserve energy delivery work before collecting minerals", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const room = createMockRoom("W1N1");
+    const mineralContainer = {
+      id: "mineralContainer1" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      room,
+      pos: { x: 10, y: 10, roomName: room.name },
+      store: {
+        [RESOURCE_UTRIUM]: 1000,
+        getUsedCapacity: (resource?: ResourceConstant) => resource === RESOURCE_UTRIUM ? 1000 : 0,
+        getFreeCapacity: () => 1000,
+        getCapacity: () => 2000
+      }
+    } as unknown as StructureContainer;
+    (room as any).find = (type: number) => {
+      if (type === FIND_MY_STRUCTURES) return [extension];
+      if (type === FIND_MY_CONSTRUCTION_SITES) return [];
+      if (type === FIND_STRUCTURES) return [];
+      if (type === FIND_MY_CREEPS) return [];
+      return [];
+    };
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : id === mineralContainer.id ? mineralContainer : null;
+
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1, working: false },
+      store: makeStore(0, 50)
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const context = makeContext(creep, room);
+    context.mineralContainers = [mineralContainer];
+    const action = evaluateEconomyBehavior(context);
+
+    expect(action.type).to.equal("withdraw");
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).resourceType).to.equal(RESOURCE_UTRIUM);
+    expect(taskBoard.describeAssignments(room.name)).to.not.contain("hauler1 -> refillExtension");
+  });
+
+  it("refreshes reserved refill work while a hauler continues energy collection state", () => {
+    const extension = makeExtension("extension1" as Id<StructureExtension>, 50);
+    const room = createMockRoom("W1N1");
+    const container = {
+      id: "container1" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      room,
+      pos: { x: 10, y: 10, roomName: room.name },
+      store: makeStore(500, 2000)
+    } as unknown as StructureContainer;
+    (room as any).find = (type: number) => {
+      if (type === FIND_MY_STRUCTURES) return [extension];
+      if (type === FIND_MY_CONSTRUCTION_SITES) return [];
+      if (type === FIND_STRUCTURES) return [];
+      if (type === FIND_MY_CREEPS) return [];
+      return [];
+    };
+    MockGame.rooms[room.name] = room;
+    MockGame.getObjectById = (id: string) => id === extension.id ? extension : id === container.id ? container : null;
+
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", family: "economy", homeRoom: room.name, version: 1, working: false },
+      store: makeStore(0, 50),
+      pos: { x: 25, y: 25, roomName: room.name, getRangeTo: () => 10, isNearTo: () => false, inRangeTo: () => false, findInRange: () => [] }
+    });
+    MockGame.creeps[creep.name] = creep;
+
+    const initialContext = makeContext(creep, room);
+    initialContext.containers = [container];
+    const firstAction = evaluateWithStateMachine(initialContext, evaluateEconomyBehavior);
+    expect(firstAction.type).to.equal("withdraw");
+
+    const assignedTaskId = (creep.memory as any).assignedTaskId;
+    const task = (Memory as any).creepTaskBoard.rooms[room.name].tasks[assignedTaskId];
+    task.reservations[creep.name].expiresTick = Game.time + 1;
+    Game.time += 1;
+
+    const continuedAction = evaluateWithStateMachine(makeContext(creep, room), evaluateEconomyBehavior);
+
+    expect(continuedAction.type).to.equal("withdraw");
+    expect(task.reservations[creep.name].expiresTick).to.equal(Game.time + 15);
+  });
+
   it("does not divert a full upgrader into storage when the controller can be upgraded", () => {
     const controller = makeController("controller1" as Id<StructureController>);
     const storage = makeStorage("storage1" as Id<StructureStorage>, 0, 1000000);

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -6663,7 +6663,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -24449,20 +24449,30 @@ function yl(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY);
 }
 
-function vl(e, t) {
+function vl(e) {
+return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
+}
+
+function gl(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return vl(e);
+var o = yl(e);
+return r.reserveEmptyEnergyDelivery && pl(t.type) ? vl(e) : Math.max(1, o);
+}
+
+function hl(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function gl(e, t) {
-if (!t.allowedRoles.includes(e.memory.role)) return !1;
+function Rl(e, t, r) {
+if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
 case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return yl(e.creep) > 0;
+return yl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && vl(e.creep) > 0;
 
 case "build":
 case "repair":
@@ -24486,7 +24496,7 @@ return !1;
 }
 }
 
-function hl(e, t) {
+function El(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24503,7 +24513,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Rl(e) {
+function Tl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24511,14 +24521,14 @@ roomName: e.roomName
 };
 }
 
-function El(e, t, r, o, n) {
+function Cl(e, t, r, o, n) {
 return {
 id: ml(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Rl(r.pos),
+targetPos: Tl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
@@ -24527,7 +24537,7 @@ expiresTick: Game.time + 50
 };
 }
 
-function Tl(e, t) {
+function Sl(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
 return null !== (r = null === (t = null === (e = cl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
@@ -24540,7 +24550,7 @@ return e.find(FIND_MY_STRUCTURES);
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && hl(t, El(e.name, "refillTower", h, g, el.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && hl(t, El(e.name, "refillExtension", h, g, el.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && hl(t, El(e.name, "refillSpawn", h, g, el.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && El(t, Cl(e.name, "refillTower", h, g, el.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && El(t, Cl(e.name, "refillExtension", h, g, el.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && El(t, Cl(e.name, "refillSpawn", h, g, el.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24554,11 +24564,11 @@ if (r) throw r.error;
 }
 }
 var R = rl(e);
-R && hl(t, El(e.name, "fillTerminalEnergy", R.terminal, R.amount, el.NORMAL));
+R && El(t, Cl(e.name, "fillTerminalEnergy", R.terminal, R.amount, el.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
 var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Os ? el.NORMAL : el.LOW, S = Math.min(E, 1e3);
-hl(t, El(e.name, "storeEnergy", e.storage, S, C));
+El(t, Cl(e.name, "storeEnergy", e.storage, S, C));
 }
 var w = sl("taskBoard.findHostiles", function() {
 return q(e);
@@ -24566,13 +24576,13 @@ return q(e);
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-hl(t, {
+El(t, {
 id: ml(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
 priority: el.CRITICAL,
 targetId: O.id,
-targetPos: Rl(O.pos),
+targetPos: Tl(O.pos),
 amount: O.hits,
 maxAssignments: 3,
 allowedRoles: il,
@@ -24600,13 +24610,13 @@ return e.hits < e.hitsMax;
 try {
 for (var A = a(k.slice(0, 5)), M = A.next(); !M.done; M = A.next()) {
 var U = M.value;
-hl(t, {
+El(t, {
 id: ml(e.name, "heal", U.id),
 roomName: e.name,
 type: "heal",
 priority: el.HIGH,
 targetId: U.id,
-targetPos: Rl(U.pos),
+targetPos: Tl(U.pos),
 amount: U.hitsMax - U.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -24627,17 +24637,17 @@ if (s) throw s.error;
 }
 }
 
-function Cl(e) {
+function wl(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function Sl(e) {
+function xl(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && Y(e));
 }
 
-function wl(e) {
+function bl(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -24662,11 +24672,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !Sl(t);
+return !xl(t);
 }
 }
 
-function xl(e, t) {
+function Ol(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -24688,7 +24698,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function bl(e, t) {
+function kl(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -24696,7 +24706,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (fl(m.type)) xl(e, m); else {
+if (fl(m.type)) Ol(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -24713,7 +24723,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-Cl(m), Game.time > m.expiresTick || !wl(m) ? xl(e, m) : (dl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !pl(m.type)) && (m.status = "assigned");
+wl(m), Game.time > m.expiresTick || !bl(m) ? Ol(e, m) : (dl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !pl(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -24731,7 +24741,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function Ol(e, t, r) {
+function Al(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -24739,15 +24749,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-Cl(t);
+wl(t);
 }
 }
 
-function kl(e, t) {
+function Ml(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function Al(e, t, r) {
+function Ul(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -24760,39 +24770,37 @@ return e.reservations[t];
 });
 }(e, t.creep.name, t.memory.assignedTaskId);
 if (s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId,
-s && kl(s, r) && wl(s) && gl(t, s)) {
+s && Ml(s, r) && bl(s) && Rl(t, s, r)) {
 if (!function(e, t) {
 var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= el.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var c = Ml(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : el.CRITICAL);
+var c = _l(e, t, r), u = (null !== (o = null == c ? void 0 : c.priority) && void 0 !== o ? o : 0) - s.priority, l = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, m = (null !== (a = null == c ? void 0 : c.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : el.CRITICAL);
 if (!c || u < l || !m) return s;
-Ol(0, s, t.creep.name), e.stats.preemptions++;
+Al(0, s, t.creep.name), e.stats.preemptions++;
 }
-var d = Ml(e, t, r);
+var d = _l(e, t, r);
 if (!d) return null;
-var p = Math.min(Math.max(1, dl(d)), function(e, t) {
-return "harvest" === t.type ? function(e) {
-return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
-}(e) : Math.max(1, yl(e));
-}(t.creep, d));
+var p = gl(t.creep, d, r);
+if (p <= 0) return null;
+var f = Math.min(Math.max(1, dl(d)), p);
 return t.memory.assignedTaskId = d.id, d.reservations[t.creep.name] = {
 creepName: t.creep.name,
-amount: p,
+amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, d.updatedTick = Game.time, Cl(d), e.stats.assigned++, d;
+}, d.updatedTick = Game.time, wl(d), e.stats.assigned++, d;
 }
 
-function Ml(e, t, r) {
+function _l(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (kl(l, r) && gl(t, l) && wl(l) && !(dl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || pl(l.type))) {
-var m = Ul(t.creep, l), d = 1e3 * l.priority - m;
+if (Ml(l, r) && Rl(t, l, r) && bl(l) && !(dl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || pl(l.type))) {
+var m = Nl(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -24810,7 +24818,7 @@ if (o) throw o.error;
 return i;
 }
 
-function Ul(e, t) {
+function Nl(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -24818,7 +24826,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function _l(e, t) {
+function Pl(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -24832,7 +24840,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: vl(e, t.creep.name)
+amount: hl(e, t.creep.name)
 };
 
 case "build":
@@ -24861,7 +24869,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (Sl(t)) return null;
+if (xl(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -24880,7 +24888,7 @@ return null;
 }
 }
 
-var Nl = function() {
+var Il = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
 return !1 !== ul().enabled;
@@ -24890,42 +24898,55 @@ ul().enabled = e;
 if (!this.isEnabled() || !cl()) return null;
 var r = ll(e.room.name);
 sl("taskBoard.cleanup", function() {
-return bl(r);
+return kl(r);
 }), sl("taskBoard.generate", function() {
-return Tl(e.room, r);
+return Sl(e.room, r);
 });
-var o = Al(r, e, {
+var o = Ul(r, e, {
 allowedTypes: t
 });
-return o ? _l(o, e) : null;
+return o ? Pl(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
 if (!this.isEnabled() || !cl()) return null;
 var t = ll(e.room.name);
 sl("taskBoard.cleanup", function() {
-return bl(t);
+return kl(t);
 }), sl("taskBoard.generate", function() {
-return Tl(e.room, t);
+return Sl(e.room, t);
 });
-var r = Al(t, e, {
+var r = Ul(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
 preemptPriority: el.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = _l(r, e);
+var o = Pl(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
+}, e.prototype.reserveDeliveryWork = function(e) {
+if (!this.isEnabled() || !cl()) return !1;
+var t = ll(e.room.name);
+return sl("taskBoard.cleanup", function() {
+return kl(t);
+}), sl("taskBoard.generate", function() {
+return Sl(e.room, t);
+}), Boolean(Ul(t, e, {
+allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
+preemptPriority: el.NORMAL,
+priorityStickinessDelta: 25,
+reserveEmptyEnergyDelivery: !0
+}));
 }, e.prototype.hasActiveTask = function(e, t) {
 var r, o = cl();
 if (!this.isEnabled() || !o) return !1;
 var n = ll(e);
 sl("taskBoard.cleanup", function() {
-return bl(n);
+return kl(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
 return a && sl("taskBoard.generate", function() {
-return Tl(a, n);
+return Sl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && wl(e);
+return t.includes(e.type) && bl(e);
 });
 }, e.prototype.refreshRoom = function(e) {
 if (this.isEnabled() && cl()) {
@@ -24953,9 +24974,9 @@ if (t) throw t.error;
 }(e.name);
 var t = ll(e.name);
 sl("taskBoard.cleanup", function() {
-return bl(t);
+return kl(t);
 }), sl("taskBoard.generate", function() {
-return Tl(e, t);
+return Sl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
@@ -24964,7 +24985,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) Ol(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) Al(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -24992,12 +25013,23 @@ if (r) throw r.error;
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
 var a = ul(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && pl(c.type) && wl(c))) return delete e.memory.assignedTaskId,
+if (!(s && c && u && c.targetId === t.target.id && pl(c.type) && bl(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = vl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = hl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-Cl(c), u.amount);
+wl(c), u.amount);
+}, e.prototype.refreshAssignedDeliveryReservation = function(e) {
+var t, r = e.memory.assignedTaskId;
+if (!r) return !1;
+var o = ul(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && pl(i.type) && bl(i))) return delete e.memory.assignedTaskId,
+!1;
+var c = gl(e.creep, i, {
+reserveEmptyEnergyDelivery: !0
+});
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, dl(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, wl(i), !0);
 }, e.prototype.clear = function(e) {
 var t = ul();
 e ? delete t.rooms[e] : t.rooms = {};
@@ -25008,9 +25040,9 @@ var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
 var n = ll(e);
 sl("taskBoard.cleanup", function() {
-return bl(n, !0);
+return kl(n, !0);
 }), sl("taskBoard.generate", function() {
-return Tl(o, n);
+return Sl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25038,7 +25070,7 @@ preemptions: n.stats.preemptions
 var t, r, o = cl(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
 var i = ll(e);
-bl(i, !0), Tl(n, i);
+kl(i, !0), Sl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25061,7 +25093,7 @@ if (t) throw t.error;
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
 var t, r, o, n, i, s = ll(e);
-bl(s, !0);
+kl(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25096,15 +25128,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), Pl = new Nl;
+}(), Gl = new Il;
 
-function Il(e) {
+function Ll(e) {
 return e === ERR_NO_PATH;
 }
 
-function Gl(e) {
+function Dl(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && Il(e.moveResult),
+clearState: void 0 !== e.moveResult && Ll(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25115,11 +25147,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var Ll, Dl = A("ActionExecutor");
+var Fl, Bl = A("ActionExecutor");
 
-function Fl(e, t, r) {
+function Wl(e, t, r) {
 var o;
-return !!Y(r) && (Dl.warn("Refusing harmful action against known ally target", {
+return !!Y(r) && (Bl.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25128,36 +25160,36 @@ target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
 }), delete e.memory.state, e.creep.id && (Ju.clearCachedPath(e.creep), Dt(e.creep)),
-Pl.releaseCreep(e.creep.name, e.creep.room.name), !0);
+Gl.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function Bl(e, t, r) {
+function Kl(e, t, r) {
 var o, n;
-if (!t || !t.type) return Dl.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return Bl.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && Dl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-"idle" === a.type ? Dl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Dl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && Bl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+"idle" === a.type ? Bl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Bl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25181,7 +25213,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = Kl(e, function() {
+i = Yl(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25195,92 +25227,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (Fl(r, a.type, a.target)) {
+if (Wl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (Fl(r, a.type, a.target)) {
+if (Wl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Kl(e, function() {
+Yl(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (Fl(r, a.type, a.target)) {
+if (Wl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Kl(e, function() {
+Yl(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-Kl(e, function() {
+Yl(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), Il(Ju.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), Ll(Ju.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (Fl(r, a.type, a.target)) {
+if (Wl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Kl(e, function() {
+i = Yl(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-Il(Ju.moveTo(e, a.target)) && (i = !0);
+Ll(Ju.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-Il(Ju.moveTo(e, {
+Ll(Ju.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25289,11 +25321,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-Il(Wl(e, a.target, a.routeType)) && (i = !0);
+Ll(Hl(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), Il(Wl(e, {
+c = new RoomPosition(25, 25, a.roomName), Ll(Hl(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25308,7 +25340,7 @@ pos: e,
 range: 10
 };
 });
-Il(Ju.moveTo(e, u, {
+Ll(Ju.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
@@ -25321,11 +25353,11 @@ priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || Il(Ju.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || Ll(Ju.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-Il(Ju.moveTo(e, a.target, {
+Ll(Ju.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
@@ -25341,7 +25373,7 @@ var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
 var d = $u(m.name);
 if (d && !e.pos.isEqualTo(d)) {
-Il(Ju.moveTo(e, d, {
+Ll(Ju.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25358,8 +25390,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, Ju.clearCachedPath(e), Dt(e), Pl.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || Pl.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, Ju.clearCachedPath(e), Dt(e), Gl.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || Gl.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25367,12 +25399,12 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function Wl(e, t, r, o) {
-if (!Ll) return Ju.moveTo(e, t, o);
+function Hl(e, t, r, o) {
+if (!Fl) return Ju.moveTo(e, t, o);
 try {
-return Ll(e, t, r, o);
+return Fl(e, t, r, o);
 } catch (n) {
-return Dl.warn("Remote movement handler failed; falling back to default movement", {
+return Bl.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25383,11 +25415,11 @@ error: n instanceof Error ? n.message : String(n)
 }
 }
 
-function Kl(e, t, r, o, n, a) {
+function Yl(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
 var s = Ju.moveTo(e, r);
-return s !== OK && Dl.info("Movement attempt returned non-OK result", {
+return s !== OK && Bl.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25395,12 +25427,12 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), Gl({
+}), Dl({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = Gl({
+var c = Dl({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
@@ -25466,7 +25498,7 @@ Yi(e).upgradeProgress += t;
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (Dl.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (Bl.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25477,13 +25509,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Hl, Yl = A("StateMachine");
+var Vl, ql = A("StateMachine");
 
-function Vl(e) {
+function jl(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function ql(e, t, r) {
+function zl(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25505,12 +25537,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== Vl(e.amount) ? {
+}, void 0 !== jl(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), Yl.info(r, {
+}(t), ql.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25518,13 +25550,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : Yl.info("Behavior returned idle action", {
+})) : ql.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (Yl.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (ql.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25535,11 +25567,11 @@ type: "idle"
 });
 }
 
-function jl(e, t, r) {
+function Ql(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, ql(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, zl(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -25619,7 +25651,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) Yl.info("State completed, evaluating new action", {
+}(a, e)) ql.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25669,7 +25701,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = Vl(e.data.amount);
+var c = jl(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -25742,12 +25774,14 @@ return null;
 }
 }(a);
 if (c) {
-if ("transfer" !== c.type || !e.memory.assignedTaskId) return c;
-var u = e.memory.assignedTaskId, l = Pl.refreshCreepReservation(e, c);
+if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
+return "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
+}(c) && Gl.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = Gl.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-Yl.info("Task-board delivery reservation missing, re-evaluating behavior", {
+ql.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25757,7 +25791,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-Yl.info("State reconstruction failed, re-evaluating behavior", {
+ql.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25765,7 +25799,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (Yl.info("State invalid, re-evaluating behavior", {
+} else a && (ql.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -25774,33 +25808,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return ql(e, t(e), "Committed new state action");
+return zl(e, t(e), "Committed new state action");
 }
 
-(Hl = {})[FIND_SOURCES] = 5e3, Hl[FIND_MINERALS] = 5e3, Hl[FIND_DEPOSITS] = 100,
-Hl[FIND_STRUCTURES] = 50, Hl[FIND_MY_STRUCTURES] = 50, Hl[FIND_HOSTILE_STRUCTURES] = 20,
-Hl[FIND_MY_SPAWNS] = 100, Hl[FIND_MY_CONSTRUCTION_SITES] = 20, Hl[FIND_CONSTRUCTION_SITES] = 20,
-Hl[FIND_CREEPS] = 5, Hl[FIND_MY_CREEPS] = 5, Hl[FIND_HOSTILE_CREEPS] = 3, Hl[FIND_DROPPED_RESOURCES] = 5,
-Hl[FIND_TOMBSTONES] = 10, Hl[FIND_RUINS] = 10, Hl[FIND_FLAGS] = 50, Hl[FIND_NUKES] = 20,
-Hl[FIND_POWER_CREEPS] = 10, Hl[FIND_MY_POWER_CREEPS] = 10;
+(Vl = {})[FIND_SOURCES] = 5e3, Vl[FIND_MINERALS] = 5e3, Vl[FIND_DEPOSITS] = 100,
+Vl[FIND_STRUCTURES] = 50, Vl[FIND_MY_STRUCTURES] = 50, Vl[FIND_HOSTILE_STRUCTURES] = 20,
+Vl[FIND_MY_SPAWNS] = 100, Vl[FIND_MY_CONSTRUCTION_SITES] = 20, Vl[FIND_CONSTRUCTION_SITES] = 20,
+Vl[FIND_CREEPS] = 5, Vl[FIND_MY_CREEPS] = 5, Vl[FIND_HOSTILE_CREEPS] = 3, Vl[FIND_DROPPED_RESOURCES] = 5,
+Vl[FIND_TOMBSTONES] = 10, Vl[FIND_RUINS] = 10, Vl[FIND_FLAGS] = 50, Vl[FIND_NUKES] = 20,
+Vl[FIND_POWER_CREEPS] = 10, Vl[FIND_MY_POWER_CREEPS] = 10;
 
-var zl, Ql, Xl = {}, Zl = {}, Jl = {}, $l = {};
+var Xl, Zl, Jl = {}, $l = {}, em = {}, tm = {};
 
-function em() {
-if (zl) return $l;
-zl = 1;
+function rm() {
+if (Xl) return tm;
+Xl = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return $l.encode = function(t) {
+return tm.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, $l;
+}, tm;
 }
 
-function tm() {
-if (Ql) return Jl;
-Ql = 1;
-const e = em();
-return Jl.encode = function(t) {
+function om() {
+if (Zl) return em;
+Zl = 1;
+const e = rm();
+return em.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25808,23 +25842,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Jl;
+}, em;
 }
 
-var rm, om, nm, am = {}, im = _r(Object.freeze({
+var nm, am, im, sm = {}, cm = _r(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function sm() {
-return om ? rm : (om = 1, rm = "function" == typeof URL ? URL : im.URL);
+function um() {
+return am ? nm : (am = 1, nm = "function" == typeof URL ? URL : cm.URL);
 }
 
-function cm() {
-if (nm) return am;
-nm = 1;
-const e = sm();
-am.getArg = function(e, t, r) {
+function lm() {
+if (im) return sm;
+im = 1;
+const e = um();
+sm.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25844,16 +25878,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-am.toSetString = t ? r : function(e) {
+sm.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, am.fromSetString = t ? r : function(e) {
+}, sm.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, am.compareByGeneratedPositionsInflated = function(e, t) {
+}, sm.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, am.parseSourceMapInput = function(e) {
+}, sm.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25907,7 +25941,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return am.normalize = f, am.join = y, am.relative = function(t, r) {
+return sm.normalize = f, sm.join = y, sm.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25919,18 +25953,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, am.computeSourceURL = function(e, t, r) {
+}, sm.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, am;
+}, sm;
 }
 
-var um, lm = {};
+var mm, dm = {};
 
-function mm() {
-if (um) return lm;
-um = 1;
+function pm() {
+if (mm) return dm;
+mm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -25963,19 +25997,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return lm.ArraySet = e, lm;
+return dm.ArraySet = e, dm;
 }
 
-var dm, pm, fm = {};
+var fm, ym, vm = {};
 
-function ym() {
-if (pm) return Zl;
-pm = 1;
-const e = tm(), t = cm(), r = mm().ArraySet, o = function() {
-if (dm) return fm;
-dm = 1;
-const e = cm();
-return fm.MappingList = class {
+function gm() {
+if (ym) return $l;
+ym = 1;
+const e = om(), t = lm(), r = pm().ArraySet, o = function() {
+if (fm) return vm;
+fm = 1;
+const e = lm();
+return vm.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -25995,7 +26029,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, fm;
+}, vm;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26124,13 +26158,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Zl.SourceMapGenerator = n, Zl;
+return n.prototype._version = 3, $l.SourceMapGenerator = n, $l;
 }
 
-var vm, gm = {}, hm = {};
+var hm, Rm = {}, Em = {};
 
-function Rm() {
-return vm || (vm = 1, function(e) {
+function Tm() {
+return hm || (hm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26142,36 +26176,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(hm)), hm;
+}(Em)), Em;
 }
 
-var Em, Tm, Cm, Sm, wm = {
+var Cm, Sm, wm, xm, bm = {
 exports: {}
 };
 
-function xm() {
-if (Em) return wm.exports;
-Em = 1;
+function Om() {
+if (Cm) return bm.exports;
+Cm = 1;
 let e = null;
-return wm.exports = function() {
+return bm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, wm.exports.initialize = t => {
+}, bm.exports.initialize = t => {
 e = t;
-}, wm.exports;
+}, bm.exports;
 }
 
-function bm() {
-if (Cm) return Tm;
-Cm = 1;
-const e = xm();
+function km() {
+if (wm) return Sm;
+wm = 1;
+const e = Om();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return Tm = function() {
+return Sm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26238,28 +26272,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, Tm;
+}, Sm;
 }
 
-var Om, km, Am, Mm, Um = {};
+var Am, Mm, Um, _m, Nm = {};
 
-function _m(e, t, r) {
+function Pm(e, t, r) {
 return e - t >= r;
 }
 
-function Nm(e, t) {
+function Im(e, t) {
 return e.priority - t.priority;
 }
 
-function Pm(e, t, r, o) {
+function Gm(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function Im(e, t, r, o) {
+function Lm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Gm(e) {
+function Dm(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26277,12 +26311,12 @@ if (t) throw t.error;
 return o;
 }
 
-km || (km = 1, Xl.SourceMapGenerator = ym().SourceMapGenerator, Xl.SourceMapConsumer = function() {
-if (Sm) return gm;
-Sm = 1;
-const e = cm(), t = Rm(), r = mm().ArraySet;
-tm();
-const o = xm(), n = bm(), a = Symbol("smcInternal");
+Mm || (Mm = 1, Jl.SourceMapGenerator = gm().SourceMapGenerator, Jl.SourceMapConsumer = function() {
+if (xm) return Rm;
+xm = 1;
+const e = lm(), t = Tm(), r = pm().ArraySet;
+om();
+const o = Om(), n = km(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26319,7 +26353,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, gm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, Rm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26509,7 +26543,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, gm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, Rm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26618,11 +26652,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return gm.IndexedSourceMapConsumer = c, gm;
-}().SourceMapConsumer, Xl.SourceNode = function() {
-if (Om) return Um;
-Om = 1;
-const e = ym().SourceMapGenerator, t = cm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return Rm.IndexedSourceMapConsumer = c, Rm;
+}().SourceMapConsumer, Jl.SourceNode = function() {
+if (Am) return Nm;
+Am = 1;
+const e = gm().SourceMapGenerator, t = lm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26761,27 +26795,27 @@ map: o
 };
 }
 }
-return Um.SourceNode = n, Um;
+return Nm.SourceNode = n, Nm;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(Mm || (Mm = {}));
+}(_m || (_m = {}));
 
-var Lm, Dm = [ Mm.CRITICAL, Mm.HIGH, Mm.MEDIUM, Mm.LOW ], Fm = {
-bucketThresholds: (Am = {}, Am[Mm.CRITICAL] = 0, Am[Mm.HIGH] = 2e3, Am[Mm.MEDIUM] = 5e3,
-Am[Mm.LOW] = 8e3, Am),
+var Fm, Bm = [ _m.CRITICAL, _m.HIGH, _m.MEDIUM, _m.LOW ], Wm = {
+bucketThresholds: (Um = {}, Um[_m.CRITICAL] = 0, Um[_m.HIGH] = 2e3, Um[_m.MEDIUM] = 5e3,
+Um[_m.LOW] = 8e3, Um),
 defaultMaxCpu: 5,
 logExecution: !1
-}, Bm = function() {
+}, Km = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Gm(Dm),
+tasksByPriority: Dm(Bm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, Fm), e);
+}, this.config = o(o({}, Wm), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26795,13 +26829,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(Nm), l = 0;
+var u = Array.from(this.tasks.values()).sort(Im), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (_m(Game.time, p.lastRun, p.interval)) if (Pm(p.priority, s, this.config.bucketThresholds, Mm.CRITICAL)) this.stats.skippedThisTick++; else {
+if (Pm(Game.time, p.lastRun, p.interval)) if (Gm(p.priority, s, this.config.bucketThresholds, _m.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (Im(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Lm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26849,7 +26883,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Gm(Dm);
+var t, r, o = Dm(Bm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26866,22 +26900,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), Wm = ((Lm = global)._computationScheduler || (Lm._computationScheduler = new Bm),
-Lm._computationScheduler), Km = new Map;
+}(), Hm = ((Fm = global)._computationScheduler || (Fm._computationScheduler = new Km),
+Fm._computationScheduler), Ym = new Map;
 
-function Hm(e) {
-var t = Km.get(e);
+function Vm(e) {
+var t = Ym.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Km.set(e, t)), t;
+}, Ym.set(e, t)), t;
 }
 
-function Ym(e, t, r) {
+function qm(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return Vm(e, t[0], r), t[0];
-var i = Hm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return jm(e, t[0], r), t[0];
+var i = Vm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26898,32 +26932,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && Vm(e, s, r), s;
+return s && jm(e, s, r), s;
 }
 
-function Vm(e, t, r) {
-var o = Hm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function jm(e, t, r) {
+var o = Vm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var qm = {
+var zm = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function jm(e, t, r) {
+function Qm(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(qm[t], ";") : "";
+var o = t ? "color: ".concat(zm[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function zm(e) {
+function Xm(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Qm = {
+var Zm = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26937,7 +26971,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(zm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(Xm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -26954,44 +26988,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(zm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(Xm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Xm() {
+function Jm() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return $m() + ed() + '<div class="module-help">'.concat(e.map(Zm).join(""), "</div>");
+return td() + rd() + '<div class="module-help">'.concat(e.map($m).join(""), "</div>");
 }
 
-var Zm = function(e) {
-var t = e.api.map(Jm).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(jm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(jm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Jm = function(e) {
+var $m = function(e) {
+var t = e.api.map(ed).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Qm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Qm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, ed = function(e) {
 var t = [];
-e.describe && t.push(jm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(jm(e.name, "blue"), ": ").concat(jm(e.desc, "green"));
+e.describe && t.push(Qm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Qm(e.name, "blue"), ": ").concat(Qm(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return jm(e.name, "blue");
-}).join(", ") : "", o = jm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Qm(e.name, "blue");
+}).join(", ") : "", o = Qm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(jm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, $m = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Qm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, td = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, ed = function() {
+}, rd = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, td = A("EnergyCollection"), rd = [ "refillSpawn", "refillExtension", "refillTower" ], od = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, od = A("EnergyCollection"), nd = [ "refillSpawn", "refillExtension", "refillTower" ], ad = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function nd(e) {
+function id(e) {
 if (e.droppedResources.length > 0) {
 var t = Lt(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27001,15 +27035,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Ym(e.creep, r, "energy_container");
-if (o) return td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = qm(e.creep, r, "energy_container");
+if (o) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (td.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (od.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27020,8 +27054,8 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Os && od.has(e.memory.role);
-}(e, n)) return td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Os && ad.has(e.memory.role);
+}(e, n)) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -27032,35 +27066,35 @@ var a = Nt(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = Ym(e.creep, a, "energy_source");
-if (s) return td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = qm(e.creep, a, "energy_source");
+if (s) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (td.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (od.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return td.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return od.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function ad(e) {
-var t = Pl.getAssignedAction(e, rd);
+function sd(e) {
+var t = Gl.getAssignedAction(e, nd);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function id(e) {
-return Pl.hasActiveTask(e.room.name, rd);
+function cd(e) {
+return Gl.hasActiveTask(e.room.name, nd);
 }
 
-function sd(e, t) {
+function ud(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27087,11 +27121,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function cd(e) {
-var t = Pl.getAssignedDeliveryAction(e);
+function ld(e) {
+var t = Gl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!id(e)) {
-var r = sd(e, "deliver");
+if (!cd(e)) {
+var r = ud(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27113,9 +27147,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var ud = /^[WE]\d+[NS]\d+$/;
+var md = /^[WE]\d+[NS]\d+$/;
 
-function ld(e) {
+function dd(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27125,28 +27159,28 @@ routeType: "hauler"
 } : null;
 }
 
-function md(e) {
-return ud.test(e);
+function pd(e) {
+return md.test(e);
 }
 
-function dd(e) {
+function fd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-if (!n || !md(n)) return ld(e);
+if (!n || !pd(n)) return dd(e);
 var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
 return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
-} : null : ld(e) : null;
+} : null : dd(e) : null;
 }
 
-function pd(e) {
+function yd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = dd(e);
+var a = fd(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !md(n)) return null;
+if (!n || !pd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27159,7 +27193,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function fd(e) {
+function vd(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27168,11 +27202,11 @@ var n = e.memory.working;
 return o !== n && Ft(e.creep), n;
 }
 
-function yd(e) {
+function gd(e) {
 e.memory.working = !1, Ft(e.creep);
 }
 
-var vd = function() {
+var hd = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27267,20 +27301,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), gd = new vd, hd = A("LarvaWorkerBehavior");
+}(), Rd = new hd, Ed = A("LarvaWorkerBehavior");
 
-function Rd(e) {
-var t = fd(e), r = dd(e);
+function Td(e) {
+var t = vd(e), r = fd(e);
 if (r) return r;
 if (t) {
-hd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = pd(e);
+Ed.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = yd(e);
 if (o) return o;
-var n = cd(e);
-if (n) return hd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = ld(e);
+if (n) return Ed.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = gd.getSwarmState(e.room.name);
+var t, r = Rd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27297,7 +27331,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return hd.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Ed.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27306,52 +27340,58 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return hd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Ed.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-hd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-yd(e);
+Ed.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+gd(e);
 }
-return nd(e);
-}
-
-function Ed(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
-}
-
-function Td(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
+return id(e);
 }
 
 function Cd(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
+
+function Sd(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
+
+function wd(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var Sd = A("HarvesterBehavior"), wd = A("HaulerBehavior"), xd = Os, bd = [ "refillSpawn", "refillExtension" ];
+var xd = A("HarvesterBehavior"), bd = A("HaulerBehavior"), Od = Os, kd = [ "refillSpawn", "refillExtension" ];
 
-function Od(e, t, r) {
+function Ad(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && Gl.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && Gl.reserveDeliveryWork(e),
+t;
+}
+
+function Md(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return Vm(e, c, r), c;
+if (c) return jm(e, c, r), c;
 }
-var u = Ym(e, t, r);
+var u = qm(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function kd(e) {
+function Ud(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27365,7 +27405,7 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-var Ad = {
+var _d = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27375,11 +27415,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, Md = Ad, Ud = function(e) {
-return Md.getLabResourceNeeds(e);
+}, Nd = _d, Pd = function(e) {
+return Nd.getLabResourceNeeds(e);
 };
 
-function _d(e) {
+function Id(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27401,7 +27441,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = Ud(e.room.name);
+var n = Pd(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27429,7 +27469,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, Md.getLabOverflow(r));
+var t, r, o = (r = e.room.name, Nd.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27444,7 +27484,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = Ud(e.room.name);
+var i = Pd(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27463,8 +27503,8 @@ type: "idle"
 }(e);
 }
 
-var Nd = {
-larvaWorker: Rd,
+var Gd = {
+larvaWorker: Td,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27475,12 +27515,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(Ed).length > 0) return {
+if (e.hostiles.filter(Cd).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (fd(e)) {
+if (vd(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27499,7 +27539,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return nd(e);
+return id(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27533,10 +27573,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(Td)) return {
+if (e.hostiles.some(Sd)) return {
 type: "idle"
 };
-if (fd(e)) {
+if (vd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27555,10 +27595,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return nd(e);
+return id(e);
 },
 harvester: function(e) {
-var t, r = (t = Cd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = wd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27607,8 +27647,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), Sd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return Sd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), xd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return xd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -27636,7 +27676,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return Sd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return xd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -27657,20 +27697,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (Sd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (xd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (Sd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (xd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = fd(e), o = "defenseRefuel" === e.memory.task;
-if (wd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = vd(e), o = "defenseRefuel" === e.memory.task;
+if (bd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -27683,9 +27723,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = Pl.getAssignedAction(e, bd);
+var t = Gl.getAssignedAction(e, kd);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (Pl.hasActiveTask(e.room.name, bd)) return null;
+if (Gl.hasActiveTask(e.room.name, kd)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27705,13 +27745,13 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = Pl.getAssignedDeliveryAction(e);
+var c = Gl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!id(e)) {
+if (!cd(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (u.length > 0 && (p = Lt(e.creep, u, "hauler_spawn", 10))) return wd.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+if (u.length > 0 && (p = Lt(e.creep, u, "hauler_spawn", 10))) return bd.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
 {
 type: "transfer",
 target: p,
@@ -27738,7 +27778,7 @@ var d = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
 var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = rl(e.room);
-return r < 2e4 && o > xd && n > 0 || Boolean(a) ? {
+return r < 2e4 && o > Od && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -27764,12 +27804,12 @@ type: "transfer",
 target: p,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return wd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return bd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-wd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-yd(e);
+bd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+gd(e);
 }
 if (o) {
 var y = function(e) {
@@ -27777,7 +27817,7 @@ var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = Od(e.creep, t, "energy_container");
+var r = Md(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -27792,21 +27832,21 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (y) return y;
 }
-if (e.droppedResources.length > 0 && (p = Lt(e.creep, e.droppedResources, "hauler_drop", 5))) return {
+if (e.droppedResources.length > 0 && (p = Lt(e.creep, e.droppedResources, "hauler_drop", 5))) return Ad(e, {
 type: "pickup",
 target: p
-};
+});
 var v = e.tombstones.filter(function(e) {
 return e.store.getUsedCapacity() > 0;
 });
 if (v.length > 0) {
 var g = Lt(e.creep, v, "hauler_tomb", 10);
 if (g) {
-if (g.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return {
+if (g.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Ad(e, {
 type: "withdraw",
 target: g,
 resourceType: RESOURCE_ENERGY
-};
+});
 var h = Object.keys(g.store).find(function(e) {
 return e !== RESOURCE_ENERGY && g.store.getUsedCapacity(e) > 0;
 });
@@ -27821,24 +27861,24 @@ var R = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (R.length > 0) {
-var E = Od(e.creep, R, "energy_container");
-if (E) return wd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-{
+var E = Md(e.creep, R, "energy_container");
+if (E) return bd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+Ad(e, {
 type: "withdraw",
 target: E,
 resourceType: RESOURCE_ENERGY
-};
-wd.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+});
+bd.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
 var T = e.creep.pos.findClosestByRange(R);
-if (T) return wd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
-{
+if (T) return bd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+Ad(e, {
 type: "withdraw",
 target: T,
 resourceType: RESOURCE_ENERGY
-};
+});
 }
 if (e.mineralContainers.length > 0) {
-var C = Od(e.creep, e.mineralContainers, "mineral_container");
+var C = Md(e.creep, e.mineralContainers, "mineral_container");
 if (C) {
 if (S = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
@@ -27848,11 +27888,11 @@ target: C,
 resourceType: S
 };
 } else {
-wd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+bd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var S, w = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (w && (S = Object.keys(w.store).find(function(e) {
 return e !== RESOURCE_ENERGY && w.store.getUsedCapacity(e) > 0;
-}))) return wd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
+}))) return bd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
 {
 type: "withdraw",
 target: w,
@@ -27866,7 +27906,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > xd || rl(e.room)) return {
+if (o < 2e4 && n > Od || rl(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -27897,31 +27937,31 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return x || (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (wd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-{
+return x ? Ad(e, x) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (bd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+Ad(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : (wd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (bd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
-}));
+});
 },
 builder: function(e) {
-var t = fd(e), r = dd(e);
+var t = vd(e), r = fd(e);
 if (r) return r;
 if (t) {
-var o = pd(e);
+var o = yd(e);
 if (o) return o;
-var n = ad(e);
+var n = sd(e);
 if (n) return n;
-if (!id(e)) {
-var a = sd(e, "builder");
+if (!cd(e)) {
+var a = ud(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = Cd(e);
+var t = wd(e);
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r) return r;
@@ -27944,15 +27984,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return nd(e);
+return id(e);
 },
 upgrader: function(e) {
-if (fd(e)) {
-if (kd(e)) {
-var t = ad(e);
+if (vd(e)) {
+if (Ud(e)) {
+var t = sd(e);
 if (t) return t;
-if (!id(e)) {
-var r = sd(e, "upgrader");
+if (!cd(e)) {
+var r = ud(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28025,7 +28065,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (fd(e)) {
+if (vd(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28049,7 +28089,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : cd(e) || (e.storage ? {
+} : ld(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28169,15 +28209,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : _d(e);
+} : Id(e);
 },
-labSupply: _d,
+labSupply: Id,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (fd(e)) {
+if (vd(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28357,7 +28397,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = fd(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = vd(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28380,9 +28420,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : cd(e) || (e.isEmpty || e.room.name !== o ? {
+} : ld(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (yd(e), {
+} : (gd(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28481,16 +28521,16 @@ roomName: o
 }
 };
 
-function Pd(e) {
+function Ld(e) {
 var t;
-return (null !== (t = Nd[e.memory.role]) && void 0 !== t ? t : Rd)(e);
+return (null !== (t = Gd[e.memory.role]) && void 0 !== t ? t : Td)(e);
 }
 
-var Id = new Set([ "build", "repair", "upgrade" ]);
+var Dd = new Set([ "build", "repair", "upgrade" ]);
 
-function Gd(e, t) {
+function Fd(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && md(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && pd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -28499,12 +28539,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : pd(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : yd(e);
 }(e, t);
-return r || (Id.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || kd(e) ? ad(e) : null : null);
+return r || (Dd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || Ud(e) ? sd(e) : null : null);
 }
 
-var Ld = "patrol", Dd = [ {
+var Bd = "patrol", Wd = [ {
 x: 10,
 y: 5
 }, {
@@ -28540,7 +28580,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], Fd = [ {
+} ], Kd = [ {
 x: 10,
 y: 10
 }, {
@@ -28557,7 +28597,7 @@ x: 25,
 y: 25
 } ];
 
-function Bd(e) {
+function Hd(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28565,7 +28605,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function Wd(e) {
+function Yd(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28575,9 +28615,9 @@ roomName: e.roomName
 });
 }
 
-function Kd(e) {
+function Vd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Le.get(e.name, {
-namespace: Ld
+namespace: Bd
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28597,25 +28637,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(Dd), !1), i(Fd), !1);
-}(t).map(Bd).filter(function(e) {
+}(e)), !1), i(Wd), !1), i(Kd), !1);
+}(t).map(Hd).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Le.set(e.name, {
-waypoints: Wd(n),
+waypoints: Yd(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: Ld,
+namespace: Bd,
 ttl: 1e3
 }), n;
 }
 
-function Hd(e, t) {
+function qd(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28625,86 +28665,86 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var Yd = A("MilitaryBehaviors");
+var jd = A("MilitaryBehaviors");
 
-function Vd(e) {
+function zd(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
 delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === $a && (delete e.task,
 delete e.targetRoom);
 }
 
-function qd(e, t) {
+function Qd(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function jd(e) {
+function Xd(e) {
 return To(vo(e));
 }
 
-function zd(e) {
+function Zd(e) {
 return e.creep.room.name === e.homeRoom && q(e.room).length > 0;
 }
 
-function Qd(e) {
+function Jd(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Xd(e, t) {
+function $d(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Zd(e) {
-return Xd(e, "guard") + Xd(e, "ranger") + Xd(e, "healer");
+function ep(e) {
+return $d(e, "guard") + $d(e, "ranger") + $d(e, "healer");
 }
 
-function Jd(e, t, r) {
+function tp(e, t, r) {
 var o = e.memory;
 return ri(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function $d(e, t) {
+function rp(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return Jd(r, e, t);
+return tp(r, e, t);
 });
 }
 
-function ep(e, t) {
+function op(e, t) {
 return "defenseAssist:".concat(e, ":").concat(t, ":active");
 }
 
-function tp(e, t, r) {
-return Xd(e, t) > function(e, t) {
+function np(e, t, r) {
+return $d(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
 return !r.spawning && o.role === t && ri(o) === e;
 }).length;
-}(e.roomName, t) || Zd(e) > 0 && jd(e.roomName) && function(e, t) {
-return $d(e, t).length;
+}(e.roomName, t) || ep(e) > 0 && Xd(e.roomName) && function(e, t) {
+return rp(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function rp(e, t) {
+function ap(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
 if (t.task && t.task !== $a) return null;
-if (zd(e)) return null;
+if (Zd(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Qd).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Jd).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== q(l).length && tp(u, t.role, e.homeRoom)) return ti(e.creep, {
+if (l && 0 !== q(l).length && np(u, t.role, e.homeRoom)) return ti(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
-squadId: ep(e.homeRoom, u.roomName),
-squadSize: jd(u.roomName) ? Math.max(5, Zd(u)) : Math.max(1, Zd(u))
+squadId: op(e.homeRoom, u.roomName),
+squadSize: Xd(u.roomName) ? Math.max(5, ep(u)) : Math.max(1, ep(u))
 }), u.roomName;
 }
 } catch (e) {
@@ -28721,7 +28761,7 @@ if (r) throw r.error;
 return null;
 }
 
-function op(e) {
+function ip(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28729,7 +28769,7 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function np(e, t) {
+function sp(e, t) {
 if (!function(e) {
 return Boolean(ri(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
@@ -28737,11 +28777,11 @@ if (e.creep.room.name !== e.homeRoom) return null;
 var r = ri(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = vo(r), n = To(o), a = n ? $d(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var o = vo(r), n = To(o), a = n ? rp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
 var r = ri(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Jd(e, r, o);
+return e.memory.defenseSquadId === t && tp(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28755,7 +28795,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return $d(e, t).reduce(function(e, t) {
+return rp(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = mo(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28777,16 +28817,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return qd(t, "parity-ready"), null;
-if (c >= u) return qd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Qd(t, "parity-ready"), null;
+if (c >= u) return Qd(t, "squad-quorum"), null;
 if (l) {
-if (!n) return qd(t, "expired-staging"), null;
+if (!n) return Qd(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = op(e) - op(t);
+var r = ip(e) - ip(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28794,11 +28834,11 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return qd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Qd(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return qd(t, "squad-quorum"), null;
-if (l) return qd(t, "expired-staging"), null;
+if (c >= u) return Qd(t, "squad-quorum"), null;
+if (l) return Qd(t, "expired-staging"), null;
 }
 var m = $u(e.room.name);
 return {
@@ -28807,7 +28847,7 @@ position: null != m ? m : e.creep.pos
 };
 }
 
-function ap(e) {
+function cp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28839,21 +28879,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function ip(e, t) {
+function up(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function sp(e, t) {
+function lp(e, t) {
 if (!e.swarmState) return null;
 var r = $u(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (Yd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+return r && e.creep.pos.getRangeTo(r) > 2 ? (jd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function cp(e) {
+function mp(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28877,7 +28917,7 @@ if (t) throw t.error;
 }
 }
 
-function up(e) {
+function dp(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28885,23 +28925,23 @@ return Boolean(e);
 });
 }
 
-function lp(e) {
+function pp(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function mp(e) {
+function fp(e) {
 var t, r = e.creep.memory;
 if (oi(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = cp(e.memory.squadId);
-if (o) return dp(e, o);
+var o = mp(e.memory.squadId);
+if (o) return yp(e, o);
 }
-var n = null !== (t = rp(e, r)) && void 0 !== t ? t : ri(r);
-if (n && !zd(e)) {
-var a = np(e, r);
+var n = null !== (t = ap(e, r)) && void 0 !== t ? t : ri(r);
+if (n && !Zd(e)) {
+var a = sp(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28914,9 +28954,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = ap(e);
+var s = cp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = ip(e.creep, RANGED_ATTACK), l = ip(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = up(e.creep, RANGED_ATTACK), l = up(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28928,7 +28968,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = ip(e.creep, RANGED_ATTACK), l = ip(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = up(e.creep, RANGED_ATTACK), l = up(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -28939,7 +28979,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (Vd(r), e.creep.room.name !== e.homeRoom) return {
+} else if (zd(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -28948,8 +28988,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = ap(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = ip(e.creep, RANGED_ATTACK), l = ip(e.creep, ATTACK),
+var m = cp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = up(e.creep, RANGED_ATTACK), l = up(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -28960,7 +29000,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = Kd(e.room), p = Hd(e.creep, d);
+var d = Vd(e.room), p = qd(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -28974,7 +29014,7 @@ type: "idle"
 };
 }
 
-function dp(e, t) {
+function yp(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -28982,7 +29022,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = lp(t);
+var n = pp(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -28990,7 +29030,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(up(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(dp(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29013,7 +29053,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = up(e).filter(function(t) {
+var t, r, o = dp(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29042,7 +29082,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = up(t).filter(function(t) {
+var r = dp(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29058,7 +29098,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = up(t).sort(function(e, t) {
+var a = dp(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29095,7 +29135,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = up(t).filter(function(e) {
+var l = dp(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29112,7 +29152,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = up(e).find(function(e) {
+return null !== (t = dp(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29123,7 +29163,7 @@ target: m
 type: "idle"
 };
 }
-var d = ap(e);
+var d = cp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29135,10 +29175,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : ip(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : up(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : ip(e.creep, ATTACK) && p <= 1 ? {
+} : up(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29154,10 +29194,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : ip(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : up(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : ip(e.creep, ATTACK) && p <= 1 ? {
+} : up(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29173,7 +29213,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: lp(t)
+target: pp(t)
 };
 
 case "dissolving":
@@ -29191,8 +29231,8 @@ type: "idle"
 }
 }
 
-var pp = {
-guard: mp,
+var vp = {
+guard: fp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29201,8 +29241,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = Kd(e.room);
-return (o = Hd(e.creep, r)) ? {
+var r = Vd(e.room);
+return (o = qd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29223,7 +29263,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = Kd(e.room), (o = Hd(e.creep, r)) ? {
+} : (r = Vd(e.room), (o = qd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29237,11 +29277,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return ip(e, HEAL);
+return up(e, HEAL);
 }), t.filter(function(e) {
-return ip(e, RANGED_ATTACK);
+return up(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return ip(e, ATTACK);
+return up(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29262,7 +29302,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = ip(e.creep, RANGED_ATTACK), u = ip(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = up(e.creep, RANGED_ATTACK), u = up(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29293,19 +29333,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = cp(e.memory.squadId);
-if (o) return dp(e, o);
+var o = mp(e.memory.squadId);
+if (o) return yp(e, o);
 }
-var n = null !== (t = rp(e, r)) && void 0 !== t ? t : ri(r);
-if (n && !zd(e)) {
-var a = np(e, r);
+var n = null !== (t = ap(e, r)) && void 0 !== t ? t : ri(r);
+if (n && !Zd(e)) {
+var a = sp(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === q(i).length) return Vd(r), {
+if (0 === q(i).length) return zd(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29399,7 +29439,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = Kd(e.room), v = Hd(e.creep, y);
+var y = Vd(e.room), v = qd(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29410,8 +29450,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = cp(e.memory.squadId);
-if (r) return dp(e, r);
+var r = mp(e.memory.squadId);
+if (r) return yp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29433,9 +29473,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = ap(e);
+var a = cp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = ip(e.creep, RANGED_ATTACK), c = ip(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = up(e.creep, RANGED_ATTACK), c = up(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29454,7 +29494,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = Kd(e.room), m = Hd(e.creep, l);
+var l = Vd(e.room), m = qd(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29476,8 +29516,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = cp(e.memory.squadId);
-if (r) return dp(e, r);
+var r = mp(e.memory.squadId);
+if (r) return yp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29538,9 +29578,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = sp(e, "siegeUnit");
+var p = lp(e, "siegeUnit");
 if (p) return p;
-var f = Kd(e.room), y = Hd(e.creep, f);
+var f = Vd(e.room), y = qd(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29551,8 +29591,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = cp(e.memory.squadId);
-if (r) return dp(e, r);
+var r = mp(e.memory.squadId);
+if (r) return yp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29569,7 +29609,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return sp(e, "harasser (no target)") || {
+if (!t) return lp(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29611,9 +29651,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = sp(e, "harasser (no targets)");
+var c = lp(e, "harasser (no targets)");
 if (c) return c;
-var u = Kd(e.room), l = Hd(e.creep, u);
+var u = Vd(e.room), l = qd(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29626,9 +29666,9 @@ var t, r, o = e.creep.memory;
 if (oi(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = cp(e.memory.squadId))) return dp(e, a);
+if (e.memory.squadId && (a = mp(e.memory.squadId))) return yp(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (ri(o) && Vd(o), e.room.name !== e.homeRoom) return {
+if (ri(o) && zd(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29642,9 +29682,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = rp(e, o)) && void 0 !== t ? t : ri(o);
-if (i && !zd(e)) {
-var s = np(e, o);
+var a, i = null !== (t = ap(e, o)) && void 0 !== t ? t : ri(o);
+if (i && !Zd(e)) {
+var s = sp(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29654,14 +29694,14 @@ roomName: i
 var u = q(c), l = j(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return Vd(o), {
+if (0 === u.length && 0 === l.length) return zd(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = ap(e);
+var m = cp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29681,8 +29721,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = cp(e.memory.squadId))) return dp(e, a);
-var p, f = ap(e);
+if (e.memory.squadId && (a = mp(e.memory.squadId))) return yp(e, a);
+var p, f = cp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29693,7 +29733,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = Kd(e.room), v = Hd(e.creep, y);
+var y = Vd(e.room), v = qd(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29714,21 +29754,21 @@ type: "idle"
 }
 };
 
-function fp(e) {
+function gp(e) {
 var t;
-return Pl.getAssignedAction(e) || (null !== (t = pp[e.memory.role]) && void 0 !== t ? t : mp)(e);
+return Gl.getAssignedAction(e) || (null !== (t = vp[e.memory.role]) && void 0 !== t ? t : fp)(e);
 }
 
-var yp = A("PowerExecutor");
+var hp = A("PowerExecutor");
 
-function vp(e, t) {
+function Rp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function gp(e) {
+function Ep(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29770,8 +29810,8 @@ type: "idle"
 };
 }
 
-var hp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Rp = {
-powerHarvester: gp,
+var Tp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Cp = {
+powerHarvester: Ep,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29843,65 +29883,65 @@ roomName: e.homeRoom
 }
 };
 
-function Ep(e) {
+function Sp(e) {
 var t;
-return (null !== (t = Rp[e.memory.role]) && void 0 !== t ? t : gp)(e);
+return (null !== (t = Cp[e.memory.role]) && void 0 !== t ? t : Ep)(e);
 }
 
-function Tp(e) {
+function wp(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var Cp = {
+var xp = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, Sp = {
+}, bp = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, wp = {
+}, Op = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, xp = {
+}, kp = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, bp = {
+}, Ap = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, Op = {
+}, Mp = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, kp = {
+}, Up = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, Ap = {
+}, _p = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function Mp(e) {
+function Np(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function Up(e) {
+function Pp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29909,7 +29949,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function _p(e) {
+function Ip(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29917,12 +29957,12 @@ y: parseInt(n, 10)
 };
 }
 
-function Np(e) {
+function Gp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = Pp(s);
+o[s.n] = Lp(s);
 }
 } catch (e) {
 t = {
@@ -29938,23 +29978,23 @@ if (t) throw t.error;
 return o;
 }
 
-function Pp(e) {
+function Lp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = Sp[e.r]) && void 0 !== t ? t : "core",
-health: Ip(e.h),
+role: null !== (t = bp[e.r]) && void 0 !== t ? t : "core",
+health: Dp(e.h),
 activeTasks: e.t,
-portals: e.p.map(Gp),
+portals: e.p.map(Fp),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Lp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Bp)
 };
 }
 
-function Ip(e) {
+function Dp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = xp[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = kp[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -29967,11 +30007,11 @@ lastUpdate: e.u
 };
 }
 
-function Gp(e) {
+function Fp(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: Up(e.sp),
+sourcePos: Pp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -29981,7 +30021,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function Lp(e) {
+function Bp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -29990,7 +30030,7 @@ bucketLevel: e.b
 };
 }
 
-function Dp(e) {
+function Wp(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30000,12 +30040,12 @@ isAlly: 1 === e.a
 };
 }
 
-function Fp(e) {
+function Kp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Bp(u);
+i[u.n] = Hp(u);
 }
 } catch (e) {
 t = {
@@ -30028,13 +30068,13 @@ updatedAt: e.u
 };
 }
 
-function Bp(e) {
+function Hp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: _p(e.pp),
+portalPos: Ip(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30045,46 +30085,46 @@ lastUpdate: e.u
 };
 }
 
-function Wp(e) {
+function Yp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = Op[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = Mp[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = Ap[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = _p[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function Kp(e, t) {
+function Vp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function Hp(e) {
+function qp(e) {
 var t;
 return {
-c: null !== (t = wp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: Kp(e.cpuUsage, 2),
+c: null !== (t = Op[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: Vp(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: Kp(e.avgRCL, 1),
+rl: Vp(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function Yp(e) {
+function jp(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: Mp(e.sourcePos),
+sp: Np(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30093,27 +30133,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function Vp(e) {
+function zp(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: Kp(e.cpuUsed, 2),
+u: Vp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function qp(e) {
+function Qp(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(jp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Xp)
 };
 }
 
-function jp(e) {
+function Xp(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30123,23 +30163,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function zp(e) {
+function Zp(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = bp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = Ap[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = kp[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = Up[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Qp(e) {
+function Jp(e) {
 return {
 name: e,
 role: "core",
@@ -30162,7 +30202,7 @@ cpuLimit: 0
 };
 }
 
-function Xp(e) {
+function $p(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30172,16 +30212,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = Cp[t.role]) && void 0 !== r ? r : t.role[0],
-h: Hp(t.health),
+r: null !== (r = xp[t.role]) && void 0 !== r ? r : t.role[0],
+h: qp(t.health),
 t: t.activeTasks,
-p: t.portals.map(Yp),
+p: t.portals.map(jp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Vp)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(zp)
 };
 }(t[0], t[1]);
 }),
-g: qp(e.globalTargets),
+g: Qp(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30195,7 +30235,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? Mp(t.portalPos) : void 0,
+pp: t.portalPos ? Np(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30207,20 +30247,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(zp),
+k: e.tasks.map(Zp),
 ls: e.lastSync
 };
 var t;
-}(e), r = Tp(JSON.stringify(t));
+}(e), r = wp(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Zp(e) {
+function ef(e) {
 try {
-var t = JSON.parse(e), r = Tp(JSON.stringify(t.d));
+var t = JSON.parse(e), r = wp(JSON.stringify(t.d));
 return t.c !== r ? (Xe.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30229,13 +30269,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: Np(a.s),
+shards: Gp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(Dp)), n),
-footprintOperation: a.o ? Fp(a.o) : void 0,
-tasks: a.k.map(Wp),
+o.en && (n.enemies = o.en.map(Wp)), n),
+footprintOperation: a.o ? Kp(a.o) : void 0,
+tasks: a.k.map(Yp),
 lastSync: a.ls,
 checksum: i
 });
@@ -30247,12 +30287,12 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Jp, $p, ef = 102400, tf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var tf, rf, of = 102400, nf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function rf(e, t, r) {
+function af(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = sf(t), s = function(e, t, r) {
+var i = lf(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30265,11 +30305,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(af(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : tf), c = null !== (a = sf(Xp(s))) && void 0 !== a ? a : {};
+}(uf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : nf), c = null !== (a = lf($p(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function of(e) {
+function sf(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30285,69 +30325,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = af(r, sf(r))) && void 0 !== t ? t : e;
+return r && null !== (t = uf(r, lf(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function nf(e, t) {
+function cf(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(rf(e, r, t)), !0;
+return InterShardMemory.setLocal(af(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function af(e, t) {
+function uf(e, t) {
 return t && function(e) {
-return cf(e.d) && "number" == typeof e.c;
-}(t) ? Zp(e) : null;
+return mf(e.d) && "number" == typeof e.c;
+}(t) ? ef(e) : null;
 }
 
-function sf(e) {
+function lf(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return cf(t) ? t : null;
+return mf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function cf(e) {
+function mf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Jp || (Jp = {})), function(e) {
+}(tf || (tf = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}($p || ($p = {}));
+}(rf || (rf = {}));
 
-var uf = null != Xe ? Xe : {
+var df = null != Xe ? Xe : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, lf = {
+}, pf = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, mf = {
+}, ff = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, df = function() {
+}, yf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, lf), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, pf), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30364,19 +30404,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Zp(r);
-o && (this.interShardMemory = o, uf.debug("Loaded InterShardMemory", {
+var o = ef(r);
+o && (this.interShardMemory = o, df.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-uf.error("Failed to load InterShardMemory: ".concat(n), {
+df.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Qp(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Jp(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30537,25 +30577,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-uf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+df.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-uf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+df.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", uf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", df.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-uf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+df.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30588,7 +30628,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-uf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+df.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30618,12 +30658,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", uf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", df.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-uf.info("War ended, transitioning to ".concat(i), {
+df.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, uf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, df.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30649,7 +30689,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = mf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = ff[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30701,13 +30741,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && uf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && df.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-uf.debug("Could not set shard limits: ".concat(S), {
+df.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30715,27 +30755,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (uf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (df.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = rf(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = af(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > ef) {
-uf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(ef), {
+if (r.length > of) {
+df.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(of), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = rf(this.interShardMemory, t, {
+var o = af(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > ef ? (uf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(ef), {
+return o.length > of ? (df.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(of), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-uf.error("Failed to sync InterShardMemory: ".concat(n), {
+df.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30773,7 +30813,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Qp(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Jp(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30791,40 +30831,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-uf.info("Repaired InterShardMemory structure", {
+df.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void uf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void df.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Zp(r);
-if (!o) return void uf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = ef(r);
+if (!o) return void df.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || uf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || df.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-uf.warn("InterShardMemory verification failed: ".concat(a), {
+df.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-uf.info("Attempting InterShardMemory recovery", {
+df.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Zp(r);
-if (o) return this.interShardMemory = o, void uf.info("Recovered InterShardMemory from storage", {
+var o = ef(r);
+if (o) return this.interShardMemory = o, void df.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30839,12 +30879,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Qp(n), uf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Jp(n), df.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-uf.error("InterShardMemory recovery failed: ".concat(a), {
+df.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30854,7 +30894,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), uf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), df.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30870,7 +30910,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-uf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+df.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30886,7 +30926,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), uf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), df.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30901,7 +30941,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, uf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, df.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30920,7 +30960,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), uf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), df.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -30966,11 +31006,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, uf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, df.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = Xp(this.interShardMemory).length, o = r / ef * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = $p(this.interShardMemory).length, o = r / of * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -30997,11 +31037,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-uf.info("Forcing InterShardMemory sync with validation", {
+df.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = Xp(this.interShardMemory).length, n = Xp(o(o({}, this.interShardMemory), {
+var e, t, r = $p(this.interShardMemory).length, n = $p(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31025,8 +31065,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: ef,
-percent: Math.round(r / ef * 1e4) / 100,
+limit: of,
+percent: Math.round(r / of * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31034,10 +31074,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Jp.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (tf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), pf = new df, ff = {
+}(), vf = new yf, gf = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31048,11 +31088,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: $p.LOW,
-NORMAL: $p.NORMAL,
-HIGH: $p.HIGH
+LOW: rf.LOW,
+NORMAL: rf.NORMAL,
+HIGH: rf.HIGH
 }
-}, yf = function() {
+}, hf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31062,7 +31102,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = pf.getActiveTransferTasks();
+var n = vf.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31089,7 +31129,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = pf.getOptimalPortalRoute(e.targetShard);
+var t = vf.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31157,7 +31197,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-pf.updateTaskProgress(e.taskId, t);
+vf.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31173,7 +31213,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = ff.optimizeBody({
+i = gf.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -31184,8 +31224,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = ff.spawnPriorities.LOW;
-e.priority >= 80 ? d = ff.spawnPriorities.HIGH : e.priority >= 50 && (d = ff.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = gf.spawnPriorities.LOW;
+e.priority >= 80 ? d = gf.spawnPriorities.HIGH : e.priority >= 50 && (d = gf.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31203,7 +31243,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-ff.spawnQueue.addRequest(y), Xe.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+gf.spawnQueue.addRequest(y), Xe.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31230,7 +31270,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void pf.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void vf.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", Xe.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -31242,8 +31282,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, pf.updateTaskProgress(e.taskId, 100, "complete"),
-pf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Xe.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, vf.updateTaskProgress(e.taskId, 100, "complete"),
+vf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Xe.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31273,12 +31313,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), vf = new yf;
+}(), Rf = new hf;
 
-function gf(e, t, r) {
+function Ef(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = of({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = sf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31293,13 +31333,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, nf(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, cf(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function hf(e) {
+function Tf(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31327,15 +31367,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (gf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Ef("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || q(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (gf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Ef("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (gf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Ef((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31352,24 +31392,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, gf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Ef("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (gf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Ef("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Rf(e) {
+function Cf(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Ef(e, t) {
+function Sf(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31403,14 +31443,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function Tf(e, t) {
+function wf(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function Cf(e) {
-var t = gd.getEmpire();
-if (Ju.isExit(e.creep.pos)) return Rf(e.room.name);
+function xf(e) {
+var t = Rd.getEmpire();
+if (Ju.isExit(e.creep.pos)) return Cf(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31425,7 +31465,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Tf(t.x, t.y - 1), Tf(t.x + 1, t.y), Tf(t.x, t.y + 1), Tf(t.x - 1, t.y) ] : [];
+return t ? [ wf(t.x, t.y - 1), wf(t.x + 1, t.y), wf(t.x, t.y + 1), wf(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31488,13 +31528,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Ef(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Sf(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Ef(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Sf(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31504,19 +31544,19 @@ type: "idle"
 };
 }
 
-function Sf(e) {
+function bf(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function wf(e) {
-return e.hostiles.some(Sf);
+function Of(e) {
+return e.hostiles.some(bf);
 }
 
-function xf(e) {
+function kf(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function bf(e) {
+function Af(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31539,8 +31579,8 @@ type: "idle"
 };
 }
 
-var Of = {
-scout: Cf,
+var Mf = {
+scout: xf,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31574,7 +31614,7 @@ return {
 type: "idle"
 };
 }
-if (Ju.isExit(e.creep.pos)) return Rf(e.room.name);
+if (Ju.isExit(e.creep.pos)) return Cf(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31596,8 +31636,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: hf,
-interShardScout: hf,
+interShardClaimer: Tf,
+interShardScout: Tf,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31673,8 +31713,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return bf(e);
-if (wf(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return Af(e);
+if (Of(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31715,7 +31755,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return xf(t) - xf(e);
+return kf(t) - kf(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31735,7 +31775,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : bf(e);
+} : Af(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31824,9 +31864,9 @@ type: "idle"
 }
 };
 
-function kf(e, t) {
+function Uf(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : wf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Of(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31834,26 +31874,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function Af(e) {
-var t;
-return (null !== (t = Of[e.memory.role]) && void 0 !== t ? t : Cf)(e);
-}
-
-function Mf(e) {
-var t = Qu(e);
-Bl(e, jl(t, Pd, {
-interrupt: Gd
-}), t);
-}
-
-function Uf(e) {
-var t = Qu(e);
-Bl(e, jl(t, Af, {
-interrupt: kf
-}), t);
-}
-
 function _f(e) {
+var t;
+return (null !== (t = Mf[e.memory.role]) && void 0 !== t ? t : xf)(e);
+}
+
+function Nf(e) {
+var t = Qu(e);
+Kl(e, Ql(t, Ld, {
+interrupt: Fd
+}), t);
+}
+
+function Pf(e) {
+var t = Qu(e);
+Kl(e, Ql(t, _f, {
+interrupt: Uf
+}), t);
+}
+
+function If(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31894,8 +31934,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && hp.has(i) && Y(s))) {
-yp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && Tp.has(i) && Y(s))) {
+hp.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31960,7 +32000,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !vp(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Rp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -31970,7 +32010,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !vp(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Rp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -31981,7 +32021,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = _t(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !vp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Rp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32034,7 +32074,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !vp(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Rp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32076,7 +32116,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !vp(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Rp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32086,7 +32126,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !vp(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Rp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -32094,7 +32134,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && q(e.room).length > 0) {
 var o = _t(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !vp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Rp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32106,7 +32146,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !vp(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Rp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32114,12 +32154,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !vp(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Rp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !vp(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Rp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32153,18 +32193,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function Nf(e) {
+function Gf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var Pf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), If = -1, Gf = Object.create(null);
+var Lf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), Df = -1, Ff = Object.create(null);
 
-function Lf(e) {
+function Bf(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var Df = {
+var Wf = {
 harvester: Je.CRITICAL,
 queenCarrier: Je.CRITICAL,
 hauler: Je.HIGH,
@@ -32199,12 +32239,12 @@ labTech: Je.IDLE,
 factoryWorker: Je.IDLE
 };
 
-function Ff(e) {
+function Kf(e) {
 var t;
-return null !== (t = Df[e]) && void 0 !== t ? t : Je.MEDIUM;
+return null !== (t = Wf[e]) && void 0 !== t ? t : Je.MEDIUM;
 }
 
-function Bf(e) {
+function Hf(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32220,20 +32260,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && Lf(o) === e && t++;
+o && Bf(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (If !== Game.time && (If = Game.time, Gf = function() {
+}(e) : null !== (r = (Df !== Game.time && (Df = Game.time, Ff = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = Lf(o);
+var n = Bf(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), Gf)[e]) && void 0 !== r ? r : 0;
+}()), Ff)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Me().cpu.disableCreepBootstrapCountCache
@@ -32243,7 +32283,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!Pf.has(t.role)) return !1;
+if (!Lf.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32253,7 +32293,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Nf(r)) return !1;
+if (!r || !Gf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32267,7 +32307,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Nf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !Gf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32275,7 +32315,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Nf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !Gf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32283,7 +32323,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Nf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !Gf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32291,7 +32331,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && Nf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && Gf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32307,7 +32347,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Nf(r)) return !1;
+if (!r || !Gf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32348,8 +32388,8 @@ case "economy":
 default:
 !function(e) {
 var t = Qu(e);
-Bl(e, jl(t, Pd, {
-interrupt: Gd
+Kl(e, Ql(t, Ld, {
+interrupt: Fd
 }), t);
 }(e);
 break;
@@ -32357,21 +32397,21 @@ break;
 case "military":
 !function(e) {
 var t = Qu(e);
-Bl(e, jl(t, fp), t);
+Kl(e, Ql(t, gp), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
 var t = Qu(e);
-Bl(e, jl(t, Af), t);
+Kl(e, Ql(t, _f), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
 var t = Qu(e);
-Bl(e, jl(t, Ep), t);
+Kl(e, Ql(t, Sp), t);
 }(e);
 }
 });
@@ -32392,7 +32432,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var Wf = function() {
+var Yf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32433,7 +32473,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Ff(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = Kf(r), n = "creep:".concat(e.name);
 gi.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -32449,7 +32489,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Bf(t);
+t && !t.spawning && Hf(t);
 }
 }), this.registeredCreeps.add(e.name), Wu.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32474,7 +32514,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Ff(u.memory.role), m = null !== (r = Je[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = Kf(u.memory.role), m = null !== (r = Je[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32499,20 +32539,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), Kf = new Wf;
+}(), Vf = new Yf;
 
-function Hf(e) {
+function qf(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, Yf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, jf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function Yf(e) {
+function jf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function Vf(e) {
+function zf(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32525,14 +32565,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function qf(e, t) {
+function Qf(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var jf = {
+var Xf = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32560,11 +32600,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function zf(e, t) {
+function Zf(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function Qf(e) {
+function Jf(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32574,9 +32614,9 @@ tick: Game.time
 }, a;
 }
 
-var Xf = [ "defense", "war", "expand", "siege" ];
+var $f = [ "defense", "war", "expand", "siege" ];
 
-function Zf(e) {
+function ey(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32589,11 +32629,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function Jf(e, t, r) {
-t >= 2 && (e.pheromones.war = zf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = zf(e.pheromones.siege + 20, r));
+function ty(e, t, r) {
+t >= 2 && (e.pheromones.war = Zf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Zf(e.pheromones.siege + 20, r));
 }
 
-var $f = function() {
+var ry = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32608,27 +32648,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), ey = function() {
+}(), oy = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, jf), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Xf), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new $f(10),
-energySpawning: new $f(10),
-energyConstruction: new $f(10),
-energyRepair: new $f(10),
-energyTower: new $f(10),
-controllerProgress: new $f(10),
-hostileCount: new $f(5),
-damageReceived: new $f(5),
-idleWorkers: new $f(10),
+energyHarvested: new ry(10),
+energySpawning: new ry(10),
+energyConstruction: new ry(10),
+energyRepair: new ry(10),
+energyTower: new ry(10),
+controllerProgress: new ry(10),
+hostileCount: new ry(5),
+damageReceived: new ry(5),
+idleWorkers: new ry(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = Qf(e);
+var o = Jf(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32701,7 +32741,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = zf(e[s] * c, t);
+e[s] = Zf(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32717,43 +32757,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = Qf(t);
+var o = Jf(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = zf(e.harvest + n / 3e3 * 10, r);
+e.harvest = Zf(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = zf(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = Zf(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = zf(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = Zf(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = zf(e.defense + 10 * o, r));
+o > 0 && (e.defense = Zf(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = zf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = zf(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = Zf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Zf(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = zf(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = Zf(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = zf(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = Zf(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = zf(e.pheromones.defense + 5 * t, o), Jf(e, r, o),
+e.danger = r, e.pheromones.defense = Zf(e.pheromones.defense + 5 * t, o), ty(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32761,7 +32801,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = zf(t / 10, o), Jf(e, r, o);
+e.danger = r, e.pheromones.defense = Zf(t / 10, o), ty(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32774,8 +32814,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = zf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = zf(f + y, o);
+var p = Zf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = Zf(f + y, o);
 }
 }
 }
@@ -32794,18 +32834,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = zf(e.pheromones.defense + 5, r), e.pheromones.build = zf(e.pheromones.build + 10, r),
+e.pheromones.defense = Zf(e.pheromones.defense + 5, r), e.pheromones.build = Zf(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = zf(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Zf(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = zf(e.pheromones.siege + 50, t), e.pheromones.defense = zf(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = Zf(e.pheromones.siege + 50, t), e.pheromones.defense = Zf(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = zf(e.pheromones.expand - 10, t), e.pheromones.defense = zf(e.pheromones.defense + 5, t);
+e.pheromones.expand = Zf(e.pheromones.expand - 10, t), e.pheromones.defense = Zf(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32815,10 +32855,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Zf(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(ey(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Xf)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a($f)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32872,7 +32912,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = zf(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = Zf(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32907,7 +32947,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), ty = new ey, ry = {
+}(), ny = new oy, ay = {
 seedNest: {
 rcl: 1
 },
@@ -32948,7 +32988,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, oy = {
+}, iy = {
 eco: {
 economy: .75,
 military: .05,
@@ -32991,7 +33031,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, ny = {
+}, sy = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33048,13 +33088,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, ay = function() {
+}, cy = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = ry.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = ry.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= ry.fortifiedHive.rcl ? "fortifiedHive" : s >= ry.matureColony.rcl ? "matureColony" : s >= ry.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = ay.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = ay.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= ay.fortifiedHive.rcl ? "fortifiedHive" : s >= ay.matureColony.rcl ? "matureColony" : s >= ay.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Le.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -33089,7 +33129,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = ry[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = ay[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33102,7 +33142,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), iy = function() {
+}(), uy = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33124,9 +33164,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return oy[e];
+return iy[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return ny[e];
+return sy[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33136,15 +33176,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), sy = new ay, cy = new iy;
+}(), ly = new cy, my = new uy;
 
-function uy(e) {
+function dy(e) {
 return !H(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function ly(e, t, r) {
+function py(e, t, r) {
 if (!e) return null;
 var o = Xr.getEmpire();
 if (H(e, {
@@ -33183,11 +33223,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function my() {
+function fy() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var dy = new Map, py = function() {
+var yy = new Map, vy = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = q(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33331,7 +33371,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: dy.get(e.name),
+previousStructures: yy.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33361,7 +33401,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && dy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && yy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33370,7 +33410,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-uy(u) && o.add(u.owner.username);
+dy(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33384,7 +33424,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) ly(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) py(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33400,7 +33440,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? ty.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? ty.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && ty.onNukeDetected(t);
+"danger" === y.type ? ny.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? ny.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && ny.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33460,10 +33500,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = my()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = fy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = my()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = fy()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33506,7 +33546,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: cy.isCombatPosture(t.posture),
+isCombatPosture: my.isCombatPosture(t.posture),
 wallRepairTarget: qo(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33530,27 +33570,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), fy = new py, yy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), gy = new vy, hy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function vy() {
+function Ry() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function gy(e, t, r, o) {
+function Ey(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: vy()
+selectedAt: Ry()
 });
 }
 
-function hy(e) {
+function Ty(e) {
 return e >= 2 && e <= 3;
 }
 
-function Ry(e, t) {
+function Cy(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33563,7 +33603,7 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-function Ey(e, t) {
+function Sy(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -33577,10 +33617,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var Ty = function() {
+var wy = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return hy(e) ? 5 : 10;
+return Ty(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -33978,16 +34018,16 @@ y: e.y - R.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-gy(t, v, E.name, f);
+Ey(t, v, E.name, f);
 var T = f >= 3 && (t.danger >= 1 || function(e, t) {
-var r = Ey(STRUCTURE_TOWER, t);
-return r > 0 && Ry(e, STRUCTURE_TOWER) < r;
+var r = Sy(STRUCTURE_TOWER, t);
+return r > 0 && Cy(e, STRUCTURE_TOWER) < r;
 }(e, f)), C = T ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Ey(STRUCTURE_TOWER, g), R = Ry(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Sy(STRUCTURE_TOWER, g), R = Cy(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34384,7 +34424,7 @@ var r, o, n, i = Mn(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && Ry(e, u) < l) return !0;
+if (!(l <= 0) && Cy(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34400,8 +34440,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + S + w + C >= 10 && !x) t.metrics.constructionSites = p.length + S + w + C; else {
-if (!cy.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== vy());
+if (!my.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Ry());
 }(t, v)) {
 var b = function(e, t, r, o, n) {
 var i, s;
@@ -34559,7 +34599,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return yy.has(e.structureType);
+return hy.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34568,7 +34608,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = hy(f) ? 2 : 3;
+var M = Ty(f) ? 2 : 3;
 (A = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -35244,13 +35284,13 @@ anchor: l
 }
 return null;
 }(e, f);
-L && (gy(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
+L && (Ey(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), Cy = new Ty;
+}(), xy = new wy;
 
-function Sy(e) {
+function by(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35272,7 +35312,7 @@ siege: e.pheromones.siege
 };
 }
 
-var wy = {
+var Oy = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35285,10 +35325,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, xy = new (function() {
+}, ky = new (function() {
 function e() {
 this.manager = new Qc({
-logger: wy
+logger: Oy
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35298,23 +35338,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = Sy(t);
+var r = by(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = Sy(t);
+var r = by(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), by = {
+}()), Ay = {
 labManager: mu,
 boostManager: iu,
-chemistryPlanner: xy,
+chemistryPlanner: ky,
 labConfigManager: uu,
 logger: Wu
-}, Oy = function() {
+}, My = function() {
 function e(e) {
-void 0 === e && (e = by), this.deps = e;
+void 0 === e && (e = Ay), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35353,9 +35393,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), ky = new Oy, Ay = function() {
+}(), Uy = new My, _y = function() {
 function e(e) {
-void 0 === e && (e = ky), this.labWorkflow = e;
+void 0 === e && (e = Uy), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35378,27 +35418,27 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), My = new Ay, Uy = {
+}(), Ny = new _y, Py = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, _y = new Map;
+}, Iy = new Map;
 
-function Ny(e) {
+function Gy(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function Py(e) {
+function Ly(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var Iy = function() {
+var Dy = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Uy), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Py), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Fi.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35440,7 +35480,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = Xr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = _y.get(e.name);
+var t = Iy.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35462,28 +35502,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return _y.set(e.name, o), o;
+return Iy.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && ty.updateMetrics(i, c),
-fy.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && ny.updateMetrics(i, c),
+gy.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), ai.assess(i, c), li.checkSafeMode(i, c), this.config.enableEvolution && (sy.updateEvolutionStage(c, i, e),
-s || sy.updateMissingStructures(c, i)), cy.updatePosture(c), this.config.enablePheromones && !s && ty.updatePheromones(c, i),
-this.config.enableTowers && fy.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Cy.getConstructionInterval(l), d = cy.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), ai.assess(i, c), li.checkSafeMode(i, c), this.config.enableEvolution && (ly.updateEvolutionStage(c, i, e),
+s || ly.updateMissingStructures(c, i)), my.updatePosture(c), this.config.enablePheromones && !s && ny.updatePheromones(c, i),
+this.config.enableTowers && gy.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = xy.getConstructionInterval(l), d = my.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = Ny(r), n = Py(e);
+var o = Gy(r), n = Ly(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Cy.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (xy.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = Ny(r), n = Py(e);
+var o = Gy(r), n = Ly(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && My.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && Ny.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35493,7 +35533,7 @@ var f = Game.cpu.getUsed() - n;
 Fi.recordRoom(i, f), Fi.endRoom(this.roomName, n);
 } else Fi.endRoom(this.roomName, n);
 }, e;
-}(), Gy = function() {
+}(), Fy = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35507,7 +35547,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new Iy(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new Dy(v.name));
 }
 } catch (t) {
 e = {
@@ -35570,7 +35610,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new Iy(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new Dy(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35591,9 +35631,9 @@ stack: c
 }
 }
 }, e;
-}(), Ly = new Gy;
+}(), By = new Fy;
 
-function Dy(e) {
+function Wy(e) {
 var t, r, o;
 if (q(e).length > 0) return Je.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return Je.HIGH;
@@ -35604,14 +35644,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? Je.MEDIUM : Je.LOW;
 }
 
-function Fy(e) {
+function Ky(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return q(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function By(e, t, r) {
+function Hy(e, t, r) {
 var o;
 return t === Je.CRITICAL ? {
 tickModulo: void 0,
@@ -35631,7 +35671,7 @@ tickOffset: void 0
 };
 }
 
-var Wy, Ky = function() {
+var Yy, Vy = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35647,7 +35687,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = gi.getProcess(i), c = Dy(n), u = Fy(n);
+var i = "room:".concat(o), s = gi.getProcess(i), c = Wy(n), u = Ky(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35666,7 +35706,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = Dy(e), o = Fy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = By(e, r, a);
+var t, r = Wy(e), o = Ky(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Hy(e, r, a);
 gi.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35683,7 +35723,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Ly.runRoom(t);
+t && By.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35691,7 +35731,7 @@ Wu.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = By(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Hy(e, t, a);
 gi.unregisterProcess(n), gi.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35708,7 +35748,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Ly.runRoom(t);
+t && By.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35730,7 +35770,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = Dy(m), p = null !== (r = Je[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = Wy(m), p = null !== (r = Je[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35757,7 +35797,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), Hy = new Ky, Yy = function() {
+}(), qy = new Vy, jy = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = gi.getStatsSummary(), t = gi.getConfig();
@@ -35834,11 +35874,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Vf(e.summary.byLayer)), "Groups: ".concat(Vf(e.summary.byGroup)), "States: ".concat(Vf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(zf(e.summary.byLayer)), "Groups: ".concat(zf(e.summary.byGroup)), "States: ".concat(zf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(qf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(Qf)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(Hf(m));
+c.push(qf(m));
 }
 } catch (e) {
 t = {
@@ -35937,7 +35977,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = Kf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = Vf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -35956,7 +35996,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = Hy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = qy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36103,7 +36143,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), Vy = function() {
+}(), zy = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -36136,7 +36176,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), qy = function() {
+}(), Qy = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36661,7 +36701,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), jy = function() {
+}(), Xy = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return ar.generateHelp();
@@ -36680,22 +36720,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), zy = function() {
+}(), Zy = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? Pl.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? Gl.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? Pl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? Gl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return Pl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return Gl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ ir({
 name: "tasks",
 description: "Show room creep task queue",
@@ -36715,21 +36755,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), Qy = ((Wy = {})[MOVE] = 50, Wy[WORK] = 100, Wy[CARRY] = 50, Wy[ATTACK] = 80,
-Wy[RANGED_ATTACK] = 150, Wy[HEAL] = 250, Wy[CLAIM] = 600, Wy[TOUGH] = 10, Wy);
+}(), Jy = ((Yy = {})[MOVE] = 50, Yy[WORK] = 100, Yy[CARRY] = 50, Yy[ATTACK] = 80,
+Yy[RANGED_ATTACK] = 150, Yy[HEAL] = 250, Yy[CLAIM] = 600, Yy[TOUGH] = 10, Yy);
 
-function Xy(e, t) {
+function $y(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, Qy), t);
+var r = o(o({}, Jy), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : Qy[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : Jy[t]);
 }, 0);
 }
 
-function Zy(e, t) {
+function ev(e, t) {
 void 0 === t && (t = 0);
-var r = Xy(e);
+var r = $y(e);
 return {
 parts: e,
 cost: r,
@@ -36737,7 +36777,7 @@ minCapacity: t || r
 };
 }
 
-function Jy() {
+function tv() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36745,11 +36785,11 @@ return Array(o).fill(r);
 });
 }
 
-var $y, ev, tv, rv = {
+var rv, ov, nv, av = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Zy([ WORK, CARRY ], 150), Zy([ WORK, CARRY, MOVE ], 200), Zy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Zy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Zy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ev([ WORK, CARRY ], 150), ev([ WORK, CARRY, MOVE ], 200), ev([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), ev([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), ev([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36757,7 +36797,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Zy([ WORK, CARRY, MOVE ], 200), Zy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Zy([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Zy([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ev([ WORK, CARRY, MOVE ], 200), ev([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), ev([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), ev([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36765,7 +36805,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Zy([ WORK, CARRY, MOVE, MOVE ], 250), Zy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ ev([ WORK, CARRY, MOVE, MOVE ], 250), ev([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36773,7 +36813,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Zy([ WORK, CARRY, MOVE ], 200), Zy([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Zy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Zy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ ev([ WORK, CARRY, MOVE ], 200), ev([ WORK, WORK, CARRY, MOVE, MOVE ], 350), ev([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), ev([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), ev([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36781,7 +36821,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Zy([ CARRY, CARRY, MOVE, MOVE ], 200), Zy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Zy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ev([ CARRY, CARRY, MOVE, MOVE ], 200), ev([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), ev(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36789,7 +36829,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Zy([ WORK, CARRY, MOVE ], 200), Zy([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ ev([ WORK, CARRY, MOVE ], 200), ev([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), ev([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), ev([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36797,7 +36837,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Zy([ WORK, CARRY, MOVE, MOVE ], 250), Zy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ ev([ WORK, CARRY, MOVE, MOVE ], 250), ev([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), ev([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36805,7 +36845,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Zy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ ev([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36813,7 +36853,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Zy([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ ev([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), ev([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36821,7 +36861,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Zy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ ev([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36829,7 +36869,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Zy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ ev([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36837,7 +36877,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Zy([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Zy([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Zy([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ ev([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), ev([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), ev([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), ev([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36845,7 +36885,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Zy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Zy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ev([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), ev(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36853,7 +36893,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Zy([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Zy([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ ev([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), ev([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36861,16 +36901,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Zy(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Zy(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Zy(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Zy(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ ev(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), ev(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), ev(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), ev(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, ov = {
+}, iv = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Zy([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Zy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Zy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Zy([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ ev([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), ev([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), ev([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), ev([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36878,7 +36918,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Zy([ TOUGH, ATTACK, MOVE, MOVE ], 190), Zy([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Zy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ ev([ TOUGH, ATTACK, MOVE, MOVE ], 190), ev([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), ev([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36886,7 +36926,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Zy([ HEAL, MOVE, MOVE ], 350), Zy([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Zy([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Zy([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ ev([ HEAL, MOVE, MOVE ], 350), ev([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), ev([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), ev([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36894,7 +36934,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Zy([ ATTACK, ATTACK, MOVE, MOVE ], 260), Zy([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Zy([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ ev([ ATTACK, ATTACK, MOVE, MOVE ], 260), ev([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), ev([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36902,7 +36942,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Zy([ WORK, WORK, MOVE, MOVE ], 300), Zy([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Zy([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ ev([ WORK, WORK, MOVE, MOVE ], 300), ev([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), ev([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36910,7 +36950,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Zy([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Zy([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Zy([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Zy([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ ev([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), ev([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), ev([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), ev([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36918,16 +36958,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Zy([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Zy([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Zy([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ ev([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), ev([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), ev([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, nv = {
+}, sv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Zy(Jy([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Zy(Jy([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ ev(tv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), ev(tv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36935,16 +36975,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Zy(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Zy(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ ev(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), ev(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, av = {
+}, cv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Zy([ MOVE ], 50) ],
+bodies: [ ev([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36952,7 +36992,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Zy([ MOVE ], 50) ],
+bodies: [ ev([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36960,7 +37000,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Zy([ CLAIM, MOVE ], 650) ],
+bodies: [ ev([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -36968,7 +37008,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Zy([ CLAIM, MOVE ], 650), Zy([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ ev([ CLAIM, MOVE ], 650), ev([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36976,7 +37016,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Zy([ WORK, CARRY, MOVE, MOVE ], 250), Zy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ ev([ WORK, CARRY, MOVE, MOVE ], 250), ev([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36984,30 +37024,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Zy([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Zy([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ ev([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), ev([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, iv = o(o(o(o({}, rv), ov), av), nv);
+}, uv = o(o(o(o({}, av), iv), cv), sv);
 
 try {
-for (var sv = a(Object.values(iv)), cv = sv.next(); !cv.done; cv = sv.next()) cv.value.bodies.sort(function(e, t) {
+for (var lv = a(Object.values(uv)), mv = lv.next(); !mv.done; mv = lv.next()) mv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-$y = {
+rv = {
 error: e
 };
 } finally {
 try {
-cv && !cv.done && (ev = sv.return) && ev.call(sv);
+mv && !mv.done && (ov = lv.return) && ov.call(lv);
 } finally {
-if ($y) throw $y.error;
+if (rv) throw rv.error;
 }
 }
 
-function uv(e) {
+function dv(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37022,11 +37062,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return lv(o);
+return pv(o);
 }
 
-function lv(e) {
-var t = Xy(e);
+function pv(e) {
+var t = $y(e);
 return {
 parts: e,
 cost: t,
@@ -37034,16 +37074,16 @@ minCapacity: t
 };
 }
 
-function mv(e, t) {
+function fv(e, t) {
 var r;
-return null !== (r = e.map(lv).filter(function(e) {
+return null !== (r = e.map(pv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function dv(e) {
+function yv(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37057,7 +37097,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = Xy(a);
+var s = $y(a);
 return {
 parts: a,
 cost: s,
@@ -37082,8 +37122,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: Xy(p),
-minCapacity: Xy(p)
+cost: $y(p),
+minCapacity: $y(p)
 };
 }(e);
 
@@ -37094,7 +37134,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return uv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return dv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37115,7 +37155,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return uv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return dv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37124,13 +37164,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(lv).filter(function(e) {
+var u = n.map(pv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = mv(n, t);
+var l = fv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37140,7 +37180,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = mv(n, t);
+var u = fv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37149,14 +37189,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = mv(r, t);
+var a = fv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function pv(e) {
+function vv(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37167,9 +37207,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function fv(e, t) {
+function gv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: pv(t)
+memory: vv(t)
 });
 var r;
 }
@@ -37177,9 +37217,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(tv || (tv = {}));
+}(nv || (nv = {}));
 
-var yv = function() {
+var hv = function() {
 function e() {
 this.queues = new Map;
 }
@@ -37274,7 +37314,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = fv(m, d);
+var p = gv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37294,7 +37334,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= tv.EMERGENCY;
+return e.priority >= nv.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37312,7 +37352,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= tv.EMERGENCY ? n.emergency++ : c.priority >= tv.HIGH ? n.high++ : c.priority >= tv.NORMAL ? n.normal++ : n.low++;
+c.priority >= nv.EMERGENCY ? n.emergency++ : c.priority >= nv.HIGH ? n.high++ : c.priority >= nv.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37327,14 +37367,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), vv = new yv, gv = {
+}(), Rv = new hv, Ev = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, hv = {
+}, Tv = {
 predictConsumption: function() {
 return 0;
 },
@@ -37353,7 +37393,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Rv = {
+}, Cv = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37371,44 +37411,44 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, Ev = {
+}, Sv = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Tv(e, t, r, o, n) {
+function wv(e, t, r, o, n) {
 return Vs(e, t, r, o, n);
 }
 
-var Cv = new Map, Sv = -1, wv = null;
+var xv = new Map, bv = -1, Ov = null;
 
-function xv() {
-Sv === Game.time && wv === Game.creeps || (Cv.clear(), Sv = Game.time, wv = Game.creeps);
+function kv() {
+bv === Game.time && Ov === Game.creeps || (xv.clear(), bv = Game.time, Ov = Game.creeps);
 }
 
-function bv(e) {
+function Av(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Ov(e, t) {
+function Mv(e, t) {
 var r;
-void 0 === t && (t = !1), xv();
-var o = t ? "".concat(e, "_active") : e, n = Cv.get(o);
+void 0 === t && (t = !1), kv();
+var o = t ? "".concat(e, "_active") : e, n = xv.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = bv(c);
+var u = Av(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Cv.set(o, a), a;
+return xv.set(o, a), a;
 }
 
-function kv(e, t, r) {
+function Uv(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37429,22 +37469,22 @@ if (o) throw o.error;
 return i;
 }
 
-function Av(e) {
+function _v(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var Mv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var Nv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function Uv(e) {
-return Mv.includes(e);
+function Pv(e) {
+return Nv.includes(e);
 }
 
-function _v(e) {
+function Iv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Nv(e, t, r, o) {
+function Gv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37457,10 +37497,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Tv(e, t, Nt(r).length, o, {
-reserved: _v(r)
+if (r) return wv(e, t, Nt(r).length, o, {
+reserved: Iv(r)
 }).recommendedHaulers;
-var n = Tv(e, t, 2, o, {
+var n = wv(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37471,7 +37511,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: Av
+filter: _v
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37482,7 +37522,7 @@ return 2;
 }
 }
 
-function Pv(e, t) {
+function Lv(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37492,13 +37532,13 @@ return null;
 }
 }
 
-function Iv() {
+function Dv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function Gv(e) {
-var t = Iv(), r = function(e) {
+function Fv(e) {
+var t = Dv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37510,14 +37550,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function Lv(e) {
+function Bv(e) {
 var t = Xr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Iv();
+var r = Dv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function Dv(e) {
+function Wv(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37525,11 +37565,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function Fv(e) {
+function Kv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function Bv() {
+function Hv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37539,9 +37579,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var Wv = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var Yv = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Kv(e, t) {
+function Vv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37553,8 +37593,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(Bv()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = vv.getPendingRequests(c).some(function(r) {
+for (var i = a(Hv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Rv.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37574,7 +37614,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function Hv() {
+function qv() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -37595,7 +37635,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function Yv(e, t) {
+function jv(e, t) {
 var r, o, n, c, u = Xr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37605,15 +37645,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !Kv(e.roomName, "claim");
+return !Vv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || Dv(t));
+return !(!r || r.my || r.owner || r.reservation || Wv(t));
 }
-return !Lv(e);
+return !Bv(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37624,11 +37664,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = Hv().filter(function(e) {
-return !Kv(e, "claim");
+var r, o, n = qv().filter(function(e) {
+return !Vv(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = Iv();
+var r, o, n = Game.rooms[e], a = Dv();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -37639,7 +37679,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Wv.has(e.type);
+return e.hits > 0 && Yv.has(e.type);
 });
 });
 }(n));
@@ -37651,7 +37691,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = Pv(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = Lv(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -37666,14 +37706,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(Hv()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(qv()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !Kv(e.roomName, "claim");
+return !e.claimed && !Vv(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -37685,20 +37725,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Iv();
+var l = Dv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !Kv(p, "claim")) {
+if (!t.has(p) && !Vv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || Gv(y)) continue;
-if (Dv(f)) continue;
+if (y.owner || Fv(y)) continue;
+if (Wv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !Kv(p, "reserve")) return p;
-} else if (!Lv(p) && !Kv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !Vv(p, "reserve")) return p;
+} else if (!Bv(p) && !Vv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37720,34 +37760,34 @@ task: "reserve"
 } : null;
 }
 
-function Vv(e) {
+function zv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function qv(e) {
-return Vv(e) ? tv.EMERGENCY : tv.HIGH;
+function Qv(e) {
+return zv(e) ? nv.EMERGENCY : nv.HIGH;
 }
 
-function jv(e, t, r) {
+function Xv(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!Fv(e)) return !1;
+if (!Kv(e)) return !1;
 var a = e.name === t ? r : Xr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function zv(e, t, r) {
+function Zv(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return jv(e, t, r);
+return Xv(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Pv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = Lv(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37755,18 +37795,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function Qv(e, t) {
+function Jv(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !jv(n, e, t)) return null;
+if (!n || !Xv(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !Fv(e);
+return !Kv(e);
 }).filter(function(e) {
-return !Dv(e);
+return !Wv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37787,9 +37827,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(Bv()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(Hv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += vv.getPendingRequests(d).filter(function(t) {
+i += Rv.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37806,12 +37846,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (Vv(e) ? 3 : 1);
+}(e.name) < (zv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Pv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = Lv(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37819,10 +37859,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (zv(u.room, e, t) === e) return {
+if (Zv(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: qv(u.room)
+priority: Qv(u.room)
 };
 }
 } catch (e) {
@@ -37839,10 +37879,10 @@ if (r) throw r.error;
 return null;
 }
 
-function Xv(e, t) {
+function $v(e, t) {
 if (t <= 0) return null;
 try {
-var r = dv({
+var r = yv({
 maxEnergy: t,
 role: e
 });
@@ -37852,18 +37892,18 @@ return null;
 }
 }
 
-function Zv(e, t, r) {
-return "healer" === e || "ranger" === e && To(r) ? null : Xv(e, t);
+function eg(e, t, r) {
+return "healer" === e || "ranger" === e && To(r) ? null : $v(e, t);
 }
 
-function Jv(e) {
+function tg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function $v(e) {
+function rg(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37877,7 +37917,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Jv(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += tg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37898,7 +37938,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Jv(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += tg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37914,23 +37954,23 @@ return i;
 }(e)) : r;
 }
 
-var eg = [ "guard", "ranger", "healer" ];
+var og = [ "guard", "ranger", "healer" ];
 
-function tg(e, t) {
+function ng(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function rg(e, t, r, o) {
+function ag(e, t, r, o) {
 void 0 === o && (o = vo(e.roomName));
-var n = tg(e, t);
+var n = ng(e, t);
 if (!bo(t)) return n;
 if (!o) return n;
-var i = ig(e.roomName), s = i[t] + xo(r, o, {
-guard: Math.max(0, tg(e, "guard") - i.guard),
-ranger: Math.max(0, tg(e, "ranger") - i.ranger),
-healer: Math.max(0, tg(e, "healer") - i.healer)
-}, cg(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = ug(e.roomName), s = i[t] + xo(r, o, {
+guard: Math.max(0, ng(e, "guard") - i.guard),
+ranger: Math.max(0, ng(e, "ranger") - i.ranger),
+healer: Math.max(0, ng(e, "healer") - i.healer)
+}, mg(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Co(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -37945,7 +37985,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && ug(u) && Co(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && dg(u) && Co(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -37963,30 +38003,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function og(e) {
+function ig(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? q(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function ng(e) {
+function sg(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === $a ? e.targetRoom : void 0;
 }
 
-function ag(e, t) {
-var r = vo(e.roomName), o = ig(e.roomName), n = xo(t.energyCapacityAvailable, r, {
-guard: Math.max(0, tg(e, "guard") - o.guard),
-ranger: Math.max(0, tg(e, "ranger") - o.ranger),
-healer: Math.max(0, tg(e, "healer") - o.healer)
-}, cg(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function cg(e, t) {
+var r = vo(e.roomName), o = ug(e.roomName), n = xo(t.energyCapacityAvailable, r, {
+guard: Math.max(0, ng(e, "guard") - o.guard),
+ranger: Math.max(0, ng(e, "ranger") - o.ranger),
+healer: Math.max(0, ng(e, "healer") - o.healer)
+}, mg(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = eg.filter(function(o) {
-return !(rg(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Co(o, t.energyCapacityAvailable, r));
+var i = og.filter(function(o) {
+return !(ag(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Co(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function ig(e) {
+function ug(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -37995,7 +38035,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-bo(p) && ng(d) === e && u[p]++;
+bo(p) && sg(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -38009,7 +38049,7 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(vv.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Rv.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
 bo(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === $a && g.targetRoom === e) && u[g.role]++;
 }
@@ -38027,21 +38067,21 @@ if (o) throw o.error;
 return u;
 }
 
-function sg(e, t, r) {
+function lg(e, t, r) {
 var o = mo(r), n = e[t];
 e[t] = n ? po(n, o) : o;
 }
 
-function cg(e) {
+function mg(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (bo(y) && ng(f) === e) {
+if (bo(y) && sg(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && sg(l, y, v);
+v.length > 0 && lg(l, y, v);
 }
 }
 } catch (e) {
@@ -38056,9 +38096,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(vv.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Rv.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-bo(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === $a && E.targetRoom === e) && sg(l, E.role, E.body.parts);
+bo(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === $a && E.targetRoom === e) && lg(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -38074,23 +38114,23 @@ if (o) throw o.error;
 return l;
 }
 
-function ug(e) {
+function dg(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === q(e).length;
 }
 
-function lg(e, t, r, o) {
+function pg(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && Zv("guard", $v(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && eg("guard", rg(r), o) ? 1 : 0;
 }
 
-function mg(e, t) {
+function fg(e, t) {
 var r;
 if (!function(e) {
 return bo(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !ug(o)) return null;
+if (!o || !dg(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38115,7 +38155,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(og);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(ig);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -38123,15 +38163,15 @@ return t.roomName !== e;
 var r = vo(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(rg(e, t, n, r), lg(e, t, o, r))
+helperNeed: Math.max(ag(e, t, n, r), pg(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return og(e.request);
+return ig(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return bo(t) ? ig(e)[t] : 0;
+return bo(t) ? ug(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38157,27 +38197,27 @@ return r[o] = s, s;
 return {
 targetRoom: r.roomName,
 task: $a,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? tv.EMERGENCY : tv.HIGH,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? nv.EMERGENCY : nv.HIGH,
 defenseSquadId: ei(e, r.roomName, n.createdAt),
-defenseSquadSize: ag(r, t),
+defenseSquadSize: cg(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var dg = "defenseRefuel", pg = {
+var yg = "defenseRefuel", vg = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function fg(e, t) {
+function gg(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || q(e).length > 0 || e.energyCapacityAvailable < pg.cost);
-}(n) ? $v(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || q(e).length > 0 || e.energyCapacityAvailable < vg.cost);
+}(n) ? rg(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38214,9 +38254,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(vv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Rv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === dg && s++;
+"hauler" === p.role && f === yg && s++;
 }
 } catch (e) {
 o = {
@@ -38231,24 +38271,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: dg,
-priority: tv.EMERGENCY,
-body: pg
+task: yg,
+priority: nv.EMERGENCY,
+body: vg
 } : null : null;
 }
 
-function yg(e) {
+function hg(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !Gv(t.controller) && !Dv(t) : !Lv(e);
+return t ? !!t.controller && !Fv(t.controller) && !Wv(t) : !Bv(e);
 }
 
-function vg(e) {
+function Rg(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !Gv(t.controller) : !Lv(e);
+return (null == t ? void 0 : t.controller) ? !Fv(t.controller) : !Bv(e);
 }
 
-function gg(e, t, r) {
-var o = iv[t];
+function Eg(e, t, r) {
+var o = uv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
@@ -38276,13 +38316,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function hg(e, t, r) {
+function Tg(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (yg(l) && kv(e, t, l) < Nv(e, l, t, Game.rooms[l])) return l;
+if (hg(l) && Uv(e, t, l) < Gv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -38298,10 +38338,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Rg(e, t, r, o) {
+function Cg(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = iv[t];
+var p = uv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -38315,32 +38355,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = iv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = iv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = uv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = uv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Ov(e), y)) return !1;
+}(t, Mv(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (Uv(t)) return !("remoteWorker" === t && function(e, t) {
-xv();
-var r = "".concat(e, ":").concat(t), o = Cv.get(r);
+if (Pv(t)) return !("remoteWorker" === t && function(e, t) {
+kv();
+var r = "".concat(e, ":").concat(t), o = xv.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Cv.set(r, n), n;
-}(e, t) >= gg(e, t, r)) && null !== hg(e, t, r);
+return xv.set(r, n), n;
+}(e, t) >= Eg(e, t, r)) && null !== Tg(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (vg(R)) {
+if (Rg(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = q(E).filter(function(e) {
@@ -38348,7 +38388,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && kv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && Uv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38365,9 +38405,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Ov(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== Qv(e, r);
-if (C >= gg(e, t, r)) return !1;
+var C = null !== (u = Mv(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== Jv(e, r);
+if (C >= Eg(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38379,14 +38419,14 @@ var r = Xr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = Pv(e, o);
+var a = Lv(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== Yv(e, r);
+if ("claimer" === t) return null !== jv(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38422,7 +38462,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = gv.getActiveRequests) || void 0 === m ? void 0 : m.call(gv)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = Ev.getActiveRequests) || void 0 === m ? void 0 : m.call(Ev)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38450,16 +38490,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Eg(e) {
+function Sg(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Tg(e) {
-return 0 === Eg(Ov(e, !0));
+function wg(e) {
+return 0 === Sg(Mv(e, !0));
 }
 
-function Cg(e) {
+function xg(e) {
 var t = Nt(e);
 return [ {
 role: "harvester",
@@ -38482,14 +38522,14 @@ minCount: 1
 } ];
 }
 
-function Sg(e, t) {
-var r, o, n, i, s = Ov(e, !0);
-if (0 === Eg(s)) return !0;
+function bg(e, t) {
+var r, o, n, i, s = Mv(e, !0);
+if (0 === Sg(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Ov(e, !1), u = Cg(t);
+var c = Mv(e, !1), u = xg(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38509,57 +38549,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function wg(e) {
+function Og(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function xg(e, t, r) {
-var n = gg(e.name, r.roleName, t);
+function kg(e, t, r) {
+var n = Eg(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function bg(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return tv.EMERGENCY;
+function Ag(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return nv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return tv.HIGH;
-if (Ev.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return nv.HIGH;
+if (Sv.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = to(e), n = oo(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return tv.EMERGENCY;
-if (a > 0) return tv.HIGH;
+if (a >= 100) return nv.EMERGENCY;
+if (a > 0) return nv.HIGH;
 }
 return function(e) {
-return e >= 90 ? tv.HIGH : e >= 60 ? tv.NORMAL : tv.LOW;
+return e >= 90 ? nv.HIGH : e >= 60 ? nv.NORMAL : nv.LOW;
 }(o);
 }
 
-function Og(e, t) {
+function Mg(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-wg(e);
-var l = Ov(e.name), m = Tg(e.name), d = [];
-if (Sg(e.name, e)) {
+Og(e);
+var l = Mv(e.name), m = wg(e.name), d = [];
+if (bg(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Eg(Ov(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Sg(Mv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Ov(e, !1), c = Cg(t);
+var s = Mv(e, !1), c = xg(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38574,7 +38614,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Rg(e, m.role, r, !0);
+var p = Cg(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38605,17 +38645,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = iv[p]) && Rg(e.name, p, t, !0) ? (d.push(xg(e, t, {
+return p && (g = uv[p]) && Cg(e.name, p, t, !0) ? (d.push(kg(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: bg(e, 0, p, g.priority, m),
+priority: Ag(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(iv)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = fg(e.name, p);
+for (var f = a(Object.entries(uv)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = gg(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38626,7 +38666,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = mg(e.name, p);
+var E = fg(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38640,8 +38680,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Rg(e.name, p, t, m)) {
-var T = Uv(p), C = T ? hg(e.name, p, t) : null, S = "claimer" === p ? Yv(e.name, t) : null, w = "pioneer" === p ? Qv(e.name, t) : null;
+}); else if (Cg(e.name, p, t, m)) {
+var T = Pv(p), C = T ? Tg(e.name, p, t) : null, S = "claimer" === p ? jv(e.name, t) : null, w = "pioneer" === p ? Jv(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38651,11 +38691,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(xg(e, t, {
+}) : d.push(kg(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: bg(e, 0, p, g.priority, m),
+priority: Ag(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38677,7 +38717,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = kg(e, l.value);
+var m = Ug(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38698,10 +38738,10 @@ requests: c
 };
 }
 
-function kg(e, t) {
+function Ug(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = hv.getMaxAffordableInTicks(e, l), d = $v(e), p = t.priority >= tv.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && bo(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= tv.EMERGENCY, g = t.assistTarget ? vo(t.assistTarget) : null, h = f ? Co(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Co(f, d, g)) && void 0 !== r ? r : Zv(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Tv.getMaxAffordableInTicks(e, l), d = rg(e), p = t.priority >= nv.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && bo(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= nv.EMERGENCY, g = t.assistTarget ? vo(t.assistTarget) : null, h = f ? Co(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Co(f, d, g)) && void 0 !== r ? r : eg(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38722,7 +38762,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : dv({
+}(t.def, p)) && void 0 !== c ? c : yv({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38758,44 +38798,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Ag = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Mg = new Set([ "guard", "ranger", "healer" ]);
+var _g = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Ng = new Set([ "guard", "ranger", "healer" ]);
 
-function Ug() {
+function Pg() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function _g(e) {
+function Ig(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Ng(e) {
+function Gg(e) {
 var t;
-return e.priority >= tv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= nv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Pg(e) {
+function Lg(e) {
 var t;
-return e.priority >= tv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= nv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Ig(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = $v(e), m = r.urgency >= 2 || t.danger >= 3 ? tv.EMERGENCY : tv.HIGH, d = yo(q(e)), p = function(e) {
+function Dg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = rg(e), m = r.urgency >= 2 || t.danger >= 3 ? nv.EMERGENCY : nv.HIGH, d = yo(q(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === tv.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === nv.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(vv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Rv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || Gg(u, e) && ("guard" === u.role && (n.guards++,
-Dg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Dg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Dg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Fg(u, e) && ("guard" === u.role && (n.guards++,
+Wg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Wg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Wg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38823,7 +38863,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Dg(n, u, l);
+0 !== l.length && Wg(n, u, l);
 }
 }
 }
@@ -38862,26 +38902,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Lg("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) Bg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Lg("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) Bg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Lg("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Bg(e, "healer", "military", tv.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Bg("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) Hg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Bg("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) Hg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Bg("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Hg(e, "healer", "military", nv.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < tv.EMERGENCY || function(e, t) {
+if (!(t < nv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Mg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Ng.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(vv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Rv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < tv.EMERGENCY || Mg.has(c.role) && Gg(c, e.name) && c.body.cost <= t && n++;
+c.priority < nv.EMERGENCY || Ng.has(c.role) && Fg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38898,7 +38938,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = Xv(t, e);
+var r = $v(t, e);
 return r ? {
 role: t,
 body: r
@@ -38913,45 +38953,45 @@ var r = mo(t.body.parts).score - mo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Bg(e, n.role, "military", tv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && Hg(e, n.role, "military", nv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Gg(e, t) {
+function Fg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Lg(e, t, r) {
+function Bg(e, t, r) {
 return r ? Co(e, t, r) : null;
 }
 
-function Dg(e, t, r) {
+function Wg(e, t, r) {
 var o = mo(r);
 e[t] = e[t] ? po(e[t], o) : o;
 }
 
-function Fg(e, t, r) {
-return vv.getPendingRequests(e).filter(function(e) {
+function Kg(e, t, r) {
+return Rv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Bg(e, t, r, o, n, a, i, s, c) {
+function Hg(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : dv({
+var u = null != i ? i : yv({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-vv.addRequest({
+Rv.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -38969,34 +39009,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Wg(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= tv.HIGH) return !1;
+function Yg(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= nv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < tv.NORMAL) {
-if (hv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < nv.NORMAL) {
+if (Tv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === tv.NORMAL && o / e.energyCapacityAvailable < .3 && hv.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === nv.NORMAL && o / e.energyCapacityAvailable < .3 && Tv.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function Kg(e, t) {
+function Vg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-wg(e);
-var s = vv.getQueueSize(e.name);
+Og(e);
+var s = Rv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Sg(e.name, e), u = Tg(e.name) && !vv.hasEmergencySpawns(e.name), l = to(e), m = oo(e);
+var c = bg(e.name, e), u = wg(e.name) && !Rv.hasEmergencySpawns(e.name), l = to(e), m = oo(e);
 if (c) {
-s > 0 && vv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Ig(e, t, l, m);
+s > 0 && Rv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Dg(e, t, l, m);
 try {
-for (var d = a(Og(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Mg(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-vv.addRequest(f);
+Rv.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -39009,8 +39049,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Ig(e, t, l, m), function(e) {
-var t, r, o = Rv.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Dg(e, t, l, m), function(e) {
+var t, r, o = Cv.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -39022,17 +39062,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = tv.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = nv.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Fg(e.name, "powerHarvester", f), g = Fg(e.name, "healer", f), h = Fg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Bg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Kg(e.name, "powerHarvester", f), g = Kg(e.name, "healer", f), h = Kg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Hg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Bg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) Hg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Bg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Hg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -39061,13 +39101,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(vv.getPendingRequests(e.name).map(_g));
+var c = new Set(Rv.getPendingRequests(e.name).map(Ig));
 try {
-for (var u = a(Og(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= tv.HIGH, p = "claimer" === m.role && Ug(), f = Ng(m), y = Pg(m);
-if (Ag.has(m.role) || d || p || f || y) {
-var v = _g(m);
-c.has(v) || (vv.addRequest(m), c.add(v));
+for (var u = a(Mg(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= nv.HIGH, p = "claimer" === m.role && Pg(), f = Gg(m), y = Lg(m);
+if (_g.has(m.role) || d || p || f || y) {
+var v = Ig(m);
+c.has(v) || (Rv.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -39084,8 +39124,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Og(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-vv.addRequest(f);
+for (var y = a(Mg(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Rv.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -39097,32 +39137,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = vv.getQueueStats(e.name);
+var g = Rv.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && vv.clearQueue(e.name);
+} else s > 0 && Rv.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = vv.getAvailableSpawns(e.name);
+var t, r, o = Rv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = $v(e);
+var n = 0, i = rg(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = vv.getNextRequest(e.name, i);
+var u = c.value, l = Rv.getNextRequest(e.name, i);
 if (!l) break;
-if (Wg(e, l, i)) {
+if (Yg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = fv(u, l);
-m === OK ? (n++, i -= l.body.cost, vv.markInProgress(e.name, l.id, u.id), vv.removeRequest(e.name, l.id),
+var m = gv(u, l);
+m === OK ? (n++, i -= l.body.cost, Rv.markInProgress(e.name, l.id, u.id), Rv.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (vv.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Rv.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -39138,7 +39178,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = vv.getQueueStats(e.name);
+}(e), o = Rv.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -39152,7 +39192,7 @@ stats: o
 }(e, t);
 }
 
-var Hg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, Yg = /^(\d{1,2})\|(.+)$/, Vg = A("SS2TerminalComms"), qg = function() {
+var qg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, jg = /^(\d{1,2})\|(.+)$/, zg = A("SS2TerminalComms"), Qg = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -39212,11 +39252,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(Hg);
+var t = e.match(qg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(Yg);
+var i = a.match(jg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -39251,7 +39291,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-Vg.warn("Missing packet in multi-packet message", {
+zg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -39267,7 +39307,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), Vg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), zg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -39291,7 +39331,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && Vg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && zg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -39303,7 +39343,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return Vg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return zg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -39311,14 +39351,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), Vg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), zg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (Vg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (zg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -39343,7 +39383,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-Vg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+zg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -39355,7 +39395,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-Vg.info("Completed sending multi-packet message", {
+zg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -39363,25 +39403,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? Vg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? zg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (Vg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (zg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else Vg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else zg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else Vg.warn("Terminal not found for queue item, removing from queue", {
+} else zg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39415,7 +39455,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && Vg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && zg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39425,7 +39465,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-Vg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+zg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39516,7 +39556,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (Vg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (zg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39538,7 +39578,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return Vg.error("Error parsing JSON", {
+return zg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39549,7 +39589,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), jg = [ {
+}(), Xg = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39569,7 +39609,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], zg = function() {
+} ], Zg = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39616,9 +39656,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), Qg = new zg;
+}(), Jg = new Zg;
 
-function Xg(e) {
+function $g(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39626,19 +39666,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function Zg(e, t) {
+function eh(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Jg(e, t) {
+function th(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var $g = {
+var rh = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39649,9 +39689,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, eh = function() {
+}, oh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, $g), e);
+void 0 === e && (e = {}), this.config = o(o({}, rh), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39672,7 +39712,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = Qg.getSwarmState(r.toRoom);
+var o = Jg.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39685,7 +39725,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = Qg.getSwarmState(c);
+var l = Jg.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39755,9 +39795,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(Zg), u = n.filter(function(e) {
+}).sort(eh), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Jg), l = [], m = [], d = function(t) {
+}).sort(th), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39779,11 +39819,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return Xg({
+return $g({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + Xg({
+}) + $g({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39882,7 +39922,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), th = new eh, rh = {
+}(), nh = new oh, ah = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39903,14 +39943,14 @@ siegeUnits: 1
 }
 };
 
-function oh(e) {
+function ih(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function nh(e) {
+function sh(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39933,9 +39973,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function ah(e) {
+function ch(e) {
 var t, r, o;
-nh(e);
+sh(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -39959,20 +39999,20 @@ if (t) throw t.error;
 return n;
 }
 
-function ih(e) {
+function uh(e) {
 var t;
-nh(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = ah(e);
+sh(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = ch(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function sh(e) {
-return !!ih(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function lh(e) {
+return !!uh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-nh(e);
+sh(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -39983,12 +40023,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = ah(e);
+var d = ch(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function ch(e, t) {
+function mh(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -40009,20 +40049,20 @@ if (r) throw r.error;
 return n;
 }
 
-function uh(e, t) {
+function dh(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = rh[r]) && void 0 !== t ? t : rh[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = ah[r]) && void 0 !== t ? t : ah[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = ch(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = mh(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: oh(r),
+targetComposition: ih(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -40034,7 +40074,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function lh(e) {
+function ph(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -40054,9 +40094,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function mh(e) {
+function fh(e) {
 var t = e.members.length;
-nh(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+sh(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -40070,7 +40110,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && sh(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && lh(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -40099,7 +40139,7 @@ subsystem: "Squad"
 }
 }
 
-var dh = {
+var yh = {
 harassment: {
 composition: {
 harassers: 3,
@@ -40186,7 +40226,7 @@ prioritizeDefenses: !0
 }
 };
 
-function ph(e, t) {
+function vh(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -40201,8 +40241,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function fh(e, t) {
-var r, o, n, i = dh[t], s = 0;
+function gh(e, t) {
+var r, o, n, i = yh[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -40228,7 +40268,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var yh, vh, gh, hh = {
+var hh, Rh, Eh, Th = {
 move: 50,
 work: 100,
 carry: 50,
@@ -40237,11 +40277,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Rh = new Map;
+}, Ch = new Map;
 
-function Eh(e, t) {
+function Sh(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Rh.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Ch.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -40253,7 +40293,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = dh[p].composition;
+d = yh[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -40268,19 +40308,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Rh.set(m, y), function(e, t, r, o) {
+v ? (Ch.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = dh[s].useBoosts;
+i = yh[s].useBoosts;
 }
-var c = tv.NORMAL;
-"siege" === t.type ? c = tv.HIGH : "defense" === t.type && (c = tv.EMERGENCY);
+var c = nv.NORMAL;
+"siege" === t.type ? c = nv.HIGH : "defense" === t.type && (c = nv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = Th(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + hh[t];
-}, 0), m = i ? Sh(r) : [], d = {
+var u = wh(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + Th[t];
+}, 0), m = i ? bh(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -40309,7 +40349,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-vv.addRequest(d), o.spawnRequests.add(d.id);
+Rv.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -40323,42 +40363,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function Th(e, t, r) {
+function wh(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Ch([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return xh([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Ch([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return xh([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Ch([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return xh([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Ch([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return xh([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Ch([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return xh([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Ch([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return xh([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Ch(e, t, r) {
+function xh(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + hh[t];
+return e + Th[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + hh[t];
+return e + Th[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Sh(e) {
+function bh(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40389,45 +40429,45 @@ return [];
 }
 }
 
-function wh(e) {
-return Rh.has(e);
+function Oh(e) {
+return Ch.has(e);
 }
 
-function xh(e) {
-return ih(e) || sh(e);
+function kh(e) {
+return uh(e) || lh(e);
 }
 
-(yh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, yh[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-yh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (vh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-vh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, vh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-vh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (gh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-gh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, gh[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-gh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, gh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(hh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, hh[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+hh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Rh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Rh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Rh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Rh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Eh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Eh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Eh[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Eh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Eh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var bh = {
+var Ah = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Oh(e, t) {
-var r = bh[t], o = Qg.getClusters();
+function Mh(e, t) {
+var r = Ah[t], o = Jg.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function kh(e, t, r) {
+function Uh(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = Qg.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = Jg.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Oh(e, i.danger),
+reservedEnergy: Mh(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40517,7 +40557,7 @@ success: !1
 });
 }
 
-var Ah = {
+var _h = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40527,7 +40567,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Mh(e, t, r) {
+function Nh(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40558,7 +40598,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function Uh(e, t, r, o) {
+function Ph(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40568,7 +40608,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function _h(e, t) {
+function Ih(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40589,19 +40629,19 @@ if (r) throw r.error;
 return n;
 }
 
-function Nh() {
-var e = Qg.getEmpire();
+function Gh() {
+var e = Jg.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function Ph(e) {
-Nh()[e.id] = e;
+function Lh(e) {
+Gh()[e.id] = e;
 }
 
-function Ih(e) {
+function Dh(e) {
 e.lastUpdate = Game.time;
-var t = Qg.getCluster(e.clusterId);
-if (!t) return e.state = "failed", Ph(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = Jg.getCluster(e.clusterId);
+if (!t) return e.state = "failed", Lh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40611,12 +40651,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (xh(r) || wh(e) || Eh(0, r), xh(r));
+return !!r && (kh(r) || Oh(e) || Sh(0, r), kh(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), Ph(e);
+})), Lh(e);
 }(e, t);
 break;
 
@@ -40627,7 +40667,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (mh(o), lh(o)) {
+if (fh(o), ph(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40656,7 +40696,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = Qg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = Jg.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40683,12 +40723,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), Ph(e);
+})), Lh(e);
 }(e, t);
 }
 }
 
-function Gh(e, t, r) {
+function Fh(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40707,11 +40747,11 @@ score: n.score + o.score
 }
 }
 
-function Lh(e, t, r) {
+function Bh(e, t, r) {
 return Co(e, t, r);
 }
 
-function Dh(e, t) {
+function Wh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40724,11 +40764,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function Fh(e) {
+function Kh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function Bh(e, t, r) {
+function Hh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40741,8 +40781,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function Wh(e, t, r) {
-var o = Lh(t, e.energyCapacityAvailable, r);
+function Yh(e, t, r) {
+var o = Bh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40750,16 +40790,16 @@ var a = mo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function Kh(e, t, r, o) {
+function Vh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = Wh(e, t, o);
-if (s !== Wh(n, t, o)) return s ? -1 : 1;
+var a, i, s = Yh(e, t, o);
+if (s !== Yh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function Hh(e, t) {
+function qh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40843,21 +40883,21 @@ if (r) throw r.error;
 return u;
 }
 
-function Yh(e, t) {
+function jh(e, t) {
 return {
-guard: Math.max(0, Dh(e, "guard") - t.counts.guard),
-ranger: Math.max(0, Dh(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, Dh(e, "healer") - t.counts.healer)
+guard: Math.max(0, Wh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, Wh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, Wh(e, "healer") - t.counts.healer)
 };
 }
 
-function Vh(e) {
+function zh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function qh(e, t) {
+function Qh(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return Vh(e.role);
+return zh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40870,12 +40910,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function jh(e) {
+function Xh(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === $a ? e.targetRoom : void 0;
 }
 
-function zh(e) {
+function Zh(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40887,7 +40927,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-Vh(m) && jh(l) === e && !u.spawning && Gh(i, m, u.body.filter(function(e) {
+zh(m) && Xh(l) === e && !u.spawning && Fh(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40905,7 +40945,7 @@ if (t) throw t.error;
 return i;
 }
 
-function Qh(e, t, r) {
+function Jh(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40935,16 +40975,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: qh(e, r)
+pendingAssist: Qh(e, r)
 };
 }
 }
 
-function Xh(e, t) {
+function $h(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = Lh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = Bh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -40965,7 +41005,7 @@ subsystem: "Cluster"
 }
 }
 
-function Zh(e, t, r) {
+function eR(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -41007,20 +41047,20 @@ exitAccess: a
 };
 }
 
-function Jh(e, t) {
+function tR(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function $h(e, t, r) {
+function rR(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function eR(e) {
+function oR(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function tR(e, t) {
+function nR(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -41031,7 +41071,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function rR(e, t, r) {
+function aR(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -41042,8 +41082,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = eR(g);
-h && (ri(g) || tR(v, h) && (t.assignedCreeps.includes(v.name) || Jh(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = oR(g);
+h && (ri(g) || nR(v, h) && (t.assignedCreeps.includes(v.name) || tR(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -41080,7 +41120,7 @@ return e.distance - t.distance;
 });
 }
 
-function oR(e, t) {
+function iR(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -41105,21 +41145,21 @@ if (r) throw r.error;
 return i;
 }
 
-function nR(e) {
+function sR(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var aR = {
+var cR = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, iR = function() {
+}, uR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, aR), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, cR), e);
 }
 return e.prototype.run = function() {
-var e = Qg.getClusters();
+var e = Jg.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -41138,7 +41178,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: jg.map(function(t) {
+steps: Xg.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -41194,7 +41234,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-th.processCluster(t);
+nh.processCluster(t);
 break;
 
 case "squads":
@@ -41226,7 +41266,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = Zh(e, new RoomPosition(s, c, e.name), "defense");
+var u = eR(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -41275,9 +41315,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = Qg.getSwarmState(i);
+var i = n.value, s = Jg.getSwarmState(i);
 if (s) {
-var c = Oh(i, s.danger);
+var c = Mh(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -41308,7 +41348,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = Qg.getSwarmState(m);
+var m = l.value, d = Jg.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -41340,7 +41380,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += nR(l.controller.level));
+}).length, i += sR(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41457,7 +41497,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-mh(i), "gathering" !== i.state || xh(i) || wh(i.id) || Eh(0, i), lh(i) && (i.state = "dissolving");
+fh(i), "gathering" !== i.state || kh(i) || Oh(i.id) || Sh(0, i), ph(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41482,7 +41522,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = uh(e, s);
+var s = i.value, c = dh(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41499,7 +41539,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(Nh()).filter(function(e) {
+var t = (a = e.id, Object.values(Gh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41510,22 +41550,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Ah), n), m = [], d = Qg.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, _h), n), m = [], d = Jg.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = Mh(f, y, d);
+var g = Nh(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = _h(e, f);
+var h = Ih(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = Uh(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = Ph(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = ph(f, {
+var C = vh(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41560,29 +41600,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-fh(e, n.doctrine) ? function(e, t, r) {
+gh(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = Qg.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = Jg.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = Mh(e, o, r);
+var n = Nh(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (Qg.getEmpire().knownRooms || {})[t], n = null != r ? r : ph(t, {
+var o = (Jg.getEmpire().knownRooms || {})[t], n = null != r ? r : vh(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!fh(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!gh(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41595,7 +41635,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-Ph(i);
+Lh(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41609,13 +41649,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = ch(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = mh(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: oh(n),
+targetComposition: ih(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41630,8 +41670,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), Ph(i), Eh(0, c), i.state = "forming", i.lastUpdate = Game.time,
-Ph(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), Lh(i), Sh(0, c), i.state = "forming", i.lastUpdate = Game.time,
+Lh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41650,11 +41690,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Rh.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Ch.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Rh.delete(c));
+}), Ch.delete(c));
 }
 } catch (t) {
 e = {
@@ -41668,10 +41708,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = Nh();
-for (var t in e) Ih(e[t]);
+var e = Gh();
+for (var t in e) Dh(e[t]);
 !function() {
-var e = Nh();
+var e = Gh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41749,14 +41789,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = Qg.getCluster(t, e);
+var t = "cluster_".concat(e), r = Jg.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = Qg.getCluster(e);
+var o = Jg.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41785,7 +41825,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && kh(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Uh(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41802,7 +41842,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = Qg.getSwarmState(t);
+var n, a, i = Jg.getSwarmState(t);
 if (!i) return "continue";
 if (no(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41843,7 +41883,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = vo(g), f[g] = zh(g);
+p[g] = vo(g), f[g] = Zh(g);
 }
 } catch (e) {
 r = {
@@ -41859,7 +41899,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = Qh(E, m, t);
+d[E] = Jh(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41878,13 +41918,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Bh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = Hh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = Hh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = qh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = xo(T, R, Yh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = xo(T, R, jh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = Kh(h, b, g.roomName, R), A = 0; A < O; A++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = Vh(h, b, g.roomName, R), A = 0; A < O; A++) {
 var M = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41896,7 +41936,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").con
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: Fh(g.urgency),
+priority: Kh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -41942,7 +41982,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) Xh(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) $h(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -41957,7 +41997,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, vv);
+}(e, Rv);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -41969,7 +42009,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = oR(f, rR(e, f, t)), v = y.reduce(function(e, t) {
+var y = iR(f, aR(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -41982,7 +42022,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), $h(f, R.role, Jh(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), rR(f, R.role, tR(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -42049,24 +42089,24 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), sR = new iR, cR = /^([WE])(\d+)([NS])(\d+)$/;
+}(), lR = new uR, mR = /^([WE])(\d+)([NS])(\d+)$/;
 
-function uR(e) {
-return cR.test(e);
+function dR(e) {
+return mR.test(e);
 }
 
-var lR = {
+var pR = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, mR = function() {
+}, fR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, lR), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, pR), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = of();
-this.updateEnemyIntelligence(e), nf(e, {
+var e = sf();
+this.updateEnemyIntelligence(e), cf(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
@@ -42129,7 +42169,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (uR(x)) {
+if (e.isAlly(x)) f.add(x); else if (dR(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -42194,14 +42234,14 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return of().globalTargets.enemies || [];
+return sf().globalTargets.enemies || [];
 }, n([ vt("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: Je.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), dR = new mR, pR = function() {
+}(), yR = new fR, vR = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -42278,9 +42318,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), fR = new pR, yR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), gR = new vR, hR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function vR(e, t) {
+function RR(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -42303,13 +42343,13 @@ if (r) throw r.error;
 return n;
 }
 
-function gR(e) {
+function ER(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function hR(e, t, r) {
-if (!gR(e)) return 0;
-var o = vR(e.name, t);
+function TR(e, t, r) {
+if (!ER(e)) return 0;
+var o = RR(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += qs(e.mineralType),
@@ -42318,7 +42358,7 @@ n += Xs(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += Js(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function RR(e, t) {
+function CR(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -42328,13 +42368,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && yR.has(e.type);
+return e.hits > 0 && hR.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function ER(e, t, r) {
+function SR(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -42344,7 +42384,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function TR(e) {
+function wR(e) {
 return function(e) {
 var t = X(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42355,8 +42395,8 @@ isSK: Z(t.x) && Z(t.y)
 }(e);
 }
 
-function CR(e) {
-var t = TR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function xR(e) {
+var t = wR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42375,14 +42415,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var SR = {
+var bR = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, wR = function() {
+}, OR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, SR), e);
+void 0 === e && (e = {}), this.config = o(o({}, bR), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42473,7 +42513,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = TR(e);
+var t = wR(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42485,14 +42525,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return CR(xR(e));
+return xR(kR(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = CR(xR(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = xR(kR(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function xR(e) {
+function kR(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = q(e), c = j(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42524,11 +42564,11 @@ swamps: d
 };
 }
 
-var bR = new wR, OR = /^([WE])(\d+)([NS])(\d+)$/, kR = {
+var AR = new OR, MR = /^([WE])(\d+)([NS])(\d+)$/, UR = {
 allies: []
-}, AR = function() {
+}, _R = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, kR), e);
+void 0 === e && (e = {}), this.config = o(o({}, UR), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42548,7 +42588,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!OR.test(e)) return !1;
+if (!MR.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42656,7 +42696,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return OR.test(e);
+return MR.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42683,7 +42723,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), MR = new AR, UR = {
+}(), NR = new _R, PR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42696,9 +42736,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, _R = function() {
+}, IR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, UR), e);
+void 0 === e && (e = {}), this.config = o(o({}, PR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = Xr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42711,7 +42751,7 @@ t.updateExpansionQueue(o);
 }), Fi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Fi.measureSubsystem("empire:warTargets", function() {
-MR.updateWarTargets(o);
+NR.updateWarTargets(o);
 }), Fi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Fi.measureSubsystem("empire:gclTracking", function() {
@@ -42719,13 +42759,13 @@ t.trackGCLProgress(o);
 }), s && Fi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Fi.measureSubsystem("empire:intelRefresh", function() {
-bR.refreshRoomIntel(o);
+AR.refreshRoomIntel(o);
 }), Fi.measureSubsystem("empire:roomDiscovery", function() {
-bR.discoverNearbyRooms(o);
+AR.discoverNearbyRooms(o);
 })), s && Fi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Fi.measureSubsystem("empire:clusterHealth", function() {
-fR.monitorClusterHealth();
+gR.monitorClusterHealth();
 }), Fi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42808,22 +42848,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = RR(f, u);
+var y = Boolean(Game.rooms[f]), v = CR(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = vR(f, t);
+var g = RR(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = ER(h, u, y);
+var h = e.knownRooms[f], R = SR(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? hR(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? TR(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42867,10 +42907,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && gR(a)) {
-var i = vR(a.name, t);
+if (a && ER(a)) {
+var i = RR(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = hR(a, t, r);
+var s = TR(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -43190,13 +43230,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), NR = new _R;
+}(), GR = new IR;
 
-function PR(e) {
+function LR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var IR = {
+var DR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -43204,10 +43244,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, GR = function() {
+}, FR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, IR), e);
+this.config = o(o({}, DR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -43351,7 +43391,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, PR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, LR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43526,7 +43566,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), LR = new GR, DR = function() {
+}(), BR = new FR, WR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Hs(o(o({}, As), e), {
 getEmpire: function() {
@@ -43562,7 +43602,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), FR = new DR, BR = function() {
+}(), KR = new WR, HR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = Xr.getEmpire();
@@ -43580,9 +43620,9 @@ lastScan: 0
 var e = Xr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), WR = new (function(e) {
+}(), YR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new BR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new HR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43594,22 +43634,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ht() ], t);
 }(Ci));
 
-function KR() {
+function VR() {
 return global;
 }
 
-function HR(e) {
+function qR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function YR(e) {
+function jR(e) {
 return Number(null != e ? e : 0);
 }
 
-var VR = function() {
+var zR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = KR();
+var e = VR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43617,12 +43657,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return KR()._pixelGenerationMemory;
+return VR()._pixelGenerationMemory;
 }, e;
-}(), qR = function(e) {
+}(), QR = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new VR) || this;
+var r = e.call(this, t, new zR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43639,7 +43679,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(HR).length : Object.values(null != t ? t : {}).filter(HR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(qR).length : Object.values(null != t ? t : {}).filter(qR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43650,9 +43690,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (YR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (YR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = YR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = YR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (jR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (jR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = jR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = jR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43674,9 +43714,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ht() ], t);
-}(wi), jR = new qR;
+}(wi), XR = new QR;
 
-function zR(e, t) {
+function ZR(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !H(e.controller.owner.username)) return {
 lost: !0,
@@ -43698,7 +43738,7 @@ lost: !1
 };
 }
 
-function QR(e, t, r) {
+function JR(e, t, r) {
 var o, n = Xr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43712,20 +43752,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var XR = Me().cpu.bucketThresholds.highMode + 1800, ZR = {
+var $R = Me().cpu.bucketThresholds.highMode + 1800, eE = {
 updateInterval: 250,
-minBucket: XR,
+minBucket: $R,
 maxSitesPerRemotePerTick: 2
 };
 
-function JR(e, t) {
+function tE(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var $R = function() {
+var rE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, ZR), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, eE), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43742,8 +43782,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = zR(l);
-m.lost && m.reason && QR(e, u, m.reason);
+var m = ZR(l);
+m.lost && m.reason && JR(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43761,10 +43801,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = JR("remoteInfrastructure.intent", function() {
+var i = tE("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-JR("remoteInfrastructure.execute", function() {
+tE("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43930,13 +43970,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = JR("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = tE("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = JR("remoteInfrastructure.roomSnapshot", function() {
+u[t] = tE("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -43969,7 +44009,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = JR("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = tE("remoteInfrastructure.calculateRemoteRoads", function() {
 return ua(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -43998,14 +44038,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = JR("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = tE("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? JR("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? tE("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -44022,7 +44062,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? JR("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? tE("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -44040,7 +44080,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return JR("remoteInfrastructure.findSources", function() {
+return tE("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -44137,10 +44177,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ yt("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Je.LOW,
 interval: 1e3,
-minBucket: XR,
+minBucket: $R,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), eE = new $R, tE = new (function(e) {
+}(), oE = new rE, nE = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -44152,7 +44192,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ht() ], t);
-}(df)), rE = function() {
+}(yf)), aE = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -44196,7 +44236,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-ty.applyDiffusion(o);
+ny.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44242,7 +44282,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ht() ], e);
-}(), oE = new rE, nE = new (function() {
+}(), iE = new aE, sE = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -44272,7 +44312,7 @@ registerProcesses: function() {
 var e;
 Wu.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), hi(oE, Rs, ws, Zi, NR, ac, LR, eE, fs, WR, jR, FR, Dc, Hc, tE, dR, _c, sR, pi),
+}), hi(iE, Rs, ws, Zi, GR, ac, BR, oE, fs, YR, XR, KR, Dc, Hc, nE, yR, _c, lR, pi),
 function() {
 var e, t, r = Me().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -44327,7 +44367,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return sR.run();
+return lR.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -44368,9 +44408,9 @@ Wu.info("Registered ".concat(gi.getProcesses().length, " processes with kernel")
 subsystem: "ProcessRegistry"
 });
 }
-}), aE = "_ownedRooms", iE = "_ownedRoomsTick";
+}), cE = "_ownedRooms", uE = "_ownedRoomsTick";
 
-function sE(e) {
+function lE(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44380,13 +44420,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var cE = Fu("NativeCallsTracker");
+var mE = Fu("NativeCallsTracker");
 
-function uE(e, t, r) {
+function dE(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) cE.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) mE.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44402,7 +44442,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-cE.warn("Failed to wrap method", {
+mE.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44412,30 +44452,30 @@ error: String(e)
 }
 }
 
-var lE, mE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], dE = "shard1", pE = {
+var pE, fE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], yE = "shard1", vE = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, fE = {
+}, gE = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, yE = {
+}, hE = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function vE() {
+function RE() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function gE() {
+function EE() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: mE,
+targetShards: fE,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44445,12 +44485,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = mE),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = fE),
 Memory.interShardOperation;
 }
 
-function hE() {
-return of({
+function TE() {
+return sf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -44463,32 +44503,32 @@ checksum: 0
 });
 }
 
-function RE(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), nf(e, {
+function CE(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), cf(e, {
 updatedSections: t
 });
 }
 
-function EE() {
-var e, t, r, o, n, i, s, c = hE(), u = vE();
+function SE() {
+var e, t, r, o, n, i, s, c = TE(), u = RE();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: mE,
+targetShards: fE,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : mE,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : fE,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && TE() ? "established" : "unreached",
+status: p === u && wE() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44506,7 +44546,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === dE ? "core" : "frontier",
+role: u === yE ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44523,24 +44563,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), RE(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), CE(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function TE() {
+function wE() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function CE() {
+function xE() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function SE(e, t) {
+function bE(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44559,9 +44599,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(CE()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(xE()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += vv.getPendingRequests(p.name).filter(function(r) {
+s += Rv.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44580,7 +44620,7 @@ if (n) throw n.error;
 return s;
 }
 
-function wE(e) {
+function OE(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44624,7 +44664,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = hE().shards[vE()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = TE().shards[RE()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44634,8 +44674,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function xE(e, t) {
-if (!(SE("scout", t) >= 1)) {
+function kE(e, t) {
+if (!(bE("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44673,13 +44713,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && vv.addRequest({
+r && Rv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: yE,
-priority: tv.LOW + 5,
+body: hE,
+priority: nv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44690,14 +44730,14 @@ task: "interShardPortalScout"
 }
 }
 
-function bE(e, t, r) {
-SE("interShardClaimer", t) >= 1 || vv.addRequest({
+function AE(e, t, r) {
+bE("interShardClaimer", t) >= 1 || Rv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: pE,
-priority: tv.NORMAL + 50,
+body: vE,
+priority: nv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44710,14 +44750,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function OE(e, t, r) {
-SE("interShardScout", t) >= 1 || vv.addRequest({
+function ME(e, t, r) {
+bE("interShardScout", t) >= 1 || Rv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: yE,
-priority: tv.NORMAL,
+body: hE,
+priority: nv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44730,15 +44770,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function kE(e, t, r) {
+function UE(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (SE("interShardPioneer", t.shard) >= 3 || vv.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (bE("interShardPioneer", t.shard) >= 3 || Rv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: fE,
-priority: tv.NORMAL + 25,
+body: gE,
+priority: nv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44751,19 +44791,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function AE(e) {
+function _E(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = vE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = RE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : mE), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : fE), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Zp(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? ef(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44795,9 +44835,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(CE()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(xE()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += vv.getPendingRequests(l.name).filter(function(e) {
+n += Rv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44816,22 +44856,22 @@ return n;
 }() < o;
 }
 
-(lE = {
-optimizeBody: dv,
+(pE = {
+optimizeBody: yv,
 spawnQueue: {
 addRequest: function(e) {
-return vv.addRequest(e);
+return Rv.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: tv.LOW,
-NORMAL: tv.NORMAL,
-HIGH: tv.HIGH
+LOW: nv.LOW,
+NORMAL: nv.NORMAL,
+HIGH: nv.HIGH
 }
-}).optimizeBody && (ff.optimizeBody = lE.optimizeBody), lE.spawnQueue && (ff.spawnQueue = lE.spawnQueue),
-lE.spawnPriorities && (ff.spawnPriorities = o(o({}, ff.spawnPriorities), lE.spawnPriorities));
+}).optimizeBody && (gf.optimizeBody = pE.optimizeBody), pE.spawnQueue && (gf.spawnQueue = pE.spawnQueue),
+pE.spawnPriorities && (gf.spawnPriorities = o(o({}, gf.spawnPriorities), pE.spawnPriorities));
 
-var ME, UE = function() {
+var NE, PE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44875,7 +44915,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function _E(e) {
+function IE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44896,7 +44936,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function NE(e, t, r) {
+function GE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -44962,16 +45002,16 @@ return u;
 });
 }
 
-function PE(e) {
+function LE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(ME || (ME = {}));
+}(NE || (NE = {}));
 
-var IE = function() {
+var DE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -45009,8 +45049,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = NE(h.pos, T.pos, this.logger);
-if (PE(C)) {
+var T = E.value, C = GE(h.pos, T.pos, this.logger);
+if (LE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -45037,8 +45077,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, A = NE(k, u.pos, this.logger);
-PE(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, A = GE(k, u.pos, this.logger);
+LE(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -45077,8 +45117,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = NE(e, t, this.logger);
-if (PE(n)) {
+var n = GE(e, t, this.logger);
+if (LE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -45088,7 +45128,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), GE = function() {
+}(), FE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -45098,7 +45138,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = _E(s);
+var c = IE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -45124,7 +45164,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), LE = function() {
+}(), BE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -45173,7 +45213,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), DE = {
+}(), WE = {
 debug: function(e, t) {
 return A("RemoteMining").debug(e, t);
 },
@@ -45186,7 +45226,7 @@ return A("RemoteMining").warn(e, t);
 error: function(e, t) {
 return A("RemoteMining").error(e, t);
 }
-}, FE = {
+}, KE = {
 getCachedPath: function(e, t) {
 var r = kt(e, t), o = Le.get(r, {
 namespace: Ot
@@ -45213,26 +45253,26 @@ direction: a
 }
 return t;
 }
-}, BE = {
+}, HE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = Mm.MEDIUM), Wm.register({
+void 0 === o && (o = _m.MEDIUM), Hm.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== Mm.CRITICAL
+skippable: o !== _m.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, WE = new IE(FE, DE), KE = new GE(DE, BE, WE), HE = new LE(DE, FE, WE, Ju.moveTo);
+}, YE = new DE(KE, WE), VE = new FE(WE, HE, YE), qE = new BE(WE, KE, YE, Ju.moveTo);
 
-function YE(e, t, r, o) {
-return HE.moveToWithRemoteCache(e, t, r, o);
+function jE(e, t, r, o) {
+return qE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var VE, qE = function() {
+var zE, QE = function() {
 function e() {
 this.logger = A("Pathfinding");
 }
@@ -45245,12 +45285,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), jE = function() {
+}(), XE = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 tt.on(e, t);
 }, e;
-}(), zE = function() {
+}(), ZE = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -45295,28 +45335,28 @@ m.length > 0 && At(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), QE = function() {
+}(), JE = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return _E(e);
+return IE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-WE.precacheRemoteRoutes(e, t);
+YE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), XE = new UE(new qE, new jE, new zE, new QE), ZE = {
+}(), $E = new PE(new QE, new XE, new ZE, new JE), eT = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, JE = function() {
+}, tT = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, ZE), e);
+this.config = o(o({}, eT), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45410,123 +45450,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new JE, (VE = {})[FIND_STRUCTURES] = {
+new tT, (zE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VE[FIND_MY_STRUCTURES] = {
+}, zE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VE[FIND_HOSTILE_STRUCTURES] = {
+}, zE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VE[FIND_SOURCES_ACTIVE] = {
+}, zE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, VE[FIND_SOURCES] = {
+}, zE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, VE[FIND_MINERALS] = {
+}, zE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, VE[FIND_DEPOSITS] = {
+}, zE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, VE[FIND_MY_CONSTRUCTION_SITES] = {
+}, zE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VE[FIND_CONSTRUCTION_SITES] = {
+}, zE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VE[FIND_CREEPS] = {
+}, zE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, VE[FIND_MY_CREEPS] = {
+}, zE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, VE[FIND_HOSTILE_CREEPS] = {
+}, zE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, VE[FIND_DROPPED_RESOURCES] = {
+}, zE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, VE[FIND_TOMBSTONES] = {
+}, zE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, VE[FIND_RUINS] = {
+}, zE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, VE[FIND_FLAGS] = {
+}, zE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VE[FIND_MY_SPAWNS] = {
+}, zE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, VE[FIND_HOSTILE_SPAWNS] = {
+}, zE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, zE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VE[FIND_NUKES] = {
+}, zE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VE[FIND_POWER_CREEPS] = {
+}, zE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, VE[FIND_MY_POWER_CREEPS] = {
+}, zE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, VE[FIND_HOSTILE_POWER_CREEPS] = {
+}, zE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, VE[FIND_EXIT_TOP] = {
+}, zE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VE[FIND_EXIT_RIGHT] = {
+}, zE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VE[FIND_EXIT_BOTTOM] = {
+}, zE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VE[FIND_EXIT_LEFT] = {
+}, zE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VE[FIND_EXIT] = {
+}, zE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var $E = new ue({}, Xr), eT = new Re({}, Xr);
+var rT = new ue({}, Xr), oT = new Re({}, Xr);
 
-function tT(e) {
+function nT(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45534,11 +45574,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var rT = !1;
+var aT = !1;
 
-function oT() {
+function iT() {
 var e, t;
-rT || (xu({
+aT || (xu({
 level: (t = Me()).debug ? ou.DEBUG : ou.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45553,11 +45593,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (gv.getPendingTransfers = function(e) {
+r.getPendingTransfers && (Ev.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (gv.needsCarrier = function(e) {
+}), r.needsCarrier && (Ev.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (gv.getActiveRequests = function() {
+}), r.getActiveRequests && (Ev.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45571,47 +45611,47 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (hv.predictConsumption = function(e) {
+a.predictConsumption && (Tv.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (hv.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Tv.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (hv.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Tv.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (hv.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Tv.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Rv.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Cv.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Rv.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Cv.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Rv.needsCarriers = function(e) {
+}), i.needsCarriers && (Cv.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Rv.requestSpawns = function(e) {
+}), i.requestSpawns && (Cv.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-Ev.getEmergencyState = function(e) {
+Sv.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: mr,
 powerBankHarvestingManager: Dc,
-resourceTransferCoordinator: vf,
+resourceTransferCoordinator: Rf,
 emergencyResponseManager: ai,
 kernel: gi
 }), function(e) {
 var t, r, o, n;
-Md = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : Ad.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : Ad.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : Ad.getLabOverflow
-} : Ad;
+Nd = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : _d.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : _d.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : _d.getLabOverflow
+} : _d;
 }({
 getLabResourceNeeds: function(e) {
 return mu.getLabResourceNeeds(e);
@@ -45625,7 +45665,7 @@ return mu.getLabOverflow(e);
 }), Fi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) cE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) mE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45639,7 +45679,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-cE.warn("Failed to wrap PathFinder.search", {
+mE.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45647,11 +45687,11 @@ error: String(e)
 }
 }
 }
-}(), uE(e = Creep.prototype, "moveTo", "moveTo"), uE(e, "move", "move"), uE(e, "harvest", "harvest"),
-uE(e, "transfer", "transfer"), uE(e, "withdraw", "withdraw"), uE(e, "build", "build"),
-uE(e, "repair", "repair"), uE(e, "upgradeController", "upgradeController"), uE(e, "attack", "attack"),
-uE(e, "rangedAttack", "rangedAttack"), uE(e, "heal", "heal"), uE(e, "dismantle", "dismantle"),
-uE(e, "say", "say")), function(e) {
+}(), dE(e = Creep.prototype, "moveTo", "moveTo"), dE(e, "move", "move"), dE(e, "harvest", "harvest"),
+dE(e, "transfer", "transfer"), dE(e, "withdraw", "withdraw"), dE(e, "build", "build"),
+dE(e, "repair", "repair"), dE(e, "upgradeController", "upgradeController"), dE(e, "attack", "attack"),
+dE(e, "rangedAttack", "rangedAttack"), dE(e, "heal", "heal"), dE(e, "dismantle", "dismantle"),
+dE(e, "say", "say")), function(e) {
 void 0 === e && (e = ze);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, Fe.L1, {
@@ -45838,15 +45878,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(gi, Xr, ty), XE.initializePathCacheEvents(), KE.initialize(Mm.MEDIUM), Ll = YE,
-wr.initialize(), tE.initialize(), rT = !0), Xr.initialize();
-var r = nE.configureForCurrentTick();
+}(gi, Xr, ny), $E.initializePathCacheEvents(), VE.initialize(_m.MEDIUM), Fl = jE,
+wr.initialize(), nE.initialize(), aT = !0), Xr.initialize();
+var r = sE.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Wu.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = gE();
-if (!1 !== r.enabled && (r.lastRun = Game.time, EE(), function() {
-var e, t, r, o, n = hE(), a = n.footprintOperation, i = vE(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = EE();
+if (!1 !== r.enabled && (r.lastRun = Game.time, SE(), function() {
+var e, t, r, o, n = TE(), a = n.footprintOperation, i = RE(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45859,15 +45899,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, RE(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, CE(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = gE();
+var e, t, r, n, i, s, c = EE();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : mE), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === dE ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : fE), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === yE ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45885,10 +45925,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !TE())) try {
+}(), !wE())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || Uf(s), "interShardPioneer" === c && Mf(s);
+"interShardClaimer" !== c && "interShardScout" !== c || Pf(s), "interShardPioneer" === c && Nf(s);
 }
 } catch (t) {
 e = {
@@ -45912,17 +45952,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Wu.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: rT
+systemsInitialized: aT
 }
-}), nE.ensureProcessesRegistered(), Fi.startTick(), Vu.clear(), nE.startEventTick();
+}), sE.ensureProcessesRegistered(), Fi.startTick(), Vu.clear(), sE.startEventTick();
 var i = function(e) {
-var t = e.cache[aE], r = e.cache[iE];
+var t = e.cache[cE], r = e.cache[uE];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[aE] = o, e.cache[iE] = e.tick, o;
+return e.cache[cE] = o, e.cache[uE] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -45944,7 +45984,7 @@ rooms: i,
 interval: o
 })), s = n.next(); !s.done; s = n.next()) {
 var c = s.value;
-Pl.refreshRoom(c);
+Gl.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -45959,18 +45999,18 @@ if (e) throw e.error;
 }
 }), Fi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = gE();
+var e, t, r, o = EE();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = EE();
+var n = SE();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : mE), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : fE), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== vE()) try {
+if (d !== RE()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Zp(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = ef(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -45988,20 +46028,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = CE().sort(function(e, t) {
+var i = xE().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : mE), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : fE), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== vE()) {
+if (u !== RE()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = wE(u);
+var m = OE(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? kE(i, l, m) : AE() ? bE(i, u, m) : (OE(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (xE(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? UE(i, l, m) : _E() ? AE(i, u, m) : (ME(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (kE(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -46018,8 +46058,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = hE();
-d.footprintOperation = n, RE(d);
+var d = TE();
+d.footprintOperation = n, CE(d);
 }
 }
 })(), function() {
@@ -46027,8 +46067,8 @@ var e, t, r, o = Game.cpu.bucket < Me().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || tT(s))) {
-var c = Kg(s, Xr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || nT(s))) {
+var c = Vg(s, Xr.getOrInitSwarmState(s.name));
 Fi.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -46045,20 +46085,20 @@ if (e) throw e.error;
 }
 }();
 }), Ju.preTick(), Fi.measureSubsystem("processSync", function() {
-Kf.syncCreepProcesses(), Hy.syncRoomProcesses();
+Vf.syncCreepProcesses(), qy.syncRoomProcesses();
 }), Fi.measureSubsystem("kernel", function() {
-nE.runProcesses();
+sE.runProcesses();
 }), Fi.measureSubsystem("eventQueue", function() {
-nE.processQueuedEvents();
+sE.processQueuedEvents();
 }), Fi.measureSubsystem("ss2PacketQueue", function() {
-qg.processQueue();
+Qg.processQueue();
 }), gi.hasCpuBudget() && Fi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && _f(n);
+void 0 !== n.ticksToLive && If(n);
 }
 } catch (t) {
 e = {
@@ -46072,7 +46112,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), sE({
+}), lE({
 hasCpuBudget: gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Fi.measureSubsystem("visualizations", function() {
@@ -46082,8 +46122,8 @@ var r, o;
 if (Me().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = $E.getConfig(), s = eT.getConfig();
-$E.setConfig(n.roomVisualizerConfig), n.renderMap && eT.setConfig(n.mapVisualizerConfig);
+var i = rT.getConfig(), s = oT.getConfig();
+rT.setConfig(n.roomVisualizerConfig), n.renderMap && oT.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -46094,7 +46134,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-$E.draw(m);
+rT.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Wu.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -46116,14 +46156,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-eT.draw();
+oT.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Wu.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-$E.setConfig(i), eT.setConfig(s);
+rT.setConfig(i), oT.setConfig(s);
 }
 }
 }
@@ -46208,19 +46248,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Ju.reconcileTraffic(), sE({
+}), Ju.reconcileTraffic(), lE({
 hasCpuBudget: gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Fi.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Wm.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Hm.run(e);
 }), Xr.persistHeapCache(), Fi.collectProcessStats(gi.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), Fi.collectKernelBudgetStats(gi), Fi.setSkippedProcesses(gi.getSkippedProcessesThisTick()),
 Fi.finalizeTick(), Wu.flush();
 }
 
-var nT = function() {
+var sT = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Me().visualizations;
@@ -46228,25 +46268,25 @@ return Ue({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = $E.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = rT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-$E.toggle(o);
-var n = $E.getConfig()[o];
+rT.toggle(o);
+var n = rT.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = eT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = oT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-eT.toggle(o);
-var n = eT.getConfig()[o];
+oT.toggle(o);
+var n = oT.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = eT.getConfig();
+var e = oT.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -46369,15 +46409,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), aT = function() {
+}(), cT = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = tE.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = nE.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = tE.getAllShards();
+var e, t, r = nE.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -46399,9 +46439,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (tE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (nE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = tE.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = nE.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -46426,19 +46466,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = tE.getOptimalPortalRoute(e, t);
+var r, o = nE.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (tE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (nE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (tE.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (nE.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = vf.getActiveRequests();
+var e, t, r = Rf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -46459,7 +46499,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = tE.getCurrentShardState();
+var e, t, r = nE.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -46480,7 +46520,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = tE.getActiveTransferTasks();
+var e, t, r, o = nE.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -46501,16 +46541,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = tE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(ef, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = nE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(of, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = tE.getMemoryStats();
+var e = nE.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return tE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return nE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = hE().footprintOperation;
+var e, t, r, o = TE().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46616,9 +46656,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), iT = new aT;
+}(), uT = new cT;
 
-function sT(e) {
+function lT(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46648,10 +46688,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? sT(e.metadata.usage) : void 0
+params: e.metadata.usage ? lT(e.metadata.usage) : void 0
 };
 });
-return Xm({
+return Jm({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46702,12 +46742,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Xm.apply(void 0, s([], i(o), !1));
+return Jm.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return jm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Qm("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Qm.form("spawnCreep", [ {
+return Zm.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46741,20 +46781,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return jm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Qm("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += jm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += jm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Qm.button({
+o += '<div style="margin-bottom: 10px;">', o += Qm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Qm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Zm.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Qm.button({
+}), o += " ", (o += Zm.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Qm.form("configureLogging", [ {
+return Zm.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46779,7 +46819,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Qm.form("configureVisualization", [ {
+return Zm.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46803,21 +46843,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Qm.button({
+e += Zm.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += Qm.button({
+}), e += " ", e += Zm.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Qm.button({
+}), e += " ", (e += Zm.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += jm("✓ Success message", "green", !0) + "\n", e += jm("⚠ Warning message", "yellow", !0) + "\n",
-e += jm("✗ Error message", "red", !0) + "\n", e += jm("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + jm("colored text", "green") + " normal text\n") + "Bold text: " + jm("important", null, !0) + "\n";
+return e += Qm("✓ Success message", "green", !0) + "\n", e += Qm("⚠ Warning message", "yellow", !0) + "\n",
+e += Qm("✗ Error message", "red", !0) + "\n", e += Qm("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Qm("colored text", "green") + " normal text\n") + "Bold text: " + Qm("important", null, !0) + "\n";
 }, n([ ir({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46863,39 +46903,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var cT = new Vy, uT = new nT, lT = new qy, mT = new Ku, dT = new Yy, pT = new jy, fT = new zy, yT = "__screepsGlobalRuntimeDiagnostics";
+var mT = new zy, dT = new sT, pT = new Qy, fT = new Ku, yT = new jy, vT = new Xy, gT = new Zy, hT = "__screepsGlobalRuntimeDiagnostics";
 
-function vT() {
+function RT() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function gT(e, t) {
+function ET(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function hT(e, t) {
+function TT(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function RT(e) {
+function CT(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function ET(e) {
+function ST(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: gT(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: gT(n.switchCount, 0),
-lastTick: hT(n.lastTick, Game.time),
-lastResetTick: hT(n.lastResetTick, Game.time),
-lastSwitchTick: RT(n.lastSwitchTick),
-lastSwitchPreviousTick: RT(n.lastSwitchPreviousTick),
-lastWarningTick: RT(n.lastWarningTick)
+resetCount: ET(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: ET(n.switchCount, 0),
+lastTick: TT(n.lastTick, Game.time),
+lastResetTick: TT(n.lastResetTick, Game.time),
+lastSwitchTick: CT(n.lastSwitchTick),
+lastSwitchPreviousTick: CT(n.lastSwitchPreviousTick),
+lastWarningTick: CT(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46909,13 +46949,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var TT = Fu("Main");
+var wT = Fu("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-ar.initialize(), sr(cT), sr(uT), sr(lT), sr(mT), sr(dT), sr(pT), sr(fT), sr(yu),
-sr(vu), sr(gu), sr(iT), sr(pr), sr(sc), sr(Ic), global.tooangel = Nc;
+ar.initialize(), sr(mT), sr(dT), sr(pT), sr(fT), sr(yT), sr(vT), sr(gT), sr(yu),
+sr(vu), sr(gu), sr(uT), sr(pr), sr(sc), sr(Ic), global.tooangel = Nc;
 var e = global;
 e.botConfig = {
 getConfig: Me,
@@ -46930,12 +46970,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : vT, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[yT];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : RT, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[hT];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[yT] = s, function(e, t) {
-var r, o = ET(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[hT] = s, function(e, t) {
+var r, o = ST(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -46953,7 +46993,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = ET(e.heapId);
+var n, a = ST(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -46974,14 +47014,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = ET(s.heapId);
+var u = ST(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: TT
-}), oT();
+logger: wT
+}), iT();
 } catch (e) {
-throw TT.error("Critical error in main loop: ".concat(String(e)), {
+throw wT.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time


### PR DESCRIPTION
## Summary
- Reserve task-board delivery work for local haulers when they choose an energy collection action.
- Refresh the delivery reservation while the state machine continues energy pickup/withdraw states.
- Avoid false energy reservations for mineral collection paths.

## Linked issue
Refs #3119

## Changes
- Added `reserveDeliveryWork` and collection-state reservation refresh support in `@ralphschuler/screeps-roles`.
- Routed hauler energy pickup/withdraw collection through reservation-aware helper logic.
- Added regression tests for empty-hauler refill reservation, mineral collection guard, and collection-state TTL refresh.
- Rebuilt `packages/screeps-bot/dist/main.js`.

## Validation
- PASS: `npm run test -w @ralphschuler/screeps-roles -- --grep "reserves refill work|does not reserve energy delivery|refreshes reserved refill"`
- PASS: `npm run test -w @ralphschuler/screeps-roles`
- PASS: `npm run lint -w @ralphschuler/screeps-roles`
- PASS: `npm run build -w @ralphschuler/screeps-roles`
- PASS: `npm run build:bot`
- PASS: `npm run test:server:smoke` (`packages/screeps-server/artifacts/smoke/summary.md` status passed)
- PASS: `npm run sync:deps:check`
- PASS: `npm run check:alliance-safety`

## Deployment impact
Affects screeps.com runtime logistics behavior. Empty local haulers can now make active task-board reservations before collecting energy, so refill/store backlog should show more assigned/reserved work while haulers are en route to energy.

## Scope notes
- This is a focused #3119 slice, not a full close. Sustained live backlog reduction still needs post-deploy verification.
- Queen carriers and remote haulers are not changed in this slice.
