### PR TITLE
[codex] Normalize framework publish dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,5 +99,8 @@ jobs:
       - name: Check framework dependency synchronization
         run: npm run sync:deps:check
 
+      - name: Check publish package dependency normalization
+        run: npm run publish:framework:check
+
       - name: Check source package import boundaries
         run: npm run check:no-deep-dist-imports

--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -94,20 +94,14 @@ jobs:
             echo "No tests defined for ${{ matrix.package.name }}"
           fi
 
-      - name: Check package is publishable
-        run: |
-          PRIVATE=$(node -p "require('./package.json').private || false")
-          if [ "$PRIVATE" = "true" ]; then
-            echo "Package ${{ matrix.package.name }} is marked as private, skipping publish"
-            exit 0
-          fi
-
       - name: Publish to npm
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.publish_scope == 'all' || contains(matrix.package.name, github.event.inputs.publish_scope)))
-        run: npm publish --access public --provenance
+        run: node scripts/publish-framework-package.mjs --package "${{ matrix.package.path }}" --publish --access public --provenance
+        working-directory: .
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run publish (for PRs and testing)
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
-        run: npm publish --dry-run --access public
+        run: node scripts/publish-framework-package.mjs --package "${{ matrix.package.path }}" --dry-run --access public
+        working-directory: .

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -164,25 +164,25 @@ All tests must pass before publishing.
 
 #### 5. Validate Package Contents
 
-Preview what will be published:
+Preview the normalized publish artifact:
 
 ```bash
-npm pack --dry-run
+node scripts/publish-framework-package.mjs --package packages/@ralphschuler/screeps-kernel --dry-run
 ```
 
-This shows exactly which files will be included in the published package.
+This stages the package, rewrites internal monorepo dependency ranges to concrete package versions, and runs the same normalized packaging path used by CI checks and release publishing.
 
 #### 6. Test Local Installation
 
 Create a test package and install:
 
 ```bash
-npm pack
+node scripts/publish-framework-package.mjs --package packages/@ralphschuler/screeps-kernel --check --stage-root /tmp/screeps-publish-check --keep-stage
 cd /tmp
 mkdir test-install
 cd test-install
 npm init -y
-npm install /path/to/ralphschuler-screeps-kernel-0.1.1.tgz
+npm install /tmp/screeps-publish-check/scope_ralphschuler__screeps-kernel/verify-pack/ralphschuler-screeps-kernel-<version>.tgz
 ```
 
 Verify the package works:
@@ -193,10 +193,10 @@ node -e "const kernel = require('@ralphschuler/screeps-kernel'); console.log(ker
 #### 7. Publish to npm
 
 ```bash
-npm publish --access public
+node scripts/publish-framework-package.mjs --package packages/@ralphschuler/screeps-kernel --publish --access public
 ```
 
-For scoped packages (`@ralphschuler/*`), you must use `--access public` unless you have a paid npm account.
+For scoped packages (`@ralphschuler/*`), the script passes `--access public` and publishes from the normalized staging directory.
 
 #### 8. Verify Publication
 
@@ -223,15 +223,10 @@ To publish all packages at once:
 
 ```bash
 # From repository root
-for pkg in kernel pathfinding remote-mining roles console stats; do
-  echo "Publishing screeps-$pkg..."
-  cd packages/@ralphschuler/screeps-$pkg
-  npm version patch
-  npm run build
-  npm test
-  npm publish --access public
-  cd ../../..
-done
+npm run build
+npm run test:all
+npm run publish:framework:check
+node scripts/publish-framework-package.mjs --all --publish --access public
 ```
 
 ## Automated Publishing (CI/CD)
@@ -283,9 +278,9 @@ The automated workflow performs:
 3. ✅ Install dependencies
 4. ✅ Build all packages (ensures dependencies are available)
 5. ✅ Run tests
