### PR TITLE
[codex] Prioritize recovery build assignments

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
@@ -16,28 +16,9 @@ import type { SquadMemory, SwarmCreepMemory, SwarmState } from "../memory/schema
 import { getActualHostileCreeps } from "@ralphschuler/screeps-defense";
 import type { CreepContext } from "./types";
 import { createLogger } from "@ralphschuler/screeps-core";
+import { compareConstructionSitePriority } from "../economy/constructionPriority";
 
 const logger = createLogger("CreepContext");
-
-/**
- * Priority order for construction sites.
- * Higher values = higher priority.
- *
- * Recovery rooms need built defensive/economy anchors before spending builder
- * throughput on extension backlogs or noncritical perimeter work.
- */
-const CONSTRUCTION_PRIORITY: Record<string, number> = {
-  [STRUCTURE_SPAWN]: 100,
-  [STRUCTURE_TOWER]: 95,
-  [STRUCTURE_STORAGE]: 90,
-  [STRUCTURE_EXTENSION]: 80,
-  [STRUCTURE_TERMINAL]: 75,
-  [STRUCTURE_LINK]: 70,
-  [STRUCTURE_CONTAINER]: 65,
-  [STRUCTURE_RAMPART]: 55,
-  [STRUCTURE_WALL]: 50,
-  [STRUCTURE_ROAD]: 30
-};
 
 /** Threat detection range for hostiles */
 const HOSTILE_THREAT_RANGE = 10;
