### PR TITLE
[codex] Throttle idle scout collection movement

### DIFF
--- a/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
+++ b/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
@@ -103,6 +103,8 @@ export interface SwarmCreepMemory {
   portalRoom?: string;
   /** Last explored room (for scouts to avoid cycling) */
   lastExploredRoom?: string;
+  /** Last tick an idle scout attempted collection-point movement. */
+  lastIdleCollectionMoveTick?: number;
   /** Current task */
   task?: string;
   /** Persistent task-board assignment ID */

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/actionExecutionPolicy.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/actionExecutionPolicy.ts
@@ -14,6 +14,33 @@ export interface RangeActionExecutionDecision extends ActionExecutionDecision {
   trackMetrics: boolean;
 }
 
+export const SCOUT_IDLE_COLLECTION_MOVE_INTERVAL = 25;
+
+export interface IdleCollectionMoveInput {
+  role: string;
+  currentTick: number;
+  lastIdleCollectionMoveTick?: number;
+  throttleInterval?: number;
+}
+
+/**
+ * Idle scouts can dominate CPU when the executor repeatedly paths them back to
+ * owned-room collection points. Non-scout idle movement remains unchanged;
+ * scouts get a small per-creep cooldown while still allowing corrupt/future
+ * timestamps to self-heal on the next idle tick.
+ */
+export function shouldAttemptIdleCollectionMove({
+  role,
+  currentTick,
+  lastIdleCollectionMoveTick,
+  throttleInterval = SCOUT_IDLE_COLLECTION_MOVE_INTERVAL,
+}: IdleCollectionMoveInput): boolean {
+  if (role !== "scout") return true;
+  if (lastIdleCollectionMoveTick === undefined) return true;
+  if (lastIdleCollectionMoveTick > currentTick) return true;
+  return currentTick - lastIdleCollectionMoveTick >= throttleInterval;
+}
+
 /**
  * Result policy for primary Screeps actions.
  */

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/executor.ts
@@ -34,6 +34,7 @@ import { getCollectionPoint } from "../utils/common";
 import { taskBoard } from "../tasks";
 import {
   decideRangeActionExecution,
+  shouldAttemptIdleCollectionMove,
   shouldClearStateForMoveResult,
   type ActionResultCode,
 } from "./actionExecutionPolicy";
@@ -501,22 +502,32 @@ export function executeAction(
         moveTo(creep, roomCenter, { priority: 2 });
         break;
       }
-      // Try to move to collection point if available
+      // Try to move to collection point if available. Idle scouts are throttled
+      // because repeated collection-point pathing was a live #3104 CPU hotspot;
+      // non-scout idle movement keeps the previous every-tick behavior.
       const room = Game.rooms[creep.pos.roomName];
       if (room && room.controller?.my) {
         const collectionPoint = getCollectionPoint(room.name);
-        if (collectionPoint) {
-          // Move to collection point if not already there
-          if (!creep.pos.isEqualTo(collectionPoint)) {
-            const idleMoveResult = moveTo(creep, collectionPoint, {
-              priority: 2,
-            });
-            // Clear state if pathfinding fails
-            if (shouldClearStateForMoveResult(idleMoveResult)) {
-              shouldClearState = true;
-            }
-            break;
+        if (
+          collectionPoint &&
+          !creep.pos.isEqualTo(collectionPoint) &&
+          shouldAttemptIdleCollectionMove({
+            role: ctx.memory.role,
+            currentTick: Game.time,
+            lastIdleCollectionMoveTick: ctx.memory.lastIdleCollectionMoveTick,
+          })
+        ) {
+          if (ctx.memory.role === "scout") {
+            ctx.memory.lastIdleCollectionMoveTick = Game.time;
           }
+          const idleMoveResult = moveTo(creep, collectionPoint, {
+            priority: 2,
+          });
+          // Clear state if pathfinding fails
+          if (shouldClearStateForMoveResult(idleMoveResult)) {
+            shouldClearState = true;
+          }
+          break;
         }
       }
       // Fallback: move away from spawns to prevent blocking new creeps

--- a/packages/@ralphschuler/screeps-roles/test/actionExecutionPolicy.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/actionExecutionPolicy.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "chai";
 import "./setup.ts";
 import {
+  SCOUT_IDLE_COLLECTION_MOVE_INTERVAL,
   decideRangeActionExecution,
+  shouldAttemptIdleCollectionMove,
   shouldClearStateForActionResult,
   shouldClearStateForMoveResult,
 } from "../src/behaviors/actionExecutionPolicy.ts";
@@ -62,5 +64,52 @@ describe("Action Execution Policy", () => {
       moved: true,
       trackMetrics: false,
     });
+  });
+
+  it("allows non-scout idle collection movement every tick", () => {
+    expect(
+      shouldAttemptIdleCollectionMove({
+        role: "builder",
+        currentTick: 100,
+        lastIdleCollectionMoveTick: 100,
+      }),
+    ).to.equal(true);
+  });
+
+  it("allows scout idle collection movement when no recent attempt exists", () => {
+    expect(
+      shouldAttemptIdleCollectionMove({
+        role: "scout",
+        currentTick: 100,
+      }),
+    ).to.equal(true);
+  });
+
+  it("throttles repeated idle scout collection movement", () => {
+    expect(
+      shouldAttemptIdleCollectionMove({
+        role: "scout",
+        currentTick: 100,
+        lastIdleCollectionMoveTick: 100 - SCOUT_IDLE_COLLECTION_MOVE_INTERVAL + 1,
+      }),
+    ).to.equal(false);
+
+    expect(
+      shouldAttemptIdleCollectionMove({
+        role: "scout",
+        currentTick: 100,
+        lastIdleCollectionMoveTick: 100 - SCOUT_IDLE_COLLECTION_MOVE_INTERVAL,
+      }),
+    ).to.equal(true);
+  });
+
+  it("does not permanently suppress scout movement after corrupt future timestamps", () => {
+    expect(
+      shouldAttemptIdleCollectionMove({
+        role: "scout",
+        currentTick: 100,
+        lastIdleCollectionMoveTick: 200,
+      }),
+    ).to.equal(true);
   });
 });

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -25452,7 +25452,15 @@ break;
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
 var d = tl(m.name);