-6. ✅ Check if package is publishable (skip if `private: true`)
-7. ✅ Publish to npm with provenance
-8. ✅ Dry-run mode for PRs (doesn't actually publish)
+6. ✅ Stage each package through `scripts/publish-framework-package.mjs`
+7. ✅ Normalize internal monorepo dependency ranges in the staged package manifest
+8. ✅ Publish to npm with provenance, or dry-run through the same staging path
 
 ### Workflow Security
 
@@ -404,11 +399,13 @@ All tests must pass. If tests fail, fix them before publishing.
 
 ### 3. Package Contents
 
-Verify `.npmignore` excludes dev files:
+Verify the publish staging path and packed manifests:
 
 ```bash
-npm pack --dry-run
+npm run publish:framework:check
 ```
+
+This fails if any packed package manifest still contains `workspace:*` or an internal `@ralphschuler/screeps-*` wildcard dependency.
 
 Should NOT include:
 - `src/` (only `dist/` should be published)
@@ -611,9 +608,8 @@ When publishing multiple packages, follow this order to satisfy dependencies:
 
 ### Internal Package References
 
-When one package depends on another from the same monorepo:
+When one package depends on another from the same monorepo, keep the source manifest on the repository-local range:
 
-**Option 1: Workspace reference (development)**
 ```json
 {
   "dependencies": {
@@ -622,14 +618,14 @@ When one package depends on another from the same monorepo:
 }
 ```
 
-**Option 2: Version range (published)**
-```json
-{
-  "dependencies": {
-    "@ralphschuler/screeps-defense": "^0.1.0"
-  }
-}
+Do not publish that source manifest directly. Use the publish staging script:
+
+```bash
+node scripts/publish-framework-package.mjs --package packages/@ralphschuler/screeps-roles --dry-run
+node scripts/publish-framework-package.mjs --package packages/@ralphschuler/screeps-roles --publish --access public
 ```
+
+The staging script packs the source package, extracts it, rewrites internal `@ralphschuler/screeps-*` dependencies from `*`/`workspace:*` to the current concrete package versions, repacks for validation, and publishes from the normalized staging directory. Source manifests remain unchanged.
 
 ### External Dependencies
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "check-versions": "node scripts/check-versions.js",
     "sync:deps": "node scripts/sync-framework-deps.js",
     "sync:deps:check": "node scripts/sync-framework-deps.js --check",
+    "publish:framework:check": "node scripts/publish-framework-package.mjs --all --check",
+    "publish:framework:dry-run": "node scripts/publish-framework-package.mjs --all --dry-run",
     "check:no-deep-dist-imports": "node scripts/check-no-deep-dist-imports.js",
     "check:bot-bundle-drift": "node scripts/check-bot-bundle-drift.mjs",
     "quality:duplication": "jscpd . --config .jscpd.json",

--- a/scripts/publish-framework-package.mjs
+++ b/scripts/publish-framework-package.mjs
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+  "devDependencies",
+];
+const INTERNAL_PACKAGE_PREFIX = "@ralphschuler/screeps-";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.PUBLISH_FRAMEWORK_REPO_ROOT
+  ? path.resolve(process.env.PUBLISH_FRAMEWORK_REPO_ROOT)
+  : path.resolve(scriptDir, "..");
+const packagesRoot = process.env.PUBLISH_FRAMEWORK_PACKAGES_DIR
+  ? path.resolve(process.env.PUBLISH_FRAMEWORK_PACKAGES_DIR)
+  : path.join(repoRoot, "packages");
+
+function usage() {
+  return `Usage:
+  node scripts/publish-framework-package.mjs --package <name-or-path> [--check|--dry-run|--publish]
+  node scripts/publish-framework-package.mjs --all --check
+
+Options:
+  --package <name-or-path>  Package name or package directory to stage.
+  --all                     Stage all public framework packages with main/types entries.
+  --check                   Pack staged package and fail on publish-time dependency issues (default).
+  --dry-run                 Run npm publish --dry-run for the normalized tarball.
+  --publish                 Run npm publish for the normalized tarball.
+  --access <value>          npm access flag for publish/dry-run (default: public).
+  --provenance              Pass --provenance to real npm publish.
+  --stage-root <dir>        Directory for temporary staging artifacts.
+  --keep-stage              Keep staging artifacts after completion.
+  --json                    Print machine-readable summary JSON after text logs.
+`;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const args = {
+    packages: [],
+    all: false,
+    mode: "check",
+    access: "public",
+    provenance: false,
+    keepStage: false,
+    json: false,
+    stageRoot: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--package":
+      case "--pkg": {
+        const value = argv[index + 1];
+        if (!value) fail(`${arg} requires a value.\n${usage()}`);
+        args.packages.push(value);
+        index += 1;
+        break;
+      }
+      case "--all":
+        args.all = true;
+        break;
+      case "--check":
+        args.mode = "check";
+        break;
+      case "--dry-run":
+        args.mode = "dry-run";
+        break;
+      case "--publish":
+        args.mode = "publish";
+        break;
+      case "--access": {
+        const value = argv[index + 1];
+        if (!value) fail("--access requires a value.");
+        args.access = value;
+        index += 1;
+        break;
+      }
+      case "--provenance":
+        args.provenance = true;
+        break;
+      case "--keep-stage":
+        args.keepStage = true;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--stage-root": {
+        const value = argv[index + 1];
+        if (!value) fail("--stage-root requires a value.");
+        args.stageRoot = path.resolve(value);
+        index += 1;
+        break;
+      }
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+        break;
+      default:
+        fail(`Unknown option: ${arg}\n${usage()}`);
+    }
+  }
+
+  if (!args.all && args.packages.length === 0) {
+    fail(`Select --all or at least one --package.\n${usage()}`);
+  }
+
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function findPackageJsons(rootDir) {
+  const results = [];
+
+  function walk(dir) {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        results.push(entryPath);
+      }
+    }
+  }
+
+  walk(rootDir);
+  return results;
+}
+
+function loadWorkspacePackages() {
+  const packageByName = new Map();
+  for (const manifestPath of findPackageJsons(packagesRoot)) {
+    const manifest = readJson(manifestPath);
+    if (typeof manifest.name !== "string") continue;
+    packageByName.set(manifest.name, {
+      dir: path.dirname(manifestPath),
+      manifest,
+      name: manifest.name,
+      private: manifest.private === true,
+      version: manifest.version,
+    });
+  }
+  return packageByName;
+}
+
+function isFrameworkPublishCandidate(workspacePackage) {
+  const manifest = workspacePackage.manifest;
+  return (
+    workspacePackage.name.startsWith(INTERNAL_PACKAGE_PREFIX) &&
+    manifest.private !== true &&
+    typeof manifest.main === "string" &&
+    typeof manifest.types === "string"
+  );
+}
+
+function resolvePackage(selection, packageByName) {
+  if (packageByName.has(selection)) return packageByName.get(selection);
+
+  const candidates = [
+    path.resolve(process.cwd(), selection),
+    path.resolve(repoRoot, selection),
+  ];
+  for (const candidate of candidates) {
+    const manifestPath = path.join(candidate, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = readJson(manifestPath);
+    return {
+      dir: candidate,
+      manifest,
+      name: manifest.name,
+      private: manifest.private === true,
+      version: manifest.version,
+    };
+  }
+
+  fail(`Unable to resolve package selection: ${selection}`);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: { ...process.env, ...(options.env ?? {}) },
+    encoding: "utf8",
+    stdio: options.stdio ?? "pipe",
+  });
+
+  if (result.status !== 0) {
+    const detail = [
+      `${command} ${args.join(" ")} failed with status ${result.status}`,
+      result.stdout,
+      result.stderr,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    throw new Error(detail);
+  }
+
+  return result;
+}
+
+function parseNpmPackJson(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error("npm pack returned no JSON output.");
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new Error("npm pack JSON did not contain a package entry.");
+    }
+    return parsed[0];
+  } catch (error) {
+    throw new Error(`Failed to parse npm pack JSON output: ${error.message}\n${stdout}`);
+  }
+}
+
+function packPackage(packageDir, packDestination) {
+  mkdirSync(packDestination, { recursive: true });
+  const result = run(
+    "npm",
+    ["pack", "--ignore-scripts", "--json", "--pack-destination", packDestination],
+    { cwd: packageDir },
+  );
+  const packInfo = parseNpmPackJson(result.stdout);
+  const tarballPath = path.isAbsolute(packInfo.filename)
+    ? packInfo.filename
+    : path.resolve(packDestination, packInfo.filename);
+  if (!existsSync(tarballPath)) {
+    throw new Error(`npm pack did not create expected tarball: ${tarballPath}`);
+  }
+  return tarballPath;
+}
+
+function extractPackage(tarballPath, destination) {
+  mkdirSync(destination, { recursive: true });
+  run("tar", ["-xzf", tarballPath, "-C", destination]);
+  const packageDir = path.join(destination, "package");
+  if (!existsSync(path.join(packageDir, "package.json"))) {
+    throw new Error(`Extracted package manifest not found under ${packageDir}`);
+  }
+  return packageDir;
+}
+
+function normalizeWorkspaceVersion(specifier, concreteVersion) {
+  if (specifier === "*" || specifier === "workspace:*" || specifier === "workspace:") {
+    return concreteVersion;
+  }
+  if (specifier === "workspace:^") return `^${concreteVersion}`;
+  if (specifier === "workspace:~") return `~${concreteVersion}`;
+  if (specifier.startsWith("workspace:")) {
+    const range = specifier.slice("workspace:".length);
+    return range || concreteVersion;
+  }
+  return specifier;
+}
+
+function normalizeManifest(manifest, packageByName) {
+  const normalized = structuredClone(manifest);
+  const changes = [];
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const dependencies = normalized[section];
+    if (!dependencies || typeof dependencies !== "object") continue;
+
+    for (const [dependencyName, specifier] of Object.entries(dependencies)) {
+      if (typeof specifier !== "string") continue;
+      const internalPackage = packageByName.get(dependencyName);
+      if (!internalPackage) continue;
+
+      const nextSpecifier = normalizeWorkspaceVersion(
+        specifier,
+        internalPackage.version,
+      );
+      if (nextSpecifier !== specifier) {
+        dependencies[dependencyName] = nextSpecifier;
+        changes.push({
+          dependencyName,
+          from: specifier,
+          section,
+          to: nextSpecifier,
+        });
+      }
+    }
+  }
+
+  return { manifest: normalized, changes };
+}
+
+function validatePublishManifest(manifest, packageByName) {
+  const errors = [];
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const dependencies = manifest[section];
+    if (!dependencies || typeof dependencies !== "object") continue;
+
+    for (const [dependencyName, specifier] of Object.entries(dependencies)) {
+      if (typeof specifier !== "string") continue;
+      if (specifier.startsWith("workspace:")) {
+        errors.push(
+          `${manifest.name}: ${section}.${dependencyName} still uses ${specifier}`,
+        );
+      }
+      if (packageByName.has(dependencyName) && specifier === "*") {
+        errors.push(
+          `${manifest.name}: ${section}.${dependencyName} still uses wildcard internal version`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+}
+
+function createRunRoot(args) {
+  if (args.stageRoot) {
+    mkdirSync(args.stageRoot, { recursive: true });
+    return args.stageRoot;
+  }
+  return mkdtempSync(path.join(tmpdir(), "screeps-framework-publish-"));
+}
+
+function safeDirectoryName(packageName) {
+  return packageName.replaceAll("/", "__").replaceAll("@", "scope_");
+}
+
+function stageAndNormalizePackage(workspacePackage, packageByName, runRoot) {
+  const packageRoot = path.resolve(workspacePackage.dir);
+  const packageName = workspacePackage.name ?? packageRoot;
+  const packageRunRoot = path.join(runRoot, safeDirectoryName(packageName));
+  const sourcePackDir = path.join(packageRunRoot, "source-pack");
+  const stageExtractDir = path.join(packageRunRoot, "stage");
+  const verifyPackDir = path.join(packageRunRoot, "verify-pack");
+  const verifyExtractDir = path.join(packageRunRoot, "verify-extract");
+
+  mkdirSync(packageRunRoot, { recursive: true });
+  const sourceTarball = packPackage(packageRoot, sourcePackDir);
+  const stagedPackageDir = extractPackage(sourceTarball, stageExtractDir);
+  const stagedManifestPath = path.join(stagedPackageDir, "package.json");
+  const stagedManifest = readJson(stagedManifestPath);
+  const { manifest: normalizedManifest, changes } = normalizeManifest(
+    stagedManifest,
+    packageByName,
+  );
+  validatePublishManifest(normalizedManifest, packageByName);
+  writeJson(stagedManifestPath, normalizedManifest);
+
+  const verifyTarball = packPackage(stagedPackageDir, verifyPackDir);
+  const verifiedPackageDir = extractPackage(verifyTarball, verifyExtractDir);
+  const verifiedManifest = readJson(path.join(verifiedPackageDir, "package.json"));
+  validatePublishManifest(verifiedManifest, packageByName);
+
+  return {
+    changes,
+    packageDir: stagedPackageDir,
+    packageName: normalizedManifest.name,
+    sourceTarball,
+    stagedManifestPath,
+    verifyTarball,
+    version: normalizedManifest.version,
+  };
+}
+
+function runPublishCommand(staged, args) {
+  const publishArgs = ["publish", staged.verifyTarball, "--access", args.access];
+  if (args.mode === "dry-run") publishArgs.push("--dry-run");
+  if (args.mode === "publish" && args.provenance) {
+    publishArgs.push("--provenance");
+  }
+  run("npm", publishArgs, { cwd: repoRoot, stdio: "inherit" });
+}
+
+function packageStat(packageDir) {
+  try {
+    return statSync(packageDir);
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const packageByName = loadWorkspacePackages();
+  const selections = args.all
+    ? [...packageByName.values()]
+        .filter(isFrameworkPublishCandidate)
+        .sort((left, right) => left.name.localeCompare(right.name))
+    : args.packages.map((selection) => resolvePackage(selection, packageByName));
+
+  const runRoot = createRunRoot(args);
+  const summary = [];
+
+  try {
+    for (const workspacePackage of selections) {
+      if (!workspacePackage?.dir || !packageStat(workspacePackage.dir)?.isDirectory()) {
+        throw new Error(`Invalid package directory for ${workspacePackage?.name ?? "unknown"}`);
+      }
+
+      if (workspacePackage.private) {
+        console.log(`skip ${workspacePackage.name}: package is private`);
+        summary.push({ name: workspacePackage.name, skipped: true, reason: "private" });
+        continue;
+      }
+
+      console.log(`stage ${workspacePackage.name}@${workspacePackage.version}`);
+      const staged = stageAndNormalizePackage(workspacePackage, packageByName, runRoot);
+      for (const change of staged.changes) {
+        console.log(
+          `normalize ${staged.packageName}: ${change.section}.${change.dependencyName} ${change.from} -> ${change.to}`,
+        );
+      }
+      if (staged.changes.length === 0) {
+        console.log(`normalize ${staged.packageName}: no internal workspace ranges found`);
+      }
+
+      if (args.mode === "dry-run" || args.mode === "publish") {
+        runPublishCommand(staged, args);
+      }
+
+      console.log(`ok ${staged.packageName}@${staged.version}`);
+      summary.push({
+        changes: staged.changes,
+        name: staged.packageName,
+        stagedManifestPath: staged.stagedManifestPath,
+        version: staged.version,
+      });
+    }
+  } finally {
+    if (!args.keepStage && !args.stageRoot) {
+      rmSync(runRoot, { force: true, recursive: true });
+    }
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({ mode: args.mode, packages: summary }, null, 2));
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/test/publish-framework-package.test.mjs
+++ b/scripts/test/publish-framework-package.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = new URL("../..", import.meta.url);
+const scriptPath = new URL("../publish-framework-package.mjs", import.meta.url);
+
+function writeFrameworkPackage(
+  packagesDir,
+  shortName,
+  { dependencies = {}, privatePackage = false, scripts = {}, version = "0.1.0" } = {},
+) {
+  const packageDir = path.join(packagesDir, "@ralphschuler", shortName);
+  mkdirSync(path.join(packageDir, "dist"), { recursive: true });
+  writeFileSync(path.join(packageDir, "dist", "index.js"), "export {};\n");
+  writeFileSync(path.join(packageDir, "dist", "index.d.ts"), "export {};\n");
+  writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `@ralphschuler/${shortName}`,
+        version,
+        private: privatePackage,
+        main: "dist/index.js",
+        types: "dist/index.d.ts",
+        scripts,
+        dependencies,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  return packageDir;
+}
+
+function makeFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "screeps-publish-fixture-"));
+  const packagesDir = path.join(root, "packages");
+  return { packagesDir, root };
+}
+
+function runPublishScript(args, packagesDir) {
+  return spawnSync(process.execPath, [scriptPath.pathname, ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PUBLISH_FRAMEWORK_PACKAGES_DIR: packagesDir,
+    },
+    encoding: "utf8",
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function stagedManifest(stageRoot, packageName) {
+  const safeName = packageName.replaceAll("/", "__").replaceAll("@", "scope_");
+  return readJson(path.join(stageRoot, safeName, "stage", "package", "package.json"));
+}
+
+function verifiedManifest(stageRoot, packageName) {
+  const safeName = packageName.replaceAll("/", "__").replaceAll("@", "scope_");
+  return readJson(
+    path.join(stageRoot, safeName, "verify-extract", "package", "package.json"),
+  );
+}
+
+test("publish package check normalizes internal wildcard dependencies only in staged pack output", () => {
+  const { packagesDir, root } = makeFixture();
+  const alphaDir = writeFrameworkPackage(packagesDir, "screeps-alpha", {
+    dependencies: {
+      "@ralphschuler/screeps-beta": "*",
+      lodash: "^4.17.21",
+    },
+    version: "0.2.0",
+  });
+  writeFrameworkPackage(packagesDir, "screeps-beta", { version: "0.4.5" });
+  const stageRoot = path.join(root, "stage-root");
+
+  const result = runPublishScript(
+    ["--package", alphaDir, "--check", "--stage-root", stageRoot, "--keep-stage"],
+    packagesDir,
+  );
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(
+    result.stdout,
+    /dependencies\.@ralphschuler\/screeps-beta \* -> 0\.4\.5/,
+  );
+  assert.equal(
+    readJson(path.join(alphaDir, "package.json")).dependencies[
+      "@ralphschuler/screeps-beta"
+    ],
+    "*",
+  );
+  assert.equal(
+    stagedManifest(stageRoot, "@ralphschuler/screeps-alpha").dependencies[
+      "@ralphschuler/screeps-beta"
+    ],
+    "0.4.5",
+  );
+  assert.equal(
+    verifiedManifest(stageRoot, "@ralphschuler/screeps-alpha").dependencies[
+      "@ralphschuler/screeps-beta"
+    ],
+    "0.4.5",
+  );
+});
+
+test("publish package check resolves workspace protocol ranges before validation", () => {
+  const { packagesDir, root } = makeFixture();
+  const alphaDir = writeFrameworkPackage(packagesDir, "screeps-alpha", {
+    dependencies: {
+      "@ralphschuler/screeps-beta": "workspace:^",
+    },
+  });
+  writeFrameworkPackage(packagesDir, "screeps-beta", { version: "0.4.5" });
+  const stageRoot = path.join(root, "stage-root");
+
+  const result = runPublishScript(
+    ["--package", alphaDir, "--check", "--stage-root", stageRoot, "--keep-stage"],
+    packagesDir,
+  );
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.equal(
+    verifiedManifest(stageRoot, "@ralphschuler/screeps-alpha").dependencies[
+      "@ralphschuler/screeps-beta"
+    ],
+    "^0.4.5",
+  );
+});
+
+test("publish package dry-run publishes the verified tarball without running staged lifecycle scripts", () => {
+  const { packagesDir, root } = makeFixture();
+  const alphaDir = writeFrameworkPackage(packagesDir, "screeps-alpha", {
+    scripts: {
+      prepublishOnly: "node -e \"process.exit(42)\"",
+    },
+  });
+
+  const result = runPublishScript(
+    [
+      "--package",
+      alphaDir,
+      "--dry-run",
+      "--stage-root",
+      path.join(root, "stage-root"),
+    ],
+    packagesDir,
+  );
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /\+ @ralphschuler\/screeps-alpha@0\.1\.0/);
+});
+
+test("publish package check fails when a packed manifest still has an unresolved workspace protocol", () => {
+  const { packagesDir, root } = makeFixture();
+  const alphaDir = writeFrameworkPackage(packagesDir, "screeps-alpha", {
+    dependencies: {
+      "external-workspace-package": "workspace:*",
+    },
+  });
+
+  const result = runPublishScript(
+    ["--package", alphaDir, "--check", "--stage-root", path.join(root, "stage-root")],
+    packagesDir,
+  );
+
+  assert.notEqual(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stderr, /still uses workspace:\*/);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/publish-framework-package.mjs` to stage framework packages, normalize internal `@ralphschuler/screeps-*` dependency ranges to concrete workspace versions, repack, and publish/check the verified tarball.
- Wires CI dependency sync to validate packed publish manifests and updates the framework publish workflow to use the same staging path for dry-run and real publish.
- Documents the normalized publish flow and adds script regression tests.

## Linked issue
Closes #3048

## Changes
- New publish staging/check/dry-run/publish script.
- New `publish:framework:check` and `publish:framework:dry-run` root scripts.
- CI check for publish package dependency normalization.
- Publish workflow now publishes normalized tarballs and skips private packages in the script.
- Publishing docs updated for source `*` internal deps vs concrete published deps.

## Validation
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run check-versions`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run build`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run typecheck`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run lint:all`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run test:scripts`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run publish:framework:check`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run sync:deps:check`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run check:no-deep-dist-imports`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && npm run check:bot-bundle-drift`
- PASS: `source /home/ralph/.nvm/nvm.sh && nvm use 24 && node scripts/publish-framework-package.mjs --package packages/@ralphschuler/screeps-core --dry-run --access public`
- PASS: `node scripts/publish-framework-package.mjs --package packages/screeps-defense --dry-run --access public` (Node 22 environment; validates command path, but Node 24 validations above are authoritative)

## Deployment impact
- No runtime bot behavior change. Deploy bundle builds unchanged and `check:bot-bundle-drift` passes.
- A screeps.com deploy is still safe after merge per backlog-processing workflow, but this PR only affects CI/publish tooling/docs.

## Scope notes
- Current source manifests use `"*"` for internal workspace links rather than `"workspace:*"`; this PR preserves source manifests and normalizes only publish artifacts.
- The script validates/publishes verified tarballs so package lifecycle scripts such as `prepublishOnly` do not rerun inside dependency-free staging directories.
