### PR TITLE
[codex] Enforce quality budgets

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -232,13 +232,15 @@ jobs:
             # Parse the JSON report
             TOTAL_FILES=$(jq -r '.totalFiles' reports/complexity-baseline.json 2>/dev/null || echo "N/A")
             FILES_OVER_LIMIT=$(jq -r '.filesOverLimit' reports/complexity-baseline.json 2>/dev/null || echo "N/A")
+            FILES_OVER_LIMIT_PERCENT=$(jq -r '.filesOverLimitPercent // "N/A"' reports/complexity-baseline.json 2>/dev/null || echo "N/A")
             AVG_LINES=$(jq -r '.averageLines' reports/complexity-baseline.json 2>/dev/null || echo "N/A")
             
             echo "📊 **Total Files**: ${TOTAL_FILES}" >> $GITHUB_STEP_SUMMARY
-            echo "📊 **Files Over 300 Lines**: ${FILES_OVER_LIMIT}" >> $GITHUB_STEP_SUMMARY
+            echo "📊 **Files Over 300 Lines**: ${FILES_OVER_LIMIT} (${FILES_OVER_LIMIT_PERCENT}%)" >> $GITHUB_STEP_SUMMARY
             echo "📊 **Average Lines per File**: ${AVG_LINES}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "🎯 **Target**: < 20% files over 300 lines" >> $GITHUB_STEP_SUMMARY
+            echo "📊 **Budget**: transitional hard gate allows up to 22% files over 300 lines" >> $GITHUB_STEP_SUMMARY
+            echo "🎯 **Long-term target**: < 20% files over 300 lines" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "View full report in the uploaded artifacts." >> $GITHUB_STEP_SUMMARY
           else

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -78,8 +78,8 @@ A passing smoke run must show tick progression, bot upload/load, room survival, 
 
 ## Quality gates
 
-- `quality:duplication` uses JSCPD and currently has a transitional threshold while framework extraction continues.
-- `quality:complexity` writes complexity artifacts under `reports/`.
+- `quality:duplication` uses JSCPD and fails when total duplication exceeds the 22% transitional threshold while framework extraction continues. The long-term target remains < 5% duplication.
+- `quality:complexity` writes complexity artifacts under `reports/` and fails when more than 22% of analyzed files exceed 300 lines. The long-term target remains < 20% files over 300 lines.
 - `build:docs` validates documentation aggregation.
 - `verify` runs the primary local gate plus alliance safety and production dependency audit.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "publish:framework:dry-run": "node scripts/publish-framework-package.mjs --all --dry-run",
     "check:no-deep-dist-imports": "node scripts/check-no-deep-dist-imports.js",
     "check:bot-bundle-drift": "node scripts/check-bot-bundle-drift.mjs",
-    "quality:duplication": "jscpd . --config .jscpd.json",
+    "quality:duplication": "node scripts/check-duplication-budget.cjs",
     "quality:complexity": "node scripts/analyze-complexity.cjs",
     "quality:baseline": "npm run quality:duplication && npm run quality:complexity",
     "profile:live:cpu": "node scripts/live-cpu-profile.mjs --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile",

--- a/scripts/analyze-complexity.cjs
+++ b/scripts/analyze-complexity.cjs
@@ -11,7 +11,15 @@ const { execSync } = require('child_process');
 
 // Configuration
 const MAX_FILE_LINES = 300;
+const MAX_FILES_OVER_LIMIT_PERCENT = 22;
 const MAX_FUNCTION_COMPLEXITY_WARNING = 15;
