### PR TITLE
[codex] Bound emergency market buys

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -15968,15 +15968,31 @@ if (t) throw t.error;
 return i.sort(function(e, t) {
 return t.deficit - e.deficit;
 }), i;
+}, e.prototype.getTerminalEnergyBudget = function(e) {
+return Math.max(0, e.store.getUsedCapacity(RESOURCE_ENERGY) - this.config.terminalEnergyReserve);
+}, e.prototype.canAffordEmergencyBuyEnergy = function(e, t, r, o) {
+return e === RESOURCE_ENERGY ? t + r <= o : r <= o;
+}, e.prototype.findAffordableEmergencyBuyAmount = function(e, t, r) {
+var o = this.getTerminalEnergyBudget(r), n = Math.floor(t.cappedOrderAmount);
+if (n <= 0) return 0;
+if (this.canAffordEmergencyBuyEnergy(e, n, t.transportCost, o)) return n;
+if (o <= 0) return 0;
+for (var a = 0; a < n; ) {
+var i = Math.ceil((a + n) / 2), s = Game.market.calcTransactionCost(i, t.order.roomName, r.room.name);
+this.canAffordEmergencyBuyEnergy(e, i, s, o) ? a = i : n = i - 1;
+}
+return a;
 }, e.prototype.executeEmergencyBuy = function(e, t, r) {
 var o, n, i, s = Game.rooms[r], c = null == s ? void 0 : s.terminal;
 if (!(null === (i = null == s ? void 0 : s.controller) || void 0 === i ? void 0 : i.my) || !c) return !1;
-var u = Math.max(1, Math.floor(t)), l = this.getMarketOrders({
+if (c.cooldown > 0) return !1;
+var u = Math.max(1, Math.floor(t));
+if (e === RESOURCE_ENERGY && this.getTerminalEnergyBudget(c) <= 0) return !1;
+var l = this.getMarketOrders({
 type: ORDER_SELL,
 resourceType: e
 });
 if (0 === l.length) return !1;
-if (c.cooldown > 0) return !1;
 var m, d = (m = {
 orders: l,
 requestedAmount: u,
@@ -16004,17 +16020,13 @@ return e.emergencyScore - t.emergencyScore;
 if (0 === d.length) return !1;
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = y.order, g = Math.min(u, y.cappedOrderAmount);
+var y = f.value, v = y.order, g = this.findAffordableEmergencyBuyAmount(e, y, c);
 if (!(g <= 0)) {
-var h = Game.market.calcTransactionCost(g, v.roomName, s.name);
-if (e === RESOURCE_ENERGY) for (;g > 0 && !(g + h <= Math.max(0, c.store.getUsedCapacity(RESOURCE_ENERGY) - this.config.terminalEnergyReserve)) && !((g -= 1) <= 0); ) h = Game.market.calcTransactionCost(g, v.roomName, s.name); else for (;g > 0 && !(h <= Math.max(0, c.store.getUsedCapacity(RESOURCE_ENERGY) - this.config.terminalEnergyReserve)) && !((g -= 1) <= 0); ) h = Game.market.calcTransactionCost(g, v.roomName, s.name);
-if (!(g <= 0)) {
-var R = Math.max(0, Math.floor((Game.market.credits - this.config.emergencyCredits) / v.price));
-if (!((g = Math.min(g, R)) <= 0) && Game.market.deal(v.id, g, s.name) === OK) return this.recordMarketDeal(v.id, g),
+var h = Math.max(0, Math.floor((Game.market.credits - this.config.emergencyCredits) / v.price));
+if (!((g = Math.min(g, h)) <= 0) && Game.market.deal(v.id, g, s.name) === OK) return this.recordMarketDeal(v.id, g),
 U.warn("EMERGENCY BUY: ".concat(g, " ").concat(e, " for ").concat(s.name, " at ").concat(v.price.toFixed(3), " credits/unit"), {
 subsystem: "Market"
 }), !0;
-}
 }
 }
 } catch (e) {

--- a/packages/screeps-economy/src/market/marketManager.ts
+++ b/packages/screeps-economy/src/market/marketManager.ts
@@ -1184,6 +1184,54 @@ export class MarketManager {
     return deficits;
   }
 
+  private getTerminalEnergyBudget(terminal: StructureTerminal): number {
+    return Math.max(0, terminal.store.getUsedCapacity(RESOURCE_ENERGY) - this.config.terminalEnergyReserve);
+  }
+
+  private canAffordEmergencyBuyEnergy(
+    resource: ResourceConstant,
+    amount: number,
+    transportCost: number,
+    terminalEnergyBudget: number
+  ): boolean {
+    return resource === RESOURCE_ENERGY
+      ? amount + transportCost <= terminalEnergyBudget
+      : transportCost <= terminalEnergyBudget;
+  }
+
+  private findAffordableEmergencyBuyAmount(
+    resource: ResourceConstant,
+    candidate: { order: Order & { roomName: string }; cappedOrderAmount: number; transportCost: number },
+    destinationTerminal: StructureTerminal
+  ): number {
+    const terminalEnergyBudget = this.getTerminalEnergyBudget(destinationTerminal);
+    let high = Math.floor(candidate.cappedOrderAmount);
+
+    if (high <= 0) return 0;
+    if (this.canAffordEmergencyBuyEnergy(resource, high, candidate.transportCost, terminalEnergyBudget)) {
+      return high;
+    }
+    if (terminalEnergyBudget <= 0) return 0;
+
+    let low = 0;
+    while (low < high) {
+      const amount = Math.ceil((low + high) / 2);
+      const transportCost = Game.market.calcTransactionCost(
+        amount,
+        candidate.order.roomName,
+        destinationTerminal.room.name
+      );
+
+      if (this.canAffordEmergencyBuyEnergy(resource, amount, transportCost, terminalEnergyBudget)) {
+        low = amount;
+      } else {
+        high = amount - 1;
+      }
+    }
+
+    return low;
+  }
+
   /**
    * Execute emergency buy at best available price for a specific room.
    */
@@ -1192,12 +1240,13 @@ export class MarketManager {
     const destinationTerminal = destinationRoom?.terminal;
 
     if (!destinationRoom?.controller?.my || !destinationTerminal) return false;
+    if (destinationTerminal.cooldown > 0) return false;
 
     const requestedAmount = Math.max(1, Math.floor(amount));
+    if (resource === RESOURCE_ENERGY && this.getTerminalEnergyBudget(destinationTerminal) <= 0) return false;
 
     const orders = this.getMarketOrders({ type: ORDER_SELL, resourceType: resource });
     if (orders.length === 0) return false;
-    if (destinationTerminal.cooldown > 0) return false;
 
     const candidateOrders = rankEmergencyBuyOrders({
       orders,
@@ -1212,32 +1261,7 @@ export class MarketManager {
 
     for (const candidate of candidateOrders) {
       const order = candidate.order;
-      let purchaseAmount = Math.min(requestedAmount, candidate.cappedOrderAmount);
-      if (purchaseAmount <= 0) continue;
-
-      let transportCost = Game.market.calcTransactionCost(purchaseAmount, order.roomName!, destinationRoom.name);
-      if (resource === RESOURCE_ENERGY) {
-        // Need ENERGY both for purchased units + transport.
-        while (purchaseAmount > 0) {
-          const budget = Math.max(0, destinationTerminal.store.getUsedCapacity(RESOURCE_ENERGY) - this.config.terminalEnergyReserve);
-          if (purchaseAmount + transportCost <= budget) break;
-
-          purchaseAmount -= 1;
-          if (purchaseAmount <= 0) break;
-          transportCost = Game.market.calcTransactionCost(purchaseAmount, order.roomName!, destinationRoom.name);
-        }
-      } else {
-        // Non-energy purchase only needs terminal energy for transport.
-        while (purchaseAmount > 0) {
-          const budget = Math.max(0, destinationTerminal.store.getUsedCapacity(RESOURCE_ENERGY) - this.config.terminalEnergyReserve);
-          if (transportCost <= budget) break;
-
-          purchaseAmount -= 1;
-          if (purchaseAmount <= 0) break;
-          transportCost = Game.market.calcTransactionCost(purchaseAmount, order.roomName!, destinationRoom.name);
-        }
-      }
-
+      let purchaseAmount = this.findAffordableEmergencyBuyAmount(resource, candidate, destinationTerminal);
       if (purchaseAmount <= 0) continue;
 
       // Credits required should stay above emergency reserve.

--- a/packages/screeps-economy/test/MarketManager.test.ts
+++ b/packages/screeps-economy/test/MarketManager.test.ts
@@ -770,6 +770,146 @@ describe("MarketManager", () => {
     expect(getEmpireMarket().pendingArbitrage).to.deep.equal([]);
   });
 
+  it("skips emergency energy market scans when terminal reserve leaves no transaction budget", () => {
+    let getAllOrdersCalls = 0;
+    setupGame({
+      credits: 50000,
+      getAllOrders: () => {
+        getAllOrdersCalls++;
+        return [
+          {
+            id: "sell-energy",
+            type: ORDER_SELL,
+            resourceType: RESOURCE_ENERGY,
+            roomName: "W9N9",
+            price: 1,
+            amount: 10000,
+            remainingAmount: 10000,
+            created: 1
+          } as Order
+        ];
+      }
+    });
+    const room = createRoom("W1N1", createStore({ [RESOURCE_ENERGY]: 1000 }), createStore({}));
+    (Game.rooms as Record<string, Room>).W1N1 = room;
+
+    new MarketManager({
+      minBucket: 0,
+      criticalResources: [RESOURCE_ENERGY],
+      emergencyBuyThreshold: 5000,
+      emergencyCredits: 0,
+      terminalEnergyReserve: 1000,
+      buyThresholds: {},
+      sellThresholds: {},
+      trackedResources: [RESOURCE_ENERGY],
+      activeTradingMinBucket: 10001,
+      priceUpdateInterval: 9999
+    }).run();
+
+    expect(getAllOrdersCalls).to.equal(0);
+  });
+
+  it("bounds emergency energy affordability search instead of decrementing per unit", () => {
+    let transactionCostCalls = 0;
+    const deals: Array<{ id: string; amount: number; roomName?: string }> = [];
+    setupGame({
+      credits: 50000,
+      getAllOrders: filter => {
+        const typedFilter = filter as OrderFilter;
+        if (typedFilter.type === ORDER_SELL && typedFilter.resourceType === RESOURCE_ENERGY) {
+          return [
+            {
+              id: "sell-energy",
+              type: ORDER_SELL,
+              resourceType: RESOURCE_ENERGY,
+              roomName: "W9N9",
+              price: 1,
+              amount: 10000,
+              remainingAmount: 10000,
+              created: 1
+            } as Order
+          ];
+        }
+        return [];
+      },
+      calcTransactionCost: amount => {
+        transactionCostCalls++;
+        return Math.ceil(amount / 2);
+      },
+      deal: (id, amount, roomName) => {
+        deals.push({ id, amount, roomName });
+        return OK;
+      }
+    });
+    const room = createRoom("W1N1", createStore({ [RESOURCE_ENERGY]: 1200 }), createStore({}));
+    (Game.rooms as Record<string, Room>).W1N1 = room;
+
+    new MarketManager({
+      minBucket: 0,
+      criticalResources: [RESOURCE_ENERGY],
+      emergencyBuyThreshold: 5000,
+      emergencyCredits: 0,
+      terminalEnergyReserve: 1000,
+      buyThresholds: {},
+      sellThresholds: {},
+      trackedResources: [RESOURCE_ENERGY],
+      maxActiveBuyAmount: 5000,
+      activeTradingMinBucket: 10001,
+      priceUpdateInterval: 9999
+    }).run();
+
+    expect(deals).to.deep.equal([{ id: "sell-energy", amount: 133, roomName: "W1N1" }]);
+    expect(transactionCostCalls).to.be.lessThan(30);
+  });
+
+  it("preserves zero-cost non-energy emergency buys at terminal reserve", () => {
+    const deals: Array<{ id: string; amount: number; roomName?: string }> = [];
+    setupGame({
+      credits: 50000,
+      getAllOrders: filter => {
+        const typedFilter = filter as OrderFilter;
+        if (typedFilter.type === ORDER_SELL && typedFilter.resourceType === RESOURCE_GHODIUM) {
+          return [
+            {
+              id: "sell-ghodium",
+              type: ORDER_SELL,
+              resourceType: RESOURCE_GHODIUM,
+              roomName: "W9N9",
+              price: 1,
+              amount: 10000,
+              remainingAmount: 10000,
+              created: 1
+            } as Order
+          ];
+        }
+        return [];
+      },
+      calcTransactionCost: () => 0,
+      deal: (id, amount, roomName) => {
+        deals.push({ id, amount, roomName });
+        return OK;
+      }
+    });
+    const room = createRoom("W1N1", createStore({ [RESOURCE_ENERGY]: 1000 }), createStore({}));
+    (Game.rooms as Record<string, Room>).W1N1 = room;
+
+    new MarketManager({
+      minBucket: 0,
+      criticalResources: [RESOURCE_GHODIUM],
+      emergencyBuyThreshold: 5000,
+      emergencyCredits: 0,
+      terminalEnergyReserve: 1000,
+      buyThresholds: {},
+      sellThresholds: {},
+      trackedResources: [RESOURCE_GHODIUM],
+      maxActiveBuyAmount: 5000,
+      activeTradingMinBucket: 10001,
+      priceUpdateInterval: 9999
+    }).run();
+
+    expect(deals).to.deep.equal([{ id: "sell-ghodium", amount: 5000, roomName: "W1N1" }]);
+  });
+
   it("skips discretionary active trading scans while CPU bucket is recovering", () => {
     let getAllOrdersCalls = 0;
     setupGame({


### PR DESCRIPTION
## Summary
- Bounds emergency market buy CPU for #3104 by skipping impossible energy emergency buys before market order scans.
- Replaces per-unit emergency affordability decrement with a bounded binary search over transaction cost.
- Preserves zero-cost non-energy emergency buys at terminal reserve and updates the generated bot bundle.

## Linked issue
Refs #3104

## Changes
- Code changes
  - Added terminal-energy budget helpers in `@ralphschuler/screeps-economy` market manager.
  - Moves terminal cooldown/no-budget guards before expensive emergency order scans.
  - Caps emergency buy affordability search to logarithmic `calcTransactionCost` calls.
- Test changes
  - Added regression coverage for no-budget energy emergency buys avoiding market scans.
  - Added regression coverage for bounded emergency affordability search.
  - Added non-energy preservation coverage for zero-cost emergency buys.
- Docs changes
  - None; internal CPU policy/test change only.

## Validation
- ✅ `npm test -w @ralphschuler/screeps-economy -- --grep "emergency energy|zero-cost non-energy"`
- ✅ `npm test -w @ralphschuler/screeps-economy`
- ✅ `npm run build:economy`
- ✅ `npm run lint:economy`
- ✅ `git diff --check -- packages/screeps-economy/src/market/marketManager.ts packages/screeps-economy/test/MarketManager.test.ts`
- ✅ `npm run build`
- ✅ `npm run typecheck`
- ✅ `npm run lint:all`
- ✅ `npm run test:all`
- ✅ `npm run sync:deps:check`
- ✅ `npm run check:alliance-safety`
- ✅ `npm run check:no-deep-dist-imports`
- ✅ `npm run check:bot-bundle-drift` after committing regenerated bundle

## Deployment impact
- Affects `screeps.com` runtime market emergency-buy CPU behavior.
- Deploy path still builds and generated bundle is committed.

## Scope notes
- Partial #3104 slice scoped to the emergency-buy market CPU path in `packages/screeps-economy`; this PR should not close the issue by itself.
- Scout CPU and broader arbitrage/resource scan throttling remain out of this PR and tracked by #3104 if live CPU remains high after deployment.
