### PR TITLE
[codex] Prioritize recovery storage after first tower

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
@@ -227,7 +227,9 @@ function getTowers(cache: RoomCache): StructureTower[] {
  */
 function getPrioritizedSites(cache: RoomCache): ConstructionSite[] {
   if (cache._prioritizedSites === undefined) {
-    cache._prioritizedSites = cache.room.find(FIND_MY_CONSTRUCTION_SITES).sort(compareConstructionSitePriority);
+    cache._prioritizedSites = cache.room
+      .find(FIND_MY_CONSTRUCTION_SITES)
+      .sort((a, b) => compareConstructionSitePriority(a, b, cache.room));
   }
   return cache._prioritizedSites;
 }

--- a/packages/@ralphschuler/screeps-roles/src/economy/constructionPriority.ts
+++ b/packages/@ralphschuler/screeps-roles/src/economy/constructionPriority.ts
@@ -5,6 +5,17 @@
  * before spending builder throughput on extension backlogs or perimeter polish.
  */
 const DEFAULT_CONSTRUCTION_PRIORITY = 50;
+const STORAGE_RECOVERY_PRIORITY_WITH_TOWER_COVERAGE = 97;
+const STORAGE_RECOVERY_MIN_RCL = 4;
+
+interface RoomConstructionPriorityState {
+  tick: number;
+  controllerLevel: number;
+  hasStorage: boolean;
+  builtTowerCount: number;
+}
+
+const roomPriorityStateByRoom = new Map<string, RoomConstructionPriorityState>();
 
 export const CONSTRUCTION_PRIORITY: Partial<Record<BuildableStructureConstant, number>> = {
   [STRUCTURE_SPAWN]: 100,
@@ -19,10 +30,38 @@ export const CONSTRUCTION_PRIORITY: Partial<Record<BuildableStructureConstant, n
   [STRUCTURE_ROAD]: 30
 };
 
-export function getConstructionPriority(site: Pick<ConstructionSite, "structureType">): number {
+function getRoomConstructionPriorityState(room: Room): RoomConstructionPriorityState {
+  const existing = roomPriorityStateByRoom.get(room.name);
+  if (existing && existing.tick === Game.time) return existing;
+
+  const structures = room.find(FIND_MY_STRUCTURES);
+  const state: RoomConstructionPriorityState = {
+    tick: Game.time,
+    controllerLevel: room.controller?.level ?? 0,
+    hasStorage: room.storage != null,
+    builtTowerCount: 0
+  };
+
+  for (const structure of structures) {
+    if (structure.structureType === STRUCTURE_STORAGE) state.hasStorage = true;
+    if (structure.structureType === STRUCTURE_TOWER) state.builtTowerCount += 1;
+  }
+
+  roomPriorityStateByRoom.set(room.name, state);
+  return state;
+}
+
+function isStorageRecoverySite(site: Pick<ConstructionSite, "structureType">, room?: Room): boolean {
+  if (!room || site.structureType !== STRUCTURE_STORAGE) return false;
+  const state = getRoomConstructionPriorityState(room);
+  return state.controllerLevel >= STORAGE_RECOVERY_MIN_RCL && !state.hasStorage && state.builtTowerCount > 0;
+}
+
+export function getConstructionPriority(site: Pick<ConstructionSite, "structureType">, room?: Room): number {
+  if (isStorageRecoverySite(site, room)) return STORAGE_RECOVERY_PRIORITY_WITH_TOWER_COVERAGE;
   return CONSTRUCTION_PRIORITY[site.structureType] ?? DEFAULT_CONSTRUCTION_PRIORITY;
 }
 
-export function compareConstructionSitePriority(a: ConstructionSite, b: ConstructionSite): number {
-  return getConstructionPriority(b) - getConstructionPriority(a);
+export function compareConstructionSitePriority(a: ConstructionSite, b: ConstructionSite, room?: Room): number {
+  return getConstructionPriority(b, room) - getConstructionPriority(a, room);
 }

--- a/packages/@ralphschuler/screeps-roles/src/economy/targetAssignmentManager.ts
+++ b/packages/@ralphschuler/screeps-roles/src/economy/targetAssignmentManager.ts
@@ -29,7 +29,7 @@ function getBuildSiteCache(room: Room): BuildSiteCache {
 
   const sites = room.find(FIND_MY_CONSTRUCTION_SITES);
   const highestPriority = sites.reduce(
-    (highest, site) => Math.max(highest, getConstructionPriority(site)),
+    (highest, site) => Math.max(highest, getConstructionPriority(site, room)),
     Number.NEGATIVE_INFINITY
   );
   const cache = { tick: Game.time, sites, highestPriority };
@@ -42,7 +42,7 @@ function isLocalBuildSite(site: ConstructionSite, room: Room): boolean {
 }
 
 function selectClosestHighestPrioritySite(creep: Creep, cache: BuildSiteCache): ConstructionSite | null {
-  const candidates = cache.sites.filter((site) => getConstructionPriority(site) === cache.highestPriority);
+  const candidates = cache.sites.filter((site) => getConstructionPriority(site, creep.room) === cache.highestPriority);
   return creep.pos.findClosestByRange(candidates) ?? candidates[0] ?? null;
 }
 
@@ -96,7 +96,7 @@ export function getAssignedBuildTarget(creep: Creep): ConstructionSite | null {
 
   if (memory.targetId) {
     const site = Game.getObjectById(memory.targetId);
-    if (site && isLocalBuildSite(site, creep.room) && getConstructionPriority(site) >= siteCache.highestPriority) {
+    if (site && isLocalBuildSite(site, creep.room) && getConstructionPriority(site, creep.room) >= siteCache.highestPriority) {
       return site;
     }
     delete memory.targetId;

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -158,6 +158,52 @@ describe("Behavior Contracts", () => {
     expect(action.target).to.equal(ctx.prioritizedSites[0]);
   });
 
+  it("promotes missing recovery storage before an extra tower after tower coverage exists", () => {
+    const room = createMockRoom("W1N1", {
+      controller: { my: true, level: 5 }
+    });
+    const sites = [
+      { id: "extension-site", structureType: STRUCTURE_EXTENSION, pos: new RoomPosition(24, 25, room.name) },
+      { id: "second-tower-site", structureType: STRUCTURE_TOWER, pos: new RoomPosition(25, 24, room.name) },
+      { id: "storage-site", structureType: STRUCTURE_STORAGE, pos: new RoomPosition(25, 25, room.name) }
+    ] as unknown as ConstructionSite[];
+    const builtTower = {
+      id: "built-tower",
+      structureType: STRUCTURE_TOWER,
+      store: makeEnergyStore(1000, 1000)
+    } as StructureTower;
+    (room as unknown as { find: Room["find"] }).find = ((type: FindConstant) => {
+      if (type === FIND_MY_CONSTRUCTION_SITES) return sites;
+      if (type === FIND_MY_STRUCTURES) return [builtTower];
+      return [];
+    }) as Room["find"];
+    const creep = createMockCreep("builder1", {
+      room,
+      memory: { role: "builder", homeRoom: room.name, working: true },
+      store: makeEnergyStore(50, 50),
+      pos: {
+        findClosestByRange: (candidateSites: ConstructionSite[]) => candidateSites[0] ?? null
+      }
+    });
+
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    clearRoomCaches();
+
+    const ctx = createRuntimeContext(creep);
+
+    expect(ctx.prioritizedSites.map(site => site.structureType)).to.deep.equal([
+      STRUCTURE_STORAGE,
+      STRUCTURE_TOWER,
+      STRUCTURE_EXTENSION
+    ]);
+
+    const action = buildBehavior(ctx);
+
+    expect(action.type).to.equal("build");
+    expect(action.target).to.equal(ctx.prioritizedSites[0]);
+  });
+
   it("keeps builder and upgrader critical energy delivery priority aligned", () => {
     const extension = {
       id: "extension1",

--- a/packages/@ralphschuler/screeps-roles/test/targetAssignmentManager.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/targetAssignmentManager.test.ts
@@ -118,4 +118,30 @@ describe("targetAssignmentManager memory initialization", () => {
     expect(result).to.equal(tower);
     expect(creep.memory.targetId).to.equal("TOWER_SITE");
   });
+
+  it("prioritizes missing RCL4 storage before an extra tower once tower coverage exists", () => {
+    const extension = site("EXT_SITE", STRUCTURE_EXTENSION, 10, 10);
+    const storage = site("STORAGE_SITE", STRUCTURE_STORAGE, 11, 11);
+    const secondTower = site("SECOND_TOWER_SITE", STRUCTURE_TOWER, 12, 12);
+    const homeRoom = createMockRoom("W1N1", { controller: { my: true, level: 5 } });
+    const builtTower = { id: "BUILT_TOWER", structureType: STRUCTURE_TOWER } as StructureTower;
+    (homeRoom as unknown as { find: Room["find"] }).find = (type: FindConstant) => {
+      if (type === FIND_MY_CONSTRUCTION_SITES) return [extension, secondTower, storage];
+      if (type === FIND_MY_STRUCTURES) return [builtTower];
+      return [];
+    };
+
+    const creep = createMockCreep("builder-storage-recovery", {
+      room: homeRoom,
+      memory: { role: "builder", homeRoom: "W1N1" },
+      pos: {
+        findClosestByRange: (sites: ConstructionSite[]) => sites[0] ?? null
+      }
+    });
+
+    const result = getAssignedBuildTarget(creep);
+
+    expect(result).to.equal(storage);
+    expect(creep.memory.targetId).to.equal("STORAGE_SITE");
+  });
 });

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -6663,7 +6663,7 @@ var r = function e() {
 var r = !1;
 try {
 r = this instanceof e;
-} catch (e) {}
+} catch {}
 return r ? Reflect.construct(t, arguments, this.constructor) : t.apply(this, arguments);
 };
 r.prototype = t.prototype;
@@ -22433,18 +22433,44 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Hu = ((Bu = {})[STRUCTURE_SPAWN] = 100, Bu[STRUCTURE_TOWER] = 95, Bu[STRUCTURE_STORAGE] = 90,
-Bu[STRUCTURE_EXTENSION] = 80, Bu[STRUCTURE_TERMINAL] = 75, Bu[STRUCTURE_LINK] = 70,
-Bu[STRUCTURE_CONTAINER] = 65, Bu[STRUCTURE_RAMPART] = 55, Bu[STRUCTURE_WALL] = 50,
-Bu[STRUCTURE_ROAD] = 30, Bu);
-
-function Yu(e) {
-var t;
-return null !== (t = Hu[e.structureType]) && void 0 !== t ? t : 50;
-}
+}(), Hu = new Map, Yu = ((Bu = {})[STRUCTURE_SPAWN] = 100, Bu[STRUCTURE_TOWER] = 95,
+Bu[STRUCTURE_STORAGE] = 90, Bu[STRUCTURE_EXTENSION] = 80, Bu[STRUCTURE_TERMINAL] = 75,
+Bu[STRUCTURE_LINK] = 70, Bu[STRUCTURE_CONTAINER] = 65, Bu[STRUCTURE_RAMPART] = 55,
+Bu[STRUCTURE_WALL] = 50, Bu[STRUCTURE_ROAD] = 30, Bu);
 
 function Vu(e, t) {
-return Yu(t) - Yu(e);
+var r;
+return function(e, t) {
+if (!t || e.structureType !== STRUCTURE_STORAGE) return !1;
+var r = function(e) {
+var t, r, o, n, i = Hu.get(e.name);
+if (i && i.tick === Game.time) return i;
+var s = e.find(FIND_MY_STRUCTURES), c = {
+tick: Game.time,
+controllerLevel: null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0,
+hasStorage: null != e.storage,
+builtTowerCount: 0
+};
+try {
+for (var u = a(s), l = u.next(); !l.done; l = u.next()) {
+var m = l.value;
+m.structureType === STRUCTURE_STORAGE && (c.hasStorage = !0), m.structureType === STRUCTURE_TOWER && (c.builtTowerCount += 1);
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+l && !l.done && (r = u.return) && r.call(u);
+} finally {
+if (t) throw t.error;
+}
+}
+return Hu.set(e.name, c), c;
+}(t);
+return r.controllerLevel >= 4 && !r.hasStorage && r.builtTowerCount > 0;
+}(e, t) ? 97 : null !== (r = Yu[e.structureType]) && void 0 !== r ? r : 50;
 }
 
 var qu = M("CreepContext"), ju = new Map;
@@ -22454,8 +22480,11 @@ e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._al
 }
 
 function Qu(e) {
-return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(Vu)),
-e._prioritizedSites;
+return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(t, r) {
+return function(e, t, r) {
+return Vu(t, r) - Vu(e, r);
+}(t, r, e.room);
+})), e._prioritizedSites;
 }
 
 function Xu(e) {
@@ -28023,8 +28052,8 @@ if (!e.room) return null;
 var t = kd(e), r = function(e) {
 var t = Od.get(e.name);
 if (t && t.tick === Game.time) return t;
-var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(e, t) {
-return Math.max(e, Yu(t));
+var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(t, r) {
+return Math.max(t, Vu(r, e));
 }, Number.NEGATIVE_INFINITY), n = {
 tick: Game.time,
 sites: r,
@@ -28037,12 +28066,12 @@ if (t.targetId) {
 var o = Game.getObjectById(t.targetId);
 if (o && function(e, t) {
 return e.pos.roomName === t.name;
-}(o, e.room) && Yu(o) >= r.highestPriority) return o;
+}(o, e.room) && Vu(o, e.room) >= r.highestPriority) return o;
 delete t.targetId;
 }
 var n = function(e, t) {
-var r, o, n = t.sites.filter(function(e) {
-return Yu(e) === t.highestPriority;
+var r, o, n = t.sites.filter(function(r) {
+return Vu(r, e.room) === t.highestPriority;
 });
 return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
 }(e, r);


### PR DESCRIPTION
## Summary
- Promote missing RCL4+ storage construction above extra tower sites after a recovery room has at least one built tower.
- Apply the room-aware construction priority through both runtime context prioritized sites and builder target assignment.

## Linked issue
Refs #3242 — partial stage; keep open until post-deploy live evidence shows W18S28 storage/critical infrastructure progress.

## Changes
- Code: added room-aware construction priority state in `@ralphschuler/screeps-roles`.
- Code: builder assignment and prioritized-site sorting now pass room state into construction priority.
- Tests: added regression coverage for RCL5 recovery storage beating an extra tower after first-tower coverage exists.
- Build: updated `packages/screeps-bot/dist/main.js`.

## Validation
- PASS: `npm test -w @ralphschuler/screeps-roles -- test/targetAssignmentManager.test.ts` (red before fix; green after)
- PASS: `npm run build:roles`
- PASS: `npm run lint:roles`
- PASS: `npm run sync:deps:check`
- PASS: `npm run check:alliance-safety`
- PASS: `npm run build`
- PASS: `npm run lint:all`
- PASS: `npm run test:roles`
- PASS: `npm test`

## Deployment impact
- Affects Screeps runtime builder construction target ordering for recovery rooms.
- Intended live impact: after W18S28 has first-tower coverage, builders should spend recovery throughput on missing storage before completing extra tower work.
- Deploy path remains `SCREEPS_HOSTNAME=screeps.com SCREEPS_BRANCH=main npm run push` after merge.

## Scope notes
- No new issues created.
- This does not close #3242 by itself; storage completion still needs post-deploy live verification.
- Wider construction/hauling throughput remains out of scope unless post-deploy evidence shows storage still stalls.