+
+function countLogicalLines(content) {
+  if (content.length === 0) {
+    return 0;
+  }
+  return content.split('\n').length - (content.endsWith('\n') ? 1 : 0);
+}
 
 async function analyzeComplexity() {
   console.log('🔍 Analyzing code complexity...\n');
@@ -27,13 +35,15 @@ async function analyzeComplexity() {
     complexFunctions: [],
     totalLines: 0,
     averageLines: 0,
-    filesOverLimit: 0
+    filesOverLimit: 0,
+    filesOverLimitPercent: 0,
+    filesOverLimitPercentRaw: 0,
+    filesOverLimitBudgetPercent: MAX_FILES_OVER_LIMIT_PERCENT
   };
 
   for (const file of files) {
     const content = fs.readFileSync(file, 'utf-8');
-    const lines = content.split('\n');
-    const lineCount = lines.length;
+    const lineCount = countLogicalLines(content);
     const relativePath = path.relative(process.cwd(), file);
 
     results.totalFiles++;
@@ -70,7 +80,9 @@ async function analyzeComplexity() {
     }
   }
 
-  results.averageLines = Math.round(results.totalLines / results.totalFiles);
+  results.averageLines = results.totalFiles > 0 ? Math.round(results.totalLines / results.totalFiles) : 0;
+  results.filesOverLimitPercentRaw = results.totalFiles > 0 ? results.filesOverLimit / results.totalFiles * 100 : 0;
+  results.filesOverLimitPercent = Number(results.filesOverLimitPercentRaw.toFixed(4));
 
   // Sort by size/complexity
   results.largeFiles.sort((a, b) => b.lines - a.lines);
@@ -82,7 +94,8 @@ async function analyzeComplexity() {
   console.log(`Total Files Analyzed: ${results.totalFiles}`);
   console.log(`Total Lines of Code: ${results.totalLines.toLocaleString()}`);
   console.log(`Average Lines per File: ${results.averageLines}`);
-  console.log(`Files over ${MAX_FILE_LINES} lines: ${results.filesOverLimit} (${Math.round(results.filesOverLimit / results.totalFiles * 100)}%)`);
+  console.log(`Files over ${MAX_FILE_LINES} lines: ${results.filesOverLimit} (${results.filesOverLimitPercent}%)`);
+  console.log(`Files-over-limit budget: ${MAX_FILES_OVER_LIMIT_PERCENT}%`);
   console.log('='.repeat(80));
   console.log('');
 
@@ -108,6 +121,17 @@ async function analyzeComplexity() {
   fs.mkdirSync(path.dirname(reportPath), { recursive: true });
   fs.writeFileSync(reportPath, JSON.stringify(results, null, 2));
   console.log(`📄 Full report saved to: ${path.relative(process.cwd(), reportPath)}`);
+
+  if (results.filesOverLimitPercentRaw > MAX_FILES_OVER_LIMIT_PERCENT) {
+    console.log(
+      `❌ Complexity budget exceeded: ${results.filesOverLimitPercent}% files over ${MAX_FILE_LINES} lines exceeds the ${MAX_FILES_OVER_LIMIT_PERCENT}% transitional budget.`
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `✅ Complexity budget met: ${results.filesOverLimitPercent}% files over ${MAX_FILE_LINES} lines is within the ${MAX_FILES_OVER_LIMIT_PERCENT}% transitional budget.`
+    );
+  }
 
   return results;
 }

--- a/scripts/check-duplication-budget.cjs
+++ b/scripts/check-duplication-budget.cjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Runs JSCPD and enforces the configured duplication budget after reports exist.
+ * JSCPD's native exitCode setting is intentionally left at 0 because it exits on
+ * any clones, not only threshold breaches, for this project baseline.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const DEFAULT_CONFIG_PATH = path.join(process.cwd(), '.jscpd.json');
+const DEFAULT_REPORT_PATH = path.join(process.cwd(), 'reports', 'duplication', 'jscpd-report.json');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readTotalDuplicationPercentage(report) {
+  const percentage = Number(report?.statistics?.total?.percentage);
+  if (!Number.isFinite(percentage)) {
+    throw new Error('JSCPD report is missing statistics.total.percentage');
+  }
+  return percentage;
+}
+
+function enforceDuplicationBudget({ configPath = DEFAULT_CONFIG_PATH, reportPath = DEFAULT_REPORT_PATH } = {}) {
+  const config = readJson(configPath);
+  const threshold = Number(config.threshold);
+  if (!Number.isFinite(threshold)) {
+    throw new Error('JSCPD config is missing numeric threshold');
+  }
+
+  const report = readJson(reportPath);
+  const percentage = readTotalDuplicationPercentage(report);
+  const result = { percentage, threshold, breached: percentage > threshold };
+
+  if (result.breached) {
+    throw new Error(
+      `Duplication budget exceeded: ${percentage.toFixed(2)}% total duplication exceeds the ${threshold}% transitional threshold.`
+    );
+  }
+
+  console.log(
+    `✅ Duplication budget met: ${percentage.toFixed(2)}% total duplication is within the ${threshold}% transitional threshold.`
+  );
+  return result;
+}
+
+function runJscpd() {
+  const result = spawnSync(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['--no-install', 'jscpd', '.', '--config', '.jscpd.json'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: 'inherit'
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`JSCPD failed before budget enforcement with exit code ${result.status}.`);
+  }
+}
+
+function main() {
+  try {
+    runJscpd();
+    enforceDuplicationBudget();
+  } catch (error) {
+    console.error(`❌ ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  enforceDuplicationBudget,
+  readTotalDuplicationPercentage
+};

--- a/scripts/test/quality-gates.test.mjs
+++ b/scripts/test/quality-gates.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { enforceDuplicationBudget } = require("../check-duplication-budget.cjs");
+const complexityScript = new URL("../analyze-complexity.cjs", import.meta.url);
+
+function makeFixture() {
+  const dir = mkdtempSync(join(tmpdir(), "screeps-quality-gate-"));
+  mkdirSync(join(dir, "packages", "fixture"), { recursive: true });
+  return dir;
+}
+
+function writeTypeScriptFile(root, name, lineCount) {
+  const lines = Array.from({ length: lineCount }, (_, index) => `export const value${index} = ${index};`);
+  writeFileSync(join(root, "packages", "fixture", name), `${lines.join("\n")}\n`);
+}
+
+function runComplexity(root) {
+  return spawnSync(process.execPath, [complexityScript.pathname], {
+    cwd: root,
+    encoding: "utf8",
+  });
+}
+
+test("duplication gate wraps JSCPD so reports are written before enforcing the threshold", () => {
+  const config = JSON.parse(readFileSync(new URL("../../.jscpd.json", import.meta.url), "utf8"));
+  const rootPackage = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
+
+  assert.equal(config.threshold, 22, "duplication should use the documented transitional threshold");
+  assert.equal(config.exitCode, 0, "JSCPD should not fail before JSON/HTML reports are written");
+  assert.ok(config.reporters.includes("json"), "duplication summaries need the JSON report artifact");
+  assert.equal(rootPackage.scripts["quality:duplication"], "node scripts/check-duplication-budget.cjs");
+});
+
+test("duplication budget enforcement fails only when total duplication exceeds the configured threshold", () => {
+  const root = makeFixture();
+  const configPath = join(root, ".jscpd.json");
+  const reportPath = join(root, "reports", "duplication", "jscpd-report.json");
+  mkdirSync(join(root, "reports", "duplication"), { recursive: true });
+  writeFileSync(configPath, JSON.stringify({ threshold: 22 }));
+
+  try {
+    writeFileSync(reportPath, JSON.stringify({ statistics: { total: { percentage: 21.99 } } }));
+    assert.deepEqual(enforceDuplicationBudget({ configPath, reportPath }), {
+      percentage: 21.99,
+      threshold: 22,
+      breached: false,
+    });
+
+    writeFileSync(reportPath, JSON.stringify({ statistics: { total: { percentage: 22.01 } } }));
+    assert.throws(
+      () => enforceDuplicationBudget({ configPath, reportPath }),
+      /Duplication budget exceeded: 22\.01% total duplication exceeds the 22% transitional threshold/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("complexity gate treats exactly 300 logical lines as within the file-size limit", () => {
+  const root = makeFixture();
+
+  try {
+    writeTypeScriptFile(root, "exact-limit.ts", 300);
+
+    const result = runComplexity(root);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const report = JSON.parse(readFileSync(join(root, "reports", "complexity-baseline.json"), "utf8"));
+    assert.equal(report.filesOverLimit, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("complexity gate passes at the transitional files-over-limit budget", () => {
+  const root = makeFixture();
+
+  try {
+    writeTypeScriptFile(root, "large.ts", 301);
+    for (let index = 0; index < 4; index += 1) {
+      writeTypeScriptFile(root, `small-${index}.ts`, 10);
+    }
+
+    const result = runComplexity(root);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const report = JSON.parse(readFileSync(join(root, "reports", "complexity-baseline.json"), "utf8"));
+    assert.equal(report.filesOverLimitPercent, 20);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("complexity gate fails when files-over-limit percentage exceeds the transitional budget", () => {
+  const root = makeFixture();
+
+  try {
+    writeTypeScriptFile(root, "large.ts", 301);
+    writeTypeScriptFile(root, "small.ts", 10);
+
+    const result = runComplexity(root);
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /Complexity budget exceeded/);
+
+    const report = JSON.parse(readFileSync(join(root, "reports", "complexity-baseline.json"), "utf8"));
+    assert.equal(report.filesOverLimitPercent, 50);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("complexity gate enforces raw just-over-budget percentages without rounding down", () => {
+  const root = makeFixture();
+
+  try {
+    for (let index = 0; index < 90; index += 1) {
+      writeTypeScriptFile(root, `large-${index}.ts`, 301);
+    }
+    for (let index = 0; index < 319; index += 1) {
+      writeTypeScriptFile(root, `small-${index}.ts`, 10);
+    }
+
+    const result = runComplexity(root);
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /22\.0049% files over 300 lines exceeds the 22% transitional budget/);
+
+    const report = JSON.parse(readFileSync(join(root, "reports", "complexity-baseline.json"), "utf8"));
+    assert.equal(report.filesOverLimitPercent, 22.0049);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Enforces duplication and complexity budgets as hard CI gates after reports are produced.
- Adds regression tests for duplication threshold enforcement, complexity threshold boundaries, raw percentage comparison, and exact 300-line handling.
- Documents transitional thresholds and keeps quality workflow summaries/artifacts useful after failures.

## Linked issue
Closes #3100

## Changes
- Code changes
  - Wraps JSCPD with `scripts/check-duplication-budget.cjs` so JSON/HTML reports are written before failing on threshold breach.
  - Updates complexity analysis to fail when raw files-over-limit percentage exceeds the 22% transitional budget.
  - Counts logical lines so exactly 300-line files are not treated as over-limit.
- Test changes
  - Adds `scripts/test/quality-gates.test.mjs` coverage for duplication and complexity hard gates.
- Docs changes
  - Documents current transitional duplication and complexity budgets in `docs/testing/README.md`.
  - Updates the quality workflow complexity summary with current percent, budget, and long-term target.

## Validation
- ✅ `node --test scripts/test/quality-gates.test.mjs`
- ✅ `npm run quality:duplication`
- ✅ `npm run quality:complexity`
- ✅ `npm run test:scripts`
- ✅ `git diff --check`
- ✅ `npm run build` (rerun with longer timeout after an initial local timeout)

## Deployment impact
- CI/tooling/docs only; no Screeps runtime behavior changes.
- Deploy path still builds.

## Scope notes
- Existing local `.tmp/` and `artifacts/` noise was left uncommitted and out of scope.
