### PR TITLE
[codex] Fix pheromones workspace test setup

### DIFF
--- a/packages/@ralphschuler/screeps-pheromones/test/pheromoneIntegration.test.ts
+++ b/packages/@ralphschuler/screeps-pheromones/test/pheromoneIntegration.test.ts
@@ -4,6 +4,7 @@
  * Tests for pheromone-driven behavior integration.
  */
 
+import "./setup";
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import {

--- a/packages/@ralphschuler/screeps-pheromones/test/setup.ts
+++ b/packages/@ralphschuler/screeps-pheromones/test/setup.ts
@@ -76,6 +76,11 @@ import { Game, Memory } from "./mock";
 (global as any).RESOURCE_KEANIUM_BAR = "keanium_bar";
 (global as any).RESOURCE_OXIDANT = "oxidant";
 
+// Power constants required when pheromone integration tests import roles behaviors.
+(global as any).PWR_DISRUPT_SPAWN = 9;
+(global as any).PWR_DISRUPT_TOWER = 11;
+(global as any).PWR_DISRUPT_TERMINAL = 15;
+
 // Return codes
 (global as any).OK = 0;
 (global as any).ERR_NOT_OWNER = -1;


### PR DESCRIPTION
## Summary
- Initialize the pheromones integration test setup before importing roles package behavior.
- Add the Screeps power constants required by roles power behavior module-load tests.

## Linked issue
Closes #3056

## Changes
- Test setup: define `PWR_DISRUPT_SPAWN`, `PWR_DISRUPT_TOWER`, and `PWR_DISRUPT_TERMINAL` for pheromones tests.
- Test import order: explicitly load `./setup` in `pheromoneIntegration.test.ts` before roles imports.

## Validation
- PASS: `npm run test:pheromones` (reproduced failure before fix, passes after fix)
- PASS: workspace test-script scan: all workspace test scripts have at least one test/spec file
- PASS: `npm run build:pheromones`
- PASS: `npm run lint:pheromones`
- PASS: `npm run test:all` (`TEST_ALL_EXIT:0`)

## Deployment impact
- Test-only change. No Screeps runtime code or deploy bundle change expected.

## Scope notes
- Existing `npm run test:all` still runs the private-server smoke workspace and mutates local generated artifacts during validation; those generated files were not included in this PR.