-if (d && !e.pos.isEqualTo(d)) {
+if (d && !e.pos.isEqualTo(d) && function(e) {
+var t = e.currentTick, r = e.lastIdleCollectionMoveTick, o = e.throttleInterval;
+return "scout" !== e.role || void 0 === r || r > t || t - r >= (void 0 === o ? 25 : o);
+}({
+role: r.memory.role,
+currentTick: Game.time,
+lastIdleCollectionMoveTick: r.memory.lastIdleCollectionMoveTick
+})) {
+"scout" === r.memory.role && (r.memory.lastIdleCollectionMoveTick = Game.time),
 Fl(el.moveTo(e, d, {
 priority: 2
 })) && (i = !0);


### PR DESCRIPTION
## Summary
- Throttles idle scout collection-point movement in `@ralphschuler/screeps-roles` so idle scouts do not repath to the owned-room collection point every tick.
- Preserves exit-tile escape, non-scout idle collection movement, and spawn-unblocking fallback behavior.
- Adds typed creep memory for the last idle scout collection movement tick.

## Linked issue
Refs #3104

## Changes
- Added `shouldAttemptIdleCollectionMove` policy and `SCOUT_IDLE_COLLECTION_MOVE_INTERVAL`.
- Applied the policy in the action executor idle branch only for scout collection-point moves.
- Added regression tests for non-scout behavior, first scout movement, throttle suppression, throttle expiry, and corrupt future timestamps.
- Rebuilt the deploy bundle and verified reproducible bundle drift.

## Validation
- ✅ `npm run build`
- ✅ `npm run typecheck`
- ✅ `npm run lint:all`
- ✅ `npm run test:roles`
- ✅ `npm run test:all`
- ✅ `npm run sync:deps:check`
- ✅ `npm run check:alliance-safety`
- ✅ `npm run check:no-deep-dist-imports`
- ✅ `npm run check:bot-bundle-drift`

## Deployment impact
- Runtime behavior change affects idle scout CPU/pathing only.
- Expected to reduce repeated `moveTo`/cartographer work for idle scouts while keeping safety movement paths intact.
- Deploy requires normal `npm run push` after merge.

## Scope notes
- This is a scoped scout slice for #3104, not full closure of the issue.
- Market CPU caching was handled separately in PR #3285; further live CPU follow-up remains tracked on #3104 if post-deploy samples stay high.
