### PR TITLE
[codex] Cache effective spawn energy per tick

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -38024,19 +38024,24 @@ function ng(e, t, r) {
 return "healer" === e || "ranger" === e && To(r) ? null : og(e, t);
 }
 
-function ag(e) {
+var ag, ig, sg = new Map;
+
+function cg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function ig(e) {
-var t, r = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0;
-return function() {
+function ug(e) {
+var t, r;
+r = Game.time, ag === Game && ig === r || (sg.clear(), ag = Game, ig = r);
+var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}() ? Math.max(r, function(e) {
+}(), n = sg.get(e.name);
+if (n && n.fallbackEnabled === o) return n.value;
+var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
 try {
 for (var s = a(function(e) {
@@ -38045,7 +38050,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += ag(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += cg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38066,7 +38071,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += ag(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += cg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38079,26 +38084,30 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e)) : r;
+}(e)) : i;
+return sg.set(e.name, {
+fallbackEnabled: o,
+value: s
+}), s;
 }
 
-var sg = [ "guard", "ranger", "healer" ];
+var lg = [ "guard", "ranger", "healer" ];
 
-function cg(e, t) {
+function mg(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-function ug(e, t, r, o) {
+function dg(e, t, r, o) {
 void 0 === o && (o = vo(e.roomName));
-var n = cg(e, t);
+var n = mg(e, t);
 if (!bo(t)) return n;
 if (!o) return n;
-var i = pg(e.roomName), s = i[t] + xo(r, o, {
-guard: Math.max(0, cg(e, "guard") - i.guard),
-ranger: Math.max(0, cg(e, "ranger") - i.ranger),
-healer: Math.max(0, cg(e, "healer") - i.healer)
-}, yg(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
+var i = vg(e.roomName), s = i[t] + xo(r, o, {
+guard: Math.max(0, mg(e, "guard") - i.guard),
+ranger: Math.max(0, mg(e, "ranger") - i.ranger),
+healer: Math.max(0, mg(e, "healer") - i.healer)
+}, hg(e.roomName)).counts[t], c = n > 0 ? function(e, t, r) {
 return function(e, t, r) {
 var o = Co(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
@@ -38113,7 +38122,7 @@ var i = 0;
 try {
 for (var s = a(Object.values(Game.rooms)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-u.name !== e.roomName && vg(u) && Co(t, u.energyCapacityAvailable, r) && i++;
+u.name !== e.roomName && Rg(u) && Co(t, u.energyCapacityAvailable, r) && i++;
 }
 } catch (e) {
 o = {
@@ -38131,30 +38140,30 @@ return i;
 return Math.max(n, s, c, u);
 }
 
-function lg(e) {
+function pg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? q(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function mg(e) {
+function fg(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === $a ? e.targetRoom : void 0;
 }
 
-function dg(e, t) {
-var r = vo(e.roomName), o = pg(e.roomName), n = xo(t.energyCapacityAvailable, r, {
-guard: Math.max(0, cg(e, "guard") - o.guard),
-ranger: Math.max(0, cg(e, "ranger") - o.ranger),
-healer: Math.max(0, cg(e, "healer") - o.healer)
-}, yg(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
+function yg(e, t) {
+var r = vo(e.roomName), o = vg(e.roomName), n = xo(t.energyCapacityAvailable, r, {
+guard: Math.max(0, mg(e, "guard") - o.guard),
+ranger: Math.max(0, mg(e, "ranger") - o.ranger),
+healer: Math.max(0, mg(e, "healer") - o.healer)
+}, hg(e.roomName)), a = n.counts.guard + n.counts.ranger + n.counts.healer;
 if (a > 0) return a;
-var i = sg.filter(function(o) {
-return !(ug(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Co(o, t.energyCapacityAvailable, r));
+var i = lg.filter(function(o) {
+return !(dg(e, o, t.energyCapacityAvailable, r) <= 0) && Boolean(Co(o, t.energyCapacityAvailable, r));
 });
 return Math.max(1, i.length);
 }
 
-function pg(e) {
+function vg(e) {
 var t, r, o, n, i, s, c, u = {
 guard: 0,
 ranger: 0,
@@ -38163,7 +38172,7 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value.memory, p = null !== (i = d.role) && void 0 !== i ? i : "";
-bo(p) && mg(d) === e && u[p]++;
+bo(p) && fg(d) === e && u[p]++;
 }
 } catch (e) {
 t = {
@@ -38195,21 +38204,21 @@ if (o) throw o.error;
 return u;
 }
 
-function fg(e, t, r) {
+function gg(e, t, r) {
 var o = mo(r), n = e[t];
 e[t] = n ? po(n, o) : o;
 }
 
-function yg(e) {
+function hg(e) {
 var t, r, o, n, i, s, c, u, l = {};
 try {
 for (var m = a(Object.values(Game.creeps)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = p.memory, y = null !== (i = f.role) && void 0 !== i ? i : "";
-if (bo(y) && mg(f) === e) {
+if (bo(y) && fg(f) === e) {
 var v = (null !== (s = p.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-v.length > 0 && fg(l, y, v);
+v.length > 0 && gg(l, y, v);
 }
 }
 } catch (e) {
@@ -38226,7 +38235,7 @@ if (t) throw t.error;
 for (var g in Game.rooms) try {
 for (var h = (o = void 0, a(Sv.getPendingRequests(g))), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-bo(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === $a && E.targetRoom === e) && fg(l, E.role, E.body.parts);
+bo(E.role) && ((null === (c = E.additionalMemory) || void 0 === c ? void 0 : c.assistTarget) === e || (null === (u = E.additionalMemory) || void 0 === u ? void 0 : u.task) === $a && E.targetRoom === e) && gg(l, E.role, E.body.parts);
 }
 } catch (e) {
 o = {
@@ -38242,23 +38251,23 @@ if (o) throw o.error;
 return l;
 }
 
-function vg(e) {
+function Rg(e) {
 var t;
 return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === q(e).length;
 }
 
-function gg(e, t, r, o) {
+function Eg(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && ng("guard", ig(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && ng("guard", ug(r), o) ? 1 : 0;
 }
 
-function hg(e, t) {
+function Tg(e, t) {
 var r;
 if (!function(e) {
 return bo(e);
 }(t)) return null;
 var o = Game.rooms[e];
-if (!o || !vg(o)) return null;
+if (!o || !Rg(o)) return null;
 var n = o.energyCapacityAvailable, s = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38283,7 +38292,7 @@ if (t) throw t.error;
 }
 }(Game.time);
 var c = function(e) {
-var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(lg);
+var t, r = null !== (t = e.defenseRequests) && void 0 !== t ? t : [], o = r.filter(pg);
 return o.length !== r.length && (e.defenseRequests = o), o;
 }(s).filter(function(t) {
 return t.roomName !== e;
@@ -38291,15 +38300,15 @@ return t.roomName !== e;
 var r = vo(e.roomName);
 return {
 request: e,
-helperNeed: Math.max(ug(e, t, n, r), gg(e, t, o, r))
+helperNeed: Math.max(dg(e, t, n, r), Eg(e, t, o, r))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
-return lg(e.request);
+return pg(e.request);
 }).filter(function(e) {
 return function(e, t) {
-return bo(t) ? pg(e)[t] : 0;
+return bo(t) ? vg(e)[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38327,25 +38336,25 @@ targetRoom: r.roomName,
 task: $a,
 priority: (null !== (o = r.urgency) && void 0 !== o ? o : 1) >= 2 ? cv.EMERGENCY : cv.HIGH,
 defenseSquadId: ei(e, r.roomName, n.createdAt),
-defenseSquadSize: dg(r, t),
+defenseSquadSize: yg(r, t),
 defenseSquadCreatedAt: n.createdAt
 };
 }(e, o, u) : null;
 }
 
-var Rg = "defenseRefuel", Eg = {
+var Cg = "defenseRefuel", Sg = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Tg(e, t) {
+function wg(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || q(e).length > 0 || e.energyCapacityAvailable < Eg.cost);
-}(n) ? ig(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || q(e).length > 0 || e.energyCapacityAvailable < Sg.cost);
+}(n) ? ug(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38384,7 +38393,7 @@ if (t) throw t.error;
 try {
 for (var m = a(Sv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Rg && s++;
+"hauler" === p.role && f === Cg && s++;
 }
 } catch (e) {
 o = {
@@ -38399,23 +38408,23 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Rg,
+task: Cg,
 priority: cv.EMERGENCY,
-body: Eg
+body: Sg
 } : null : null;
 }
 
-function Cg(e) {
+function xg(e) {
 var t = Game.rooms[e];
 return t ? !!t.controller && !Hv(t.controller) && !Vv(t) : !Yv(e);
 }
 
-function Sg(e) {
+function bg(e) {
 var t = Game.rooms[e];
 return (null == t ? void 0 : t.controller) ? !Hv(t.controller) : !Yv(e);
 }
 
-function wg(e, t, r) {
+function Og(e, t, r) {
 var o = pv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
@@ -38444,13 +38453,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function xg(e, t, r) {
+function kg(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Cg(l) && Iv(e, t, l) < Bv(e, l, t, Game.rooms[l])) return l;
+if (xg(l) && Iv(e, t, l) < Bv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -38466,7 +38475,7 @@ if (o) throw o.error;
 return null;
 }
 
-function bg(e, t, r, o) {
+function Mg(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
 var p = pv[t];
@@ -38501,14 +38510,14 @@ var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
 return Mv.set(r, n), n;
-}(e, t) >= wg(e, t, r)) && null !== xg(e, t, r);
+}(e, t) >= Og(e, t, r)) && null !== kg(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Sg(R)) {
+if (bg(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = q(E).filter(function(e) {
@@ -38535,7 +38544,7 @@ return !1;
 }
 var C = null !== (u = Pv(e).get(t)) && void 0 !== u ? u : 0;
 if ("pioneer" === t) return null !== rg(e, r);
-if (C >= wg(e, t, r)) return !1;
+if (C >= Og(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38618,16 +38627,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Og(e) {
+function Ag(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function kg(e) {
-return 0 === Og(Pv(e, !0));
+function Ug(e) {
+return 0 === Ag(Pv(e, !0));
 }
 
-function Mg(e) {
+function _g(e) {
 var t = Nt(e);
 return [ {
 role: "harvester",
@@ -38650,14 +38659,14 @@ minCount: 1
 } ];
 }
 
-function Ag(e, t) {
+function Ng(e, t) {
 var r, o, n, i, s = Pv(e, !0);
-if (0 === Og(s)) return !0;
+if (0 === Ag(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Pv(e, !1), u = Mg(t);
+var c = Pv(e, !1), u = _g(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -38677,19 +38686,19 @@ if (r) throw r.error;
 return !1;
 }
 
-function Ug(e) {
+function Pg(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function _g(e, t, r) {
-var n = wg(e.name, r.roleName, t);
+function Ig(e, t, r) {
+var n = Og(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Ng(e, t, r, o, n) {
+function Gg(e, t, r, o, n) {
 if (n && ("larvaWorker" === r || "harvester" === r)) return cv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
@@ -38711,23 +38720,23 @@ return e >= 90 ? cv.HIGH : e >= 60 ? cv.NORMAL : cv.LOW;
 }(o);
 }
 
-function Pg(e, t) {
+function Lg(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-Ug(e);
-var l = Pv(e.name), m = kg(e.name), d = [];
-if (Ag(e.name, e)) {
+Pg(e);
+var l = Pv(e.name), m = Ug(e.name), d = [];
+if (Ng(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Og(Pv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Ag(Pv(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Pv(e, !1), c = Mg(t);
+var s = Pv(e, !1), c = _g(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -38742,7 +38751,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = bg(e, m.role, r, !0);
+var p = Mg(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -38773,17 +38782,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = pv[p]) && bg(e.name, p, t, !0) ? (d.push(_g(e, t, {
+return p && (g = pv[p]) && Mg(e.name, p, t, !0) ? (d.push(Ig(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: Ng(e, 0, p, g.priority, m),
+priority: Gg(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
 for (var f = a(Object.entries(pv)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Tg(e.name, p);
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = wg(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -38794,7 +38803,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = hg(e.name, p);
+var E = Tg(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -38808,8 +38817,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (bg(e.name, p, t, m)) {
-var T = Dv(p), C = T ? xg(e.name, p, t) : null, S = "claimer" === p ? Zv(e.name, t) : null, w = "pioneer" === p ? rg(e.name, t) : null;
+}); else if (Mg(e.name, p, t, m)) {
+var T = Dv(p), C = T ? kg(e.name, p, t) : null, S = "claimer" === p ? Zv(e.name, t) : null, w = "pioneer" === p ? rg(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -38819,11 +38828,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(_g(e, t, {
+}) : d.push(Ig(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: Ng(e, 0, p, g.priority, m),
+priority: Gg(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -38845,7 +38854,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Ig(e, l.value);
+var m = Dg(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -38866,10 +38875,10 @@ requests: c
 };
 }
 
-function Ig(e, t) {
+function Dg(e, t) {
 var r, n, i, s, c, u = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = xv.getMaxAffordableInTicks(e, l), d = ig(e), p = t.priority >= cv.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && bo(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= cv.EMERGENCY, g = t.assistTarget ? vo(t.assistTarget) : null, h = f ? Co(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Co(f, d, g)) && void 0 !== r ? r : ng(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
+var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = xv.getMaxAffordableInTicks(e, l), d = ug(e), p = t.priority >= cv.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && bo(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= cv.EMERGENCY, g = t.assistTarget ? vo(t.assistTarget) : null, h = f ? Co(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Co(f, d, g)) && void 0 !== r ? r : ng(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
 if (y && g && !E && !t.bodyOverride) return null;
 var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
 var r, o, n = null;
@@ -38926,30 +38935,30 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Gg = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Lg = new Set([ "guard", "ranger", "healer" ]);
+var Fg = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Bg = new Set([ "guard", "ranger", "healer" ]);
 
-function Dg() {
+function Wg() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Fg(e) {
+function Kg(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Bg(e) {
+function Hg(e) {
 var t;
 return e.priority >= cv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Wg(e) {
+function Yg(e) {
 var t;
 return e.priority >= cv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Kg(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = ig(e), m = r.urgency >= 2 || t.danger >= 3 ? cv.EMERGENCY : cv.HIGH, d = yo(q(e)), p = function(e) {
+function Vg(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = ug(e), m = r.urgency >= 2 || t.danger >= 3 ? cv.EMERGENCY : cv.HIGH, d = yo(q(e)), p = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
 }(d) ? u : m === cv.EMERGENCY ? l : u, f = function(e, t) {
@@ -38961,9 +38970,9 @@ healers: 0
 try {
 for (var s = a(Sv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || Hg(u, e) && ("guard" === u.role && (n.guards++,
-Vg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Vg(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Vg(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || qg(u, e) && ("guard" === u.role && (n.guards++,
+zg(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, zg(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, zg(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -38991,7 +39000,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Vg(n, u, l);
+0 !== l.length && zg(n, u, l);
 }
 }
 }
@@ -39030,26 +39039,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - f.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Yg("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) jg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Yg("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) jg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Yg("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) jg(e, "healer", "military", cv.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : jg("guard", p, d);
+if (h > 0 && R) for (var E = 0; E < h; E++) Xg(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
+var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : jg("ranger", p, d);
+if (T > 0 && C) for (E = 0; E < T; E++) Xg(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
+var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : jg("healer", p, d);
+if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) Xg(e, "healer", "military", cv.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
 !function(e, t, r, o) {
 if (!(t < cv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Lg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Bg.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
 for (var i = a(Sv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < cv.EMERGENCY || Lg.has(c.role) && Hg(c, e.name) && c.body.cost <= t && n++;
+c.priority < cv.EMERGENCY || Bg.has(c.role) && qg(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39081,35 +39090,35 @@ var r = mo(t.body.parts).score - mo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && jg(e, n.role, "military", cv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && Xg(e, n.role, "military", cv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Hg(e, t) {
+function qg(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Yg(e, t, r) {
+function jg(e, t, r) {
 return r ? Co(e, t, r) : null;
 }
 
-function Vg(e, t, r) {
+function zg(e, t, r) {
 var o = mo(r);
 e[t] = e[t] ? po(e[t], o) : o;
 }
 
-function qg(e, t, r) {
+function Qg(e, t, r) {
 return Sv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function jg(e, t, r, o, n, a, i, s, c) {
+function Xg(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
 var u = null != i ? i : Rv({
@@ -39137,7 +39146,7 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function zg(e, t, r) {
+function Zg(e, t, r) {
 if (void 0 === r && (r = e.energyAvailable), t.priority >= cv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
@@ -39149,20 +39158,20 @@ if (o / e.energyCapacityAvailable < .5) return !0;
 return t.priority === cv.NORMAL && o / e.energyCapacityAvailable < .3 && xv.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function Qg(e, t) {
+function Jg(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Ug(e);
+Pg(e);
 var s = Sv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Ag(e.name, e), u = kg(e.name) && !Sv.hasEmergencySpawns(e.name), l = to(e), m = oo(e);
+var c = Ng(e.name, e), u = Ug(e.name) && !Sv.hasEmergencySpawns(e.name), l = to(e), m = oo(e);
 if (c) {
-s > 0 && Sv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Kg(e, t, l, m);
+s > 0 && Sv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Vg(e, t, l, m);
 try {
-for (var d = a(Pg(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Lg(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 Sv.addRequest(f);
 }
@@ -39177,7 +39186,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Kg(e, t, l, m), function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Vg(e, t, l, m), function(e) {
 var t, r, o = bv.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
@@ -39196,11 +39205,11 @@ for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = qg(e.name, "powerHarvester", f), g = qg(e.name, "healer", f), h = qg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) jg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Qg(e.name, "powerHarvester", f), g = Qg(e.name, "healer", f), h = Qg(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Xg(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) jg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) Xg(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) jg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Xg(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -39229,12 +39238,12 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Sv.getPendingRequests(e.name).map(Fg));
+var c = new Set(Sv.getPendingRequests(e.name).map(Kg));
 try {
-for (var u = a(Pg(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= cv.HIGH, p = "claimer" === m.role && Dg(), f = Bg(m), y = Wg(m);
-if (Gg.has(m.role) || d || p || f || y) {
-var v = Fg(m);
+for (var u = a(Lg(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= cv.HIGH, p = "claimer" === m.role && Wg(), f = Hg(m), y = Yg(m);
+if (Fg.has(m.role) || d || p || f || y) {
+var v = Kg(m);
 c.has(v) || (Sv.addRequest(m), c.add(v));
 }
 }
@@ -39252,7 +39261,7 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Pg(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+for (var y = a(Lg(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
 Sv.addRequest(f);
 } catch (e) {
 n = {
@@ -39275,12 +39284,12 @@ subsystem: "SpawnPipeline"
 var r = function(e) {
 var t, r, o = Sv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = ig(e);
+var n = 0, i = ug(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Sv.getNextRequest(e.name, i);
 if (!l) break;
-if (zg(e, l, i)) {
+if (Zg(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
@@ -39320,7 +39329,7 @@ stats: o
 }(e, t);
 }
 
-var Xg = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, Zg = /^(\d{1,2})\|(.+)$/, Jg = M("SS2TerminalComms"), $g = function() {
+var $g = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, eh = /^(\d{1,2})\|(.+)$/, th = M("SS2TerminalComms"), rh = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -39380,11 +39389,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(Xg);
+var t = e.match($g);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(Zg);
+var i = a.match(eh);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -39419,7 +39428,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-Jg.warn("Missing packet in multi-packet message", {
+th.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -39435,7 +39444,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), Jg.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), th.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -39459,7 +39468,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && Jg.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && th.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -39471,7 +39480,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return Jg.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return th.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -39479,14 +39488,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), Jg.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), th.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (Jg.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (th.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -39511,7 +39520,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-Jg.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+th.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -39523,7 +39532,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-Jg.info("Completed sending multi-packet message", {
+th.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -39531,25 +39540,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? Jg.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? th.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (Jg.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (th.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else Jg.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else th.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else Jg.warn("Terminal not found for queue item, removing from queue", {
+} else th.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -39583,7 +39592,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && Jg.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && th.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -39593,7 +39602,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-Jg.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+th.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -39684,7 +39693,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (Jg.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (th.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -39706,7 +39715,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return Jg.error("Error parsing JSON", {
+return th.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -39717,7 +39726,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), eh = [ {
+}(), oh = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -39737,7 +39746,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], th = function() {
+} ], nh = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -39784,9 +39793,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), rh = new th;
+}(), ah = new nh;
 
-function oh(e) {
+function ih(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -39794,19 +39803,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function nh(e, t) {
+function sh(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function ah(e, t) {
+function ch(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var ih = {
+var uh = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -39817,9 +39826,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, sh = function() {
+}, lh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, ih), e);
+void 0 === e && (e = {}), this.config = o(o({}, uh), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -39840,7 +39849,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = rh.getSwarmState(r.toRoom);
+var o = ah.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -39853,7 +39862,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = rh.getSwarmState(c);
+var l = ah.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -39923,9 +39932,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(nh), u = n.filter(function(e) {
+}).sort(sh), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(ah), l = [], m = [], d = function(t) {
+}).sort(ch), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -39947,11 +39956,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return oh({
+return ih({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + oh({
+}) + ih({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -40050,7 +40059,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), ch = new sh, uh = {
+}(), mh = new lh, dh = {
 1: {
 guards: 1,
 rangers: 1,
@@ -40071,14 +40080,14 @@ siegeUnits: 1
 }
 };
 
-function lh(e) {
+function ph(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function mh(e) {
+function fh(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -40101,9 +40110,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function dh(e) {
+function yh(e) {
 var t, r, o;
-mh(e);
+fh(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -40127,20 +40136,20 @@ if (t) throw t.error;
 return n;
 }
 
-function ph(e) {
+function vh(e) {
 var t;
-mh(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = dh(e);
+fh(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = yh(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function fh(e) {
-return !!ph(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function gh(e) {
+return !!vh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-mh(e);
+fh(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -40151,12 +40160,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = dh(e);
+var d = yh(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function yh(e, t) {
+function hh(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -40177,20 +40186,20 @@ if (r) throw r.error;
 return n;
 }
 
-function vh(e, t) {
+function Rh(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = uh[r]) && void 0 !== t ? t : uh[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = dh[r]) && void 0 !== t ? t : dh[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = yh(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = hh(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: lh(r),
+targetComposition: ph(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -40202,7 +40211,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function gh(e) {
+function Eh(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -40222,9 +40231,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function hh(e) {
+function Th(e) {
 var t = e.members.length;
-mh(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+fh(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -40238,7 +40247,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && fh(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && gh(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -40267,7 +40276,7 @@ subsystem: "Squad"
 }
 }
 
-var Rh = {
+var Ch = {
 harassment: {
 composition: {
 harassers: 3,
@@ -40354,7 +40363,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Eh(e, t) {
+function Sh(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -40369,8 +40378,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Th(e, t) {
-var r, o, n, i = Rh[t], s = 0;
+function wh(e, t) {
+var r, o, n, i = Ch[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -40396,7 +40405,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Ch, Sh, wh, xh = {
+var xh, bh, Oh, kh = {
 move: 50,
 work: 100,
 carry: 50,
@@ -40405,11 +40414,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, bh = new Map;
+}, Mh = new Map;
 
-function Oh(e, t) {
+function Ah(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (bh.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (Mh.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -40421,7 +40430,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Rh[p].composition;
+d = Ch[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -40436,19 +40445,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (bh.set(m, y), function(e, t, r, o) {
+v ? (Mh.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Rh[s].useBoosts;
+i = Ch[s].useBoosts;
 }
 var c = cv.NORMAL;
 "siege" === t.type ? c = cv.HIGH : "defense" === t.type && (c = cv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = kh(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + xh[t];
-}, 0), m = i ? Ah(r) : [], d = {
+var u = Uh(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + kh[t];
+}, 0), m = i ? Nh(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -40491,42 +40500,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function kh(e, t, r) {
+function Uh(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return Mh([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return _h([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return Mh([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return _h([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return Mh([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return _h([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return Mh([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return _h([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return Mh([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return _h([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return Mh([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return _h([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function Mh(e, t, r) {
+function _h(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + xh[t];
+return e + kh[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + xh[t];
+return e + kh[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function Ah(e) {
+function Nh(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -40557,45 +40566,45 @@ return [];
 }
 }
 
-function Uh(e) {
-return bh.has(e);
+function Ph(e) {
+return Mh.has(e);
 }
 
-function _h(e) {
-return ph(e) || fh(e);
+function Ih(e) {
+return vh(e) || gh(e);
 }
 
-(Ch = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Ch[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Ch[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Sh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Sh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Sh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Sh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (wh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-wh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, wh[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-wh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, wh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(xh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, xh[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+xh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (bh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+bh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, bh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+bh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (Oh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+Oh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Oh[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+Oh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, Oh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var Nh = {
+var Gh = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function Ph(e, t) {
-var r = Nh[t], o = rh.getClusters();
+function Lh(e, t) {
+var r = Gh[t], o = ah.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function Ih(e, t, r) {
+function Dh(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = rh.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = ah.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: Ph(e, i.danger),
+reservedEnergy: Lh(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -40685,7 +40694,7 @@ success: !1
 });
 }
 
-var Gh = {
+var Fh = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -40695,7 +40704,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function Lh(e, t, r) {
+function Bh(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -40726,7 +40735,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function Dh(e, t, r, o) {
+function Wh(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -40736,7 +40745,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function Fh(e, t) {
+function Kh(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -40757,19 +40766,19 @@ if (r) throw r.error;
 return n;
 }
 
-function Bh() {
-var e = rh.getEmpire();
+function Hh() {
+var e = ah.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function Wh(e) {
-Bh()[e.id] = e;
+function Yh(e) {
+Hh()[e.id] = e;
 }
 
-function Kh(e) {
+function Vh(e) {
 e.lastUpdate = Game.time;
-var t = rh.getCluster(e.clusterId);
-if (!t) return e.state = "failed", Wh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = ah.getCluster(e.clusterId);
+if (!t) return e.state = "failed", Yh(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -40779,12 +40788,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (_h(r) || Uh(e) || Oh(0, r), _h(r));
+return !!r && (Ih(r) || Ph(e) || Ah(0, r), Ih(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), Wh(e);
+})), Yh(e);
 }(e, t);
 break;
 
@@ -40795,7 +40804,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (hh(o), gh(o)) {
+if (Th(o), Eh(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -40824,7 +40833,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = rh.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = ah.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -40851,12 +40860,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), Wh(e);
+})), Yh(e);
 }(e, t);
 }
 }
 
-function Hh(e, t, r) {
+function qh(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -40875,11 +40884,11 @@ score: n.score + o.score
 }
 }
 
-function Yh(e, t, r) {
+function jh(e, t, r) {
 return Co(e, t, r);
 }
 
-function Vh(e, t) {
+function zh(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -40892,11 +40901,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function qh(e) {
+function Qh(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function jh(e, t, r) {
+function Xh(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -40909,8 +40918,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function zh(e, t, r) {
-var o = Yh(t, e.energyCapacityAvailable, r);
+function Zh(e, t, r) {
+var o = jh(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -40918,16 +40927,16 @@ var a = mo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function Qh(e, t, r, o) {
+function Jh(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = zh(e, t, o);
-if (s !== zh(n, t, o)) return s ? -1 : 1;
+var a, i, s = Zh(e, t, o);
+if (s !== Zh(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function Xh(e, t) {
+function $h(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -41011,21 +41020,21 @@ if (r) throw r.error;
 return u;
 }
 
-function Zh(e, t) {
+function eR(e, t) {
 return {
-guard: Math.max(0, Vh(e, "guard") - t.counts.guard),
-ranger: Math.max(0, Vh(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, Vh(e, "healer") - t.counts.healer)
+guard: Math.max(0, zh(e, "guard") - t.counts.guard),
+ranger: Math.max(0, zh(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, zh(e, "healer") - t.counts.healer)
 };
 }
 
-function Jh(e) {
+function tR(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function $h(e, t) {
+function rR(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return Jh(e.role);
+return tR(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -41038,12 +41047,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function eR(e) {
+function oR(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === $a ? e.targetRoom : void 0;
 }
 
-function tR(e) {
+function nR(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -41055,7 +41064,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-Jh(m) && eR(l) === e && !u.spawning && Hh(i, m, u.body.filter(function(e) {
+tR(m) && oR(l) === e && !u.spawning && qh(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -41073,7 +41082,7 @@ if (t) throw t.error;
 return i;
 }
 
-function rR(e, t, r) {
+function aR(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -41103,16 +41112,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: $h(e, r)
+pendingAssist: rR(e, r)
 };
 }
 }
 
-function oR(e, t) {
+function iR(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = Yh(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = jh(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -41133,7 +41142,7 @@ subsystem: "Cluster"
 }
 }
 
-function nR(e, t, r) {
+function sR(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -41175,20 +41184,20 @@ exitAccess: a
 };
 }
 
-function aR(e, t) {
+function cR(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function iR(e, t, r) {
+function uR(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function sR(e) {
+function lR(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function cR(e, t) {
+function mR(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -41199,7 +41208,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function uR(e, t, r) {
+function dR(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -41210,8 +41219,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = sR(g);
-h && (ri(g) || cR(v, h) && (t.assignedCreeps.includes(v.name) || aR(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = lR(g);
+h && (ri(g) || mR(v, h) && (t.assignedCreeps.includes(v.name) || cR(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -41248,7 +41257,7 @@ return e.distance - t.distance;
 });
 }
 
-function lR(e, t) {
+function pR(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -41273,21 +41282,21 @@ if (r) throw r.error;
 return i;
 }
 
-function mR(e) {
+function fR(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var dR = {
+var yR = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, pR = function() {
+}, vR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, dR), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, yR), e);
 }
 return e.prototype.run = function() {
-var e = rh.getClusters();
+var e = ah.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -41306,7 +41315,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: eh.map(function(t) {
+steps: oh.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -41362,7 +41371,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-ch.processCluster(t);
+mh.processCluster(t);
 break;
 
 case "squads":
@@ -41394,7 +41403,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = nR(e, new RoomPosition(s, c, e.name), "defense");
+var u = sR(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -41443,9 +41452,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = rh.getSwarmState(i);
+var i = n.value, s = ah.getSwarmState(i);
 if (s) {
-var c = Ph(i, s.danger);
+var c = Lh(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -41476,7 +41485,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = rh.getSwarmState(m);
+var m = l.value, d = ah.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -41508,7 +41517,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += mR(l.controller.level));
+}).length, i += fR(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -41625,7 +41634,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-hh(i), "gathering" !== i.state || _h(i) || Uh(i.id) || Oh(0, i), gh(i) && (i.state = "dissolving");
+Th(i), "gathering" !== i.state || Ih(i) || Ph(i.id) || Ah(0, i), Eh(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -41650,7 +41659,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = vh(e, s);
+var s = i.value, c = Rh(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -41667,7 +41676,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(Bh()).filter(function(e) {
+var t = (a = e.id, Object.values(Hh()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -41678,22 +41687,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, Gh), n), m = [], d = rh.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, Fh), n), m = [], d = ah.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = Lh(f, y, d);
+var g = Bh(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = Fh(e, f);
+var h = Kh(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = Dh(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = Wh(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Eh(f, {
+var C = Sh(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -41728,29 +41737,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Th(e, n.doctrine) ? function(e, t, r) {
+wh(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = rh.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = ah.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = Lh(e, o, r);
+var n = Bh(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (rh.getEmpire().knownRooms || {})[t], n = null != r ? r : Eh(t, {
+var o = (ah.getEmpire().knownRooms || {})[t], n = null != r ? r : Sh(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Th(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!wh(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -41763,7 +41772,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-Wh(i);
+Yh(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -41777,13 +41786,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = yh(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = hh(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: lh(n),
+targetComposition: ph(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -41798,8 +41807,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), Wh(i), Oh(0, c), i.state = "forming", i.lastUpdate = Game.time,
-Wh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), Yh(i), Ah(0, c), i.state = "forming", i.lastUpdate = Game.time,
+Yh(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -41818,11 +41827,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(bh.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Mh.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), bh.delete(c));
+}), Mh.delete(c));
 }
 } catch (t) {
 e = {
@@ -41836,10 +41845,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = Bh();
-for (var t in e) Kh(e[t]);
+var e = Hh();
+for (var t in e) Vh(e[t]);
 !function() {
-var e = Bh();
+var e = Hh();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -41917,14 +41926,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = rh.getCluster(t, e);
+var t = "cluster_".concat(e), r = ah.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = rh.getCluster(e);
+var o = ah.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -41953,7 +41962,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Ih(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && Dh(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -41970,7 +41979,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = rh.getSwarmState(t);
+var n, a, i = ah.getSwarmState(t);
 if (!i) return "continue";
 if (no(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -42011,7 +42020,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = vo(g), f[g] = tR(g);
+p[g] = vo(g), f[g] = nR(g);
 }
 } catch (e) {
 r = {
@@ -42027,7 +42036,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = rR(E, m, t);
+d[E] = aR(E, m, t);
 }
 } catch (e) {
 n = {
@@ -42046,13 +42055,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = jh(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = Xh(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = Xh(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = $h(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = xo(T, R, Zh(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = xo(T, R, eR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = Qh(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = Jh(h, b, g.roomName, R), M = 0; M < O; M++) {
 var A = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -42064,7 +42073,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(A.roomName, "_").con
 roomName: A.roomName,
 role: b,
 family: "military",
-priority: qh(g.urgency),
+priority: Qh(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -42110,7 +42119,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) oR(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) iR(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -42137,7 +42146,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = lR(f, uR(e, f, t)), v = y.reduce(function(e, t) {
+var y = pR(f, dR(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -42150,7 +42159,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), iR(f, R.role, aR(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), uR(f, R.role, cR(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -42217,19 +42226,19 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), fR = new pR, yR = /^([WE])(\d+)([NS])(\d+)$/;
+}(), gR = new vR, hR = /^([WE])(\d+)([NS])(\d+)$/;
 
-function vR(e) {
-return yR.test(e);
+function RR(e) {
+return hR.test(e);
 }
 
-var gR = {
+var ER = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, hR = function() {
+}, TR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, gR), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, ER), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
@@ -42297,7 +42306,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (vR(x)) {
+if (e.isAlly(x)) f.add(x); else if (RR(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -42369,7 +42378,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), RR = new hR, ER = function() {
+}(), CR = new TR, SR = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -42446,9 +42455,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), TR = new ER, CR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), wR = new SR, xR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function SR(e, t) {
+function bR(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -42471,13 +42480,13 @@ if (r) throw r.error;
 return n;
 }
 
-function wR(e) {
+function OR(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function xR(e, t, r) {
-if (!wR(e)) return 0;
-var o = SR(e.name, t);
+function kR(e, t, r) {
+if (!OR(e)) return 0;
+var o = bR(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += qs(e.mineralType),
@@ -42486,7 +42495,7 @@ n += Xs(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += Js(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function bR(e, t) {
+function MR(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -42496,13 +42505,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return q(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && CR.has(e.type);
+return e.hits > 0 && xR.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function OR(e, t, r) {
+function AR(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -42512,7 +42521,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function kR(e) {
+function UR(e) {
 return function(e) {
 var t = X(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -42523,8 +42532,8 @@ isSK: Z(t.x) && Z(t.y)
 }(e);
 }
 
-function MR(e) {
-var t = kR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function _R(e) {
+var t = UR(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -42543,14 +42552,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var AR = {
+var NR = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, UR = function() {
+}, PR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, AR), e);
+void 0 === e && (e = {}), this.config = o(o({}, NR), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -42641,7 +42650,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = kR(e);
+var t = UR(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -42653,14 +42662,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return MR(_R(e));
+return _R(IR(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = MR(_R(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = _R(IR(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function _R(e) {
+function IR(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = q(e), c = j(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -42692,11 +42701,11 @@ swamps: d
 };
 }
 
-var NR = new UR, PR = /^([WE])(\d+)([NS])(\d+)$/, IR = {
+var GR = new PR, LR = /^([WE])(\d+)([NS])(\d+)$/, DR = {
 allies: []
-}, GR = function() {
+}, FR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, IR), e);
+void 0 === e && (e = {}), this.config = o(o({}, DR), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -42716,7 +42725,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!PR.test(e)) return !1;
+if (!LR.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -42824,7 +42833,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return PR.test(e);
+return LR.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -42851,7 +42860,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), LR = new GR, DR = {
+}(), BR = new FR, WR = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -42864,9 +42873,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, FR = function() {
+}, KR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, DR), e);
+void 0 === e && (e = {}), this.config = o(o({}, WR), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = Xr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -42879,7 +42888,7 @@ t.updateExpansionQueue(o);
 }), Fi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), Fi.measureSubsystem("empire:warTargets", function() {
-LR.updateWarTargets(o);
+BR.updateWarTargets(o);
 }), Fi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), Fi.measureSubsystem("empire:gclTracking", function() {
@@ -42887,13 +42896,13 @@ t.trackGCLProgress(o);
 }), s && Fi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (Fi.measureSubsystem("empire:intelRefresh", function() {
-NR.refreshRoomIntel(o);
+GR.refreshRoomIntel(o);
 }), Fi.measureSubsystem("empire:roomDiscovery", function() {
-NR.discoverNearbyRooms(o);
+GR.discoverNearbyRooms(o);
 })), s && Fi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (Fi.measureSubsystem("empire:clusterHealth", function() {
-TR.monitorClusterHealth();
+wR.monitorClusterHealth();
 }), Fi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -42976,22 +42985,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = bR(f, u);
+var y = Boolean(Game.rooms[f]), v = MR(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = SR(f, t);
+var g = bR(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = OR(h, u, y);
+var h = e.knownRooms[f], R = AR(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? xR(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? kR(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -43035,10 +43044,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && wR(a)) {
-var i = SR(a.name, t);
+if (a && OR(a)) {
+var i = bR(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = xR(a, t, r);
+var s = kR(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -43358,13 +43367,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), BR = new FR;
+}(), HR = new KR;
 
-function WR(e) {
+function YR(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var KR = {
+var VR = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -43372,10 +43381,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, HR = function() {
+}, qR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, KR), e);
+this.config = o(o({}, VR), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -43519,7 +43528,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, WR(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, YR(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -43694,7 +43703,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), YR = new HR, VR = function() {
+}(), jR = new qR, zR = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Hs(o(o({}, Ms), e), {
 getEmpire: function() {
@@ -43730,7 +43739,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), qR = new VR, jR = function() {
+}(), QR = new zR, XR = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = Xr.getEmpire();
@@ -43748,9 +43757,9 @@ lastScan: 0
 var e = Xr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), zR = new (function(e) {
+}(), ZR = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new jR) || this;
+return void 0 === t && (t = {}), e.call(this, t, new XR) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -43762,22 +43771,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ht() ], t);
 }(Ci));
 
-function QR() {
+function JR() {
 return global;
 }
 
-function XR(e) {
+function $R(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function ZR(e) {
+function eE(e) {
 return Number(null != e ? e : 0);
 }
 
-var JR = function() {
+var tE = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = QR();
+var e = JR();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -43785,12 +43794,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return QR()._pixelGenerationMemory;
+return JR()._pixelGenerationMemory;
 }, e;
-}(), $R = function(e) {
+}(), rE = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new JR) || this;
+var r = e.call(this, t, new tE) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -43807,7 +43816,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(XR).length : Object.values(null != t ? t : {}).filter(XR).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter($R).length : Object.values(null != t ? t : {}).filter($R).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -43818,9 +43827,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (ZR(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (ZR(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = ZR(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = ZR(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (eE(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (eE(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = eE(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = eE(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -43842,9 +43851,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ht() ], t);
-}(wi), eE = new $R;
+}(wi), oE = new rE;
 
-function tE(e, t) {
+function nE(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !H(e.controller.owner.username)) return {
 lost: !0,
@@ -43866,7 +43875,7 @@ lost: !1
 };
 }
 
-function rE(e, t, r) {
+function aE(e, t, r) {
 var o, n = Xr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -43880,20 +43889,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var oE = Ae().cpu.bucketThresholds.highMode + 1800, nE = {
+var iE = Ae().cpu.bucketThresholds.highMode + 1800, sE = {
 updateInterval: 250,
-minBucket: oE,
+minBucket: iE,
 maxSitesPerRemotePerTick: 2
 };
 
-function aE(e, t) {
+function cE(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var iE = function() {
+var uE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, nE), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, sE), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -43910,8 +43919,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = tE(l);
-m.lost && m.reason && rE(e, u, m.reason);
+var m = nE(l);
+m.lost && m.reason && aE(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -43929,10 +43938,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = aE("remoteInfrastructure.intent", function() {
+var i = cE("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-aE("remoteInfrastructure.execute", function() {
+cE("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -44098,13 +44107,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = aE("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = cE("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = aE("remoteInfrastructure.roomSnapshot", function() {
+u[t] = cE("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -44137,7 +44146,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = aE("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = cE("remoteInfrastructure.calculateRemoteRoads", function() {
 return ua(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -44166,14 +44175,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = aE("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = cE("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? aE("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? cE("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -44190,7 +44199,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? aE("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? cE("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -44208,7 +44217,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return aE("remoteInfrastructure.findSources", function() {
+return cE("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -44305,10 +44314,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ yt("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Je.LOW,
 interval: 1e3,
-minBucket: oE,
+minBucket: iE,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ht() ], e);
-}(), sE = new iE, cE = new (function(e) {
+}(), lE = new uE, mE = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -44320,7 +44329,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ht() ], t);
-}(Rf)), uE = function() {
+}(Rf)), dE = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -44410,7 +44419,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ht() ], e);
-}(), lE = new uE, mE = new (function() {
+}(), pE = new dE, fE = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -44440,7 +44449,7 @@ registerProcesses: function() {
 var e;
 Wu.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), hi(lE, Rs, ws, Zi, BR, ac, YR, sE, fs, zR, eE, qR, Dc, Hc, cE, RR, _c, fR, pi),
+}), hi(pE, Rs, ws, Zi, HR, ac, jR, lE, fs, ZR, oE, QR, Dc, Hc, mE, CR, _c, gR, pi),
 function() {
 var e, t, r = Ae().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -44495,7 +44504,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return fR.run();
+return gR.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -44536,9 +44545,9 @@ Wu.info("Registered ".concat(gi.getProcesses().length, " processes with kernel")
 subsystem: "ProcessRegistry"
 });
 }
-}), dE = "_ownedRooms", pE = "_ownedRoomsTick";
+}), yE = "_ownedRooms", vE = "_ownedRoomsTick";
 
-function fE(e) {
+function gE(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -44548,13 +44557,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var yE = Fu("NativeCallsTracker");
+var hE = Fu("NativeCallsTracker");
 
-function vE(e, t, r) {
+function RE(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) yE.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) hE.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -44570,7 +44579,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-yE.warn("Failed to wrap method", {
+hE.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -44580,30 +44589,30 @@ error: String(e)
 }
 }
 
-var gE, hE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], RE = "shard1", EE = {
+var EE, TE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], CE = "shard1", SE = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, TE = {
+}, wE = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, CE = {
+}, xE = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function SE() {
+function bE() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function wE() {
+function OE() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: hE,
+targetShards: TE,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -44613,11 +44622,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = hE),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = TE),
 Memory.interShardOperation;
 }
 
-function xE() {
+function kE() {
 return mf({
 version: 1,
 shards: {},
@@ -44631,32 +44640,32 @@ checksum: 0
 });
 }
 
-function bE(e, t) {
+function ME(e, t) {
 void 0 === t && (t = [ "footprintOperation" ]), df(e, {
 updatedSections: t
 });
 }
 
-function OE() {
-var e, t, r, o, n, i, s, c = xE(), u = SE();
+function AE() {
+var e, t, r, o, n, i, s, c = kE(), u = bE();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: hE,
+targetShards: TE,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : hE,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : TE,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && kE() ? "established" : "unreached",
+status: p === u && UE() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -44674,7 +44683,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === RE ? "core" : "frontier",
+role: u === CE ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -44691,24 +44700,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), bE(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), ME(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function kE() {
+function UE() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function ME() {
+function _E() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function AE(e, t) {
+function NE(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -44727,7 +44736,7 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(ME()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(_E()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 s += Sv.getPendingRequests(p.name).filter(function(r) {
 var o;
@@ -44748,7 +44757,7 @@ if (n) throw n.error;
 return s;
 }
 
-function UE(e) {
+function PE(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -44792,7 +44801,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = xE().shards[SE()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = kE().shards[bE()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -44802,8 +44811,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function _E(e, t) {
-if (!(AE("scout", t) >= 1)) {
+function IE(e, t) {
+if (!(NE("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -44846,7 +44855,7 @@ id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: CE,
+body: xE,
 priority: cv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
@@ -44858,13 +44867,13 @@ task: "interShardPortalScout"
 }
 }
 
-function NE(e, t, r) {
-AE("interShardClaimer", t) >= 1 || Sv.addRequest({
+function GE(e, t, r) {
+NE("interShardClaimer", t) >= 1 || Sv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: EE,
+body: SE,
 priority: cv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
@@ -44878,13 +44887,13 @@ workflowState: "movingToPortal"
 });
 }
 
-function PE(e, t, r) {
-AE("interShardScout", t) >= 1 || Sv.addRequest({
+function LE(e, t, r) {
+NE("interShardScout", t) >= 1 || Sv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: CE,
+body: xE,
 priority: cv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
@@ -44898,14 +44907,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function IE(e, t, r) {
+function DE(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (AE("interShardPioneer", t.shard) >= 3 || Sv.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (NE("interShardPioneer", t.shard) >= 3 || Sv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: TE,
+body: wE,
 priority: cv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
@@ -44919,16 +44928,16 @@ workflowState: "movingToPortal"
 }));
 }
 
-function GE(e) {
+function FE(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = SE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = bE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : hE), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : TE), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
 var f = InterShardMemory.getRemote(p), y = f ? nf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
@@ -44963,7 +44972,7 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(ME()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(_E()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 n += Sv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
@@ -44984,7 +44993,7 @@ return n;
 }() < o;
 }
 
-(gE = {
+(EE = {
 optimizeBody: Rv,
 spawnQueue: {
 addRequest: function(e) {
@@ -44996,10 +45005,10 @@ LOW: cv.LOW,
 NORMAL: cv.NORMAL,
 HIGH: cv.HIGH
 }
-}).optimizeBody && (Tf.optimizeBody = gE.optimizeBody), gE.spawnQueue && (Tf.spawnQueue = gE.spawnQueue),
-gE.spawnPriorities && (Tf.spawnPriorities = o(o({}, Tf.spawnPriorities), gE.spawnPriorities));
+}).optimizeBody && (Tf.optimizeBody = EE.optimizeBody), EE.spawnQueue && (Tf.spawnQueue = EE.spawnQueue),
+EE.spawnPriorities && (Tf.spawnPriorities = o(o({}, Tf.spawnPriorities), EE.spawnPriorities));
 
-var LE, DE = function() {
+var BE, WE = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -45043,7 +45052,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function FE(e) {
+function KE(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -45064,7 +45073,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function BE(e, t, r) {
+function HE(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -45130,16 +45139,16 @@ return u;
 });
 }
 
-function WE(e) {
+function YE(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(LE || (LE = {}));
+}(BE || (BE = {}));
 
-var KE = function() {
+var VE = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -45177,8 +45186,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = BE(h.pos, T.pos, this.logger);
-if (WE(C)) {
+var T = E.value, C = HE(h.pos, T.pos, this.logger);
+if (YE(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -45205,8 +45214,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, M = BE(k, u.pos, this.logger);
-WE(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, M = HE(k, u.pos, this.logger);
+YE(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -45245,8 +45254,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = BE(e, t, this.logger);
-if (WE(n)) {
+var n = HE(e, t, this.logger);
+if (YE(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -45256,7 +45265,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), HE = function() {
+}(), qE = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -45266,7 +45275,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = FE(s);
+var c = KE(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -45292,7 +45301,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), YE = function() {
+}(), jE = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -45341,7 +45350,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), VE = {
+}(), zE = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -45354,7 +45363,7 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, qE = {
+}, QE = {
 getCachedPath: function(e, t) {
 var r = kt(e, t), o = Le.get(r, {
 namespace: Ot
@@ -45381,7 +45390,7 @@ direction: a
 }
 return t;
 }
-}, jE = {
+}, XE = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
 void 0 === o && (o = Pm.MEDIUM), Vm.register({
@@ -45394,13 +45403,13 @@ skippable: o !== Pm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, zE = new KE(qE, VE), QE = new HE(VE, jE, zE), XE = new YE(VE, qE, zE, el.moveTo);
+}, ZE = new VE(QE, zE), JE = new qE(zE, XE, ZE), $E = new jE(zE, QE, ZE, el.moveTo);
 
-function ZE(e, t, r, o) {
-return XE.moveToWithRemoteCache(e, t, r, o);
+function eT(e, t, r, o) {
+return $E.moveToWithRemoteCache(e, t, r, o);
 }
 
-var JE, $E = function() {
+var tT, rT = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -45413,12 +45422,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), eT = function() {
+}(), oT = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 tt.on(e, t);
 }, e;
-}(), tT = function() {
+}(), nT = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -45463,28 +45472,28 @@ m.length > 0 && Mt(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), rT = function() {
+}(), aT = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return FE(e);
+return KE(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-zE.precacheRemoteRoutes(e, t);
+ZE.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), oT = new DE(new $E, new eT, new tT, new rT), nT = {
+}(), iT = new WE(new rT, new oT, new nT, new aT), sT = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, aT = function() {
+}, cT = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, nT), e);
+this.config = o(o({}, sT), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -45578,123 +45587,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new aT, (JE = {})[FIND_STRUCTURES] = {
+new cT, (tT = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, JE[FIND_MY_STRUCTURES] = {
+}, tT[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, JE[FIND_HOSTILE_STRUCTURES] = {
+}, tT[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, JE[FIND_SOURCES_ACTIVE] = {
+}, tT[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, JE[FIND_SOURCES] = {
+}, tT[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, JE[FIND_MINERALS] = {
+}, tT[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, JE[FIND_DEPOSITS] = {
+}, tT[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, JE[FIND_MY_CONSTRUCTION_SITES] = {
+}, tT[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, JE[FIND_CONSTRUCTION_SITES] = {
+}, tT[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, JE[FIND_CREEPS] = {
+}, tT[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, JE[FIND_MY_CREEPS] = {
+}, tT[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, JE[FIND_HOSTILE_CREEPS] = {
+}, tT[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, JE[FIND_DROPPED_RESOURCES] = {
+}, tT[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, JE[FIND_TOMBSTONES] = {
+}, tT[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, JE[FIND_RUINS] = {
+}, tT[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, JE[FIND_FLAGS] = {
+}, tT[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, JE[FIND_MY_SPAWNS] = {
+}, tT[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, JE[FIND_HOSTILE_SPAWNS] = {
+}, tT[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, JE[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, tT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, JE[FIND_NUKES] = {
+}, tT[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, JE[FIND_POWER_CREEPS] = {
+}, tT[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, JE[FIND_MY_POWER_CREEPS] = {
+}, tT[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, JE[FIND_HOSTILE_POWER_CREEPS] = {
+}, tT[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, JE[FIND_EXIT_TOP] = {
+}, tT[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, JE[FIND_EXIT_RIGHT] = {
+}, tT[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, JE[FIND_EXIT_BOTTOM] = {
+}, tT[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, JE[FIND_EXIT_LEFT] = {
+}, tT[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, JE[FIND_EXIT] = {
+}, tT[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var iT = new ue({}, Xr), sT = new Re({}, Xr);
+var uT = new ue({}, Xr), lT = new Re({}, Xr);
 
-function cT(e) {
+function mT(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -45702,11 +45711,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var uT = !1;
+var dT = !1;
 
-function lT() {
+function pT() {
 var e, t;
-uT || (xu({
+dT || (xu({
 level: (t = Ae()).debug ? ou.DEBUG : ou.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -45793,7 +45802,7 @@ return mu.getLabOverflow(e);
 }), Fi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) yE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) hE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -45807,7 +45816,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-yE.warn("Failed to wrap PathFinder.search", {
+hE.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -45815,11 +45824,11 @@ error: String(e)
 }
 }
 }
-}(), vE(e = Creep.prototype, "moveTo", "moveTo"), vE(e, "move", "move"), vE(e, "harvest", "harvest"),
-vE(e, "transfer", "transfer"), vE(e, "withdraw", "withdraw"), vE(e, "build", "build"),
-vE(e, "repair", "repair"), vE(e, "upgradeController", "upgradeController"), vE(e, "attack", "attack"),
-vE(e, "rangedAttack", "rangedAttack"), vE(e, "heal", "heal"), vE(e, "dismantle", "dismantle"),
-vE(e, "say", "say")), function(e) {
+}(), RE(e = Creep.prototype, "moveTo", "moveTo"), RE(e, "move", "move"), RE(e, "harvest", "harvest"),
+RE(e, "transfer", "transfer"), RE(e, "withdraw", "withdraw"), RE(e, "build", "build"),
+RE(e, "repair", "repair"), RE(e, "upgradeController", "upgradeController"), RE(e, "attack", "attack"),
+RE(e, "rangedAttack", "rangedAttack"), RE(e, "heal", "heal"), RE(e, "dismantle", "dismantle"),
+RE(e, "say", "say")), function(e) {
 void 0 === e && (e = ze);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, Fe.L1, {
@@ -46006,15 +46015,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(gi, Xr, cy), oT.initializePathCacheEvents(), QE.initialize(Pm.MEDIUM), Wl = ZE,
-wr.initialize(), cE.initialize(), uT = !0), Xr.initialize();
-var r = mE.configureForCurrentTick();
+}(gi, Xr, cy), iT.initializePathCacheEvents(), JE.initialize(Pm.MEDIUM), Wl = eT,
+wr.initialize(), mE.initialize(), dT = !0), Xr.initialize();
+var r = fE.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Wu.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = wE();
-if (!1 !== r.enabled && (r.lastRun = Game.time, OE(), function() {
-var e, t, r, o, n = xE(), a = n.footprintOperation, i = SE(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = OE();
+if (!1 !== r.enabled && (r.lastRun = Game.time, AE(), function() {
+var e, t, r, o, n = kE(), a = n.footprintOperation, i = bE(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -46027,15 +46036,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, bE(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, ME(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = wE();
+var e, t, r, n, i, s, c = OE();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : hE), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === RE ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : TE), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === CE ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -46053,7 +46062,7 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !kE())) try {
+}(), !UE())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
 "interShardClaimer" !== c && "interShardScout" !== c || Df(s), "interShardPioneer" === c && Lf(s);
@@ -46080,17 +46089,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Wu.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: uT
+systemsInitialized: dT
 }
-}), mE.ensureProcessesRegistered(), Fi.startTick(), ju.clear(), mE.startEventTick();
+}), fE.ensureProcessesRegistered(), Fi.startTick(), ju.clear(), fE.startEventTick();
 var i = function(e) {
-var t = e.cache[dE], r = e.cache[pE];
+var t = e.cache[yE], r = e.cache[vE];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[dE] = o, e.cache[pE] = e.tick, o;
+return e.cache[yE] = o, e.cache[vE] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -46127,15 +46136,15 @@ if (e) throw e.error;
 }
 }), Fi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = wE();
+var e, t, r, o = OE();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = OE();
+var n = AE();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : hE), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : TE), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== SE()) try {
+if (d !== bE()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
 var f = nf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
@@ -46156,20 +46165,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = ME().sort(function(e, t) {
+var i = _E().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : hE), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : TE), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== SE()) {
+if (u !== bE()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = UE(u);
+var m = PE(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? IE(i, l, m) : GE() ? NE(i, u, m) : (PE(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (_E(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? DE(i, l, m) : FE() ? GE(i, u, m) : (LE(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (IE(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -46186,8 +46195,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = xE();
-d.footprintOperation = n, bE(d);
+var d = kE();
+d.footprintOperation = n, ME(d);
 }
 }
 })(), function() {
@@ -46195,8 +46204,8 @@ var e, t, r, o = Game.cpu.bucket < Ae().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || cT(s))) {
-var c = Qg(s, Xr.getOrInitSwarmState(s.name));
+if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (!o || mT(s))) {
+var c = Jg(s, Xr.getOrInitSwarmState(s.name));
 Fi.recordSpawnQueue(s.name, c.stats, c.spawned);
 }
 }
@@ -46215,11 +46224,11 @@ if (e) throw e.error;
 }), el.preTick(), Fi.measureSubsystem("processSync", function() {
 Qf.syncCreepProcesses(), Xy.syncRoomProcesses();
 }), Fi.measureSubsystem("kernel", function() {
-mE.runProcesses();
+fE.runProcesses();
 }), Fi.measureSubsystem("eventQueue", function() {
-mE.processQueuedEvents();
+fE.processQueuedEvents();
 }), Fi.measureSubsystem("ss2PacketQueue", function() {
-$g.processQueue();
+rh.processQueue();
 }), gi.hasCpuBudget() && Fi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
@@ -46240,7 +46249,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), fE({
+}), gE({
 hasCpuBudget: gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Fi.measureSubsystem("visualizations", function() {
@@ -46250,8 +46259,8 @@ var r, o;
 if (Ae().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = iT.getConfig(), s = sT.getConfig();
-iT.setConfig(n.roomVisualizerConfig), n.renderMap && sT.setConfig(n.mapVisualizerConfig);
+var i = uT.getConfig(), s = lT.getConfig();
+uT.setConfig(n.roomVisualizerConfig), n.renderMap && lT.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -46262,7 +46271,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-iT.draw(m);
+uT.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Wu.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -46284,14 +46293,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-sT.draw();
+lT.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Wu.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-iT.setConfig(i), sT.setConfig(s);
+uT.setConfig(i), lT.setConfig(s);
 }
 }
 }
@@ -46376,7 +46385,7 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), el.reconcileTraffic(), fE({
+}), el.reconcileTraffic(), gE({
 hasCpuBudget: gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && Fi.measureSubsystem("scheduledTasks", function() {
@@ -46388,7 +46397,7 @@ return e.set(t.id, t), e;
 Fi.finalizeTick(), Wu.flush();
 }
 
-var mT = function() {
+var fT = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Ae().visualizations;
@@ -46396,25 +46405,25 @@ return Ue({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = iT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = uT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-iT.toggle(o);
-var n = iT.getConfig()[o];
+uT.toggle(o);
+var n = uT.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = sT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = lT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-sT.toggle(o);
-var n = sT.getConfig()[o];
+lT.toggle(o);
+var n = lT.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = sT.getConfig();
+var e = lT.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -46537,15 +46546,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), dT = function() {
+}(), yT = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = cE.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = mE.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = cE.getAllShards();
+var e, t, r = mE.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -46567,9 +46576,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (cE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (mE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = cE.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = mE.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -46594,16 +46603,16 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = cE.getOptimalPortalRoute(e, t);
+var r, o = mE.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (cE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (mE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (cE.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (mE.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
 var e, t, r = Sf.getActiveRequests();
@@ -46627,7 +46636,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = cE.getCurrentShardState();
+var e, t, r = mE.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -46648,7 +46657,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = cE.getActiveTransferTasks();
+var e, t, r, o = mE.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -46669,16 +46678,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = cE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+var e = mE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
 return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(cf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = cE.getMemoryStats();
+var e = mE.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return cE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return mE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = xE().footprintOperation;
+var e, t, r, o = kE().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -46784,9 +46793,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), pT = new dT;
+}(), vT = new yT;
 
-function fT(e) {
+function gT(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -46816,7 +46825,7 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? fT(e.metadata.usage) : void 0
+params: e.metadata.usage ? gT(e.metadata.usage) : void 0
 };
 });
 return ed({
@@ -47031,39 +47040,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var yT = new Jy, vT = new mT, gT = new $y, hT = new Ku, RT = new Zy, ET = new ev, TT = new tv, CT = "__screepsGlobalRuntimeDiagnostics";
+var hT = new Jy, RT = new fT, ET = new $y, TT = new Ku, CT = new Zy, ST = new ev, wT = new tv, xT = "__screepsGlobalRuntimeDiagnostics";
 
-function ST() {
+function bT() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function wT(e, t) {
+function OT(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function xT(e, t) {
+function kT(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function bT(e) {
+function MT(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function OT(e) {
+function AT(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: wT(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: wT(n.switchCount, 0),
-lastTick: xT(n.lastTick, Game.time),
-lastResetTick: xT(n.lastResetTick, Game.time),
-lastSwitchTick: bT(n.lastSwitchTick),
-lastSwitchPreviousTick: bT(n.lastSwitchPreviousTick),
-lastWarningTick: bT(n.lastWarningTick)
+resetCount: OT(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: OT(n.switchCount, 0),
+lastTick: kT(n.lastTick, Game.time),
+lastResetTick: kT(n.lastResetTick, Game.time),
+lastSwitchTick: MT(n.lastSwitchTick),
+lastSwitchPreviousTick: MT(n.lastSwitchPreviousTick),
+lastWarningTick: MT(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -47077,13 +47086,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var kT = Fu("Main");
+var UT = Fu("Main");
 
 !function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-ar.initialize(), sr(yT), sr(vT), sr(gT), sr(hT), sr(RT), sr(ET), sr(TT), sr(yu),
-sr(vu), sr(gu), sr(pT), sr(pr), sr(sc), sr(Ic), global.tooangel = Nc;
+ar.initialize(), sr(hT), sr(RT), sr(ET), sr(TT), sr(CT), sr(ST), sr(wT), sr(yu),
+sr(vu), sr(gu), sr(vT), sr(pr), sr(sc), sr(Ic), global.tooangel = Nc;
 var e = global;
 e.botConfig = {
 getConfig: Ae,
@@ -47098,12 +47107,12 @@ try {
 (function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : ST, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[CT];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : bT, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[xT];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[CT] = s, function(e, t) {
-var r, o = OT(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[xT] = s, function(e, t) {
+var r, o = AT(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -47121,7 +47130,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = OT(e.heapId);
+var n, a = AT(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -47142,14 +47151,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = OT(s.heapId);
+var u = AT(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 })({
-logger: kT
-}), lT();
+logger: UT
+}), pT();
 } catch (e) {
-throw kT.error("Critical error in main loop: ".concat(String(e)), {
+throw UT.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-spawn/src/roomEnergy.ts
+++ b/packages/screeps-spawn/src/roomEnergy.ts
@@ -4,6 +4,24 @@ interface SpawnEnergySettings {
   structureEnergyFallback?: boolean;
 }
 
+interface EffectiveRoomEnergyCacheEntry {
+  fallbackEnabled: boolean;
+  value: number;
+}
+
+const effectiveRoomEnergyCache = new Map<string, EffectiveRoomEnergyCacheEntry>();
+let effectiveRoomEnergyCacheGame: Game | undefined;
+let effectiveRoomEnergyCacheTick: number | undefined;
+
+function resetEffectiveRoomEnergyCacheForCurrentTick(): void {
+  const tick = Game.time;
+  if (effectiveRoomEnergyCacheGame === Game && effectiveRoomEnergyCacheTick === tick) return;
+
+  effectiveRoomEnergyCache.clear();
+  effectiveRoomEnergyCacheGame = Game;
+  effectiveRoomEnergyCacheTick = tick;
+}
+
 function isStructureEnergyFallbackEnabled(): boolean {
   const mem = Memory as unknown as { spawnSettings?: SpawnEnergySettings };
   return mem.spawnSettings?.structureEnergyFallback !== false;
@@ -59,8 +77,15 @@ function getStoredSpawnExtensionEnergy(room: Room): number {
  * `Memory.spawnSettings = { structureEnergyFallback: false }`.
  */
 export function getEffectiveRoomEnergyAvailable(room: Room): number {
-  const roomEnergy = room.energyAvailable ?? 0;
-  if (!isStructureEnergyFallbackEnabled()) return roomEnergy;
+  resetEffectiveRoomEnergyCacheForCurrentTick();
 
-  return Math.max(roomEnergy, getStoredSpawnExtensionEnergy(room));
+  const fallbackEnabled = isStructureEnergyFallbackEnabled();
+  const cached = effectiveRoomEnergyCache.get(room.name);
+  if (cached && cached.fallbackEnabled === fallbackEnabled) return cached.value;
+
+  const roomEnergy = room.energyAvailable ?? 0;
+  const value = fallbackEnabled ? Math.max(roomEnergy, getStoredSpawnExtensionEnergy(room)) : roomEnergy;
+  effectiveRoomEnergyCache.set(room.name, { fallbackEnabled, value });
+
+  return value;
 }

--- a/packages/screeps-spawn/test/roomEnergy.test.ts
+++ b/packages/screeps-spawn/test/roomEnergy.test.ts
@@ -1,0 +1,103 @@
+import { expect } from "chai";
+import { getEffectiveRoomEnergyAvailable } from "../src/roomEnergy";
+
+function createEnergyStore(getEnergy: () => number): Store<RESOURCE_ENERGY, false> {
+  return {
+    getUsedCapacity: (resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? getEnergy() : 0)
+  } as unknown as Store<RESOURCE_ENERGY, false>;
+}
+
+function createEnergyStructure(
+  structureType: typeof STRUCTURE_SPAWN | typeof STRUCTURE_EXTENSION,
+  getEnergy: () => number
+): StructureSpawn | StructureExtension {
+  return {
+    structureType,
+    store: createEnergyStore(getEnergy)
+  } as unknown as StructureSpawn | StructureExtension;
+}
+
+function createRoomWithTrackedFinds(options: {
+  name?: string;
+  energyAvailable?: number;
+  spawnEnergy?: () => number;
+  extensionEnergy?: () => number;
+}): { room: Room; findCallTypes: FindConstant[] } {
+  const findCallTypes: FindConstant[] = [];
+  const spawn = createEnergyStructure(STRUCTURE_SPAWN, options.spawnEnergy ?? (() => 0));
+  const extension = createEnergyStructure(STRUCTURE_EXTENSION, options.extensionEnergy ?? (() => 0));
+
+  const room = {
+    name: options.name ?? "E1N1",
+    energyAvailable: options.energyAvailable ?? 0,
+    energyCapacityAvailable: 800,
+    find: (type: FindConstant) => {
+      findCallTypes.push(type);
+      if (type === FIND_MY_SPAWNS) return [spawn];
+      if (type === FIND_MY_STRUCTURES) return [spawn, extension];
+      return [];
+    }
+  } as unknown as Room;
+
+  return { room, findCallTypes };
+}
+
+describe("room energy fallback cache", () => {
+  beforeEach(() => {
+    (globalThis as any).Game = {
+      time: 20_000,
+      rooms: {},
+      creeps: {},
+      spawns: {},
+      structures: {}
+    };
+    (globalThis as any).Memory = {};
+  });
+
+  it("caches effective spawn energy per room for the current tick", () => {
+    const { room, findCallTypes } = createRoomWithTrackedFinds({
+      energyAvailable: 0,
+      spawnEnergy: () => 300,
+      extensionEnergy: () => 50
+    });
+
+    expect(getEffectiveRoomEnergyAvailable(room)).to.equal(350);
+    expect(getEffectiveRoomEnergyAvailable(room)).to.equal(350);
+
+    expect(findCallTypes).to.deep.equal([FIND_MY_SPAWNS, FIND_MY_STRUCTURES]);
+  });
+
+  it("recomputes effective spawn energy on a later tick", () => {
+    let spawnEnergy = 300;
+    const { room, findCallTypes } = createRoomWithTrackedFinds({
+      energyAvailable: 0,
+      spawnEnergy: () => spawnEnergy
+    });
+
+    expect(getEffectiveRoomEnergyAvailable(room)).to.equal(300);
+
+    spawnEnergy = 400;
+    Game.time += 1;
+
+    expect(getEffectiveRoomEnergyAvailable(room)).to.equal(400);
+    expect(findCallTypes).to.deep.equal([
+      FIND_MY_SPAWNS,
+      FIND_MY_STRUCTURES,
+      FIND_MY_SPAWNS,
+      FIND_MY_STRUCTURES
+    ]);
+  });
+
+  it("preserves the structure-energy fallback disable switch without scanning structures", () => {
+    (globalThis as any).Memory = { spawnSettings: { structureEnergyFallback: false } };
+    const { room, findCallTypes } = createRoomWithTrackedFinds({
+      energyAvailable: 0,
+      spawnEnergy: () => 300,
+      extensionEnergy: () => 50
+    });
+
+    expect(getEffectiveRoomEnergyAvailable(room)).to.equal(0);
+    expect(getEffectiveRoomEnergyAvailable(room)).to.equal(0);
+    expect(findCallTypes).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Cache effective room spawn energy once per room/tick in `@ralphschuler/screeps-spawn`.
- Preserve the private-server spawn/extension store fallback and its Memory disable switch.
- Add regression coverage for cache hits, tick invalidation, and disabled fallback behavior.
- Update the generated Screeps bot bundle to keep bundle drift checks green.

## Linked issue
Closes #3234

## Changes
- Code: added a per-tick heap cache inside `packages/screeps-spawn/src/roomEnergy.ts`.
- Tests: added `packages/screeps-spawn/test/roomEnergy.test.ts` covering repeated calls, next-tick recompute, and fallback disable behavior.
- Bundle: rebuilt `packages/screeps-bot/dist/main.js` after the framework change.
- Docs: not changed; runtime-internal CPU optimization only.

## Validation
- `npm test -w @ralphschuler/screeps-spawn -- --grep "room energy fallback cache"` ✅
- `npm run test:spawn` ✅
- `npm run lint:spawn` ✅
- `npm run build:spawn` ✅
- `npx tsc --noEmit -p packages/screeps-spawn/tsconfig.test.json` ✅
- `npm run build:bot` ✅
- `npm run check:bot-bundle-drift` ✅
- `npm run sync:deps:check` ✅
- `npm run check:alliance-safety` ✅

## Deployment impact
- Affects Screeps runtime spawn planning/execution CPU by avoiding repeated same-tick room scans.
- No Memory schema or deploy command changes.

## Scope notes
- Scoped to existing issue #3234 only.
- Existing untracked local artifact directories were left untouched and not included.