@@ -246,11 +227,7 @@ function getTowers(cache: RoomCache): StructureTower[] {
  */
 function getPrioritizedSites(cache: RoomCache): ConstructionSite[] {
   if (cache._prioritizedSites === undefined) {
-    cache._prioritizedSites = cache.room.find(FIND_MY_CONSTRUCTION_SITES).sort((a, b) => {
-      const priorityA = CONSTRUCTION_PRIORITY[a.structureType] ?? 50;
-      const priorityB = CONSTRUCTION_PRIORITY[b.structureType] ?? 50;
-      return priorityB - priorityA;
-    });
+    cache._prioritizedSites = cache.room.find(FIND_MY_CONSTRUCTION_SITES).sort(compareConstructionSitePriority);
   }
   return cache._prioritizedSites;
 }

--- a/packages/@ralphschuler/screeps-roles/src/economy/constructionPriority.ts
+++ b/packages/@ralphschuler/screeps-roles/src/economy/constructionPriority.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared construction-site priority policy for economy roles.
+ *
+ * Higher values are built first. Recovery rooms need defensive/economy anchors
+ * before spending builder throughput on extension backlogs or perimeter polish.
+ */
+const DEFAULT_CONSTRUCTION_PRIORITY = 50;
+
+export const CONSTRUCTION_PRIORITY: Partial<Record<BuildableStructureConstant, number>> = {
+  [STRUCTURE_SPAWN]: 100,
+  [STRUCTURE_TOWER]: 95,
+  [STRUCTURE_STORAGE]: 90,
+  [STRUCTURE_EXTENSION]: 80,
+  [STRUCTURE_TERMINAL]: 75,
+  [STRUCTURE_LINK]: 70,
+  [STRUCTURE_CONTAINER]: 65,
+  [STRUCTURE_RAMPART]: 55,
+  [STRUCTURE_WALL]: 50,
+  [STRUCTURE_ROAD]: 30
+};
+
+export function getConstructionPriority(site: Pick<ConstructionSite, "structureType">): number {
+  return CONSTRUCTION_PRIORITY[site.structureType] ?? DEFAULT_CONSTRUCTION_PRIORITY;
+}
+
+export function compareConstructionSitePriority(a: ConstructionSite, b: ConstructionSite): number {
+  return getConstructionPriority(b) - getConstructionPriority(a);
+}

--- a/packages/@ralphschuler/screeps-roles/src/economy/targetAssignmentManager.ts
+++ b/packages/@ralphschuler/screeps-roles/src/economy/targetAssignmentManager.ts
@@ -8,11 +8,43 @@
  */
 
 import type { BaseCreepMemory } from "../framework/types";
+import { getConstructionPriority } from "./constructionPriority";
 
 type MutableCreepMemory<T extends BaseCreepMemory> = CreepMemory &
   BaseCreepMemory &
   { room?: string } &
   Partial<T>;
+
+interface BuildSiteCache {
+  tick: number;
+  sites: ConstructionSite[];
+  highestPriority: number;
+}
+
+const buildSiteCacheByRoom = new Map<string, BuildSiteCache>();
+
+function getBuildSiteCache(room: Room): BuildSiteCache {
+  const existing = buildSiteCacheByRoom.get(room.name);
+  if (existing && existing.tick === Game.time) return existing;
+
+  const sites = room.find(FIND_MY_CONSTRUCTION_SITES);
+  const highestPriority = sites.reduce(
+    (highest, site) => Math.max(highest, getConstructionPriority(site)),
+    Number.NEGATIVE_INFINITY
+  );
+  const cache = { tick: Game.time, sites, highestPriority };
+  buildSiteCacheByRoom.set(room.name, cache);
+  return cache;
+}
+
+function isLocalBuildSite(site: ConstructionSite, room: Room): boolean {
+  return site.pos.roomName === room.name;
+}
+
+function selectClosestHighestPrioritySite(creep: Creep, cache: BuildSiteCache): ConstructionSite | null {
+  const candidates = cache.sites.filter((site) => getConstructionPriority(site) === cache.highestPriority);
+  return creep.pos.findClosestByRange(candidates) ?? candidates[0] ?? null;
+}
 
 /**
  * Get assigned source for a harvester.
@@ -46,26 +78,35 @@ export function getAssignedSource(creep: Creep): Source | null {
 }
 
 /**
- * Get assigned build target for a builder
- * Falls back to finding closest construction site
+ * Get assigned build target for a builder.
+ *
+ * Existing lower-priority assignments are replaced when recovery-critical
+ * construction sites appear, so builders do not spend throughput on extension,
+ * wall, or road backlogs while tower/storage/spawn sites remain unbuilt.
  */
 export function getAssignedBuildTarget(creep: Creep): ConstructionSite | null {
   if (!creep.room) return null;
   
   const memory = getMutableCreepMemory<BaseCreepMemory & { targetId?: Id<ConstructionSite> }>(creep);
+  const siteCache = getBuildSiteCache(creep.room);
+  if (siteCache.sites.length === 0) {
+    delete memory.targetId;
+    return null;
+  }
+
   if (memory.targetId) {
     const site = Game.getObjectById(memory.targetId);
-    if (site) return site;
+    if (site && isLocalBuildSite(site, creep.room) && getConstructionPriority(site) >= siteCache.highestPriority) {
+      return site;
+    }
+    delete memory.targetId;
   }
   
-  const sites = creep.room.find(FIND_MY_CONSTRUCTION_SITES);
-  if (sites.length === 0) return null;
-  
-  const closest = creep.pos.findClosestByRange(sites);
-  if (closest) {
-    memory.targetId = closest.id;
+  const assignedSite = selectClosestHighestPrioritySite(creep, siteCache);
+  if (assignedSite) {
+    memory.targetId = assignedSite.id;
   }
-  return closest;
+  return assignedSite;
 }
 
 /**

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -131,7 +131,11 @@ describe("Behavior Contracts", () => {
     }) as Room["find"];
     const creep = createMockCreep("builder1", {
       room,
-      memory: { role: "builder", homeRoom: room.name, working: true }
+      memory: { role: "builder", homeRoom: room.name, working: true },
+      store: makeEnergyStore(50, 50),
+      pos: {
+        findClosestByRange: (candidateSites: ConstructionSite[]) => candidateSites[0] ?? null
+      }
     });
 
     Game.rooms[room.name] = room;
@@ -147,6 +151,11 @@ describe("Behavior Contracts", () => {
       STRUCTURE_WALL,
       STRUCTURE_ROAD
     ]);
+
+    const action = buildBehavior(ctx);
+
+    expect(action.type).to.equal("build");
+    expect(action.target).to.equal(ctx.prioritizedSites[0]);
   });
 
   it("keeps builder and upgrader critical energy delivery priority aligned", () => {

--- a/packages/@ralphschuler/screeps-roles/test/targetAssignmentManager.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/targetAssignmentManager.test.ts
@@ -10,6 +10,14 @@ describe("targetAssignmentManager memory initialization", () => {
     MockGame.getObjectById = () => null;
   });
 
+  function site(id: string, structureType: BuildableStructureConstant, x: number, y: number, roomName = "W1N1"): ConstructionSite {
+    return {
+      id: id as Id<ConstructionSite>,
+      structureType,
+      pos: new RoomPosition(x, y, roomName)
+    } as ConstructionSite;
+  }
+
   it("initializes missing core memory fields for assignment lookups", () => {
     const creep = createMockCreep("worker1", {
       memory: {}
@@ -64,5 +72,50 @@ describe("targetAssignmentManager memory initialization", () => {
 
     expect(result).to.equal(source);
     expect(creep.memory.sourceId).to.equal("SRC1");
+  });
+
+  it("assigns the highest-priority recovery construction type instead of the closest site", () => {
+    const extension = site("EXT_SITE", STRUCTURE_EXTENSION, 10, 10);
+    const tower = site("TOWER_SITE", STRUCTURE_TOWER, 40, 40);
+    const wall = site("WALL_SITE", STRUCTURE_WALL, 5, 5);
+    const homeRoom = createMockRoom("W1N1");
+    (homeRoom as unknown as { find: Room["find"] }).find = (type: FindConstant) =>
+      type === FIND_MY_CONSTRUCTION_SITES ? [wall, extension, tower] : [];
+
+    const creep = createMockCreep("builder-priority", {
+      room: homeRoom,
+      memory: { role: "builder", homeRoom: "W1N1" },
+      pos: {
+        findClosestByRange: (sites: ConstructionSite[]) => sites[0] ?? null
+      }
+    });
+
+    const result = getAssignedBuildTarget(creep);
+
+    expect(result).to.equal(tower);
+    expect(creep.memory.targetId).to.equal("TOWER_SITE");
+  });
+
+  it("replaces a stale lower-priority assignment when recovery-critical sites are available", () => {
+    const extension = site("EXT_SITE", STRUCTURE_EXTENSION, 10, 10);
+    const storage = site("STORAGE_SITE", STRUCTURE_STORAGE, 11, 11);
+    const tower = site("TOWER_SITE", STRUCTURE_TOWER, 12, 12);
+    const homeRoom = createMockRoom("W1N1");
+    (homeRoom as unknown as { find: Room["find"] }).find = (type: FindConstant) =>
+      type === FIND_MY_CONSTRUCTION_SITES ? [extension, storage, tower] : [];
+    MockGame.getObjectById = (id) => (id === "EXT_SITE" ? extension : null);
+
+    const creep = createMockCreep("builder-reassign", {
+      room: homeRoom,
+      memory: { role: "builder", homeRoom: "W1N1", targetId: "EXT_SITE" },
+      pos: {
+        findClosestByRange: (sites: ConstructionSite[]) => sites[0] ?? null
+      }
+    });
+
+    const result = getAssignedBuildTarget(creep);
+
+    expect(result).to.equal(tower);
+    expect(creep.memory.targetId).to.equal("TOWER_SITE");
   });
 });

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -6663,7 +6663,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -22405,31 +22405,40 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Ku = A("CreepContext"), Yu = ((Bu = {})[STRUCTURE_SPAWN] = 100, Bu[STRUCTURE_TOWER] = 95,
-Bu[STRUCTURE_STORAGE] = 90, Bu[STRUCTURE_EXTENSION] = 80, Bu[STRUCTURE_TERMINAL] = 75,
-Bu[STRUCTURE_LINK] = 70, Bu[STRUCTURE_CONTAINER] = 65, Bu[STRUCTURE_RAMPART] = 55,
-Bu[STRUCTURE_WALL] = 50, Bu[STRUCTURE_ROAD] = 30, Bu), Vu = new Map;
+}(), Ku = ((Bu = {})[STRUCTURE_SPAWN] = 100, Bu[STRUCTURE_TOWER] = 95, Bu[STRUCTURE_STORAGE] = 90,
+Bu[STRUCTURE_EXTENSION] = 80, Bu[STRUCTURE_TERMINAL] = 75, Bu[STRUCTURE_LINK] = 70,
+Bu[STRUCTURE_CONTAINER] = 65, Bu[STRUCTURE_RAMPART] = 55, Bu[STRUCTURE_WALL] = 50,
+Bu[STRUCTURE_ROAD] = 30, Bu);
 
-function qu(e) {
+function Yu(e) {
+var t;
+return null !== (t = Ku[e.structureType]) && void 0 !== t ? t : 50;
+}
+
+function Vu(e, t) {
+return Yu(t) - Yu(e);
+}
+
+var qu = A("CreepContext"), ju = new Map;
+
+function zu(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function ju(e) {
-return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-var r, o, n = null !== (r = Yu[e.structureType]) && void 0 !== r ? r : 50;
-return (null !== (o = Yu[t.structureType]) && void 0 !== o ? o : 50) - n;
-})), e._prioritizedSites;
+function Qu(e) {
+return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(Vu)),
+e._prioritizedSites;
 }
 
-function zu(e) {
-return void 0 === e._repairTargets && (qu(e), e._repairTargets = e.allStructures.filter(function(e) {
+function Xu(e) {
+return void 0 === e._repairTargets && (zu(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function Qu(e) {
+function Zu(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = Vu.get(e.name);
+var t = ju.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22438,9 +22447,9 @@ hostiles: q(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return Vu.set(e.name, r), r;
+return ju.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Ku.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, qu.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -22505,10 +22514,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return ju(i).length;
+return Qu(i).length;
 },
 get damagedStructureCount() {
-return zu(i).length;
+return Xu(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -22519,13 +22528,13 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return void 0 === (e = i)._containers && (qu(e), e._containers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._containers && (zu(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 var e;
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (qu(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (zu(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -22554,10 +22563,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return ju(i);
+return Qu(i);
 },
 get repairTargets() {
-return zu(i);
+return Xu(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -22591,9 +22600,9 @@ var e;
 };
 }
 
-var Xu, Zu = {}, Ju = function() {
-if (Xu) return Zu;
-Xu = 1, Object.defineProperty(Zu, "__esModule", {
+var Ju, $u = {}, el = function() {
+if (Ju) return $u;
+Ju = 1, Object.defineProperty($u, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== Ur ? Ur : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -24270,14 +24279,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, Ms = "_rsi";
-return Zu.CachingStrategies = vi, Zu.CoordListSerializer = fi, Zu.CoordSerializer = pi,
-Zu.Keys = ji, Zu.MoveTargetListSerializer = li, Zu.MoveTargetSerializer = ui, Zu.NumberSerializer = Oa,
-Zu.PositionListSerializer = di, Zu.PositionSerializer = mi, Zu.adjacentWalkablePositions = xi,
-Zu.blockSquare = function(e) {
+return $u.CachingStrategies = vi, $u.CoordListSerializer = fi, $u.CoordSerializer = pi,
+$u.Keys = ji, $u.MoveTargetListSerializer = li, $u.MoveTargetSerializer = ui, $u.NumberSerializer = Oa,
+$u.PositionListSerializer = di, $u.PositionSerializer = mi, $u.adjacentWalkablePositions = xi,
+$u.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, Zu.cachePath = ys, Zu.cachedPathKey = ps, Zu.calculateAdjacencyMatrix = Ti, Zu.calculateAdjacentPositions = Ci,
-Zu.calculateNearbyPositions = Si, Zu.calculatePositionsAtRange = wi, Zu.cleanAllCaches = yi,
-Zu.clearCachedPath = ks, Zu.compressPath = e => {
+}, $u.cachePath = ys, $u.cachedPathKey = ps, $u.calculateAdjacencyMatrix = Ti, $u.calculateAdjacentPositions = Ci,
+$u.calculateNearbyPositions = Si, $u.calculatePositionsAtRange = wi, $u.cleanAllCaches = yi,
+$u.clearCachedPath = ks, $u.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24286,19 +24295,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, Zu.config = Ta, Zu.decompressPath = e => {
+}, $u.config = Ta, $u.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, Zu.fastRoomPosition = Ga, Zu.fixEdgePosition = Ei, Zu.follow = function(e, t) {
+}, $u.fastRoomPosition = Ga, $u.fixEdgePosition = Ei, $u.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, Zu.followPath = hs, Zu.fromGlobalPosition = ti, Zu.generatePath = ts, Zu.getCachedPath = vs,
-Zu.getMoveIntents = ns, Zu.getRangeTo = ri, Zu.globalPosition = ei, Zu.isExit = hi,
-Zu.isPositionWalkable = bi, Zu.move = ds, Zu.moveByPath = function(e, t, r) {
+}, $u.followPath = hs, $u.fromGlobalPosition = ti, $u.generatePath = ts, $u.getCachedPath = vs,
+$u.getMoveIntents = ns, $u.getRangeTo = ri, $u.globalPosition = ei, $u.isExit = hi,
+$u.isPositionWalkable = bi, $u.move = ds, $u.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, Ms));
@@ -24327,9 +24336,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = Ai(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : As(e, d, r)) : ERR_NO_PATH;
-}, Zu.moveTo = As, Zu.normalizeTargets = Ri, Zu.offsetRoomPosition = Da, Zu.packCoord = qa,
-Zu.packCoordList = za, Zu.packPos = Ya, Zu.packPosList = Xa, Zu.packRoomName = ii,
-Zu.packRoomNames = ni, Zu.posAtDirection = oi, Zu.preTick = function() {
+}, $u.moveTo = As, $u.normalizeTargets = Ri, $u.offsetRoomPosition = Da, $u.packCoord = qa,
+$u.packCoordList = za, $u.packPos = Ya, $u.packPosList = Xa, $u.packRoomName = ii,
+$u.packRoomNames = ni, $u.posAtDirection = oi, $u.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) Ui(e), Bi(e);
 !function() {
@@ -24341,34 +24350,34 @@ n.expires && n.expires < Game.time ? (null === (e = Fi.get(n.room1)) || void 0 =
 null === (t = Fi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, Zu.reconcileTraffic = function(e) {
+}, $u.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 _a.with(Oa).set(cs, Game.time);
-}, Zu.reconciledRecently = us, Zu.resetCachedPath = gs, Zu.roomNameFromCoords = $a,
-Zu.roomNameToCoords = Ja, Zu.sameRoomPosition = La, Zu.unpackCoord = ja, Zu.unpackCoordList = Qa,
-Zu.unpackPos = Va, Zu.unpackPosList = Za, Zu.unpackRoomName = si, Zu.unpackRoomNames = ai,
-Zu;
+}, $u.reconciledRecently = us, $u.resetCachedPath = gs, $u.roomNameFromCoords = $a,
+$u.roomNameToCoords = Ja, $u.sameRoomPosition = La, $u.unpackCoord = ja, $u.unpackCoordList = Qa,
+$u.unpackPos = Va, $u.unpackPosList = Za, $u.unpackRoomName = si, $u.unpackRoomNames = ai,
+$u;
 }();
 
-function $u(e) {
+function tl(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var el, tl = 5e5;
+var rl, ol = 5e5;
 
-function rl(e) {
+function nl(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > tl;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > ol;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - tl), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - ol), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24380,21 +24389,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(el || (el = {}));
+}(rl || (rl = {}));
 
-var ol = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], nl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], al = new Set([ "build", "repair", "upgrade" ]), il = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var al = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], il = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], sl = new Set([ "build", "repair", "upgrade" ]), cl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function sl(e, t) {
+function ul(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function cl() {
+function ll() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function ul() {
+function ml() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24409,8 +24418,8 @@ rooms: {}
 };
 }
 
-function ll(e) {
-var t = ul();
+function dl(e) {
+var t = ml();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24429,42 +24438,42 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function ml(e, t, r) {
+function pl(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function dl(e) {
+function fl(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function pl(e) {
-return nl.includes(e);
-}
-
-function fl(e) {
-return al.has(e);
-}
-
 function yl(e) {
-return e.store.getUsedCapacity(RESOURCE_ENERGY);
+return il.includes(e);
 }
 
 function vl(e) {
+return sl.has(e);
+}
+
+function gl(e) {
+return e.store.getUsedCapacity(RESOURCE_ENERGY);
+}
+
+function hl(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function gl(e, t, r) {
-if (void 0 === r && (r = {}), "harvest" === t.type) return vl(e);
-var o = yl(e);
-return r.reserveEmptyEnergyDelivery && pl(t.type) ? vl(e) : Math.max(1, o);
+function Rl(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return hl(e);
+var o = gl(e);
+return r.reserveEmptyEnergyDelivery && yl(t.type) ? hl(e) : Math.max(1, o);
 }
 
-function hl(e, t) {
+function El(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function Rl(e, t, r) {
+function Tl(e, t, r) {
 if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -24472,12 +24481,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return yl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && vl(e.creep) > 0;
+return gl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && hl(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return yl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return gl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -24496,7 +24505,7 @@ return !1;
 }
 }
 
-function El(e, t) {
+function Cl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24513,7 +24522,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Tl(e) {
+function Sl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24521,36 +24530,36 @@ roomName: e.roomName
 };
 }
 
-function Cl(e, t, r, o, n) {
+function wl(e, t, r, o, n) {
 return {
-id: ml(e, t, r.id),
+id: pl(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Tl(r.pos),
+targetPos: Sl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: ol,
+allowedRoles: al,
 expiresTick: Game.time + 50
 };
 }
 
-function Sl(e, t) {
+function xl(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = cl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = ll()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < p)) {
 t.lastGeneratedTick = Game.time;
-var f = sl("taskBoard.findMyStructures", function() {
+var f = ul("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && El(t, Cl(e.name, "refillTower", h, g, el.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && El(t, Cl(e.name, "refillExtension", h, g, el.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && El(t, Cl(e.name, "refillSpawn", h, g, el.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Cl(t, wl(e.name, "refillTower", h, g, rl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Cl(t, wl(e.name, "refillExtension", h, g, rl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Cl(t, wl(e.name, "refillSpawn", h, g, rl.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24563,29 +24572,29 @@ v && !v.done && (o = y.return) && o.call(y);
 if (r) throw r.error;
 }
 }
-var R = rl(e);
-R && El(t, Cl(e.name, "fillTerminalEnergy", R.terminal, R.amount, el.NORMAL));
+var R = nl(e);
+R && Cl(t, wl(e.name, "fillTerminalEnergy", R.terminal, R.amount, rl.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
-var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Os ? el.NORMAL : el.LOW, S = Math.min(E, 1e3);
-El(t, Cl(e.name, "storeEnergy", e.storage, S, C));
+var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Os ? rl.NORMAL : rl.LOW, S = Math.min(E, 1e3);
+Cl(t, wl(e.name, "storeEnergy", e.storage, S, C));
 }
-var w = sl("taskBoard.findHostiles", function() {
+var w = ul("taskBoard.findHostiles", function() {
 return q(e);
 });
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-El(t, {
-id: ml(e.name, "defend", O.id),
+Cl(t, {
+id: pl(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
-priority: el.CRITICAL,
+priority: rl.CRITICAL,
 targetId: O.id,
-targetPos: Tl(O.pos),
+targetPos: Sl(O.pos),
 amount: O.hits,
 maxAssignments: 3,
-allowedRoles: il,
+allowedRoles: cl,
 expiresTick: Game.time + 50
 });
 }
@@ -24600,7 +24609,7 @@ b && !b.done && (i = x.return) && i.call(x);
 if (n) throw n.error;
 }
 }
-var k = sl("taskBoard.findInjuredAllies", function() {
+var k = ul("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -24610,13 +24619,13 @@ return e.hits < e.hitsMax;
 try {
 for (var A = a(k.slice(0, 5)), M = A.next(); !M.done; M = A.next()) {
 var U = M.value;
-El(t, {
-id: ml(e.name, "heal", U.id),
+Cl(t, {
+id: pl(e.name, "heal", U.id),
 roomName: e.name,
 type: "heal",
-priority: el.HIGH,
+priority: rl.HIGH,
 targetId: U.id,
-targetPos: Tl(U.pos),
+targetPos: Sl(U.pos),
 amount: U.hitsMax - U.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -24637,17 +24646,17 @@ if (s) throw s.error;
 }
 }
 
-function wl(e) {
+function bl(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function xl(e) {
+function Ol(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && Y(e));
 }
 
-function bl(e) {
+function kl(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -24659,7 +24668,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? rl(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? nl(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -24672,11 +24681,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !xl(t);
+return !Ol(t);
 }
 }
 
-function Ol(e, t) {
+function Al(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -24698,7 +24707,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function kl(e, t) {
+function Ml(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -24706,7 +24715,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (fl(m.type)) Ol(e, m); else {
+if (vl(m.type)) Al(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -24723,7 +24732,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-wl(m), Game.time > m.expiresTick || !bl(m) ? Ol(e, m) : (dl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !pl(m.type)) && (m.status = "assigned");
+bl(m), Game.time > m.expiresTick || !kl(m) ? Al(e, m) : (fl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !yl(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -24741,7 +24750,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function Al(e, t, r) {
+function Ul(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -24749,15 +24758,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-wl(t);
+bl(t);
 }
 }
 
-function Ml(e, t) {
+function _l(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function Ul(e, t, r) {
+function Nl(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -24771,37 +24780,37 @@ return e.reservations[t];
 }(e, t.creep.name, t.memory.assignedTaskId);
 s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId;
 var c = null;
-if (s && Ml(s, r) && bl(s) && Rl(t, s, r)) {
+if (s && _l(s, r) && kl(s) && Tl(t, s, r)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= el.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= rl.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var u = _l(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : el.CRITICAL);
+var u = Pl(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : rl.CRITICAL);
 if (!u || l < m || !d) return s;
-c = u, Al(0, s, t.creep.name), e.stats.preemptions++;
-} else if (s && (c = _l(e, t, r), Al(0, s, t.creep.name), e.stats.preemptions++,
+c = u, Ul(0, s, t.creep.name), e.stats.preemptions++;
+} else if (s && (c = Pl(e, t, r), Ul(0, s, t.creep.name), e.stats.preemptions++,
 !c)) return null;
-if (null != c || (c = _l(e, t, r)), !c) return null;
-var p = gl(t.creep, c, r);
+if (null != c || (c = Pl(e, t, r)), !c) return null;
+var p = Rl(t.creep, c, r);
 if (p <= 0) return null;
-var f = Math.min(Math.max(1, dl(c)), p);
+var f = Math.min(Math.max(1, fl(c)), p);
 return t.memory.assignedTaskId = c.id, c.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, c.updatedTick = Game.time, wl(c), e.stats.assigned++, c;
+}, c.updatedTick = Game.time, bl(c), e.stats.assigned++, c;
 }
 
-function _l(e, t, r) {
+function Pl(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Ml(l, r) && Rl(t, l, r) && bl(l) && !(dl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || pl(l.type))) {
-var m = Nl(t.creep, l), d = 1e3 * l.priority - m;
+if (_l(l, r) && Tl(t, l, r) && kl(l) && !(fl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || yl(l.type))) {
+var m = Il(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -24819,7 +24828,7 @@ if (o) throw o.error;
 return i;
 }
 
-function Nl(e, t) {
+function Il(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -24827,7 +24836,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function Pl(e, t) {
+function Gl(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -24841,7 +24850,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: hl(e, t.creep.name)
+amount: El(e, t.creep.name)
 };
 
 case "build":
@@ -24870,7 +24879,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (xl(t)) return null;
+if (Ol(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -24889,83 +24898,83 @@ return null;
 }
 }
 
-var Il = function() {
+var Ll = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== ul().enabled;
+return !1 !== ml().enabled;
 }, e.prototype.setEnabled = function(e) {
-ul().enabled = e;
+ml().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !cl()) return null;
-var r = ll(e.room.name);
-sl("taskBoard.cleanup", function() {
-return kl(r);
-}), sl("taskBoard.generate", function() {
-return Sl(e.room, r);
+if (!this.isEnabled() || !ll()) return null;
+var r = dl(e.room.name);
+ul("taskBoard.cleanup", function() {
+return Ml(r);
+}), ul("taskBoard.generate", function() {
+return xl(e.room, r);
 });
-var o = Ul(r, e, {
+var o = Nl(r, e, {
 allowedTypes: t
 });
-return o ? Pl(o, e) : null;
+return o ? Gl(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !cl()) return null;
-var t = ll(e.room.name);
-sl("taskBoard.cleanup", function() {
-return kl(t);
-}), sl("taskBoard.generate", function() {
-return Sl(e.room, t);
+if (!this.isEnabled() || !ll()) return null;
+var t = dl(e.room.name);
+ul("taskBoard.cleanup", function() {
+return Ml(t);
+}), ul("taskBoard.generate", function() {
+return xl(e.room, t);
 });
-var r = Ul(t, e, {
+var r = Nl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: el.NORMAL,
+preemptPriority: rl.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = Pl(r, e);
+var o = Gl(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.reserveDeliveryWork = function(e) {
-if (!this.isEnabled() || !cl()) return !1;
-var t = ll(e.room.name);
-return sl("taskBoard.cleanup", function() {
-return kl(t);
-}), sl("taskBoard.generate", function() {
-return Sl(e.room, t);
-}), Boolean(Ul(t, e, {
+if (!this.isEnabled() || !ll()) return !1;
+var t = dl(e.room.name);
+return ul("taskBoard.cleanup", function() {
+return Ml(t);
+}), ul("taskBoard.generate", function() {
+return xl(e.room, t);
+}), Boolean(Nl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: el.NORMAL,
+preemptPriority: rl.NORMAL,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.reserveCriticalDeliveryWork = function(e) {
-if (!this.isEnabled() || !cl()) return !1;
-var t = ll(e.room.name);
-return sl("taskBoard.cleanup", function() {
-return kl(t);
-}), sl("taskBoard.generate", function() {
-return Sl(e.room, t);
-}), Boolean(Ul(t, e, {
+if (!this.isEnabled() || !ll()) return !1;
+var t = dl(e.room.name);
+return ul("taskBoard.cleanup", function() {
+return Ml(t);
+}), ul("taskBoard.generate", function() {
+return xl(e.room, t);
+}), Boolean(Nl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower" ],
-preemptPriority: el.HIGH,
+preemptPriority: rl.HIGH,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = cl();
+var r, o = ll();
 if (!this.isEnabled() || !o) return !1;
-var n = ll(e);
-sl("taskBoard.cleanup", function() {
-return kl(n);
+var n = dl(e);
+ul("taskBoard.cleanup", function() {
+return Ml(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && sl("taskBoard.generate", function() {
-return Sl(a, n);
+return a && ul("taskBoard.generate", function() {
+return xl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && bl(e);
+return t.includes(e.type) && kl(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && cl()) {
+if (this.isEnabled() && ll()) {
 !function(e) {
-var t, r, o, n, s = ul();
+var t, r, o, n, s = ml();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -24986,20 +24995,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = ll(e.name);
-sl("taskBoard.cleanup", function() {
-return kl(t);
-}), sl("taskBoard.generate", function() {
-return Sl(e, t);
+var t = dl(e.name);
+ul("taskBoard.cleanup", function() {
+return Ml(t);
+}), ul("taskBoard.generate", function() {
+return xl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = ul(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = ml(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) Al(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) Ul(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -25026,37 +25035,37 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = ul(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && pl(c.type) && bl(c))) return delete e.memory.assignedTaskId,
+var a = ml(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && yl(c.type) && kl(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = hl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = El(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-wl(c), u.amount);
+bl(c), u.amount);
 }, e.prototype.refreshAssignedDeliveryReservation = function(e) {
 var t, r = e.memory.assignedTaskId;
 if (!r) return !1;
-var o = ul(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
-if (!(a && i && s && pl(i.type) && bl(i))) return delete e.memory.assignedTaskId,
+var o = ml(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && yl(i.type) && kl(i))) return delete e.memory.assignedTaskId,
 !1;
-var c = gl(e.creep, i, {
+var c = Rl(e.creep, i, {
 reserveEmptyEnergyDelivery: !0
 });
-return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, dl(i) + s.amount), c),
-s.expiresTick = Game.time + 15, i.updatedTick = Game.time, wl(i), !0);
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, fl(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, bl(i), !0);
 }, e.prototype.clear = function(e) {
-var t = ul();
+var t = ml();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = cl();
+var t, r = ll();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = ll(e);
-sl("taskBoard.cleanup", function() {
-return kl(n, !0);
-}), sl("taskBoard.generate", function() {
-return Sl(o, n);
+var n = dl(e);
+ul("taskBoard.cleanup", function() {
+return Ml(n, !0);
+}), ul("taskBoard.generate", function() {
+return xl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25081,10 +25090,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = cl(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = ll(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = ll(e);
-kl(i, !0), Sl(n, i);
+var i = dl(e);
+Ml(i, !0), xl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25106,8 +25115,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = ll(e);
-kl(s, !0);
+var t, r, o, n, i, s = dl(e);
+Ml(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25142,15 +25151,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), Gl = new Il;
+}(), Dl = new Ll;
 
-function Ll(e) {
+function Fl(e) {
 return e === ERR_NO_PATH;
 }
 
-function Dl(e) {
+function Bl(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && Ll(e.moveResult),
+clearState: void 0 !== e.moveResult && Fl(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25161,11 +25170,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var Fl, Bl = A("ActionExecutor");
+var Wl, Hl = A("ActionExecutor");
 
-function Wl(e, t, r) {
+function Kl(e, t, r) {
 var o;
-return !!Y(r) && (Bl.warn("Refusing harmful action against known ally target", {
+return !!Y(r) && (Hl.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25173,37 +25182,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (Ju.clearCachedPath(e.creep), Dt(e.creep)),
-Gl.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (el.clearCachedPath(e.creep), Dt(e.creep)),
+Dl.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function Hl(e, t, r) {
+function Yl(e, t, r) {
 var o, n;
-if (!t || !t.type) return Bl.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return Hl.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && Bl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-"idle" === a.type ? Bl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Bl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && Hl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+"idle" === a.type ? Hl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Hl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25227,7 +25236,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = Yl(e, function() {
+i = ql(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25241,92 +25250,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (Wl(r, a.type, a.target)) {
+if (Kl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (Wl(r, a.type, a.target)) {
+if (Kl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Yl(e, function() {
+ql(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (Wl(r, a.type, a.target)) {
+if (Kl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Yl(e, function() {
+ql(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-Yl(e, function() {
+ql(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), Ll(Ju.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), Fl(el.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (Wl(r, a.type, a.target)) {
+if (Kl(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Yl(e, function() {
+i = ql(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-Ll(Ju.moveTo(e, a.target)) && (i = !0);
+Fl(el.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-Ll(Ju.moveTo(e, {
+Fl(el.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25335,11 +25344,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-Ll(Kl(e, a.target, a.routeType)) && (i = !0);
+Fl(Vl(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), Ll(Kl(e, {
+c = new RoomPosition(25, 25, a.roomName), Fl(Vl(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25354,40 +25363,40 @@ pos: e,
 range: 10
 };
 });
-Ll(Ju.moveTo(e, u, {
+Fl(el.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (Ju.isExit(e.pos)) {
+if (el.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-Ju.moveTo(e, l, {
+el.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || Ll(Ju.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || Fl(el.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-Ll(Ju.moveTo(e, a.target, {
+Fl(el.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (Ju.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), Ju.moveTo(e, l, {
+if (el.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), el.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = $u(m.name);
+var d = tl(m.name);
 if (d && !e.pos.isEqualTo(d)) {
-Ll(Ju.moveTo(e, d, {
+Fl(el.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25396,7 +25405,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && Ju.moveTo(e, {
+p && el.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25404,8 +25413,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, Ju.clearCachedPath(e), Dt(e), Gl.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || Gl.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, el.clearCachedPath(e), Dt(e), Dl.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || Dl.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25413,27 +25422,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function Kl(e, t, r, o) {
-if (!Fl) return Ju.moveTo(e, t, o);
+function Vl(e, t, r, o) {
+if (!Wl) return el.moveTo(e, t, o);
 try {
-return Fl(e, t, r, o);
+return Wl(e, t, r, o);
 } catch (n) {
-return Bl.warn("Remote movement handler failed; falling back to default movement", {
+return Hl.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), Ju.moveTo(e, t, o);
+}), el.moveTo(e, t, o);
 }
 }
 
-function Yl(e, t, r, o, n, a) {
+function ql(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = Ju.moveTo(e, r);
-return s !== OK && Bl.info("Movement attempt returned non-OK result", {
+var s = el.moveTo(e, r);
+return s !== OK && Hl.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25441,12 +25450,12 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), Dl({
+}), Bl({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = Dl({
+var c = Bl({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
@@ -25512,7 +25521,7 @@ Yi(e).upgradeProgress += t;
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (Bl.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (Hl.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25523,13 +25532,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Vl, ql = A("StateMachine");
+var jl, zl = A("StateMachine");
 
-function jl(e) {
+function Ql(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function zl(e, t, r) {
+function Xl(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25551,12 +25560,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== jl(e.amount) ? {
+}, void 0 !== Ql(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), ql.info(r, {
+}(t), zl.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25564,13 +25573,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : ql.info("Behavior returned idle action", {
+})) : zl.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (ql.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (zl.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25581,11 +25590,11 @@ type: "idle"
 });
 }
 
-function Ql(e, t, r) {
+function Zl(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, zl(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, Xl(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -25665,7 +25674,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) ql.info("State completed, evaluating new action", {
+}(a, e)) zl.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25715,7 +25724,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = jl(e.data.amount);
+var c = Ql(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -25790,12 +25799,12 @@ return null;
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(c) && Gl.refreshAssignedDeliveryReservation(e), c;
-var u = e.memory.assignedTaskId, l = Gl.refreshCreepReservation(e, c);
+}(c) && Dl.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = Dl.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-ql.info("Task-board delivery reservation missing, re-evaluating behavior", {
+zl.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25805,7 +25814,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-ql.info("State reconstruction failed, re-evaluating behavior", {
+zl.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25813,7 +25822,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (ql.info("State invalid, re-evaluating behavior", {
+} else a && (zl.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -25822,33 +25831,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return zl(e, t(e), "Committed new state action");
+return Xl(e, t(e), "Committed new state action");
 }
 
-(Vl = {})[FIND_SOURCES] = 5e3, Vl[FIND_MINERALS] = 5e3, Vl[FIND_DEPOSITS] = 100,
-Vl[FIND_STRUCTURES] = 50, Vl[FIND_MY_STRUCTURES] = 50, Vl[FIND_HOSTILE_STRUCTURES] = 20,
-Vl[FIND_MY_SPAWNS] = 100, Vl[FIND_MY_CONSTRUCTION_SITES] = 20, Vl[FIND_CONSTRUCTION_SITES] = 20,
-Vl[FIND_CREEPS] = 5, Vl[FIND_MY_CREEPS] = 5, Vl[FIND_HOSTILE_CREEPS] = 3, Vl[FIND_DROPPED_RESOURCES] = 5,
-Vl[FIND_TOMBSTONES] = 10, Vl[FIND_RUINS] = 10, Vl[FIND_FLAGS] = 50, Vl[FIND_NUKES] = 20,
-Vl[FIND_POWER_CREEPS] = 10, Vl[FIND_MY_POWER_CREEPS] = 10;
+(jl = {})[FIND_SOURCES] = 5e3, jl[FIND_MINERALS] = 5e3, jl[FIND_DEPOSITS] = 100,
+jl[FIND_STRUCTURES] = 50, jl[FIND_MY_STRUCTURES] = 50, jl[FIND_HOSTILE_STRUCTURES] = 20,
+jl[FIND_MY_SPAWNS] = 100, jl[FIND_MY_CONSTRUCTION_SITES] = 20, jl[FIND_CONSTRUCTION_SITES] = 20,
+jl[FIND_CREEPS] = 5, jl[FIND_MY_CREEPS] = 5, jl[FIND_HOSTILE_CREEPS] = 3, jl[FIND_DROPPED_RESOURCES] = 5,
+jl[FIND_TOMBSTONES] = 10, jl[FIND_RUINS] = 10, jl[FIND_FLAGS] = 50, jl[FIND_NUKES] = 20,
+jl[FIND_POWER_CREEPS] = 10, jl[FIND_MY_POWER_CREEPS] = 10;
 
-var Xl, Zl, Jl = {}, $l = {}, em = {}, tm = {};
+var Jl, $l, em = {}, tm = {}, rm = {}, om = {};
 
-function rm() {
-if (Xl) return tm;
-Xl = 1;
+function nm() {
+if (Jl) return om;
+Jl = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return tm.encode = function(t) {
+return om.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, tm;
+}, om;
 }
 
-function om() {
-if (Zl) return em;
-Zl = 1;
-const e = rm();
-return em.encode = function(t) {
+function am() {
+if ($l) return rm;
+$l = 1;
+const e = nm();
+return rm.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -25856,23 +25865,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, em;
+}, rm;
 }
 
-var nm, am, im, sm = {}, cm = _r(Object.freeze({
+var im, sm, cm, um = {}, lm = _r(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function um() {
-return am ? nm : (am = 1, nm = "function" == typeof URL ? URL : cm.URL);
+function mm() {
+return sm ? im : (sm = 1, im = "function" == typeof URL ? URL : lm.URL);
 }
 
-function lm() {
-if (im) return sm;
-im = 1;
-const e = um();
-sm.getArg = function(e, t, r) {
+function dm() {
+if (cm) return um;
+cm = 1;
+const e = mm();
+um.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -25892,16 +25901,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-sm.toSetString = t ? r : function(e) {
+um.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, sm.fromSetString = t ? r : function(e) {
+}, um.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, sm.compareByGeneratedPositionsInflated = function(e, t) {
+}, um.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, sm.parseSourceMapInput = function(e) {
+}, um.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -25955,7 +25964,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return sm.normalize = f, sm.join = y, sm.relative = function(t, r) {
+return um.normalize = f, um.join = y, um.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -25967,18 +25976,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, sm.computeSourceURL = function(e, t, r) {
+}, um.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, sm;
+}, um;
 }
 
-var mm, dm = {};
+var pm, fm = {};
 
-function pm() {
-if (mm) return dm;
-mm = 1;
+function ym() {
+if (pm) return fm;
+pm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -26011,19 +26020,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return dm.ArraySet = e, dm;
+return fm.ArraySet = e, fm;
 }
 
-var fm, ym, vm = {};
+var vm, gm, hm = {};
 
-function gm() {
-if (ym) return $l;
-ym = 1;
-const e = om(), t = lm(), r = pm().ArraySet, o = function() {
-if (fm) return vm;
-fm = 1;
-const e = lm();
-return vm.MappingList = class {
+function Rm() {
+if (gm) return tm;
+gm = 1;
+const e = am(), t = dm(), r = ym().ArraySet, o = function() {
+if (vm) return hm;
+vm = 1;
+const e = dm();
+return hm.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -26043,7 +26052,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, vm;
+}, hm;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26172,13 +26181,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, $l.SourceMapGenerator = n, $l;
+return n.prototype._version = 3, tm.SourceMapGenerator = n, tm;
 }
 
-var hm, Rm = {}, Em = {};
+var Em, Tm = {}, Cm = {};
 
-function Tm() {
-return hm || (hm = 1, function(e) {
+function Sm() {
+return Em || (Em = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26190,36 +26199,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(Em)), Em;
+}(Cm)), Cm;
 }
 
-var Cm, Sm, wm, xm, bm = {
+var wm, xm, bm, Om, km = {
 exports: {}
 };
 
-function Om() {
-if (Cm) return bm.exports;
-Cm = 1;
+function Am() {
+if (wm) return km.exports;
+wm = 1;
 let e = null;
-return bm.exports = function() {
+return km.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, bm.exports.initialize = t => {
+}, km.exports.initialize = t => {
 e = t;
-}, bm.exports;
+}, km.exports;
 }
 
-function km() {
-if (wm) return Sm;
-wm = 1;
-const e = Om();
+function Mm() {
+if (bm) return xm;
+bm = 1;
+const e = Am();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return Sm = function() {
+return xm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26286,28 +26295,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, Sm;
+}, xm;
 }
 
-var Am, Mm, Um, _m, Nm = {};
+var Um, _m, Nm, Pm, Im = {};
 
-function Pm(e, t, r) {
+function Gm(e, t, r) {
 return e - t >= r;
 }
 
-function Im(e, t) {
+function Lm(e, t) {
 return e.priority - t.priority;
 }
 
-function Gm(e, t, r, o) {
+function Dm(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function Lm(e, t, r, o) {
+function Fm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Dm(e) {
+function Bm(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26325,12 +26334,12 @@ if (t) throw t.error;
 return o;
 }
 
-Mm || (Mm = 1, Jl.SourceMapGenerator = gm().SourceMapGenerator, Jl.SourceMapConsumer = function() {
-if (xm) return Rm;
-xm = 1;
-const e = lm(), t = Tm(), r = pm().ArraySet;
-om();
-const o = Om(), n = km(), a = Symbol("smcInternal");
+_m || (_m = 1, em.SourceMapGenerator = Rm().SourceMapGenerator, em.SourceMapConsumer = function() {
+if (Om) return Tm;
+Om = 1;
+const e = dm(), t = Sm(), r = ym().ArraySet;
+am();
+const o = Am(), n = Mm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26367,7 +26376,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, Rm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, Tm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26557,7 +26566,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, Rm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, Tm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26666,11 +26675,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return Rm.IndexedSourceMapConsumer = c, Rm;
-}().SourceMapConsumer, Jl.SourceNode = function() {
-if (Am) return Nm;
-Am = 1;
-const e = gm().SourceMapGenerator, t = lm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return Tm.IndexedSourceMapConsumer = c, Tm;
+}().SourceMapConsumer, em.SourceNode = function() {
+if (Um) return Im;
+Um = 1;
+const e = Rm().SourceMapGenerator, t = dm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -26809,27 +26818,27 @@ map: o
 };
 }
 }
-return Nm.SourceNode = n, Nm;
+return Im.SourceNode = n, Im;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(_m || (_m = {}));
+}(Pm || (Pm = {}));
 
-var Fm, Bm = [ _m.CRITICAL, _m.HIGH, _m.MEDIUM, _m.LOW ], Wm = {
-bucketThresholds: (Um = {}, Um[_m.CRITICAL] = 0, Um[_m.HIGH] = 2e3, Um[_m.MEDIUM] = 5e3,
-Um[_m.LOW] = 8e3, Um),
+var Wm, Hm = [ Pm.CRITICAL, Pm.HIGH, Pm.MEDIUM, Pm.LOW ], Km = {
+bucketThresholds: (Nm = {}, Nm[Pm.CRITICAL] = 0, Nm[Pm.HIGH] = 2e3, Nm[Pm.MEDIUM] = 5e3,
+Nm[Pm.LOW] = 8e3, Nm),
 defaultMaxCpu: 5,
 logExecution: !1
-}, Hm = function() {
+}, Ym = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Dm(Bm),
+tasksByPriority: Bm(Hm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, Wm), e);
+}, this.config = o(o({}, Km), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -26843,13 +26852,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(Im), l = 0;
+var u = Array.from(this.tasks.values()).sort(Lm), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (Pm(Game.time, p.lastRun, p.interval)) if (Gm(p.priority, s, this.config.bucketThresholds, _m.CRITICAL)) this.stats.skippedThisTick++; else {
+if (Gm(Game.time, p.lastRun, p.interval)) if (Dm(p.priority, s, this.config.bucketThresholds, Pm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (Lm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Fm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -26897,7 +26906,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Dm(Bm);
+var t, r, o = Bm(Hm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -26914,22 +26923,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), Km = ((Fm = global)._computationScheduler || (Fm._computationScheduler = new Hm),
-Fm._computationScheduler), Ym = new Map;
+}(), Vm = ((Wm = global)._computationScheduler || (Wm._computationScheduler = new Ym),
+Wm._computationScheduler), qm = new Map;
 
-function Vm(e) {
-var t = Ym.get(e);
+function jm(e) {
+var t = qm.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Ym.set(e, t)), t;
+}, qm.set(e, t)), t;
 }
 
-function qm(e, t, r) {
+function zm(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return jm(e, t[0], r), t[0];
-var i = Vm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Qm(e, t[0], r), t[0];
+var i = jm(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -26946,32 +26955,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && jm(e, s, r), s;
+return s && Qm(e, s, r), s;
 }
 
-function jm(e, t, r) {
-var o = Vm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Qm(e, t, r) {
+var o = jm(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var zm = {
+var Xm = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function Qm(e, t, r) {
+function Zm(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(zm[t], ";") : "";
+var o = t ? "color: ".concat(Xm[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function Xm(e) {
+function Jm(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Zm = {
+var $m = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -26985,7 +26994,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(Xm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(Jm((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -27002,44 +27011,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(Xm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(Jm(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Jm() {
+function ed() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return td() + rd() + '<div class="module-help">'.concat(e.map($m).join(""), "</div>");
+return od() + nd() + '<div class="module-help">'.concat(e.map(td).join(""), "</div>");
 }
 
-var $m = function(e) {
-var t = e.api.map(ed).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Qm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Qm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, ed = function(e) {
+var td = function(e) {
+var t = e.api.map(rd).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Zm(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Zm(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, rd = function(e) {
 var t = [];
-e.describe && t.push(Qm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(Qm(e.name, "blue"), ": ").concat(Qm(e.desc, "green"));
+e.describe && t.push(Zm(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Zm(e.name, "blue"), ": ").concat(Zm(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return Qm(e.name, "blue");
-}).join(", ") : "", o = Qm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Zm(e.name, "blue");
+}).join(", ") : "", o = Zm(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Qm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, td = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Zm(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, od = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, rd = function() {
+}, nd = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, od = A("EnergyCollection"), nd = [ "refillSpawn", "refillExtension", "refillTower" ], ad = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, ad = A("EnergyCollection"), id = [ "refillSpawn", "refillExtension", "refillTower" ], sd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function id(e) {
+function cd(e) {
 if (e.droppedResources.length > 0) {
 var t = Lt(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return ad.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27049,15 +27058,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = qm(e.creep, r, "energy_container");
-if (o) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = zm(e.creep, r, "energy_container");
+if (o) return ad.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (od.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (ad.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return ad.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27068,8 +27077,8 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Os && ad.has(e.memory.role);
-}(e, n)) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Os && sd.has(e.memory.role);
+}(e, n)) return ad.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -27080,41 +27089,41 @@ var a = Nt(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = qm(e.creep, a, "energy_source");
-if (s) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = zm(e.creep, a, "energy_source");
+if (s) return ad.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (od.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return od.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (ad.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return ad.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return od.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return ad.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function sd(e) {
-var t = Gl.getAssignedAction(e, nd);
+function ud(e) {
+var t = Dl.getAssignedAction(e, id);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function cd(e) {
-return Gl.hasActiveTask(e.room.name, nd);
+function ld(e) {
+return Dl.hasActiveTask(e.room.name, id);
 }
 
-function ud(e, t) {
+function md(e, t) {
 return function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(t) && Gl.reserveCriticalDeliveryWork(e), t;
+}(t) && Dl.reserveCriticalDeliveryWork(e), t;
 }
 
-function ld(e, t) {
+function dd(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27141,11 +27150,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function md(e) {
-var t = Gl.getAssignedDeliveryAction(e);
+function pd(e) {
+var t = Dl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!cd(e)) {
-var r = ld(e, "deliver");
+if (!ld(e)) {
+var r = dd(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27167,9 +27176,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var dd = /^[WE]\d+[NS]\d+$/;
+var fd = /^[WE]\d+[NS]\d+$/;
 
-function pd(e) {
+function yd(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27179,28 +27188,28 @@ routeType: "hauler"
 } : null;
 }
 
-function fd(e) {
-return dd.test(e);
+function vd(e) {
+return fd.test(e);
 }
 
-function yd(e) {
+function gd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-if (!n || !fd(n)) return pd(e);
+if (!n || !vd(n)) return yd(e);
 var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
 return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
-} : null : pd(e) : null;
+} : null : yd(e) : null;
 }
 
-function vd(e) {
+function hd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = yd(e);
+var a = gd(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !fd(n)) return null;
+if (!n || !vd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27213,7 +27222,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function gd(e) {
+function Rd(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27222,11 +27231,11 @@ var n = e.memory.working;
 return o !== n && Ft(e.creep), n;
 }
 
-function hd(e) {
+function Ed(e) {
 e.memory.working = !1, Ft(e.creep);
 }
 
-var Rd = function() {
+var Td = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27321,20 +27330,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), Ed = new Rd, Td = A("LarvaWorkerBehavior");
+}(), Cd = new Td, Sd = A("LarvaWorkerBehavior");
 
-function Cd(e) {
-var t = gd(e), r = yd(e);
+function wd(e) {
+var t = Rd(e), r = gd(e);
 if (r) return r;
 if (t) {
-Td.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = vd(e);
+Sd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = hd(e);
 if (o) return o;
-var n = md(e);
-if (n) return Td.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = pd(e);
+if (n) return Sd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = Ed.getSwarmState(e.room.name);
+var t, r = Cd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27351,7 +27360,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Td.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Sd.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27360,58 +27369,60 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Td.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Sd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Td.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-hd(e);
+Sd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+Ed(e);
 }
-return ud(e, id(e));
-}
-
-function Sd(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
-}
-
-function wd(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
+return md(e, cd(e));
 }
 
 function xd(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
+
+function bd(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
+
+var Od = new Map;
+
+function kd(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var bd = A("HarvesterBehavior"), Od = A("HaulerBehavior"), kd = Os, Ad = [ "refillSpawn", "refillExtension" ];
+var Ad = A("HarvesterBehavior"), Md = A("HaulerBehavior"), Ud = Os, _d = [ "refillSpawn", "refillExtension" ];
 
-function Md(e, t) {
-return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && Gl.reserveDeliveryWork(e),
-"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && Gl.reserveDeliveryWork(e),
+function Nd(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && Dl.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && Dl.reserveDeliveryWork(e),
 t;
 }
 
-function Ud(e, t, r) {
+function Pd(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return jm(e, c, r), c;
+if (c) return Qm(e, c, r), c;
 }
-var u = qm(e, t, r);
+var u = zm(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function _d(e) {
+function Id(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27425,7 +27436,7 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-var Nd = {
+var Gd = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27435,11 +27446,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, Pd = Nd, Id = function(e) {
-return Pd.getLabResourceNeeds(e);
+}, Ld = Gd, Dd = function(e) {
+return Ld.getLabResourceNeeds(e);
 };
 
-function Gd(e) {
+function Fd(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27461,7 +27472,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = Id(e.room.name);
+var n = Dd(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27489,7 +27500,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, Pd.getLabOverflow(r));
+var t, r, o = (r = e.room.name, Ld.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27504,7 +27515,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = Id(e.room.name);
+var i = Dd(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27523,8 +27534,8 @@ type: "idle"
 }(e);
 }
 
-var Ld = {
-larvaWorker: Cd,
+var Bd = {
+larvaWorker: wd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27535,12 +27546,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(Sd).length > 0) return {
+if (e.hostiles.filter(xd).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (gd(e)) {
+if (Rd(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27559,7 +27570,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return id(e);
+return cd(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27593,10 +27604,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(wd)) return {
+if (e.hostiles.some(bd)) return {
 type: "idle"
 };
-if (gd(e)) {
+if (Rd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27615,10 +27626,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return id(e);
+return cd(e);
 },
 harvester: function(e) {
-var t, r = (t = xd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = kd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27667,8 +27678,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), bd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return bd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), Ad.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return Ad.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -27696,7 +27707,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return bd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return Ad.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -27717,20 +27728,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (bd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (Ad.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (bd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (Ad.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = gd(e), o = "defenseRefuel" === e.memory.task;
-if (Od.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = Rd(e), o = "defenseRefuel" === e.memory.task;
+if (Md.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -27743,9 +27754,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = Gl.getAssignedAction(e, Ad);
+var t = Dl.getAssignedAction(e, _d);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (Gl.hasActiveTask(e.room.name, Ad)) return null;
+if (Dl.hasActiveTask(e.room.name, _d)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27765,13 +27776,13 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = Gl.getAssignedDeliveryAction(e);
+var c = Dl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!cd(e)) {
+if (!ld(e)) {
 var u = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (u.length > 0 && (p = Lt(e.creep, u, "hauler_spawn", 10))) return Od.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
+if (u.length > 0 && (p = Lt(e.creep, u, "hauler_spawn", 10))) return Md.debug("".concat(e.creep.name, " hauler delivering to spawn ").concat(p.id)),
 {
 type: "transfer",
 target: p,
@@ -27797,8 +27808,8 @@ resourceType: RESOURCE_ENERGY
 var d = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = rl(e.room);
-return r < 2e4 && o > kd && n > 0 || Boolean(a) ? {
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = nl(e.room);
+return r < 2e4 && o > Ud && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -27824,12 +27835,12 @@ type: "transfer",
 target: p,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return Od.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return Md.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-Od.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-hd(e);
+Md.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+Ed(e);
 }
 if (o) {
 var y = function(e) {
@@ -27837,7 +27848,7 @@ var t = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = Ud(e.creep, t, "energy_container");
+var r = Pd(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -27852,7 +27863,7 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (y) return y;
 }
-if (e.droppedResources.length > 0 && (p = Lt(e.creep, e.droppedResources, "hauler_drop", 5))) return Md(e, {
+if (e.droppedResources.length > 0 && (p = Lt(e.creep, e.droppedResources, "hauler_drop", 5))) return Nd(e, {
 type: "pickup",
 target: p
 });
@@ -27862,7 +27873,7 @@ return e.store.getUsedCapacity() > 0;
 if (v.length > 0) {
 var g = Lt(e.creep, v, "hauler_tomb", 10);
 if (g) {
-if (g.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Md(e, {
+if (g.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Nd(e, {
 type: "withdraw",
 target: g,
 resourceType: RESOURCE_ENERGY
@@ -27881,24 +27892,24 @@ var R = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (R.length > 0) {
-var E = Ud(e.creep, R, "energy_container");
-if (E) return Od.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-Md(e, {
+var E = Pd(e.creep, R, "energy_container");
+if (E) return Md.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(E.id, " with ").concat(E.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+Nd(e, {
 type: "withdraw",
 target: E,
 resourceType: RESOURCE_ENERGY
 });
-Od.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
+Md.warn("".concat(e.creep.name, " hauler found ").concat(R.length, " containers but distribution returned null, falling back to closest"));
 var T = e.creep.pos.findClosestByRange(R);
-if (T) return Od.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
-Md(e, {
+if (T) return Md.debug("".concat(e.creep.name, " hauler using fallback container ").concat(T.id)),
+Nd(e, {
 type: "withdraw",
 target: T,
 resourceType: RESOURCE_ENERGY
 });
 }
 if (e.mineralContainers.length > 0) {
-var C = Ud(e.creep, e.mineralContainers, "mineral_container");
+var C = Pd(e.creep, e.mineralContainers, "mineral_container");
 if (C) {
 if (S = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
@@ -27908,11 +27919,11 @@ target: C,
 resourceType: S
 };
 } else {
-Od.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+Md.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var S, w = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (w && (S = Object.keys(w.store).find(function(e) {
 return e !== RESOURCE_ENERGY && w.store.getUsedCapacity(e) > 0;
-}))) return Od.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
+}))) return Md.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(w.id)),
 {
 type: "withdraw",
 target: w,
@@ -27926,7 +27937,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > kd || rl(e.room)) return {
+if (o < 2e4 && n > Ud || nl(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -27957,38 +27968,56 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return x ? Md(e, x) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (Od.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-Md(e, {
+return x ? Nd(e, x) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (Md.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+Nd(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-})) : (Od.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (Md.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 });
 },
 builder: function(e) {
-var t = gd(e), r = yd(e);
+var t = Rd(e), r = gd(e);
 if (r) return r;
 if (t) {
-var o = vd(e);
+var o = hd(e);
 if (o) return o;
-var n = sd(e);
+var n = ud(e);
 if (n) return n;
-if (!cd(e)) {
-var a = ld(e, "builder");
+if (!ld(e)) {
+var a = dd(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = xd(e);
+var t = kd(e), r = function(e) {
+var t = Od.get(e.name);
+if (t && t.tick === Game.time) return t;
+var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(e, t) {
+return Math.max(e, Yu(t));
+}, Number.NEGATIVE_INFINITY), n = {
+tick: Game.time,
+sites: r,
+highestPriority: o
+};
+return Od.set(e.name, n), n;
+}(e.room);
+if (0 === r.sites.length) return delete t.targetId, null;
 if (t.targetId) {
-var r = Game.getObjectById(t.targetId);
-if (r) return r;
+var o = Game.getObjectById(t.targetId);
+if (o && function(e, t) {
+return e.pos.roomName === t.name;
+}(o, e.room) && Yu(o) >= r.highestPriority) return o;
+delete t.targetId;
 }
-var o = e.room.find(FIND_MY_CONSTRUCTION_SITES);
-if (0 === o.length) return null;
-var n = e.pos.findClosestByRange(o);
+var n = function(e, t) {
+var r, o, n = t.sites.filter(function(e) {
+return Yu(e) === t.highestPriority;
+});
+return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
+}(e, r);
 return n && (t.targetId = n.id), n;
 }(e.creep);
 return i ? {
@@ -28004,15 +28033,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return ud(e, id(e));
+return md(e, cd(e));
 },
 upgrader: function(e) {
-if (gd(e)) {
-if (_d(e)) {
-var t = sd(e);
+if (Rd(e)) {
+if (Id(e)) {
+var t = ud(e);
 if (t) return t;
-if (!cd(e)) {
-var r = ld(e, "upgrader");
+if (!ld(e)) {
+var r = dd(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28023,8 +28052,8 @@ target: e.room.controller
 type: "idle"
 };
 }
-var o = _d(e), n = function(t) {
-return o ? ud(e, t) : t;
+var o = Id(e), n = function(t) {
+return o ? md(e, t) : t;
 }, a = e.room.controller;
 if (a) {
 var i = a.pos.findInRange(FIND_MY_STRUCTURES, 2, {
@@ -28087,7 +28116,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (gd(e)) {
+if (Rd(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28111,7 +28140,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : md(e) || (e.storage ? {
+} : pd(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28130,15 +28159,15 @@ return e.pos.getRangeTo(t) <= 2;
 })[0];
 }
 }(e.room);
-return r ? ud(e, {
+return r ? md(e, {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
-}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? ud(e, {
+}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? md(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? ud(e, {
+}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? md(e, {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28231,15 +28260,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : Gd(e);
+} : Fd(e);
 },
-labSupply: Gd,
+labSupply: Fd,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (gd(e)) {
+if (Rd(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28419,7 +28448,7 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t = gd(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
+var t = Rd(e), r = e.memory.targetRoom, o = e.memory.homeRoom;
 if (!r || r === o) return {
 type: "idle"
 };
@@ -28442,9 +28471,9 @@ if (t) return e.room.name !== o ? {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
-} : md(e) || (e.isEmpty || e.room.name !== o ? {
+} : pd(e) || (e.isEmpty || e.room.name !== o ? {
 type: "idle"
-} : (hd(e), {
+} : (Ed(e), {
 type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
@@ -28543,16 +28572,16 @@ roomName: o
 }
 };
 
-function Dd(e) {
+function Wd(e) {
 var t;
-return (null !== (t = Ld[e.memory.role]) && void 0 !== t ? t : Cd)(e);
+return (null !== (t = Bd[e.memory.role]) && void 0 !== t ? t : wd)(e);
 }
 
-var Fd = new Set([ "build", "repair", "upgrade" ]);
+var Hd = new Set([ "build", "repair", "upgrade" ]);
 
-function Bd(e, t) {
+function Kd(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && fd(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && vd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -28561,12 +28590,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : vd(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : hd(e);
 }(e, t);
-return r || (Fd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || _d(e) ? sd(e) : null : null);
+return r || (Hd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || Id(e) ? ud(e) : null : null);
 }
 
-var Wd = "patrol", Hd = [ {
+var Yd = "patrol", Vd = [ {
 x: 10,
 y: 5
 }, {
@@ -28602,7 +28631,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], Kd = [ {
+} ], qd = [ {
 x: 10,
 y: 10
 }, {
@@ -28619,7 +28648,7 @@ x: 25,
 y: 25
 } ];
 
-function Yd(e) {
+function jd(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28627,7 +28656,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function Vd(e) {
+function zd(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28637,9 +28666,9 @@ roomName: e.roomName
 });
 }
 
-function qd(e) {
+function Qd(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Le.get(e.name, {
-namespace: Wd
+namespace: Yd
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28659,25 +28688,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(Hd), !1), i(Kd), !1);
-}(t).map(Yd).filter(function(e) {
+}(e)), !1), i(Vd), !1), i(qd), !1);
+}(t).map(jd).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Le.set(e.name, {
-waypoints: Vd(n),
+waypoints: zd(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: Wd,
+namespace: Yd,
 ttl: 1e3
 }), n;
 }
 
-function jd(e, t) {
+function Xd(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28687,86 +28716,86 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var zd = A("MilitaryBehaviors");
+var Zd = A("MilitaryBehaviors");
 
-function Qd(e) {
+function Jd(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
 delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === $a && (delete e.task,
 delete e.targetRoom);
 }
 
-function Xd(e, t) {
+function $d(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function Zd(e) {
+function ep(e) {
 return To(vo(e));
 }
 
-function Jd(e) {
+function tp(e) {
 return e.creep.room.name === e.homeRoom && q(e.room).length > 0;
 }
 
-function $d(e) {
+function rp(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function ep(e, t) {
+function op(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function tp(e) {
-return ep(e, "guard") + ep(e, "ranger") + ep(e, "healer");
+function np(e) {
+return op(e, "guard") + op(e, "ranger") + op(e, "healer");
 }
 
-function rp(e, t, r) {
+function ap(e, t, r) {
 var o = e.memory;
 return ri(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function op(e, t) {
+function ip(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return rp(r, e, t);
+return ap(r, e, t);
 });
 }
 
-function np(e, t) {
+function sp(e, t) {
 return "defenseAssist:".concat(e, ":").concat(t, ":active");
 }
 
-function ap(e, t, r) {
-return ep(e, t) > function(e, t) {
+function cp(e, t, r) {
+return op(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
 return !r.spawning && o.role === t && ri(o) === e;
 }).length;
-}(e.roomName, t) || tp(e) > 0 && Zd(e.roomName) && function(e, t) {
-return op(e, t).length;
+}(e.roomName, t) || np(e) > 0 && ep(e.roomName) && function(e, t) {
+return ip(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function ip(e, t) {
+function up(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
 if (t.task && t.task !== $a) return null;
-if (Jd(e)) return null;
+if (tp(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter($d).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(rp).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== q(l).length && ap(u, t.role, e.homeRoom)) return ti(e.creep, {
+if (l && 0 !== q(l).length && cp(u, t.role, e.homeRoom)) return ti(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
-squadId: np(e.homeRoom, u.roomName),
-squadSize: Zd(u.roomName) ? Math.max(5, tp(u)) : Math.max(1, tp(u))
+squadId: sp(e.homeRoom, u.roomName),
+squadSize: ep(u.roomName) ? Math.max(5, np(u)) : Math.max(1, np(u))
 }), u.roomName;
 }
 } catch (e) {
@@ -28783,7 +28812,7 @@ if (r) throw r.error;
 return null;
 }
 
-function sp(e) {
+function lp(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -28791,7 +28820,7 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function cp(e, t) {
+function mp(e, t) {
 if (!function(e) {
 return Boolean(ri(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
@@ -28799,11 +28828,11 @@ if (e.creep.room.name !== e.homeRoom) return null;
 var r = ri(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = vo(r), n = To(o), a = n ? op(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var o = vo(r), n = To(o), a = n ? ip(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
 var r = ri(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && rp(e, r, o);
+return e.memory.defenseSquadId === t && ap(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -28817,7 +28846,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return op(e, t).reduce(function(e, t) {
+return ip(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = mo(t.body.filter(function(e) {
 return e.hits > 0;
@@ -28839,16 +28868,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return Xd(t, "parity-ready"), null;
-if (c >= u) return Xd(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return $d(t, "parity-ready"), null;
+if (c >= u) return $d(t, "squad-quorum"), null;
 if (l) {
-if (!n) return Xd(t, "expired-staging"), null;
+if (!n) return $d(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = sp(e) - sp(t);
+var r = lp(e) - lp(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -28856,20 +28885,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return Xd(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return $d(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return Xd(t, "squad-quorum"), null;
-if (l) return Xd(t, "expired-staging"), null;
+if (c >= u) return $d(t, "squad-quorum"), null;
+if (l) return $d(t, "expired-staging"), null;
 }
-var m = $u(e.room.name);
+var m = tl(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function up(e) {
+function dp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -28901,21 +28930,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function lp(e, t) {
+function pp(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function mp(e, t) {
+function fp(e, t) {
 if (!e.swarmState) return null;
-var r = $u(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (zd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = tl(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (Zd.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function dp(e) {
+function yp(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -28939,7 +28968,7 @@ if (t) throw t.error;
 }
 }
 
-function pp(e) {
+function vp(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -28947,23 +28976,23 @@ return Boolean(e);
 });
 }
 
-function fp(e) {
+function gp(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function yp(e) {
+function hp(e) {
 var t, r = e.creep.memory;
 if (oi(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = dp(e.memory.squadId);
-if (o) return vp(e, o);
+var o = yp(e.memory.squadId);
+if (o) return Rp(e, o);
 }
-var n = null !== (t = ip(e, r)) && void 0 !== t ? t : ri(r);
-if (n && !Jd(e)) {
-var a = cp(e, r);
+var n = null !== (t = up(e, r)) && void 0 !== t ? t : ri(r);
+if (n && !tp(e)) {
+var a = mp(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -28976,9 +29005,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = up(e);
+var s = dp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = lp(e.creep, RANGED_ATTACK), l = lp(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = pp(e.creep, RANGED_ATTACK), l = pp(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -28990,7 +29019,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = lp(e.creep, RANGED_ATTACK), l = lp(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = pp(e.creep, RANGED_ATTACK), l = pp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29001,7 +29030,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (Qd(r), e.creep.room.name !== e.homeRoom) return {
+} else if (Jd(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29010,8 +29039,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = up(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = lp(e.creep, RANGED_ATTACK), l = lp(e.creep, ATTACK),
+var m = dp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = pp(e.creep, RANGED_ATTACK), l = pp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -29022,7 +29051,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = qd(e.room), p = jd(e.creep, d);
+var d = Qd(e.room), p = Xd(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -29036,7 +29065,7 @@ type: "idle"
 };
 }
 
-function vp(e, t) {
+function Rp(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -29044,7 +29073,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = fp(t);
+var n = gp(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -29052,7 +29081,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(pp(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(vp(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29075,7 +29104,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = pp(e).filter(function(t) {
+var t, r, o = vp(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29104,7 +29133,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = pp(t).filter(function(t) {
+var r = vp(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29120,7 +29149,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = pp(t).sort(function(e, t) {
+var a = vp(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29157,7 +29186,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = pp(t).filter(function(e) {
+var l = vp(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29174,7 +29203,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = pp(e).find(function(e) {
+return null !== (t = vp(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29185,7 +29214,7 @@ target: m
 type: "idle"
 };
 }
-var d = up(e);
+var d = dp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29197,10 +29226,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : lp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : pp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : lp(e.creep, ATTACK) && p <= 1 ? {
+} : pp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29216,10 +29245,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : lp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : pp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : lp(e.creep, ATTACK) && p <= 1 ? {
+} : pp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29235,7 +29264,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: fp(t)
+target: gp(t)
 };
 
 case "dissolving":
@@ -29253,8 +29282,8 @@ type: "idle"
 }
 }
 
-var gp = {
-guard: yp,
+var Ep = {
+guard: hp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29263,8 +29292,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = qd(e.room);
-return (o = jd(e.creep, r)) ? {
+var r = Qd(e.room);
+return (o = Xd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29285,7 +29314,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = qd(e.room), (o = jd(e.creep, r)) ? {
+} : (r = Qd(e.room), (o = Xd(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29299,11 +29328,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return lp(e, HEAL);
+return pp(e, HEAL);
 }), t.filter(function(e) {
-return lp(e, RANGED_ATTACK);
+return pp(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return lp(e, ATTACK);
+return pp(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29324,7 +29353,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = lp(e.creep, RANGED_ATTACK), u = lp(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = pp(e.creep, RANGED_ATTACK), u = pp(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29355,19 +29384,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = dp(e.memory.squadId);
-if (o) return vp(e, o);
+var o = yp(e.memory.squadId);
+if (o) return Rp(e, o);
 }
-var n = null !== (t = ip(e, r)) && void 0 !== t ? t : ri(r);
-if (n && !Jd(e)) {
-var a = cp(e, r);
+var n = null !== (t = up(e, r)) && void 0 !== t ? t : ri(r);
+if (n && !tp(e)) {
+var a = mp(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === q(i).length) return Qd(r), {
+if (0 === q(i).length) return Jd(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29461,7 +29490,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = qd(e.room), v = jd(e.creep, y);
+var y = Qd(e.room), v = Xd(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29472,8 +29501,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = dp(e.memory.squadId);
-if (r) return vp(e, r);
+var r = yp(e.memory.squadId);
+if (r) return Rp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29495,9 +29524,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = up(e);
+var a = dp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = lp(e.creep, RANGED_ATTACK), c = lp(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = pp(e.creep, RANGED_ATTACK), c = pp(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29516,7 +29545,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = qd(e.room), m = jd(e.creep, l);
+var l = Qd(e.room), m = Xd(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29538,8 +29567,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = dp(e.memory.squadId);
-if (r) return vp(e, r);
+var r = yp(e.memory.squadId);
+if (r) return Rp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29600,9 +29629,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = mp(e, "siegeUnit");
+var p = fp(e, "siegeUnit");
 if (p) return p;
-var f = qd(e.room), y = jd(e.creep, f);
+var f = Qd(e.room), y = Xd(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29613,8 +29642,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = dp(e.memory.squadId);
-if (r) return vp(e, r);
+var r = yp(e.memory.squadId);
+if (r) return Rp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29631,7 +29660,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return mp(e, "harasser (no target)") || {
+if (!t) return fp(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29673,9 +29702,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = mp(e, "harasser (no targets)");
+var c = fp(e, "harasser (no targets)");
 if (c) return c;
-var u = qd(e.room), l = jd(e.creep, u);
+var u = Qd(e.room), l = Xd(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29688,9 +29717,9 @@ var t, r, o = e.creep.memory;
 if (oi(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = dp(e.memory.squadId))) return vp(e, a);
+if (e.memory.squadId && (a = yp(e.memory.squadId))) return Rp(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (ri(o) && Qd(o), e.room.name !== e.homeRoom) return {
+if (ri(o) && Jd(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29704,9 +29733,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = ip(e, o)) && void 0 !== t ? t : ri(o);
-if (i && !Jd(e)) {
-var s = cp(e, o);
+var a, i = null !== (t = up(e, o)) && void 0 !== t ? t : ri(o);
+if (i && !tp(e)) {
+var s = mp(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -29716,14 +29745,14 @@ roomName: i
 var u = q(c), l = j(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return Qd(o), {
+if (0 === u.length && 0 === l.length) return Jd(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = up(e);
+var m = dp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -29743,8 +29772,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = dp(e.memory.squadId))) return vp(e, a);
-var p, f = up(e);
+if (e.memory.squadId && (a = yp(e.memory.squadId))) return Rp(e, a);
+var p, f = dp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -29755,7 +29784,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = qd(e.room), v = jd(e.creep, y);
+var y = Qd(e.room), v = Xd(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -29776,21 +29805,21 @@ type: "idle"
 }
 };
 
-function hp(e) {
+function Tp(e) {
 var t;
-return Gl.getAssignedAction(e) || (null !== (t = gp[e.memory.role]) && void 0 !== t ? t : yp)(e);
+return Dl.getAssignedAction(e) || (null !== (t = Ep[e.memory.role]) && void 0 !== t ? t : hp)(e);
 }
 
-var Rp = A("PowerExecutor");
+var Cp = A("PowerExecutor");
 
-function Ep(e, t) {
+function Sp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Tp(e) {
+function wp(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -29832,8 +29861,8 @@ type: "idle"
 };
 }
 
-var Cp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Sp = {
-powerHarvester: Tp,
+var xp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), bp = {
+powerHarvester: wp,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -29905,65 +29934,65 @@ roomName: e.homeRoom
 }
 };
 
-function wp(e) {
+function Op(e) {
 var t;
-return (null !== (t = Sp[e.memory.role]) && void 0 !== t ? t : Tp)(e);
+return (null !== (t = bp[e.memory.role]) && void 0 !== t ? t : wp)(e);
 }
 
-function xp(e) {
+function kp(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var bp = {
+var Ap = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, Op = {
+}, Mp = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, kp = {
+}, Up = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, Ap = {
+}, _p = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, Mp = {
+}, Np = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, Up = {
+}, Pp = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, _p = {
+}, Ip = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, Np = {
+}, Gp = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function Pp(e) {
+function Lp(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function Ip(e) {
+function Dp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -29971,7 +30000,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function Gp(e) {
+function Fp(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -29979,12 +30008,12 @@ y: parseInt(n, 10)
 };
 }
 
-function Lp(e) {
+function Bp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = Dp(s);
+o[s.n] = Wp(s);
 }
 } catch (e) {
 t = {
@@ -30000,23 +30029,23 @@ if (t) throw t.error;
 return o;
 }
 
-function Dp(e) {
+function Wp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = Op[e.r]) && void 0 !== t ? t : "core",
-health: Fp(e.h),
+role: null !== (t = Mp[e.r]) && void 0 !== t ? t : "core",
+health: Hp(e.h),
 activeTasks: e.t,
-portals: e.p.map(Bp),
+portals: e.p.map(Kp),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Wp)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Yp)
 };
 }
 
-function Fp(e) {
+function Hp(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = Ap[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = _p[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -30029,11 +30058,11 @@ lastUpdate: e.u
 };
 }
 
-function Bp(e) {
+function Kp(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: Ip(e.sp),
+sourcePos: Dp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -30043,7 +30072,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function Wp(e) {
+function Yp(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -30052,7 +30081,7 @@ bucketLevel: e.b
 };
 }
 
-function Hp(e) {
+function Vp(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30062,12 +30091,12 @@ isAlly: 1 === e.a
 };
 }
 
-function Kp(e) {
+function qp(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Yp(u);
+i[u.n] = jp(u);
 }
 } catch (e) {
 t = {
@@ -30090,13 +30119,13 @@ updatedAt: e.u
 };
 }
 
-function Yp(e) {
+function jp(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: Gp(e.pp),
+portalPos: Fp(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30107,46 +30136,46 @@ lastUpdate: e.u
 };
 }
 
-function Vp(e) {
+function zp(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = Up[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = Pp[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = Np[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = Gp[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function qp(e, t) {
+function Qp(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function jp(e) {
+function Xp(e) {
 var t;
 return {
-c: null !== (t = kp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: qp(e.cpuUsage, 2),
+c: null !== (t = Up[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: Qp(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: qp(e.avgRCL, 1),
+rl: Qp(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function zp(e) {
+function Zp(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: Pp(e.sourcePos),
+sp: Lp(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30155,27 +30184,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function Qp(e) {
+function Jp(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: qp(e.cpuUsed, 2),
+u: Qp(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function Xp(e) {
+function $p(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Zp)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(ef)
 };
 }
 
-function Zp(e) {
+function ef(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30185,23 +30214,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Jp(e) {
+function tf(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = Mp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = Np[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = _p[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = Ip[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function $p(e) {
+function rf(e) {
 return {
 name: e,
 role: "core",
@@ -30224,7 +30253,7 @@ cpuLimit: 0
 };
 }
 
-function ef(e) {
+function of(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30234,16 +30263,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = bp[t.role]) && void 0 !== r ? r : t.role[0],
-h: jp(t.health),
+r: null !== (r = Ap[t.role]) && void 0 !== r ? r : t.role[0],
+h: Xp(t.health),
 t: t.activeTasks,
-p: t.portals.map(zp),
+p: t.portals.map(Zp),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Qp)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Jp)
 };
 }(t[0], t[1]);
 }),
-g: Xp(e.globalTargets),
+g: $p(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30257,7 +30286,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? Pp(t.portalPos) : void 0,
+pp: t.portalPos ? Lp(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30269,20 +30298,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Jp),
+k: e.tasks.map(tf),
 ls: e.lastSync
 };
 var t;
-}(e), r = xp(JSON.stringify(t));
+}(e), r = kp(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function tf(e) {
+function nf(e) {
 try {
-var t = JSON.parse(e), r = xp(JSON.stringify(t.d));
+var t = JSON.parse(e), r = kp(JSON.stringify(t.d));
 return t.c !== r ? (Xe.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30291,13 +30320,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: Lp(a.s),
+shards: Bp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(Hp)), n),
-footprintOperation: a.o ? Kp(a.o) : void 0,
-tasks: a.k.map(Vp),
+o.en && (n.enemies = o.en.map(Vp)), n),
+footprintOperation: a.o ? qp(a.o) : void 0,
+tasks: a.k.map(zp),
 lastSync: a.ls,
 checksum: i
 });
@@ -30309,12 +30338,12 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var rf, of, nf = 102400, af = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var af, sf, cf = 102400, uf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function sf(e, t, r) {
+function lf(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = mf(t), s = function(e, t, r) {
+var i = ff(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30327,11 +30356,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(lf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : af), c = null !== (a = mf(ef(s))) && void 0 !== a ? a : {};
+}(pf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : uf), c = null !== (a = ff(of(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function cf(e) {
+function mf(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30347,69 +30376,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = lf(r, mf(r))) && void 0 !== t ? t : e;
+return r && null !== (t = pf(r, ff(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function uf(e, t) {
+function df(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(sf(e, r, t)), !0;
+return InterShardMemory.setLocal(lf(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function lf(e, t) {
+function pf(e, t) {
 return t && function(e) {
-return df(e.d) && "number" == typeof e.c;
-}(t) ? tf(e) : null;
+return yf(e.d) && "number" == typeof e.c;
+}(t) ? nf(e) : null;
 }
 
-function mf(e) {
+function ff(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return df(t) ? t : null;
+return yf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function df(e) {
+function yf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(rf || (rf = {})), function(e) {
+}(af || (af = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(of || (of = {}));
+}(sf || (sf = {}));
 
-var pf = null != Xe ? Xe : {
+var vf = null != Xe ? Xe : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, ff = {
+}, gf = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, yf = {
+}, hf = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, vf = function() {
+}, Rf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, ff), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, gf), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30426,19 +30455,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = tf(r);
-o && (this.interShardMemory = o, pf.debug("Loaded InterShardMemory", {
+var o = nf(r);
+o && (this.interShardMemory = o, vf.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-pf.error("Failed to load InterShardMemory: ".concat(n), {
+vf.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = $p(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = rf(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30599,25 +30628,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-pf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+vf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-pf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+vf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", pf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", vf.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-pf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+vf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30650,7 +30679,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-pf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+vf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30680,12 +30709,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", pf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", vf.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-pf.info("War ended, transitioning to ".concat(i), {
+vf.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, pf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, vf.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -30711,7 +30740,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = yf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = hf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -30763,13 +30792,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && pf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && vf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-pf.debug("Could not set shard limits: ".concat(S), {
+vf.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -30777,27 +30806,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (pf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (vf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = sf(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = lf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > nf) {
-pf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(nf), {
+if (r.length > cf) {
+vf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(cf), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = sf(this.interShardMemory, t, {
+var o = lf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > nf ? (pf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(nf), {
+return o.length > cf ? (vf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(cf), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-pf.error("Failed to sync InterShardMemory: ".concat(n), {
+vf.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -30835,7 +30864,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = $p(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = rf(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -30853,40 +30882,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-pf.info("Repaired InterShardMemory structure", {
+vf.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void pf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void vf.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = tf(r);
-if (!o) return void pf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = nf(r);
+if (!o) return void vf.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || pf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || vf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-pf.warn("InterShardMemory verification failed: ".concat(a), {
+vf.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-pf.info("Attempting InterShardMemory recovery", {
+vf.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = tf(r);
-if (o) return this.interShardMemory = o, void pf.info("Recovered InterShardMemory from storage", {
+var o = nf(r);
+if (o) return this.interShardMemory = o, void vf.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -30901,12 +30930,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = $p(n), pf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = rf(n), vf.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-pf.error("InterShardMemory recovery failed: ".concat(a), {
+vf.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30916,7 +30945,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), pf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), vf.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -30932,7 +30961,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-pf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+vf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -30948,7 +30977,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), pf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), vf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -30963,7 +30992,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, pf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, vf.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -30982,7 +31011,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), pf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), vf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -31028,11 +31057,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, pf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, vf.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = ef(this.interShardMemory).length, o = r / nf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = of(this.interShardMemory).length, o = r / cf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -31059,11 +31088,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-pf.info("Forcing InterShardMemory sync with validation", {
+vf.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = ef(this.interShardMemory).length, n = ef(o(o({}, this.interShardMemory), {
+var e, t, r = of(this.interShardMemory).length, n = of(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31087,8 +31116,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: nf,
-percent: Math.round(r / nf * 1e4) / 100,
+limit: cf,
+percent: Math.round(r / cf * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31096,10 +31125,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (rf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (af.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), gf = new vf, hf = {
+}(), Ef = new Rf, Tf = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31110,11 +31139,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: of.LOW,
-NORMAL: of.NORMAL,
-HIGH: of.HIGH
+LOW: sf.LOW,
+NORMAL: sf.NORMAL,
+HIGH: sf.HIGH
 }
-}, Rf = function() {
+}, Cf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31124,7 +31153,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = gf.getActiveTransferTasks();
+var n = Ef.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31151,7 +31180,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = gf.getOptimalPortalRoute(e.targetShard);
+var t = Ef.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31219,7 +31248,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-gf.updateTaskProgress(e.taskId, t);
+Ef.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31235,7 +31264,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = hf.optimizeBody({
+i = Tf.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -31246,8 +31275,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = hf.spawnPriorities.LOW;
-e.priority >= 80 ? d = hf.spawnPriorities.HIGH : e.priority >= 50 && (d = hf.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Tf.spawnPriorities.LOW;
+e.priority >= 80 ? d = Tf.spawnPriorities.HIGH : e.priority >= 50 && (d = Tf.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31265,7 +31294,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-hf.spawnQueue.addRequest(y), Xe.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Tf.spawnQueue.addRequest(y), Xe.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31292,7 +31321,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void gf.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Ef.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", Xe.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -31304,8 +31333,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, gf.updateTaskProgress(e.taskId, 100, "complete"),
-gf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Xe.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Ef.updateTaskProgress(e.taskId, 100, "complete"),
+Ef.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Xe.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31335,12 +31364,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Ef = new Rf;
+}(), Sf = new Cf;
 
-function Tf(e, t, r) {
+function wf(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = cf({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = mf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31355,13 +31384,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, uf(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, df(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function Cf(e) {
+function xf(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31389,15 +31418,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Tf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (wf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || q(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Tf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (wf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Tf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (wf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31414,24 +31443,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Tf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, wf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Tf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (wf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Sf(e) {
+function bf(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function wf(e, t) {
+function Of(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31465,14 +31494,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function xf(e, t) {
+function kf(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function bf(e) {
-var t = Ed.getEmpire();
-if (Ju.isExit(e.creep.pos)) return Sf(e.room.name);
+function Af(e) {
+var t = Cd.getEmpire();
+if (el.isExit(e.creep.pos)) return bf(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31487,7 +31516,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ xf(t.x, t.y - 1), xf(t.x + 1, t.y), xf(t.x, t.y + 1), xf(t.x - 1, t.y) ] : [];
+return t ? [ kf(t.x, t.y - 1), kf(t.x + 1, t.y), kf(t.x, t.y + 1), kf(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31550,13 +31579,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (wf(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Of(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (wf(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Of(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31566,19 +31595,19 @@ type: "idle"
 };
 }
 
-function Of(e) {
+function Mf(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function kf(e) {
-return e.hostiles.some(Of);
+function Uf(e) {
+return e.hostiles.some(Mf);
 }
 
-function Af(e) {
+function _f(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function Mf(e) {
+function Nf(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31601,8 +31630,8 @@ type: "idle"
 };
 }
 
-var Uf = {
-scout: bf,
+var Pf = {
+scout: Af,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31636,7 +31665,7 @@ return {
 type: "idle"
 };
 }
-if (Ju.isExit(e.creep.pos)) return Sf(e.room.name);
+if (el.isExit(e.creep.pos)) return bf(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31658,8 +31687,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Cf,
-interShardScout: Cf,
+interShardClaimer: xf,
+interShardScout: xf,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -31735,8 +31764,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return Mf(e);
-if (kf(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return Nf(e);
+if (Uf(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31777,7 +31806,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return Af(t) - Af(e);
+return _f(t) - _f(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -31797,7 +31826,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : Mf(e);
+} : Nf(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -31886,9 +31915,9 @@ type: "idle"
 }
 };
 
-function _f(e, t) {
+function If(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : kf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Uf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -31896,26 +31925,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function Nf(e) {
-var t;
-return (null !== (t = Uf[e.memory.role]) && void 0 !== t ? t : bf)(e);
-}
-
-function Pf(e) {
-var t = Qu(e);
-Hl(e, Ql(t, Dd, {
-interrupt: Bd
-}), t);
-}
-
-function If(e) {
-var t = Qu(e);
-Hl(e, Ql(t, Nf, {
-interrupt: _f
-}), t);
-}
-
 function Gf(e) {
+var t;
+return (null !== (t = Pf[e.memory.role]) && void 0 !== t ? t : Af)(e);
+}
+
+function Lf(e) {
+var t = Zu(e);
+Yl(e, Zl(t, Wd, {
+interrupt: Kd
+}), t);
+}
+
+function Df(e) {
+var t = Zu(e);
+Yl(e, Zl(t, Gf, {
+interrupt: If
+}), t);
+}
+
+function Ff(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -31956,8 +31985,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Cp.has(i) && Y(s))) {
-Rp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && xp.has(i) && Y(s))) {
+Cp.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -31968,16 +31997,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && Ju.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && el.moveTo(e, t.target);
 break;
 
 case "moveTo":
-Ju.moveTo(e, t.target);
+el.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-Ju.moveTo(e, {
+el.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -31986,11 +32015,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && Ju.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && el.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && Ju.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && el.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -32022,7 +32051,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Ep(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Sp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -32032,7 +32061,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Ep(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Sp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -32043,7 +32072,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = _t(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Ep(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Sp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32096,7 +32125,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Ep(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Sp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32138,7 +32167,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Ep(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Sp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32148,7 +32177,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Ep(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Sp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -32156,7 +32185,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && q(e.room).length > 0) {
 var o = _t(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Ep(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Sp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32168,7 +32197,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Ep(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Sp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32176,12 +32205,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Ep(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Sp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Ep(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Sp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32215,18 +32244,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function Lf(e) {
+function Bf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var Df = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), Ff = -1, Bf = Object.create(null);
+var Wf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), Hf = -1, Kf = Object.create(null);
 
-function Wf(e) {
+function Yf(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var Hf = {
+var Vf = {
 harvester: Je.CRITICAL,
 queenCarrier: Je.CRITICAL,
 hauler: Je.HIGH,
@@ -32261,12 +32290,12 @@ labTech: Je.IDLE,
 factoryWorker: Je.IDLE
 };
 
-function Kf(e) {
+function qf(e) {
 var t;
-return null !== (t = Hf[e]) && void 0 !== t ? t : Je.MEDIUM;
+return null !== (t = Vf[e]) && void 0 !== t ? t : Je.MEDIUM;
 }
 
-function Yf(e) {
+function jf(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32282,20 +32311,20 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && Wf(o) === e && t++;
+o && Yf(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (Ff !== Game.time && (Ff = Game.time, Bf = function() {
+}(e) : null !== (r = (Hf !== Game.time && (Hf = Game.time, Kf = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = Wf(o);
+var n = Yf(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), Bf)[e]) && void 0 !== r ? r : 0;
+}()), Kf)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Me().cpu.disableCreepBootstrapCountCache
@@ -32305,7 +32334,7 @@ subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!Df.has(t.role)) return !1;
+if (!Wf.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32315,7 +32344,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Lf(r)) return !1;
+if (!r || !Bf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32329,7 +32358,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Lf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !Bf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32337,7 +32366,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Lf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !Bf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32345,7 +32374,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Lf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !Bf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32353,7 +32382,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && Lf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && Bf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32369,7 +32398,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Lf(r)) return !1;
+if (!r || !Bf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32409,31 +32438,31 @@ switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = Qu(e);
-Hl(e, Ql(t, Dd, {
-interrupt: Bd
+var t = Zu(e);
+Yl(e, Zl(t, Wd, {
+interrupt: Kd
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = Qu(e);
-Hl(e, Ql(t, hp), t);
+var t = Zu(e);
+Yl(e, Zl(t, Tp), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = Qu(e);
-Hl(e, Ql(t, Nf), t);
+var t = Zu(e);
+Yl(e, Zl(t, Gf), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = Qu(e);
-Hl(e, Ql(t, wp), t);
+var t = Zu(e);
+Yl(e, Zl(t, Op), t);
 }(e);
 }
 });
@@ -32454,7 +32483,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var Vf = function() {
+var zf = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32495,7 +32524,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Kf(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = qf(r), n = "creep:".concat(e.name);
 gi.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -32511,7 +32540,7 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Yf(t);
+t && !t.spawning && jf(t);
 }
 }), this.registeredCreeps.add(e.name), Wu.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
@@ -32536,7 +32565,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Kf(u.memory.role), m = null !== (r = Je[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = qf(u.memory.role), m = null !== (r = Je[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32561,20 +32590,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), qf = new Vf;
+}(), Qf = new zf;
 
-function jf(e) {
+function Xf(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, zf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, Zf(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function zf(e) {
+function Zf(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function Qf(e) {
+function Jf(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32587,14 +32616,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function Xf(e, t) {
+function $f(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var Zf = {
+var ey = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32622,11 +32651,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function Jf(e, t) {
+function ty(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function $f(e) {
+function ry(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32636,9 +32665,9 @@ tick: Game.time
 }, a;
 }
 
-var ey = [ "defense", "war", "expand", "siege" ];
+var oy = [ "defense", "war", "expand", "siege" ];
 
-function ty(e) {
+function ny(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32651,11 +32680,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function ry(e, t, r) {
-t >= 2 && (e.pheromones.war = Jf(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Jf(e.pheromones.siege + 20, r));
+function ay(e, t, r) {
+t >= 2 && (e.pheromones.war = ty(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = ty(e.pheromones.siege + 20, r));
 }
 
-var oy = function() {
+var iy = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32670,27 +32699,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), ny = function() {
+}(), sy = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Zf), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, ey), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new oy(10),
-energySpawning: new oy(10),
-energyConstruction: new oy(10),
-energyRepair: new oy(10),
-energyTower: new oy(10),
-controllerProgress: new oy(10),
-hostileCount: new oy(5),
-damageReceived: new oy(5),
-idleWorkers: new oy(10),
+energyHarvested: new iy(10),
+energySpawning: new iy(10),
+energyConstruction: new iy(10),
+energyRepair: new iy(10),
+energyTower: new iy(10),
+controllerProgress: new iy(10),
+hostileCount: new iy(5),
+damageReceived: new iy(5),
+idleWorkers: new iy(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = $f(e);
+var o = ry(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -32763,7 +32792,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = Jf(e[s] * c, t);
+e[s] = ty(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -32779,43 +32808,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = $f(t);
+var o = ry(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = Jf(e.harvest + n / 3e3 * 10, r);
+e.harvest = ty(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = Jf(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = ty(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = Jf(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = ty(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = Jf(e.defense + 10 * o, r));
+o > 0 && (e.defense = ty(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = Jf(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Jf(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = ty(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = ty(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = Jf(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = ty(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = Jf(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = ty(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Jf(e.pheromones.defense + 5 * t, o), ry(e, r, o),
+e.danger = r, e.pheromones.defense = ty(e.pheromones.defense + 5 * t, o), ay(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -32823,7 +32852,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Jf(t / 10, o), ry(e, r, o);
+e.danger = r, e.pheromones.defense = ty(t / 10, o), ay(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -32836,8 +32865,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = Jf(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = Jf(f + y, o);
+var p = ty(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = ty(f + y, o);
 }
 }
 }
@@ -32856,18 +32885,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = Jf(e.pheromones.defense + 5, r), e.pheromones.build = Jf(e.pheromones.build + 10, r),
+e.pheromones.defense = ty(e.pheromones.defense + 5, r), e.pheromones.build = ty(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Jf(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = ty(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = Jf(e.pheromones.siege + 50, t), e.pheromones.defense = Jf(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = ty(e.pheromones.siege + 50, t), e.pheromones.defense = ty(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = Jf(e.pheromones.expand - 10, t), e.pheromones.defense = Jf(e.pheromones.defense + 5, t);
+e.pheromones.expand = ty(e.pheromones.expand - 10, t), e.pheromones.defense = ty(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -32877,10 +32906,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(ty(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(ny(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(ey)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(oy)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -32934,7 +32963,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = Jf(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = ty(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -32969,7 +32998,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), ay = new ny, iy = {
+}(), cy = new sy, uy = {
 seedNest: {
 rcl: 1
 },
@@ -33010,7 +33039,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, sy = {
+}, ly = {
 eco: {
 economy: .75,
 military: .05,
@@ -33053,7 +33082,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, cy = {
+}, my = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33110,13 +33139,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, uy = function() {
+}, dy = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = iy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = iy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= iy.fortifiedHive.rcl ? "fortifiedHive" : s >= iy.matureColony.rcl ? "matureColony" : s >= iy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = uy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = uy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= uy.fortifiedHive.rcl ? "fortifiedHive" : s >= uy.matureColony.rcl ? "matureColony" : s >= uy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Le.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -33151,7 +33180,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = iy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = uy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33164,7 +33193,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), ly = function() {
+}(), py = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33186,9 +33215,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return sy[e];
+return ly[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return cy[e];
+return my[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33198,15 +33227,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), my = new uy, dy = new ly;
+}(), fy = new dy, yy = new py;
 
-function py(e) {
+function vy(e) {
 return !K(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function fy(e, t, r) {
+function gy(e, t, r) {
 if (!e) return null;
 var o = Xr.getEmpire();
 if (K(e, {
@@ -33245,11 +33274,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function yy() {
+function hy() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var vy = new Map, gy = function() {
+var Ry = new Map, Ey = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = q(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33393,7 +33422,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: vy.get(e.name),
+previousStructures: Ry.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33423,7 +33452,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && vy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Ry.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33432,7 +33461,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-py(u) && o.add(u.owner.username);
+vy(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33446,7 +33475,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) fy(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) gy(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33462,7 +33491,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? ay.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? ay.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && ay.onNukeDetected(t);
+"danger" === y.type ? cy.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? cy.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && cy.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33522,10 +33551,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = yy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = hy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = yy()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = hy()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33568,7 +33597,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: dy.isCombatPosture(t.posture),
+isCombatPosture: yy.isCombatPosture(t.posture),
 wallRepairTarget: qo(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -33592,27 +33621,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), hy = new gy, Ry = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Ty = new Ey, Cy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Ey() {
+function Sy() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Ty(e, t, r, o) {
+function wy(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Ey()
+selectedAt: Sy()
 });
 }
 
-function Cy(e) {
+function xy(e) {
 return e >= 2 && e <= 3;
 }
 
-function Sy(e, t) {
+function by(e, t) {
 var r = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33625,7 +33654,7 @@ return e.structureType === t;
 return r.length + o.length;
 }
 
-function wy(e, t) {
+function Oy(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -33639,10 +33668,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var xy = function() {
+var ky = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Cy(e) ? 5 : 10;
+return xy(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -34040,16 +34069,16 @@ y: e.y - R.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Ty(t, v, E.name, f);
+wy(t, v, E.name, f);
 var T = f >= 3 && (t.danger >= 1 || function(e, t) {
-var r = wy(STRUCTURE_TOWER, t);
-return r > 0 && Sy(e, STRUCTURE_TOWER) < r;
+var r = Oy(STRUCTURE_TOWER, t);
+return r > 0 && by(e, STRUCTURE_TOWER) < r;
 }(e, f)), C = T ? function(e, t, r) {
 var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = wy(STRUCTURE_TOWER, g), R = Sy(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Oy(STRUCTURE_TOWER, g), R = by(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34446,7 +34475,7 @@ var r, o, n, i = Mn(t);
 try {
 for (var s = a(Object.keys(i)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (n = i[u]) && void 0 !== n ? n : 0;
-if (!(l <= 0) && Sy(e, u) < l) return !0;
+if (!(l <= 0) && by(e, u) < l) return !0;
 }
 } catch (e) {
 r = {
@@ -34462,8 +34491,8 @@ if (r) throw r.error;
 return !1;
 }(e, f);
 if (p.length + S + w + C >= 10 && !x) t.metrics.constructionSites = p.length + S + w + C; else {
-if (!dy.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Ey());
+if (!yy.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Sy());
 }(t, v)) {
 var b = function(e, t, r, o, n) {
 var i, s;
@@ -34621,7 +34650,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Ry.has(e.structureType);
+return Cy.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34630,7 +34659,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var M = Cy(f) ? 2 : 3;
+var M = xy(f) ? 2 : 3;
 (A = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -35306,13 +35335,13 @@ anchor: l
 }
 return null;
 }(e, f);
-L && (Ty(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
+L && (wy(t, L.anchor, L.blueprint.name, f), e.createConstructionSite(L.anchor.x, L.anchor.y, STRUCTURE_SPAWN));
 }
 }
 }, e;
-}(), by = new xy;
+}(), Ay = new ky;
 
-function Oy(e) {
+function My(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35334,7 +35363,7 @@ siege: e.pheromones.siege
 };
 }
 
-var ky = {
+var Uy = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35347,10 +35376,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Ay = new (function() {
+}, _y = new (function() {
 function e() {
 this.manager = new Qc({
-logger: ky
+logger: Uy
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35360,23 +35389,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = Oy(t);
+var r = My(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = Oy(t);
+var r = My(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), My = {
+}()), Ny = {
 labManager: mu,
 boostManager: iu,
-chemistryPlanner: Ay,
+chemistryPlanner: _y,
 labConfigManager: uu,
 logger: Wu
-}, Uy = function() {
+}, Py = function() {
 function e(e) {
-void 0 === e && (e = My), this.deps = e;
+void 0 === e && (e = Ny), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35415,9 +35444,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), _y = new Uy, Ny = function() {
+}(), Iy = new Py, Gy = function() {
 function e(e) {
-void 0 === e && (e = _y), this.labWorkflow = e;
+void 0 === e && (e = Iy), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35440,27 +35469,27 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), Py = new Ny, Iy = {
+}(), Ly = new Gy, Dy = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, Gy = new Map;
+}, Fy = new Map;
 
-function Ly(e) {
+function By(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function Dy(e) {
+function Wy(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var Fy = function() {
+var Hy = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Iy), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Dy), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = Fi.startRoom(this.roomName), i = Game.rooms[this.roomName];
@@ -35502,7 +35531,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = Xr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = Gy.get(e.name);
+var t = Fy.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35524,28 +35553,28 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return Gy.set(e.name, o), o;
+return Fy.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && ay.updateMetrics(i, c),
-hy.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && cy.updateMetrics(i, c),
+Ty.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), ai.assess(i, c), li.checkSafeMode(i, c), this.config.enableEvolution && (my.updateEvolutionStage(c, i, e),
-s || my.updateMissingStructures(c, i)), dy.updatePosture(c), this.config.enablePheromones && !s && ay.updatePheromones(c, i),
-this.config.enableTowers && hy.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = by.getConstructionInterval(l), d = dy.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), ai.assess(i, c), li.checkSafeMode(i, c), this.config.enableEvolution && (fy.updateEvolutionStage(c, i, e),
+s || fy.updateMissingStructures(c, i)), yy.updatePosture(c), this.config.enablePheromones && !s && cy.updatePheromones(c, i),
+this.config.enableTowers && Ty.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Ay.getConstructionInterval(l), d = yy.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = Ly(r), n = Dy(e);
+var o = By(r), n = Wy(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (by.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (Ay.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = Ly(r), n = Dy(e);
+var o = By(r), n = Wy(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && Py.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && Ly.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
@@ -35555,7 +35584,7 @@ var f = Game.cpu.getUsed() - n;
 Fi.recordRoom(i, f), Fi.endRoom(this.roomName, n);
 } else Fi.endRoom(this.roomName, n);
 }, e;
-}(), By = function() {
+}(), Ky = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35569,7 +35598,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new Fy(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new Hy(v.name));
 }
 } catch (t) {
 e = {
@@ -35632,7 +35661,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new Fy(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new Hy(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35653,9 +35682,9 @@ stack: c
 }
 }
 }, e;
-}(), Wy = new By;
+}(), Yy = new Ky;
 
-function Hy(e) {
+function Vy(e) {
 var t, r, o;
 if (q(e).length > 0) return Je.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return Je.HIGH;
@@ -35666,14 +35695,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? Je.MEDIUM : Je.LOW;
 }
 
-function Ky(e) {
+function qy(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return q(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function Yy(e, t, r) {
+function jy(e, t, r) {
 var o;
 return t === Je.CRITICAL ? {
 tickModulo: void 0,
@@ -35693,7 +35722,7 @@ tickOffset: void 0
 };
 }
 
-var Vy, qy = function() {
+var zy, Qy = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -35709,7 +35738,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = gi.getProcess(i), c = Hy(n), u = Ky(n);
+var i = "room:".concat(o), s = gi.getProcess(i), c = Vy(n), u = qy(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -35728,7 +35757,7 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = Hy(e), o = Ky(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Yy(e, r, a);
+var t, r = Vy(e), o = qy(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = jy(e, r, a);
 gi.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
@@ -35745,7 +35774,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Wy.runRoom(t);
+t && Yy.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
@@ -35753,7 +35782,7 @@ Wu.debug("Registered room process: ".concat(e.name, " with priority ").concat(r,
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = Yy(e, t, a);
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = jy(e, t, a);
 gi.unregisterProcess(n), gi.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
@@ -35770,7 +35799,7 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Wy.runRoom(t);
+t && Yy.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
@@ -35792,7 +35821,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = Hy(m), p = null !== (r = Je[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = Vy(m), p = null !== (r = Je[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -35819,7 +35848,7 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), jy = new qy, zy = function() {
+}(), Xy = new Qy, Zy = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = gi.getStatsSummary(), t = gi.getConfig();
@@ -35896,11 +35925,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Qf(e.summary.byLayer)), "Groups: ".concat(Qf(e.summary.byGroup)), "States: ".concat(Qf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Jf(e.summary.byLayer)), "Groups: ".concat(Jf(e.summary.byGroup)), "States: ".concat(Jf(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(Xf)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort($f)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(jf(m));
+c.push(Xf(m));
 }
 } catch (e) {
 t = {
@@ -35999,7 +36028,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = qf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = Qf.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36018,7 +36047,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = jy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = Xy.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36165,7 +36194,7 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), Qy = function() {
+}(), Jy = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
@@ -36198,7 +36227,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), Xy = function() {
+}(), $y = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36723,7 +36752,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Zy = function() {
+}(), ev = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return ar.generateHelp();
@@ -36742,22 +36771,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), Jy = function() {
+}(), tv = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? Gl.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? Dl.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? Gl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? Dl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return Gl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return Dl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ ir({
 name: "tasks",
 description: "Show room creep task queue",
@@ -36777,21 +36806,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), $y = ((Vy = {})[MOVE] = 50, Vy[WORK] = 100, Vy[CARRY] = 50, Vy[ATTACK] = 80,
-Vy[RANGED_ATTACK] = 150, Vy[HEAL] = 250, Vy[CLAIM] = 600, Vy[TOUGH] = 10, Vy);
+}(), rv = ((zy = {})[MOVE] = 50, zy[WORK] = 100, zy[CARRY] = 50, zy[ATTACK] = 80,
+zy[RANGED_ATTACK] = 150, zy[HEAL] = 250, zy[CLAIM] = 600, zy[TOUGH] = 10, zy);
 
-function ev(e, t) {
+function ov(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, $y), t);
+var r = o(o({}, rv), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : $y[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : rv[t]);
 }, 0);
 }
 
-function tv(e, t) {
+function nv(e, t) {
 void 0 === t && (t = 0);
-var r = ev(e);
+var r = ov(e);
 return {
 parts: e,
 cost: r,
@@ -36799,7 +36828,7 @@ minCapacity: t || r
 };
 }
 
-function rv() {
+function av() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -36807,11 +36836,11 @@ return Array(o).fill(r);
 });
 }
 
-var ov, nv, av, iv = {
+var iv, sv, cv, uv = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ tv([ WORK, CARRY ], 150), tv([ WORK, CARRY, MOVE ], 200), tv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), tv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), tv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ nv([ WORK, CARRY ], 150), nv([ WORK, CARRY, MOVE ], 200), nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), nv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -36819,7 +36848,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ tv([ WORK, CARRY, MOVE ], 200), tv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), tv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), tv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ nv([ WORK, CARRY, MOVE ], 200), nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), nv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), nv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36827,7 +36856,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ tv([ WORK, CARRY, MOVE, MOVE ], 250), tv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ nv([ WORK, CARRY, MOVE, MOVE ], 250), nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -36835,7 +36864,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ tv([ WORK, CARRY, MOVE ], 200), tv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), tv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), tv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), tv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ nv([ WORK, CARRY, MOVE ], 200), nv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), nv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), nv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36843,7 +36872,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ tv([ CARRY, CARRY, MOVE, MOVE ], 200), tv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), tv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ nv([ CARRY, CARRY, MOVE, MOVE ], 200), nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36851,7 +36880,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ tv([ WORK, CARRY, MOVE ], 200), tv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), tv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), tv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ nv([ WORK, CARRY, MOVE ], 200), nv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -36859,7 +36888,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ tv([ WORK, CARRY, MOVE, MOVE ], 250), tv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), tv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ nv([ WORK, CARRY, MOVE, MOVE ], 250), nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), nv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36867,7 +36896,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ tv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -36875,7 +36904,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ tv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), tv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ nv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), nv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36883,7 +36912,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ tv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36891,7 +36920,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ tv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36899,7 +36928,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ tv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), tv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), tv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), tv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ nv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), nv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36907,7 +36936,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ tv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), tv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -36915,7 +36944,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ tv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), tv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36923,16 +36952,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ tv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), tv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), tv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), tv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ nv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), nv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), nv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, sv = {
+}, lv = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ tv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), tv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), tv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), tv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ nv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), nv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), nv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), nv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36940,7 +36969,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ tv([ TOUGH, ATTACK, MOVE, MOVE ], 190), tv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), tv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ nv([ TOUGH, ATTACK, MOVE, MOVE ], 190), nv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), nv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36948,7 +36977,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ tv([ HEAL, MOVE, MOVE ], 350), tv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), tv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), tv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ nv([ HEAL, MOVE, MOVE ], 350), nv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), nv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), nv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36956,7 +36985,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ tv([ ATTACK, ATTACK, MOVE, MOVE ], 260), tv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), tv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ nv([ ATTACK, ATTACK, MOVE, MOVE ], 260), nv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), nv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36964,7 +36993,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ tv([ WORK, WORK, MOVE, MOVE ], 300), tv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), tv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ nv([ WORK, WORK, MOVE, MOVE ], 300), nv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), nv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -36972,7 +37001,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ tv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), tv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), tv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), tv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ nv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), nv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), nv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), nv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -36980,16 +37009,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ tv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), tv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), tv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ nv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), nv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), nv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, cv = {
+}, mv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ tv(rv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), tv(rv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ nv(av([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), nv(av([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -36997,16 +37026,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ tv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), tv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ nv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), nv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, uv = {
+}, dv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ tv([ MOVE ], 50) ],
+bodies: [ nv([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37014,7 +37043,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ tv([ MOVE ], 50) ],
+bodies: [ nv([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37022,7 +37051,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ tv([ CLAIM, MOVE ], 650) ],
+bodies: [ nv([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37030,7 +37059,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ tv([ CLAIM, MOVE ], 650), tv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ nv([ CLAIM, MOVE ], 650), nv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37038,7 +37067,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ tv([ WORK, CARRY, MOVE, MOVE ], 250), tv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ nv([ WORK, CARRY, MOVE, MOVE ], 250), nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37046,30 +37075,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ tv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), tv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, lv = o(o(o(o({}, iv), sv), uv), cv);
+}, pv = o(o(o(o({}, uv), lv), dv), mv);
 
 try {
-for (var mv = a(Object.values(lv)), dv = mv.next(); !dv.done; dv = mv.next()) dv.value.bodies.sort(function(e, t) {
+for (var fv = a(Object.values(pv)), yv = fv.next(); !yv.done; yv = fv.next()) yv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-ov = {
+iv = {
 error: e
 };
 } finally {
 try {
-dv && !dv.done && (nv = mv.return) && nv.call(mv);
+yv && !yv.done && (sv = fv.return) && sv.call(fv);
 } finally {
-if (ov) throw ov.error;
+if (iv) throw iv.error;
 }
 }
 
-function pv(e) {
+function vv(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37084,11 +37113,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return fv(o);
+return gv(o);
 }
 
-function fv(e) {
-var t = ev(e);
+function gv(e) {
+var t = ov(e);
 return {
 parts: e,
 cost: t,
@@ -37096,16 +37125,16 @@ minCapacity: t
 };
 }
 
-function yv(e, t) {
+function hv(e, t) {
 var r;
-return null !== (r = e.map(fv).filter(function(e) {
+return null !== (r = e.map(gv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function vv(e) {
+function Rv(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37119,7 +37148,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = ev(a);
+var s = ov(a);
 return {
 parts: a,
 cost: s,
@@ -37144,8 +37173,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: ev(p),
-minCapacity: ev(p)
+cost: ov(p),
+minCapacity: ov(p)
 };
 }(e);
 
@@ -37156,7 +37185,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return pv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return vv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37177,7 +37206,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return pv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return vv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37186,13 +37215,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(fv).filter(function(e) {
+var u = n.map(gv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = yv(n, t);
+var l = hv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37202,7 +37231,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = yv(n, t);
+var u = hv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37211,14 +37240,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = yv(r, t);
+var a = hv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function gv(e) {
+function Ev(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37229,9 +37258,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function hv(e, t) {
+function Tv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: gv(t)
+memory: Ev(t)
 });
 var r;
 }
@@ -37239,9 +37268,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(av || (av = {}));
+}(cv || (cv = {}));
 
-var Rv = function() {
+var Cv = function() {
 function e() {
 this.queues = new Map;
 }
@@ -37336,7 +37365,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = hv(m, d);
+var p = Tv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37356,7 +37385,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= av.EMERGENCY;
+return e.priority >= cv.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37374,7 +37403,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= av.EMERGENCY ? n.emergency++ : c.priority >= av.HIGH ? n.high++ : c.priority >= av.NORMAL ? n.normal++ : n.low++;
+c.priority >= cv.EMERGENCY ? n.emergency++ : c.priority >= cv.HIGH ? n.high++ : c.priority >= cv.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37389,14 +37418,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Ev = new Rv, Tv = {
+}(), Sv = new Cv, wv = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Cv = {
+}, xv = {
 predictConsumption: function() {
 return 0;
 },
@@ -37415,7 +37444,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Sv = {
+}, bv = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37433,44 +37462,44 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, wv = {
+}, Ov = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function xv(e, t, r, o, n) {
+function kv(e, t, r, o, n) {
 return Vs(e, t, r, o, n);
 }
 
-var bv = new Map, Ov = -1, kv = null;
+var Av = new Map, Mv = -1, Uv = null;
 
-function Av() {
-Ov === Game.time && kv === Game.creeps || (bv.clear(), Ov = Game.time, kv = Game.creeps);
+function _v() {
+Mv === Game.time && Uv === Game.creeps || (Av.clear(), Mv = Game.time, Uv = Game.creeps);
 }
 
-function Mv(e) {
+function Nv(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Uv(e, t) {
+function Pv(e, t) {
 var r;
-void 0 === t && (t = !1), Av();
-var o = t ? "".concat(e, "_active") : e, n = bv.get(o);
+void 0 === t && (t = !1), _v();
+var o = t ? "".concat(e, "_active") : e, n = Av.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Mv(c);
+var u = Nv(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return bv.set(o, a), a;
+return Av.set(o, a), a;
 }
 
-function _v(e, t, r) {
+function Iv(e, t, r) {
 var o, n, i = 0;
 try {
 for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
@@ -37491,22 +37520,22 @@ if (o) throw o.error;
 return i;
 }
 
-function Nv(e) {
+function Gv(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var Pv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var Lv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function Iv(e) {
-return Pv.includes(e);
+function Dv(e) {
+return Lv.includes(e);
 }
 
-function Gv(e) {
+function Fv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Lv(e, t, r, o) {
+function Bv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37519,10 +37548,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return xv(e, t, Nt(r).length, o, {
-reserved: Gv(r)
+if (r) return kv(e, t, Nt(r).length, o, {
+reserved: Fv(r)
 }).recommendedHaulers;
-var n = xv(e, t, 2, o, {
+var n = kv(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37533,7 +37562,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: Nv
+filter: Gv
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37544,7 +37573,7 @@ return 2;
 }
 }
 
-function Dv(e, t) {
+function Wv(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37554,13 +37583,13 @@ return null;
 }
 }
 
-function Fv() {
+function Hv() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function Bv(e) {
-var t = Fv(), r = function(e) {
+function Kv(e) {
+var t = Hv(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37572,14 +37601,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function Wv(e) {
+function Yv(e) {
 var t = Xr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Fv();
+var r = Hv();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function Hv(e) {
+function Vv(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37587,11 +37616,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function Kv(e) {
+function qv(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function Yv() {
+function jv() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37601,9 +37630,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var Vv = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var zv = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function qv(e, t) {
+function Qv(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37615,8 +37644,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(Yv()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Ev.getPendingRequests(c).some(function(r) {
+for (var i = a(jv()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Sv.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37636,7 +37665,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function jv() {
+function Xv() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -37657,7 +37686,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function zv(e, t) {
+function Zv(e, t) {
 var r, o, n, c, u = Xr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -37667,15 +37696,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !qv(e.roomName, "claim");
+return !Qv(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || Hv(t));
+return !(!r || r.my || r.owner || r.reservation || Vv(t));
 }
-return !Wv(e);
+return !Yv(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -37686,11 +37715,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = jv().filter(function(e) {
-return !qv(e, "claim");
+var r, o, n = Xv().filter(function(e) {
+return !Qv(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = Fv();
+var r, o, n = Game.rooms[e], a = Hv();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -37701,7 +37730,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Vv.has(e.type);
+return e.hits > 0 && zv.has(e.type);
 });
 });
 }(n));
@@ -37713,7 +37742,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = Dv(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = Wv(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -37728,14 +37757,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(jv()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(Xv()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !qv(e.roomName, "claim");
+return !e.claimed && !Qv(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -37747,20 +37776,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Fv();
+var l = Hv();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !qv(p, "claim")) {
+if (!t.has(p) && !Qv(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || Bv(y)) continue;
-if (Hv(f)) continue;
+if (y.owner || Kv(y)) continue;
+if (Vv(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !qv(p, "reserve")) return p;
-} else if (!Wv(p) && !qv(p, "reserve")) return p;
+if ((!v || g < 3e3) && !Qv(p, "reserve")) return p;
+} else if (!Yv(p) && !Qv(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -37782,34 +37811,34 @@ task: "reserve"
 } : null;
 }
 
-function Qv(e) {
+function Jv(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function Xv(e) {
-return Qv(e) ? av.EMERGENCY : av.HIGH;
+function $v(e) {
+return Jv(e) ? cv.EMERGENCY : cv.HIGH;
 }
 
-function Zv(e, t, r) {
+function eg(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!Kv(e)) return !1;
+if (!qv(e)) return !1;
 var a = e.name === t ? r : Xr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function Jv(e, t, r) {
+function tg(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return Zv(e, t, r);
+return eg(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Dv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = Wv(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37817,18 +37846,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function $v(e, t) {
+function rg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !Zv(n, e, t)) return null;
+if (!n || !eg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !Kv(e);
+return !qv(e);
 }).filter(function(e) {
-return !Hv(e);
+return !Vv(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -37849,9 +37878,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(Yv()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(jv()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Ev.getPendingRequests(d).filter(function(t) {
+i += Sv.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -37868,12 +37897,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (Qv(e) ? 3 : 1);
+}(e.name) < (Jv(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Dv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = Wv(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -37881,10 +37910,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (Jv(u.room, e, t) === e) return {
+if (tg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: Xv(u.room)
+priority: $v(u.room)
 };
 }
 } catch (e) {
@@ -37901,10 +37930,10 @@ if (r) throw r.error;
 return null;
 }
 
-function eg(e, t) {
+function og(e, t) {
 if (t <= 0) return null;
 try {
-var r = vv({
+var r = Rv({
 maxEnergy: t,
 role: e
 });
@@ -37914,18 +37943,18 @@ return null;
 }
 }
 
-function tg(e, t, r) {
-return "healer" === e || "ranger" === e && To(r) ? null : eg(e, t);
+function ng(e, t, r) {
+return "healer" === e || "ranger" === e && To(r) ? null : og(e, t);
 }
 
-function rg(e) {
+function ag(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function og(e) {
+function ig(e) {
 var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
 return function() {
 var e;
@@ -37939,7 +37968,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += rg(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += ag(c.value);
 } catch (e) {
 t = {
 error: e
@@ -37960,7 +37989,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += rg(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += ag(l.value);
 } catch (e) {
 o = {
 error: e
@@ -37976,23 +38005,23 @@ return i;
 }(e)) : r;
 }
 
-var ng = [ "guard", "ranger", "healer" ];
+var sg = [ "guard", "ranger", "healer" ];
 
-function ag(e, t) {
+function cg(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function ig(e, t, r, o) {
+function ug(e, t, r, o) {
 void 0 === o && (o = vo(e.roomName));
-var n = ag(e, t);
+var n = cg(e, t);
 if (!bo(t)) return n;
 if (!o) return n;
-var i = lg(e.roomName), s = i[t] + xo(r, o, {
-guard: Math.max(0, ag(e, "guard") - i.guard),
-ranger: Math.max(0, ag(e, "ranger") - i.ranger),
-healer: Math.max(0, ag(e, "healer") - i.healer)
-}, dg(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = pg(e.roomName), s = i[t] + xo(r, o, {
+guard: Math.max(0, cg(e, "guard") - i.guard),
+ranger: Math.max(0, cg(e, "ranger") - i.ranger),
+healer: Math.max(0, cg(e, "healer") - i.healer)
+}, yg(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Co(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -38007,7 +38036,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && pg(u) && Co(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && vg(u) && Co(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -38025,30 +38054,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function sg(e) {
+function lg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? q(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function cg(e) {
+function mg(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === $a ? e.targetRoom : void 0;
 }
 
-function ug(e, t) {
-var r = vo(e.roomName), o = lg(e.roomName), n = xo(t.energyCapacityAvailable, r, {
-guard: Math.max(0, ag(e, "guard") - o.guard),
-ranger: Math.max(0, ag(e, "ranger") - o.ranger),
-healer: Math.max(0, ag(e, "healer") - o.healer)
-}, dg(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function dg(e, t) {
+var r = vo(e.roomName), o = pg(e.roomName), n = xo(t.energyCapacityAvailable, r, {
+guard: Math.max(0, cg(e, "guard") - o.guard),
+ranger: Math.max(0, cg(e, "ranger") - o.ranger),
+healer: Math.max(0, cg(e, "healer") - o.healer)
+}, yg(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = ng.filter(function(o) {
-return !(ig(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Co(o, t.energyCapacityAvailable, r));
+var i = sg.filter(function(o) {
+return !(ug(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Co(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function lg(e) {
+function pg(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -38057,7 +38086,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-bo(p) && cg(d) === e && u[p]++;
+bo(p) && mg(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -38071,7 +38100,7 @@ if (t) throw t.error;
 }
 }
 for (var f in Game.rooms) try {
-for (var y = (o = void 0, a(Ev.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
+for (var y = (o = void 0, a(Sv.getPendingRequests(f))), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
 bo(g.role) && ((null === (s = g.additionalMemory) || void 0 === s ? void 0 : s.assistTarget) === e || (null === (c = g.additionalMemory) || void 0 === c ? void 0 : c.task) === $a && g.targetRoom === e) && u[g.role]++;
 }
@@ -38089,21 +38118,21 @@ if (o) throw o.error;
 return u;
 }
 
-function mg(e, t, r) {
+function fg(e, t, r) {
 var o = mo(r), n = e[t];
 e[t] = n ? po(n, o) : o;
 }
 
-function dg(e) {
+function yg(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (bo(y) && cg(f) === e) {
+if (bo(y) && mg(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && mg(l, y, v);
+v.length > 0 && fg(l, y, v);
 }
 }
 } catch (e) {
@@ -38118,9 +38147,9 @@ if (t) throw t.error;
 }
 }
 for (var g in Game.rooms) try {
-for (var h = (o = void 0, a(Ev.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
+for (var h = (o = void 0, a(Sv.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-bo(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === $a && E.targetRoom === e) && mg(l, E.role, E.body.parts);
+bo(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === $a && E.targetRoom === e) && fg(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -38136,23 +38165,23 @@ if (o) throw o.error;
 return l;
 }
 
-function pg(e) {
+function vg(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === q(e).length;
 }
 
-function fg(e, t, r, o) {
+function gg(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && tg("guard", og(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && ng("guard", ig(r), o) ? 1 : 0;
 }
 
-function yg(e, t) {
+function hg(e, t) {
 var r;
 if (!function(e) {
 return bo(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !pg(o)) return null;
+if (!o || !vg(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38177,7 +38206,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(sg);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(lg);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -38185,15 +38214,15 @@ return t.roomName !== e;
 var r = vo(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(ig(e, t, n, r), fg(e, t, o, r))
+helperNeed: Math.max(ug(e, t, n, r), gg(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return sg(e.request);
+return lg(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return bo(t) ? lg(e)[t] : 0;
+return bo(t) ? pg(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38219,27 +38248,27 @@ return r[o] = s, s;
 return {
 targetRoom: r.roomName,
 task: $a,
-priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? av.EMERGENCY : av.HIGH,
+priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? cv.EMERGENCY : cv.HIGH,
 defenseSquadId: ei(e, r.roomName, n.createdAt),
-defenseSquadSize: ug(r, t),
+defenseSquadSize: dg(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var vg = "defenseRefuel", gg = {
+var Rg = "defenseRefuel", Eg = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function hg(e, t) {
+function Tg(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || q(e).length > 0 || e.energyCapacityAvailable < gg.cost);
-}(n) ? og(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || q(e).length > 0 || e.energyCapacityAvailable < Eg.cost);
+}(n) ? ig(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38276,9 +38305,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Ev.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Sv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === vg && s++;
+"hauler" === p.role && f === Rg && s++;
 }
 } catch (e) {
 o = {
@@ -38293,24 +38322,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: vg,
-priority: av.EMERGENCY,
-body: gg
+task: Rg,
+priority: cv.EMERGENCY,
+body: Eg
 } : null : null;
 }
 
-function Rg(e) {
+function Cg(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !Bv(t.controller) && !Hv(t) : !Wv(e);
+return t ? !!t.controller && !Kv(t.controller) && !Vv(t) : !Yv(e);
 }
 
-function Eg(e) {
+function Sg(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !Bv(t.controller) : !Wv(e);
+return (null == t ? void 0 : t.controller) ? !Kv(t.controller) : !Yv(e);
 }
 
-function Tg(e, t, r) {
-var o = lv[t];
+function wg(e, t, r) {
+var o = pv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
@@ -38338,13 +38367,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Cg(e, t, r) {
+function xg(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Rg(l) && _v(e, t, l) < Lv(e, l, t, Game.rooms[l])) return l;
+if (Cg(l) && Iv(e, t, l) < Bv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -38360,10 +38389,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Sg(e, t, r, o) {
+function bg(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = lv[t];
+var p = pv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -38377,32 +38406,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = lv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = lv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = pv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = pv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Uv(e), y)) return !1;
+}(t, Pv(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (Iv(t)) return !("remoteWorker" === t && function(e, t) {
-Av();
-var r = "".concat(e, ":").concat(t), o = bv.get(r);
+if (Dv(t)) return !("remoteWorker" === t && function(e, t) {
+_v();
+var r = "".concat(e, ":").concat(t), o = Av.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return bv.set(r, n), n;
-}(e, t) >= Tg(e, t, r)) && null !== Cg(e, t, r);
+return Av.set(r, n), n;
+}(e, t) >= wg(e, t, r)) && null !== xg(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Eg(R)) {
+if (Sg(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = q(E).filter(function(e) {
@@ -38410,7 +38439,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && _v(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && Iv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38427,9 +38456,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Uv(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== $v(e, r);
-if (C >= Tg(e, t, r)) return !1;
+var C = null !== (u = Pv(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== rg(e, r);
+if (C >= wg(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38441,14 +38470,14 @@ var r = Xr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = Dv(e, o);
+var a = Wv(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== zv(e, r);
+if ("claimer" === t) return null !== Zv(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38484,7 +38513,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Tv.getActiveRequests) || void 0 === m ? void 0 : m.call(Tv)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = wv.getActiveRequests) || void 0 === m ? void 0 : m.call(wv)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38512,16 +38541,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function wg(e) {
+function Og(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function xg(e) {
-return 0 === wg(Uv(e, !0));
+function kg(e) {
+return 0 === Og(Pv(e, !0));
 }
 
-function bg(e) {
+function Ag(e) {
 var t = Nt(e);
 return [ {
 role: "harvester",
@@ -38544,14 +38573,14 @@ minCount: 1
 } ];
 }
 
-function Og(e, t) {
-var r, o, n, i, s = Uv(e, !0);
-if (0 === wg(s)) return !0;
+function Mg(e, t) {
+var r, o, n, i, s = Pv(e, !0);
+if (0 === Og(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Uv(e, !1), u = bg(t);
+var c = Pv(e, !1), u = Ag(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38571,57 +38600,57 @@ if (r) throw r.error;
 return !1;
 }
 
-function kg(e) {
+function Ug(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Ag(e, t, r) {
-var n = Tg(e.name, r.roleName, t);
+function _g(e, t, r) {
+var n = wg(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Mg(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return av.EMERGENCY;
+function Ng(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return cv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return av.HIGH;
-if (wv.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return cv.HIGH;
+if (Ov.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = to(e), n = oo(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return av.EMERGENCY;
-if (a > 0) return av.HIGH;
+if (a >= 100) return cv.EMERGENCY;
+if (a > 0) return cv.HIGH;
 }
 return function(e) {
-return e >= 90 ? av.HIGH : e >= 60 ? av.NORMAL : av.LOW;
+return e >= 90 ? cv.HIGH : e >= 60 ? cv.NORMAL : cv.LOW;
 }(o);
 }
 
-function Ug(e, t) {
+function Pg(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-kg(e);
-var l = Uv(e.name), m = xg(e.name), d = [];
-if (Og(e.name, e)) {
+Ug(e);
+var l = Pv(e.name), m = kg(e.name), d = [];
+if (Mg(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === wg(Uv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Og(Pv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Uv(e, !1), c = bg(t);
+var s = Pv(e, !1), c = Ag(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38636,7 +38665,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Sg(e, m.role, r, !0);
+var p = bg(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38667,17 +38696,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = lv[p]) && Sg(e.name, p, t, !0) ? (d.push(Ag(e, t, {
+return p && (g = pv[p]) && bg(e.name, p, t, !0) ? (d.push(_g(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: Mg(e, 0, p, g.priority, m),
+priority: Ng(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(lv)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = hg(e.name, p);
+for (var f = a(Object.entries(pv)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Tg(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38688,7 +38717,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = yg(e.name, p);
+var E = hg(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38702,8 +38731,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (Sg(e.name, p, t, m)) {
-var T = Iv(p), C = T ? Cg(e.name, p, t) : null, S = "claimer" === p ? zv(e.name, t) : null, w = "pioneer" === p ? $v(e.name, t) : null;
+}); else if (bg(e.name, p, t, m)) {
+var T = Dv(p), C = T ? xg(e.name, p, t) : null, S = "claimer" === p ? Zv(e.name, t) : null, w = "pioneer" === p ? rg(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38713,11 +38742,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(Ag(e, t, {
+}) : d.push(_g(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: Mg(e, 0, p, g.priority, m),
+priority: Ng(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38739,7 +38768,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = _g(e, l.value);
+var m = Ig(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38760,10 +38789,10 @@ requests: c
 };
 }
 
-function _g(e, t) {
+function Ig(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Cv.getMaxAffordableInTicks(e, l), d = og(e), p = t.priority >= av.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && bo(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= av.EMERGENCY, g = t.assistTarget ? vo(t.assistTarget) : null, h = f ? Co(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Co(f, d, g)) && void 0 !== r ? r : tg(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = xv.getMaxAffordableInTicks(e, l), d = ig(e), p = t.priority >= cv.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && bo(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= cv.EMERGENCY, g = t.assistTarget ? vo(t.assistTarget) : null, h = f ? Co(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Co(f, d, g)) && void 0 !== r ? r : ng(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38784,7 +38813,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : vv({
+}(t.def, p)) && void 0 !== c ? c : Rv({
 maxEnergy: p,
 role: t.roleName
 }), C = t.bodyOverride ? u : E ? v ? d : u : p;
@@ -38820,44 +38849,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Ng = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Pg = new Set([ "guard", "ranger", "healer" ]);
+var Gg = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Lg = new Set([ "guard", "ranger", "healer" ]);
 
-function Ig() {
+function Dg() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Gg(e) {
+function Fg(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Lg(e) {
+function Bg(e) {
 var t;
-return e.priority >= av.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= cv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Dg(e) {
+function Wg(e) {
 var t;
-return e.priority >= av.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= cv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Fg(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = og(e), m = r.urgency >= 2 || t.danger >= 3 ? av.EMERGENCY : av.HIGH, d = yo(q(e)), p = function(e) {
+function Hg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = ig(e), m = r.urgency >= 2 || t.danger >= 3 ? cv.EMERGENCY : cv.HIGH, d = yo(q(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === av.EMERGENCY ? l : u, f = function(e, t) {
+}(d) ? u : m === cv.EMERGENCY ? l : u, f = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Ev.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Sv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || Bg(u, e) && ("guard" === u.role && (n.guards++,
-Hg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Hg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Hg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Kg(u, e) && ("guard" === u.role && (n.guards++,
+Vg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Vg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Vg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38885,7 +38914,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Hg(n, u, l);
+0 !== l.length && Vg(n, u, l);
 }
 }
 }
@@ -38924,26 +38953,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Wg("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) Yg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Wg("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) Yg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Wg("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Yg(e, "healer", "military", av.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Yg("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) jg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Yg("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) jg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Yg("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) jg(e, "healer", "military", cv.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
-if (!(t < av.EMERGENCY || function(e, t) {
+if (!(t < cv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Pg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Lg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Ev.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Sv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < av.EMERGENCY || Pg.has(c.role) && Bg(c, e.name) && c.body.cost <= t && n++;
+c.priority < cv.EMERGENCY || Lg.has(c.role) && Kg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -38960,7 +38989,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = eg(t, e);
+var r = og(t, e);
 return r ? {
 role: t,
 body: r
@@ -38975,45 +39004,45 @@ var r = mo(t.body.parts).score - mo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Yg(e, n.role, "military", av.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && jg(e, n.role, "military", cv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Bg(e, t) {
+function Kg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Wg(e, t, r) {
+function Yg(e, t, r) {
 return r ? Co(e, t, r) : null;
 }
 
-function Hg(e, t, r) {
+function Vg(e, t, r) {
 var o = mo(r);
 e[t] = e[t] ? po(e[t], o) : o;
 }
 
-function Kg(e, t, r) {
-return Ev.getPendingRequests(e).filter(function(e) {
+function qg(e, t, r) {
+return Sv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Yg(e, t, r, o, n, a, i, s, c) {
+function jg(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : vv({
+var u = null != i ? i : Rv({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Ev.addRequest({
+Sv.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -39031,34 +39060,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Vg(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= av.HIGH) return !1;
+function zg(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= cv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < av.NORMAL) {
-if (Cv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < cv.NORMAL) {
+if (xv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === av.NORMAL && o / e.energyCapacityAvailable < .3 && Cv.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === cv.NORMAL && o / e.energyCapacityAvailable < .3 && xv.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function qg(e, t) {
+function Qg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-kg(e);
-var s = Ev.getQueueSize(e.name);
+Ug(e);
+var s = Sv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Og(e.name, e), u = xg(e.name) && !Ev.hasEmergencySpawns(e.name), l = to(e), m = oo(e);
+var c = Mg(e.name, e), u = kg(e.name) && !Sv.hasEmergencySpawns(e.name), l = to(e), m = oo(e);
 if (c) {
-s > 0 && Ev.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Fg(e, t, l, m);
+s > 0 && Sv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Hg(e, t, l, m);
 try {
-for (var d = a(Ug(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Pg(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Ev.addRequest(f);
+Sv.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -39071,8 +39100,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Fg(e, t, l, m), function(e) {
-var t, r, o = Sv.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Hg(e, t, l, m), function(e) {
+var t, r, o = bv.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -39084,17 +39113,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = av.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = cv.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Kg(e.name, "powerHarvester", f), g = Kg(e.name, "healer", f), h = Kg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Yg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = qg(e.name, "powerHarvester", f), g = qg(e.name, "healer", f), h = qg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) jg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Yg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) jg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Yg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) jg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -39123,13 +39152,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Ev.getPendingRequests(e.name).map(Gg));
+var c = new Set(Sv.getPendingRequests(e.name).map(Fg));
 try {
-for (var u = a(Ug(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= av.HIGH, p = "claimer" === m.role && Ig(), f = Lg(m), y = Dg(m);
-if (Ng.has(m.role) || d || p || f || y) {
-var v = Gg(m);
-c.has(v) || (Ev.addRequest(m), c.add(v));
+for (var u = a(Pg(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= cv.HIGH, p = "claimer" === m.role && Dg(), f = Bg(m), y = Wg(m);
+if (Gg.has(m.role) || d || p || f || y) {
+var v = Fg(m);
+c.has(v) || (Sv.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -39146,8 +39175,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Ug(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Ev.addRequest(f);
+for (var y = a(Pg(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Sv.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -39159,32 +39188,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Ev.getQueueStats(e.name);
+var g = Sv.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Ev.clearQueue(e.name);
+} else s > 0 && Sv.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Ev.getAvailableSpawns(e.name);
+var t, r, o = Sv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = og(e);
+var n = 0, i = ig(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Ev.getNextRequest(e.name, i);
+var u = c.value, l = Sv.getNextRequest(e.name, i);
 if (!l) break;
-if (Vg(e, l, i)) {
+if (zg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = hv(u, l);
-m === OK ? (n++, i -= l.body.cost, Ev.markInProgress(e.name, l.id, u.id), Ev.removeRequest(e.name, l.id),
+var m = Tv(u, l);
+m === OK ? (n++, i -= l.body.cost, Sv.markInProgress(e.name, l.id, u.id), Sv.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Ev.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Sv.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -39200,7 +39229,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Ev.getQueueStats(e.name);
+}(e), o = Sv.getQueueStats(e.name);
 return r > 0 && U.debug("Spawned ".concat(r, " creeps in ").concat(e.name), {
 subsystem: "SpawnPipeline"
 }), Game.time % 100 == 0 && U.debug("Spawn queue stats for ".concat(e.name, ": ").concat(o.total, " pending (").concat(o.inProgress, " in progress)"), {
@@ -39214,7 +39243,7 @@ stats: o
 }(e, t);
 }
 
-var jg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, zg = /^(\d{1,2})\|(.+)$/, Qg = A("SS2TerminalComms"), Xg = function() {
+var Xg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, Zg = /^(\d{1,2})\|(.+)$/, Jg = A("SS2TerminalComms"), $g = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -39274,11 +39303,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(jg);
+var t = e.match(Xg);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(zg);
+var i = a.match(Zg);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -39313,7 +39342,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-Qg.warn("Missing packet in multi-packet message", {
+Jg.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -39329,7 +39358,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), Qg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), Jg.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -39353,7 +39382,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && Qg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && Jg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -39365,7 +39394,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return Qg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return Jg.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -39373,14 +39402,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), Qg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), Jg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (Qg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (Jg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -39405,7 +39434,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-Qg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+Jg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -39417,7 +39446,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-Qg.info("Completed sending multi-packet message", {
+Jg.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -39425,25 +39454,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? Qg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? Jg.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (Qg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (Jg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else Qg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else Jg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else Qg.warn("Terminal not found for queue item, removing from queue", {
+} else Jg.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39477,7 +39506,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && Qg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && Jg.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39487,7 +39516,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-Qg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+Jg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39578,7 +39607,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (Qg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (Jg.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39600,7 +39629,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return Qg.error("Error parsing JSON", {
+return Jg.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39611,7 +39640,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), Zg = [ {
+}(), eh = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39631,7 +39660,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Jg = function() {
+} ], th = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39678,9 +39707,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), $g = new Jg;
+}(), rh = new th;
 
-function eh(e) {
+function oh(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39688,19 +39717,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function th(e, t) {
+function nh(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function rh(e, t) {
+function ah(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var oh = {
+var ih = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39711,9 +39740,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, nh = function() {
+}, sh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, oh), e);
+void 0 === e && (e = {}), this.config = o(o({}, ih), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39734,7 +39763,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = $g.getSwarmState(r.toRoom);
+var o = rh.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39747,7 +39776,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = $g.getSwarmState(c);
+var l = rh.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39817,9 +39846,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(th), u = n.filter(function(e) {
+}).sort(nh), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(rh), l = [], m = [], d = function(t) {
+}).sort(ah), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39841,11 +39870,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return eh({
+return oh({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + eh({
+}) + oh({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -39944,7 +39973,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), ah = new nh, ih = {
+}(), ch = new sh, uh = {
 1: {
 guards: 1,
 rangers: 1,
@@ -39965,14 +39994,14 @@ siegeUnits: 1
 }
 };
 
-function sh(e) {
+function lh(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function ch(e) {
+function mh(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -39995,9 +40024,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function uh(e) {
+function dh(e) {
 var t, r, o;
-ch(e);
+mh(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -40021,20 +40050,20 @@ if (t) throw t.error;
 return n;
 }
 
-function lh(e) {
+function ph(e) {
 var t;
-ch(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = uh(e);
+mh(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = dh(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function mh(e) {
-return !!lh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function fh(e) {
+return !!ph(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-ch(e);
+mh(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -40045,12 +40074,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = uh(e);
+var d = dh(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function dh(e, t) {
+function yh(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -40071,20 +40100,20 @@ if (r) throw r.error;
 return n;
 }
 
-function ph(e, t) {
+function vh(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = ih[r]) && void 0 !== t ? t : ih[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = uh[r]) && void 0 !== t ? t : uh[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = dh(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = yh(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: sh(r),
+targetComposition: lh(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -40096,7 +40125,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function fh(e) {
+function gh(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -40116,9 +40145,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function yh(e) {
+function hh(e) {
 var t = e.members.length;
-ch(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+mh(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -40132,7 +40161,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && mh(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && fh(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -40161,7 +40190,7 @@ subsystem: "Squad"
 }
 }
 
-var vh = {
+var Rh = {
 harassment: {
 composition: {
 harassers: 3,
@@ -40248,7 +40277,7 @@ prioritizeDefenses: !0
 }
 };
 
-function gh(e, t) {
+function Eh(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -40263,8 +40292,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function hh(e, t) {
-var r, o, n, i = vh[t], s = 0;
+function Th(e, t) {
+var r, o, n, i = Rh[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -40290,7 +40319,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Rh, Eh, Th, Ch = {
+var Ch, Sh, wh, xh = {
 move: 50,
 work: 100,
 carry: 50,
@@ -40299,11 +40328,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, Sh = new Map;
+}, bh = new Map;
 
-function wh(e, t) {
+function Oh(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (Sh.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (bh.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -40315,7 +40344,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = vh[p].composition;
+d = Rh[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -40330,19 +40359,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (Sh.set(m, y), function(e, t, r, o) {
+v ? (bh.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = vh[s].useBoosts;
+i = Rh[s].useBoosts;
 }
-var c = av.NORMAL;
-"siege" === t.type ? c = av.HIGH : "defense" === t.type && (c = av.EMERGENCY);
+var c = cv.NORMAL;
+"siege" === t.type ? c = cv.HIGH : "defense" === t.type && (c = cv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = xh(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + Ch[t];
-}, 0), m = i ? Oh(r) : [], d = {
+var u = kh(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + xh[t];
+}, 0), m = i ? Mh(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -40371,7 +40400,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Ev.addRequest(d), o.spawnRequests.add(d.id);
+Sv.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -40385,42 +40414,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function xh(e, t, r) {
+function kh(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return bh([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return Ah([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return bh([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Ah([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return bh([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return Ah([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return bh([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return Ah([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return bh([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return Ah([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return bh([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return Ah([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function bh(e, t, r) {
+function Ah(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + Ch[t];
+return e + xh[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + Ch[t];
+return e + xh[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Oh(e) {
+function Mh(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40451,45 +40480,45 @@ return [];
 }
 }
 
-function kh(e) {
-return Sh.has(e);
+function Uh(e) {
+return bh.has(e);
 }
 
-function Ah(e) {
-return lh(e) || mh(e);
+function _h(e) {
+return ph(e) || fh(e);
 }
 
-(Rh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Rh[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Rh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Eh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Eh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Eh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Eh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Th = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-Th[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Th[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-Th[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Th[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(Ch = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Ch[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+Ch[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Sh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+Sh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Sh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+Sh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (wh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+wh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, wh[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+wh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, wh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var Mh = {
+var Nh = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Uh(e, t) {
-var r = Mh[t], o = $g.getClusters();
+function Ph(e, t) {
+var r = Nh[t], o = rh.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function _h(e, t, r) {
+function Ih(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = $g.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = rh.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Uh(e, i.danger),
+reservedEnergy: Ph(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40579,7 +40608,7 @@ success: !1
 });
 }
 
-var Nh = {
+var Gh = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40589,7 +40618,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Ph(e, t, r) {
+function Lh(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40620,7 +40649,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function Ih(e, t, r, o) {
+function Dh(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40630,7 +40659,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function Gh(e, t) {
+function Fh(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40651,19 +40680,19 @@ if (r) throw r.error;
 return n;
 }
 
-function Lh() {
-var e = $g.getEmpire();
+function Bh() {
+var e = rh.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function Dh(e) {
-Lh()[e.id] = e;
+function Wh(e) {
+Bh()[e.id] = e;
 }
 
-function Fh(e) {
+function Hh(e) {
 e.lastUpdate = Game.time;
-var t = $g.getCluster(e.clusterId);
-if (!t) return e.state = "failed", Dh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = rh.getCluster(e.clusterId);
+if (!t) return e.state = "failed", Wh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40673,12 +40702,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (Ah(r) || kh(e) || wh(0, r), Ah(r));
+return !!r && (_h(r) || Uh(e) || Oh(0, r), _h(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), Dh(e);
+})), Wh(e);
 }(e, t);
 break;
 
@@ -40689,7 +40718,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (yh(o), fh(o)) {
+if (hh(o), gh(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40718,7 +40747,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = $g.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = rh.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40745,12 +40774,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), Dh(e);
+})), Wh(e);
 }(e, t);
 }
 }
 
-function Bh(e, t, r) {
+function Kh(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40769,11 +40798,11 @@ score: n.score + o.score
 }
 }
 
-function Wh(e, t, r) {
+function Yh(e, t, r) {
 return Co(e, t, r);
 }
 
-function Hh(e, t) {
+function Vh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40786,11 +40815,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function Kh(e) {
+function qh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function Yh(e, t, r) {
+function jh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40803,8 +40832,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function Vh(e, t, r) {
-var o = Wh(t, e.energyCapacityAvailable, r);
+function zh(e, t, r) {
+var o = Yh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40812,16 +40841,16 @@ var a = mo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function qh(e, t, r, o) {
+function Qh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = Vh(e, t, o);
-if (s !== Vh(n, t, o)) return s ? -1 : 1;
+var a, i, s = zh(e, t, o);
+if (s !== zh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function jh(e, t) {
+function Xh(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -40905,21 +40934,21 @@ if (r) throw r.error;
 return u;
 }
 
-function zh(e, t) {
+function Zh(e, t) {
 return {
-guard: Math.max(0, Hh(e, "guard") - t.counts.guard),
-ranger: Math.max(0, Hh(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, Hh(e, "healer") - t.counts.healer)
+guard: Math.max(0, Vh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, Vh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, Vh(e, "healer") - t.counts.healer)
 };
 }
 
-function Qh(e) {
+function Jh(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function Xh(e, t) {
+function $h(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return Qh(e.role);
+return Jh(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -40932,12 +40961,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function Zh(e) {
+function eR(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === $a ? e.targetRoom : void 0;
 }
 
-function Jh(e) {
+function tR(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -40949,7 +40978,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-Qh(m) && Zh(l) === e && !u.spawning && Bh(i, m, u.body.filter(function(e) {
+Jh(m) && eR(l) === e && !u.spawning && Kh(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -40967,7 +40996,7 @@ if (t) throw t.error;
 return i;
 }
 
-function $h(e, t, r) {
+function rR(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -40997,16 +41026,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: Xh(e, r)
+pendingAssist: $h(e, r)
 };
 }
 }
 
-function eR(e, t) {
+function oR(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = Wh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = Yh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -41027,7 +41056,7 @@ subsystem: "Cluster"
 }
 }
 
-function tR(e, t, r) {
+function nR(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -41069,20 +41098,20 @@ exitAccess: a
 };
 }
 
-function rR(e, t) {
+function aR(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function oR(e, t, r) {
+function iR(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function nR(e) {
+function sR(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function aR(e, t) {
+function cR(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -41093,7 +41122,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function iR(e, t, r) {
+function uR(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -41104,8 +41133,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = nR(g);
-h && (ri(g) || aR(v, h) && (t.assignedCreeps.includes(v.name) || rR(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = sR(g);
+h && (ri(g) || cR(v, h) && (t.assignedCreeps.includes(v.name) || aR(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -41142,7 +41171,7 @@ return e.distance - t.distance;
 });
 }
 
-function sR(e, t) {
+function lR(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -41167,21 +41196,21 @@ if (r) throw r.error;
 return i;
 }
 
-function cR(e) {
+function mR(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var uR = {
+var dR = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, lR = function() {
+}, pR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, uR), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, dR), e);
 }
 return e.prototype.run = function() {
-var e = $g.getClusters();
+var e = rh.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -41200,7 +41229,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: Zg.map(function(t) {
+steps: eh.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -41256,7 +41285,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-ah.processCluster(t);
+ch.processCluster(t);
 break;
 
 case "squads":
@@ -41288,7 +41317,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = tR(e, new RoomPosition(s, c, e.name), "defense");
+var u = nR(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -41337,9 +41366,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = $g.getSwarmState(i);
+var i = n.value, s = rh.getSwarmState(i);
 if (s) {
-var c = Uh(i, s.danger);
+var c = Ph(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -41370,7 +41399,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = $g.getSwarmState(m);
+var m = l.value, d = rh.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -41402,7 +41431,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += cR(l.controller.level));
+}).length, i += mR(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41519,7 +41548,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-yh(i), "gathering" !== i.state || Ah(i) || kh(i.id) || wh(0, i), fh(i) && (i.state = "dissolving");
+hh(i), "gathering" !== i.state || _h(i) || Uh(i.id) || Oh(0, i), gh(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41544,7 +41573,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = ph(e, s);
+var s = i.value, c = vh(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41561,7 +41590,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(Lh()).filter(function(e) {
+var t = (a = e.id, Object.values(Bh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41572,22 +41601,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Nh), n), m = [], d = $g.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, Gh), n), m = [], d = rh.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = Ph(f, y, d);
+var g = Lh(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = Gh(e, f);
+var h = Fh(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = Ih(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = Dh(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = gh(f, {
+var C = Eh(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41622,29 +41651,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-hh(e, n.doctrine) ? function(e, t, r) {
+Th(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = $g.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = rh.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = Ph(e, o, r);
+var n = Lh(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = ($g.getEmpire().knownRooms || {})[t], n = null != r ? r : gh(t, {
+var o = (rh.getEmpire().knownRooms || {})[t], n = null != r ? r : Eh(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!hh(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Th(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41657,7 +41686,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-Dh(i);
+Wh(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41671,13 +41700,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = dh(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = yh(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: sh(n),
+targetComposition: lh(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41692,8 +41721,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), Dh(i), wh(0, c), i.state = "forming", i.lastUpdate = Game.time,
-Dh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), Wh(i), Oh(0, c), i.state = "forming", i.lastUpdate = Game.time,
+Wh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41712,11 +41741,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(Sh.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(bh.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), Sh.delete(c));
+}), bh.delete(c));
 }
 } catch (t) {
 e = {
@@ -41730,10 +41759,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = Lh();
-for (var t in e) Fh(e[t]);
+var e = Bh();
+for (var t in e) Hh(e[t]);
 !function() {
-var e = Lh();
+var e = Bh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41811,14 +41840,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = $g.getCluster(t, e);
+var t = "cluster_".concat(e), r = rh.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = $g.getCluster(e);
+var o = rh.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41847,7 +41876,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && _h(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Ih(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41864,7 +41893,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = $g.getSwarmState(t);
+var n, a, i = rh.getSwarmState(t);
 if (!i) return "continue";
 if (no(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -41905,7 +41934,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = vo(g), f[g] = Jh(g);
+p[g] = vo(g), f[g] = tR(g);
 }
 } catch (e) {
 r = {
@@ -41921,7 +41950,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = $h(E, m, t);
+d[E] = rR(E, m, t);
 }
 } catch (e) {
 n = {
@@ -41940,13 +41969,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Yh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = jh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = jh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = Xh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = xo(T, R, zh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = xo(T, R, Zh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = qh(h, b, g.roomName, R), A = 0; A < O; A++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = Qh(h, b, g.roomName, R), A = 0; A < O; A++) {
 var M = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -41958,7 +41987,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").con
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: Kh(g.urgency),
+priority: qh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -42004,7 +42033,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) eR(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) oR(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -42019,7 +42048,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Ev);
+}(e, Sv);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -42031,7 +42060,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = sR(f, iR(e, f, t)), v = y.reduce(function(e, t) {
+var y = lR(f, uR(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -42044,7 +42073,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), oR(f, R.role, rR(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), iR(f, R.role, aR(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -42111,24 +42140,24 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), mR = new lR, dR = /^([WE])(\d+)([NS])(\d+)$/;
+}(), fR = new pR, yR = /^([WE])(\d+)([NS])(\d+)$/;
 
-function pR(e) {
-return dR.test(e);
+function vR(e) {
+return yR.test(e);
 }
 
-var fR = {
+var gR = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, yR = function() {
+}, hR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, fR), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, gR), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = cf();
-this.updateEnemyIntelligence(e), uf(e, {
+var e = mf();
+this.updateEnemyIntelligence(e), df(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
@@ -42191,7 +42220,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (pR(x)) {
+if (e.isAlly(x)) f.add(x); else if (vR(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -42256,14 +42285,14 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return cf().globalTargets.enemies || [];
+return mf().globalTargets.enemies || [];
 }, n([ vt("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: Je.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), vR = new yR, gR = function() {
+}(), RR = new hR, ER = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -42340,9 +42369,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), hR = new gR, RR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), TR = new ER, CR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function ER(e, t) {
+function SR(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -42365,13 +42394,13 @@ if (r) throw r.error;
 return n;
 }
 
-function TR(e) {
+function wR(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function CR(e, t, r) {
-if (!TR(e)) return 0;
-var o = ER(e.name, t);
+function xR(e, t, r) {
+if (!wR(e)) return 0;
+var o = SR(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += qs(e.mineralType),
@@ -42380,7 +42409,7 @@ n += Xs(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += Js(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function SR(e, t) {
+function bR(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -42390,13 +42419,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && RR.has(e.type);
+return e.hits > 0 && CR.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function wR(e, t, r) {
+function OR(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -42406,7 +42435,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function xR(e) {
+function kR(e) {
 return function(e) {
 var t = X(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42417,8 +42446,8 @@ isSK: Z(t.x) && Z(t.y)
 }(e);
 }
 
-function bR(e) {
-var t = xR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function AR(e) {
+var t = kR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42437,14 +42466,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var OR = {
+var MR = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, kR = function() {
+}, UR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, OR), e);
+void 0 === e && (e = {}), this.config = o(o({}, MR), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42535,7 +42564,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = xR(e);
+var t = kR(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42547,14 +42576,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return bR(AR(e));
+return AR(_R(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = bR(AR(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = AR(_R(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function AR(e) {
+function _R(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = q(e), c = j(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42586,11 +42615,11 @@ swamps: d
 };
 }
 
-var MR = new kR, UR = /^([WE])(\d+)([NS])(\d+)$/, _R = {
+var NR = new UR, PR = /^([WE])(\d+)([NS])(\d+)$/, IR = {
 allies: []
-}, NR = function() {
+}, GR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, _R), e);
+void 0 === e && (e = {}), this.config = o(o({}, IR), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42610,7 +42639,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!UR.test(e)) return !1;
+if (!PR.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42718,7 +42747,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return UR.test(e);
+return PR.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42745,7 +42774,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), PR = new NR, IR = {
+}(), LR = new GR, DR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42758,9 +42787,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, GR = function() {
+}, FR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, IR), e);
+void 0 === e && (e = {}), this.config = o(o({}, DR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = Xr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42773,7 +42802,7 @@ t.updateExpansionQueue(o);
 }), Fi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Fi.measureSubsystem("empire:warTargets", function() {
-PR.updateWarTargets(o);
+LR.updateWarTargets(o);
 }), Fi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Fi.measureSubsystem("empire:gclTracking", function() {
@@ -42781,13 +42810,13 @@ t.trackGCLProgress(o);
 }), s && Fi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Fi.measureSubsystem("empire:intelRefresh", function() {
-MR.refreshRoomIntel(o);
+NR.refreshRoomIntel(o);
 }), Fi.measureSubsystem("empire:roomDiscovery", function() {
-MR.discoverNearbyRooms(o);
+NR.discoverNearbyRooms(o);
 })), s && Fi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Fi.measureSubsystem("empire:clusterHealth", function() {
-hR.monitorClusterHealth();
+TR.monitorClusterHealth();
 }), Fi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42870,22 +42899,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = SR(f, u);
+var y = Boolean(Game.rooms[f]), v = bR(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = ER(f, t);
+var g = SR(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = wR(h, u, y);
+var h = e.knownRooms[f], R = OR(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? CR(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? xR(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -42929,10 +42958,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && TR(a)) {
-var i = ER(a.name, t);
+if (a && wR(a)) {
+var i = SR(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = CR(a, t, r);
+var s = xR(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -43252,13 +43281,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), LR = new GR;
+}(), BR = new FR;
 
-function DR(e) {
+function WR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var FR = {
+var HR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -43266,10 +43295,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, BR = function() {
+}, KR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, FR), e);
+this.config = o(o({}, HR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -43413,7 +43442,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, DR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, WR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43588,7 +43617,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), WR = new BR, HR = function() {
+}(), YR = new KR, VR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Ks(o(o({}, As), e), {
 getEmpire: function() {
@@ -43624,7 +43653,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), KR = new HR, YR = function() {
+}(), qR = new VR, jR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = Xr.getEmpire();
@@ -43642,9 +43671,9 @@ lastScan: 0
 var e = Xr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), VR = new (function(e) {
+}(), zR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new YR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new jR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43656,22 +43685,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ht() ], t);
 }(Ci));
 
-function qR() {
+function QR() {
 return global;
 }
 
-function jR(e) {
+function XR(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function zR(e) {
+function ZR(e) {
 return Number(null != e ? e : 0);
 }
 
-var QR = function() {
+var JR = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = qR();
+var e = QR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43679,12 +43708,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return qR()._pixelGenerationMemory;
+return QR()._pixelGenerationMemory;
 }, e;
-}(), XR = function(e) {
+}(), $R = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new QR) || this;
+var r = e.call(this, t, new JR) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43701,7 +43730,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(jR).length : Object.values(null != t ? t : {}).filter(jR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(XR).length : Object.values(null != t ? t : {}).filter(XR).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43712,9 +43741,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (zR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (zR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = zR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = zR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (ZR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (ZR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = ZR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = ZR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43736,9 +43765,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ht() ], t);
-}(wi), ZR = new XR;
+}(wi), eE = new $R;
 
-function JR(e, t) {
+function tE(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !K(e.controller.owner.username)) return {
 lost: !0,
@@ -43760,7 +43789,7 @@ lost: !1
 };
 }
 
-function $R(e, t, r) {
+function rE(e, t, r) {
 var o, n = Xr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43774,20 +43803,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var eE = Me().cpu.bucketThresholds.highMode + 1800, tE = {
+var oE = Me().cpu.bucketThresholds.highMode + 1800, nE = {
 updateInterval: 250,
-minBucket: eE,
+minBucket: oE,
 maxSitesPerRemotePerTick: 2
 };
 
-function rE(e, t) {
+function aE(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var oE = function() {
+var iE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, tE), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, nE), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43804,8 +43833,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = JR(l);
-m.lost && m.reason && $R(e, u, m.reason);
+var m = tE(l);
+m.lost && m.reason && rE(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43823,10 +43852,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = rE("remoteInfrastructure.intent", function() {
+var i = aE("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-rE("remoteInfrastructure.execute", function() {
+aE("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -43992,13 +44021,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = rE("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = aE("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = rE("remoteInfrastructure.roomSnapshot", function() {
+u[t] = aE("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -44031,7 +44060,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = rE("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = aE("remoteInfrastructure.calculateRemoteRoads", function() {
 return ua(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -44060,14 +44089,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = rE("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = aE("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? rE("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? aE("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -44084,7 +44113,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? rE("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? aE("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -44102,7 +44131,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return rE("remoteInfrastructure.findSources", function() {
+return aE("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -44199,10 +44228,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ yt("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Je.LOW,
 interval: 1e3,
-minBucket: eE,
+minBucket: oE,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), nE = new oE, aE = new (function(e) {
+}(), sE = new iE, cE = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -44214,7 +44243,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ht() ], t);
-}(vf)), iE = function() {
+}(Rf)), uE = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -44258,7 +44287,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-ay.applyDiffusion(o);
+cy.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44304,7 +44333,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ht() ], e);
-}(), sE = new iE, cE = new (function() {
+}(), lE = new uE, mE = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -44334,7 +44363,7 @@ registerProcesses: function() {
 var e;
 Wu.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), hi(sE, Rs, ws, Zi, LR, ac, WR, nE, fs, VR, ZR, KR, Dc, Kc, aE, vR, _c, mR, pi),
+}), hi(lE, Rs, ws, Zi, BR, ac, YR, sE, fs, zR, eE, qR, Dc, Kc, cE, RR, _c, fR, pi),
 function() {
 var e, t, r = Me().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -44389,7 +44418,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return mR.run();
+return fR.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -44430,9 +44459,9 @@ Wu.info("Registered ".concat(gi.getProcesses().length, " processes with kernel")
 subsystem: "ProcessRegistry"
 });
 }
-}), uE = "_ownedRooms", lE = "_ownedRoomsTick";
+}), dE = "_ownedRooms", pE = "_ownedRoomsTick";
 
-function mE(e) {
+function fE(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44442,13 +44471,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var dE = Fu("NativeCallsTracker");
+var yE = Fu("NativeCallsTracker");
 
-function pE(e, t, r) {
+function vE(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) dE.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) yE.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44464,7 +44493,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-dE.warn("Failed to wrap method", {
+yE.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44474,30 +44503,30 @@ error: String(e)
 }
 }
 
-var fE, yE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], vE = "shard1", gE = {
+var gE, hE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], RE = "shard1", EE = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, hE = {
+}, TE = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, RE = {
+}, CE = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function EE() {
+function SE() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function TE() {
+function wE() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: yE,
+targetShards: hE,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44507,12 +44536,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = yE),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = hE),
 Memory.interShardOperation;
 }
 
-function CE() {
-return cf({
+function xE() {
+return mf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -44525,32 +44554,32 @@ checksum: 0
 });
 }
 
-function SE(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), uf(e, {
+function bE(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), df(e, {
 updatedSections: t
 });
 }
 
-function wE() {
-var e, t, r, o, n, i, s, c = CE(), u = EE();
+function OE() {
+var e, t, r, o, n, i, s, c = xE(), u = SE();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: yE,
+targetShards: hE,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : yE,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : hE,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && xE() ? "established" : "unreached",
+status: p === u && kE() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44568,7 +44597,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === vE ? "core" : "frontier",
+role: u === RE ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44585,24 +44614,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), SE(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), bE(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function xE() {
+function kE() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function bE() {
+function AE() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function OE(e, t) {
+function ME(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44621,9 +44650,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(bE()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(AE()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Ev.getPendingRequests(p.name).filter(function(r) {
+s += Sv.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -44642,7 +44671,7 @@ if (n) throw n.error;
 return s;
 }
 
-function kE(e) {
+function UE(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44686,7 +44715,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = CE().shards[EE()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = xE().shards[SE()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44696,8 +44725,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function AE(e, t) {
-if (!(OE("scout", t) >= 1)) {
+function _E(e, t) {
+if (!(ME("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44735,13 +44764,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Ev.addRequest({
+r && Sv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: RE,
-priority: av.LOW + 5,
+body: CE,
+priority: cv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -44752,14 +44781,14 @@ task: "interShardPortalScout"
 }
 }
 
-function ME(e, t, r) {
-OE("interShardClaimer", t) >= 1 || Ev.addRequest({
+function NE(e, t, r) {
+ME("interShardClaimer", t) >= 1 || Sv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: gE,
-priority: av.NORMAL + 50,
+body: EE,
+priority: cv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44772,14 +44801,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function UE(e, t, r) {
-OE("interShardScout", t) >= 1 || Ev.addRequest({
+function PE(e, t, r) {
+ME("interShardScout", t) >= 1 || Sv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: RE,
-priority: av.NORMAL,
+body: CE,
+priority: cv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44792,15 +44821,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function _E(e, t, r) {
+function IE(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (OE("interShardPioneer", t.shard) >= 3 || Ev.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (ME("interShardPioneer", t.shard) >= 3 || Sv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: hE,
-priority: av.NORMAL + 25,
+body: TE,
+priority: cv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -44813,19 +44842,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function NE(e) {
+function GE(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = EE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = SE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : yE), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : hE), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? tf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? nf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -44857,9 +44886,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(bE()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(AE()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Ev.getPendingRequests(l.name).filter(function(e) {
+n += Sv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -44878,22 +44907,22 @@ return n;
 }() < o;
 }
 
-(fE = {
-optimizeBody: vv,
+(gE = {
+optimizeBody: Rv,
 spawnQueue: {
 addRequest: function(e) {
-return Ev.addRequest(e);
+return Sv.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: av.LOW,
-NORMAL: av.NORMAL,
-HIGH: av.HIGH
+LOW: cv.LOW,
+NORMAL: cv.NORMAL,
+HIGH: cv.HIGH
 }
-}).optimizeBody && (hf.optimizeBody = fE.optimizeBody), fE.spawnQueue && (hf.spawnQueue = fE.spawnQueue),
-fE.spawnPriorities && (hf.spawnPriorities = o(o({}, hf.spawnPriorities), fE.spawnPriorities));
+}).optimizeBody && (Tf.optimizeBody = gE.optimizeBody), gE.spawnQueue && (Tf.spawnQueue = gE.spawnQueue),
+gE.spawnPriorities && (Tf.spawnPriorities = o(o({}, Tf.spawnPriorities), gE.spawnPriorities));
 
-var PE, IE = function() {
+var LE, DE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -44937,7 +44966,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function GE(e) {
+function FE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -44958,7 +44987,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function LE(e, t, r) {
+function BE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -45024,16 +45053,16 @@ return u;
 });
 }
 
-function DE(e) {
+function WE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(PE || (PE = {}));
+}(LE || (LE = {}));
 
-var FE = function() {
+var HE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -45071,8 +45100,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = LE(h.pos, T.pos, this.logger);
-if (DE(C)) {
+var T = E.value, C = BE(h.pos, T.pos, this.logger);
+if (WE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -45099,8 +45128,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, A = LE(k, u.pos, this.logger);
-DE(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, A = BE(k, u.pos, this.logger);
+WE(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -45139,8 +45168,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = LE(e, t, this.logger);
-if (DE(n)) {
+var n = BE(e, t, this.logger);
+if (WE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -45150,7 +45179,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), BE = function() {
+}(), KE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -45160,7 +45189,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = GE(s);
+var c = FE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -45186,7 +45215,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), WE = function() {
+}(), YE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -45235,7 +45264,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), HE = {
+}(), VE = {
 debug: function(e, t) {
 return A("RemoteMining").debug(e, t);
 },
@@ -45248,7 +45277,7 @@ return A("RemoteMining").warn(e, t);
 error: function(e, t) {
 return A("RemoteMining").error(e, t);
 }
-}, KE = {
+}, qE = {
 getCachedPath: function(e, t) {
 var r = kt(e, t), o = Le.get(r, {
 namespace: Ot
@@ -45275,26 +45304,26 @@ direction: a
 }
 return t;
 }
-}, YE = {
+}, jE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = _m.MEDIUM), Km.register({
+void 0 === o && (o = Pm.MEDIUM), Vm.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== _m.CRITICAL
+skippable: o !== Pm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, VE = new FE(KE, HE), qE = new BE(HE, YE, VE), jE = new WE(HE, KE, VE, Ju.moveTo);
+}, zE = new HE(qE, VE), QE = new KE(VE, jE, zE), XE = new YE(VE, qE, zE, el.moveTo);
 
-function zE(e, t, r, o) {
-return jE.moveToWithRemoteCache(e, t, r, o);
+function ZE(e, t, r, o) {
+return XE.moveToWithRemoteCache(e, t, r, o);
 }
 
-var QE, XE = function() {
+var JE, $E = function() {
 function e() {
 this.logger = A("Pathfinding");
 }
@@ -45307,12 +45336,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), ZE = function() {
+}(), eT = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 tt.on(e, t);
 }, e;
-}(), JE = function() {
+}(), tT = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -45357,28 +45386,28 @@ m.length > 0 && At(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), $E = function() {
+}(), rT = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return GE(e);
+return FE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-VE.precacheRemoteRoutes(e, t);
+zE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), eT = new IE(new XE, new ZE, new JE, new $E), tT = {
+}(), oT = new DE(new $E, new eT, new tT, new rT), nT = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, rT = function() {
+}, aT = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, tT), e);
+this.config = o(o({}, nT), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45472,123 +45501,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new rT, (QE = {})[FIND_STRUCTURES] = {
+new aT, (JE = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, QE[FIND_MY_STRUCTURES] = {
+}, JE[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, QE[FIND_HOSTILE_STRUCTURES] = {
+}, JE[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, QE[FIND_SOURCES_ACTIVE] = {
+}, JE[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, QE[FIND_SOURCES] = {
+}, JE[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, QE[FIND_MINERALS] = {
+}, JE[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, QE[FIND_DEPOSITS] = {
+}, JE[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, QE[FIND_MY_CONSTRUCTION_SITES] = {
+}, JE[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, QE[FIND_CONSTRUCTION_SITES] = {
+}, JE[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, QE[FIND_CREEPS] = {
+}, JE[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, QE[FIND_MY_CREEPS] = {
+}, JE[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, QE[FIND_HOSTILE_CREEPS] = {
+}, JE[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, QE[FIND_DROPPED_RESOURCES] = {
+}, JE[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, QE[FIND_TOMBSTONES] = {
+}, JE[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, QE[FIND_RUINS] = {
+}, JE[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, QE[FIND_FLAGS] = {
+}, JE[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, QE[FIND_MY_SPAWNS] = {
+}, JE[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, QE[FIND_HOSTILE_SPAWNS] = {
+}, JE[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, QE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, JE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, QE[FIND_NUKES] = {
+}, JE[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, QE[FIND_POWER_CREEPS] = {
+}, JE[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, QE[FIND_MY_POWER_CREEPS] = {
+}, JE[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, QE[FIND_HOSTILE_POWER_CREEPS] = {
+}, JE[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, QE[FIND_EXIT_TOP] = {
+}, JE[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, QE[FIND_EXIT_RIGHT] = {
+}, JE[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, QE[FIND_EXIT_BOTTOM] = {
+}, JE[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, QE[FIND_EXIT_LEFT] = {
+}, JE[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, QE[FIND_EXIT] = {
+}, JE[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var oT = new ue({}, Xr), nT = new Re({}, Xr);
+var iT = new ue({}, Xr), sT = new Re({}, Xr);
 
-function aT(e) {
+function cT(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45596,11 +45625,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var iT = !1;
+var uT = !1;
 
-function sT() {
+function lT() {
 var e, t;
-iT || (xu({
+uT || (xu({
 level: (t = Me()).debug ? ou.DEBUG : ou.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45615,11 +45644,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Tv.getPendingTransfers = function(e) {
+r.getPendingTransfers && (wv.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Tv.needsCarrier = function(e) {
+}), r.needsCarrier && (wv.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Tv.getActiveRequests = function() {
+}), r.getActiveRequests && (wv.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -45633,47 +45662,47 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Cv.predictConsumption = function(e) {
+a.predictConsumption && (xv.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Cv.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (xv.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Cv.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (xv.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Cv.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (xv.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Sv.getActivePowerBanks = function() {
+i.getActivePowerBanks && (bv.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Sv.needsHarvesters = function(e) {
+}), i.needsHarvesters && (bv.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Sv.needsCarriers = function(e) {
+}), i.needsCarriers && (bv.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Sv.requestSpawns = function(e) {
+}), i.requestSpawns && (bv.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-wv.getEmergencyState = function(e) {
+Ov.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: mr,
 powerBankHarvestingManager: Dc,
-resourceTransferCoordinator: Ef,
+resourceTransferCoordinator: Sf,
 emergencyResponseManager: ai,
 kernel: gi
 }), function(e) {
 var t, r, o, n;
-Pd = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : Nd.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : Nd.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : Nd.getLabOverflow
-} : Nd;
+Ld = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : Gd.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : Gd.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : Gd.getLabOverflow
+} : Gd;
 }({
 getLabResourceNeeds: function(e) {
 return mu.getLabResourceNeeds(e);
@@ -45687,7 +45716,7 @@ return mu.getLabOverflow(e);
 }), Fi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) dE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) yE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45701,7 +45730,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-dE.warn("Failed to wrap PathFinder.search", {
+yE.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45709,11 +45738,11 @@ error: String(e)
 }
 }
 }
-}(), pE(e = Creep.prototype, "moveTo", "moveTo"), pE(e, "move", "move"), pE(e, "harvest", "harvest"),
-pE(e, "transfer", "transfer"), pE(e, "withdraw", "withdraw"), pE(e, "build", "build"),
-pE(e, "repair", "repair"), pE(e, "upgradeController", "upgradeController"), pE(e, "attack", "attack"),
-pE(e, "rangedAttack", "rangedAttack"), pE(e, "heal", "heal"), pE(e, "dismantle", "dismantle"),
-pE(e, "say", "say")), function(e) {
+}(), vE(e = Creep.prototype, "moveTo", "moveTo"), vE(e, "move", "move"), vE(e, "harvest", "harvest"),
+vE(e, "transfer", "transfer"), vE(e, "withdraw", "withdraw"), vE(e, "build", "build"),
+vE(e, "repair", "repair"), vE(e, "upgradeController", "upgradeController"), vE(e, "attack", "attack"),
+vE(e, "rangedAttack", "rangedAttack"), vE(e, "heal", "heal"), vE(e, "dismantle", "dismantle"),
+vE(e, "say", "say")), function(e) {
 void 0 === e && (e = ze);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, Fe.L1, {
@@ -45900,15 +45929,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(gi, Xr, ay), eT.initializePathCacheEvents(), qE.initialize(_m.MEDIUM), Fl = zE,
-wr.initialize(), aE.initialize(), iT = !0), Xr.initialize();
-var r = cE.configureForCurrentTick();
+}(gi, Xr, cy), oT.initializePathCacheEvents(), QE.initialize(Pm.MEDIUM), Wl = ZE,
+wr.initialize(), cE.initialize(), uT = !0), Xr.initialize();
+var r = mE.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Wu.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = TE();
-if (!1 !== r.enabled && (r.lastRun = Game.time, wE(), function() {
-var e, t, r, o, n = CE(), a = n.footprintOperation, i = EE(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = wE();
+if (!1 !== r.enabled && (r.lastRun = Game.time, OE(), function() {
+var e, t, r, o, n = xE(), a = n.footprintOperation, i = SE(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45921,15 +45950,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, SE(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, bE(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = TE();
+var e, t, r, n, i, s, c = wE();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : yE), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === vE ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : hE), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === RE ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -45947,10 +45976,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !xE())) try {
+}(), !kE())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || If(s), "interShardPioneer" === c && Pf(s);
+"interShardClaimer" !== c && "interShardScout" !== c || Df(s), "interShardPioneer" === c && Lf(s);
 }
 } catch (t) {
 e = {
@@ -45974,17 +46003,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Wu.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: iT
+systemsInitialized: uT
 }
-}), cE.ensureProcessesRegistered(), Fi.startTick(), Vu.clear(), cE.startEventTick();
+}), mE.ensureProcessesRegistered(), Fi.startTick(), ju.clear(), mE.startEventTick();
 var i = function(e) {
-var t = e.cache[uE], r = e.cache[lE];
+var t = e.cache[dE], r = e.cache[pE];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[uE] = o, e.cache[lE] = e.tick, o;
+return e.cache[dE] = o, e.cache[pE] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -46006,7 +46035,7 @@ rooms: i,
 interval: o
 })), s = n.next(); !s.done; s = n.next()) {
 var c = s.value;
-Gl.refreshRoom(c);
+Dl.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -46021,18 +46050,18 @@ if (e) throw e.error;
 }
 }), Fi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = TE();
+var e, t, r, o = wE();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = wE();
+var n = OE();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : yE), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : hE), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== EE()) try {
+if (d !== SE()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = tf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = nf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -46050,20 +46079,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = bE().sort(function(e, t) {
+var i = AE().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : yE), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : hE), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== EE()) {
+if (u !== SE()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = kE(u);
+var m = UE(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? _E(i, l, m) : NE() ? ME(i, u, m) : (UE(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (AE(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? IE(i, l, m) : GE() ? NE(i, u, m) : (PE(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (_E(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -46080,8 +46109,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = CE();
-d.footprintOperation = n, SE(d);
+var d = xE();
+d.footprintOperation = n, bE(d);
 }
 }
 })(), function() {
@@ -46089,8 +46118,8 @@ var e, t, r, o = Game.cpu.bucket < Me().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || aT(s))) {
-var c = qg(s, Xr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || cT(s))) {
+var c = Qg(s, Xr.getOrInitSwarmState(s.name));
 Fi.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -46106,21 +46135,21 @@ if (e) throw e.error;
 }
 }
 }();
-}), Ju.preTick(), Fi.measureSubsystem("processSync", function() {
-qf.syncCreepProcesses(), jy.syncRoomProcesses();
+}), el.preTick(), Fi.measureSubsystem("processSync", function() {
+Qf.syncCreepProcesses(), Xy.syncRoomProcesses();
 }), Fi.measureSubsystem("kernel", function() {
-cE.runProcesses();
+mE.runProcesses();
 }), Fi.measureSubsystem("eventQueue", function() {
-cE.processQueuedEvents();
+mE.processQueuedEvents();
 }), Fi.measureSubsystem("ss2PacketQueue", function() {
-Xg.processQueue();
+$g.processQueue();
 }), gi.hasCpuBudget() && Fi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && Gf(n);
+void 0 !== n.ticksToLive && Ff(n);
 }
 } catch (t) {
 e = {
@@ -46134,7 +46163,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), mE({
+}), fE({
 hasCpuBudget: gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Fi.measureSubsystem("visualizations", function() {
@@ -46144,8 +46173,8 @@ var r, o;
 if (Me().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = oT.getConfig(), s = nT.getConfig();
-oT.setConfig(n.roomVisualizerConfig), n.renderMap && nT.setConfig(n.mapVisualizerConfig);
+var i = iT.getConfig(), s = sT.getConfig();
+iT.setConfig(n.roomVisualizerConfig), n.renderMap && sT.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -46156,7 +46185,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-oT.draw(m);
+iT.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Wu.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -46178,14 +46207,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-nT.draw();
+sT.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Wu.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-oT.setConfig(i), nT.setConfig(s);
+iT.setConfig(i), sT.setConfig(s);
 }
 }
 }
@@ -46270,19 +46299,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Ju.reconcileTraffic(), mE({
+}), el.reconcileTraffic(), fE({
 hasCpuBudget: gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Fi.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Km.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Vm.run(e);
 }), Xr.persistHeapCache(), Fi.collectProcessStats(gi.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), Fi.collectKernelBudgetStats(gi), Fi.setSkippedProcesses(gi.getSkippedProcessesThisTick()),
 Fi.finalizeTick(), Wu.flush();
 }
 
-var cT = function() {
+var mT = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Me().visualizations;
@@ -46290,25 +46319,25 @@ return Ue({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = oT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = iT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-oT.toggle(o);
-var n = oT.getConfig()[o];
+iT.toggle(o);
+var n = iT.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = nT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = sT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-nT.toggle(o);
-var n = nT.getConfig()[o];
+sT.toggle(o);
+var n = sT.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = nT.getConfig();
+var e = sT.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -46431,15 +46460,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), uT = function() {
+}(), dT = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = aE.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = cE.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = aE.getAllShards();
+var e, t, r = cE.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -46461,9 +46490,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (aE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (cE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = aE.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = cE.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -46488,19 +46517,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = aE.getOptimalPortalRoute(e, t);
+var r, o = cE.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (aE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (cE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (aE.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (cE.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Ef.getActiveRequests();
+var e, t, r = Sf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -46521,7 +46550,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = aE.getCurrentShardState();
+var e, t, r = cE.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -46542,7 +46571,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = aE.getActiveTransferTasks();
+var e, t, r, o = cE.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -46563,16 +46592,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = aE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(nf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = cE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(cf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = aE.getMemoryStats();
+var e = cE.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return aE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return cE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = CE().footprintOperation;
+var e, t, r, o = xE().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46678,9 +46707,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), lT = new uT;
+}(), pT = new dT;
 
-function mT(e) {
+function fT(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46710,10 +46739,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? mT(e.metadata.usage) : void 0
+params: e.metadata.usage ? fT(e.metadata.usage) : void 0
 };
 });
-return Jm({
+return ed({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -46764,12 +46793,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Jm.apply(void 0, s([], i(o), !1));
+return ed.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return Qm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Zm("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Zm.form("spawnCreep", [ {
+return $m.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -46803,20 +46832,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return Qm("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Zm("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += Qm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += Qm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Zm.button({
+o += '<div style="margin-bottom: 10px;">', o += Zm("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Zm("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += $m.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Zm.button({
+}), o += " ", (o += $m.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Zm.form("configureLogging", [ {
+return $m.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -46841,7 +46870,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Zm.form("configureVisualization", [ {
+return $m.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -46865,21 +46894,21 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Zm.button({
+e += $m.button({
 content: "🚨 Emergency Mode",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += Zm.button({
+}), e += " ", e += $m.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Zm.button({
+}), e += " ", (e += $m.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += Qm("✓ Success message", "green", !0) + "\n", e += Qm("⚠ Warning message", "yellow", !0) + "\n",
-e += Qm("✗ Error message", "red", !0) + "\n", e += Qm("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + Qm("colored text", "green") + " normal text\n") + "Bold text: " + Qm("important", null, !0) + "\n";
+return e += Zm("✓ Success message", "green", !0) + "\n", e += Zm("⚠ Warning message", "yellow", !0) + "\n",
+e += Zm("✗ Error message", "red", !0) + "\n", e += Zm("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Zm("colored text", "green") + " normal text\n") + "Bold text: " + Zm("important", null, !0) + "\n";
 }, n([ ir({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -46925,39 +46954,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var dT = new Qy, pT = new cT, fT = new Xy, yT = new Hu, vT = new zy, gT = new Zy, hT = new Jy, RT = "__screepsGlobalRuntimeDiagnostics";
+var yT = new Jy, vT = new mT, gT = new $y, hT = new Hu, RT = new Zy, ET = new ev, TT = new tv, CT = "__screepsGlobalRuntimeDiagnostics";
 
-function ET() {
+function ST() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function TT(e, t) {
+function wT(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function CT(e, t) {
+function xT(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function ST(e) {
+function bT(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function wT(e) {
+function OT(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: TT(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: TT(n.switchCount, 0),
-lastTick: CT(n.lastTick, Game.time),
-lastResetTick: CT(n.lastResetTick, Game.time),
-lastSwitchTick: ST(n.lastSwitchTick),
-lastSwitchPreviousTick: ST(n.lastSwitchPreviousTick),
-lastWarningTick: ST(n.lastWarningTick)
+resetCount: wT(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: wT(n.switchCount, 0),
+lastTick: xT(n.lastTick, Game.time),
+lastResetTick: xT(n.lastResetTick, Game.time),
+lastSwitchTick: bT(n.lastSwitchTick),
+lastSwitchPreviousTick: bT(n.lastSwitchPreviousTick),
+lastWarningTick: bT(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -46971,13 +47000,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var xT = Fu("Main");
+var kT = Fu("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-ar.initialize(), sr(dT), sr(pT), sr(fT), sr(yT), sr(vT), sr(gT), sr(hT), sr(yu),
-sr(vu), sr(gu), sr(lT), sr(pr), sr(sc), sr(Ic), global.tooangel = Nc;
+ar.initialize(), sr(yT), sr(vT), sr(gT), sr(hT), sr(RT), sr(ET), sr(TT), sr(yu),
+sr(vu), sr(gu), sr(pT), sr(pr), sr(sc), sr(Ic), global.tooangel = Nc;
 var e = global;
 e.botConfig = {
 getConfig: Me,
@@ -46992,12 +47021,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : ET, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[RT];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : ST, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[CT];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[RT] = s, function(e, t) {
-var r, o = wT(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[CT] = s, function(e, t) {
+var r, o = OT(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -47015,7 +47044,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = wT(e.heapId);
+var n, a = OT(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -47036,14 +47065,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = wT(s.heapId);
+var u = OT(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: xT
-}), sT();
+logger: kT
+}), lT();
 } catch (e) {
-throw xT.error("Critical error in main loop: ".concat(String(e)), {
+throw kT.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time


### PR DESCRIPTION
## Summary
- Keeps builder construction assignments aligned with the recovery-critical construction priority policy.
- Replaces stale lower-priority builder `targetId` assignments when higher-priority tower/storage/spawn sites are available.
- Shares the construction priority table between runtime context ordering and target assignment.

## Linked issue
Refs #3242

## Changes
- Code: added shared construction priority helper in `@ralphschuler/screeps-roles`.
- Code: cached room construction-site priority once per tick in `targetAssignmentManager` and selects closest site within the highest priority tier.
- Tests: added assignment regression coverage for priority selection and stale lower-priority reassignment; extended behavior contract coverage.
- Build: regenerated `packages/screeps-bot/dist/main.js`.

## Validation
- `npm test -w @ralphschuler/screeps-roles -- --grep targetAssignmentManager` ✅
- `npm test -w @ralphschuler/screeps-roles -- --grep "recovery-critical tower"` ✅
- `npm run build:roles` ✅
- `npm test -w @ralphschuler/screeps-roles` ✅
- `npm run lint:roles` ✅
- `npm run build:bot` ✅
- `npm run build` ✅
- `npm run lint:all` ✅
- `npm run check:alliance-safety` ✅
- `npm run sync:deps:check` ✅
- `npm run test:server:smoke` ✅ (`Status: passed`, 49/49 screepsmod-testing assertions)

## Deployment impact
Affects screeps.com runtime builder target selection. Existing lower-priority construction assignments can be replaced when recovery-critical sites exist, improving W18S28 tower/storage build throughput without changing construction-site creation.

## Scope notes
Focused on existing construction sites and builder assignment. If W18S28 still lacks tower/storage progress after deployment, the next blocker is likely builder throughput/energy flow or construction-site creation/cap behavior inside the same existing issue; no new issue created.
