### PR TITLE
[codex] Make smoke exit artifacts unambiguous

### DIFF
--- a/packages/screeps-server/scripts/private-server-harness.d.ts
+++ b/packages/screeps-server/scripts/private-server-harness.d.ts
@@ -32,6 +32,9 @@ export function createInitialSummary(options: HarnessOptions, now?: Date): any;
 export function decodeMemoryData(data: unknown): any;
 export function inspectMemorySnapshot(memory: any, summary: any, now?: Date, options?: HarnessOptions): void;
 export function prepareArtifactsDir(options: { artifactsDir: string }): void;
+export function formatHarnessError(error: unknown): string;
+export function recordHarnessError(summary: any, error: unknown): string;
+export function writeFailedSummaryForError(options: HarnessOptions, summary: any, error: unknown): Promise<any>;
 export function resolveAvailablePorts(options: {
   serverPort: number;
   cliPort: number;

--- a/packages/screeps-server/scripts/private-server-harness.js
+++ b/packages/screeps-server/scripts/private-server-harness.js
@@ -305,6 +305,20 @@ export function prepareArtifactsDir(options) {
   fs.writeFileSync(path.join(options.artifactsDir, "harness.log"), "");
 }
 
+export function formatHarnessError(error) {
+  if (error && typeof error === "object") {
+    if (typeof error.stack === "string" && error.stack.length > 0) return error.stack;
+    if (typeof error.message === "string" && error.message.length > 0) return error.message;
+  }
+  return String(error);
+}
+
+export function recordHarnessError(summary, error) {
+  const message = formatHarnessError(error);
+  if (!summary.errors.includes(message)) summary.errors.push(message);
+  return message;
+}
+
 function createLogger(options) {
   return function log(message) {
     const line = `[${new Date().toISOString()}] ${message}`;
@@ -779,6 +793,12 @@ async function writeSummary(options, summary, status) {
   );
 }
 
+export async function writeFailedSummaryForError(options, summary, error) {
+  recordHarnessError(summary, error);
+  await writeSummary(options, summary, "failed");
+  return summary;
+}
+
 export async function runPrivateServerTest(options = parseHarnessArgs()) {
   prepareArtifactsDir(options);
   const summary = createInitialSummary(options);
@@ -860,11 +880,11 @@ export async function runPrivateServerTest(options = parseHarnessArgs()) {
     await writeSummary(options, summary, "passed");
     return summary;
   } catch (error) {
-    summary.errors.push(error.stack || error.message || String(error));
+    recordHarnessError(summary, error);
     try {
       await collectLogs(options, summary, log);
     } catch {}
-    await writeSummary(options, summary, "failed");
+    await writeFailedSummaryForError(options, summary, error);
     throw error;
   } finally {
     await compose(options, log, "down", "-v", "--remove-orphans").catch(

--- a/packages/screeps-server/scripts/run-private-server-test.d.ts
+++ b/packages/screeps-server/scripts/run-private-server-test.d.ts
@@ -1,0 +1,11 @@
+import type { HarnessOptions } from "./private-server-harness.js";
+
+export interface RunPrivateServerCliOptions {
+  argv?: string[];
+  env?: Record<string, string | undefined>;
+  getProcessExitCode?: () => number | string | undefined | null;
+  logError?: (message: string) => void;
+  runTest?: (options: HarnessOptions) => Promise<any>;
+}
+
+export function runPrivateServerCli(options?: RunPrivateServerCliOptions): Promise<number>;

--- a/packages/screeps-server/scripts/run-private-server-test.js
+++ b/packages/screeps-server/scripts/run-private-server-test.js
@@ -1,9 +1,44 @@
 #!/usr/bin/env node
 
-import { parseHarnessArgs, runPrivateServerTest } from './private-server-harness.js';
+import { pathToFileURL } from "node:url";
+import {
+  formatHarnessError,
+  parseHarnessArgs,
+  runPrivateServerTest,
+  writeFailedSummaryForError,
+} from "./private-server-harness.js";
 
-try {
-  await runPrivateServerTest(parseHarnessArgs());
-} catch {
-  process.exitCode = 1;
+export async function runPrivateServerCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  getProcessExitCode = () => process.exitCode ?? 0,
+  logError = (message) => console.error(message),
+  runTest = runPrivateServerTest,
+} = {}) {
+  const options = parseHarnessArgs(argv, env);
+
+  try {
+    const summary = await runTest(options);
+    const exitCode = Number(getProcessExitCode() ?? 0);
+
+    if (summary?.status === "passed" && exitCode !== 0) {
+      const error = new Error(
+        `private-server harness produced a passed summary but process.exitCode=${exitCode}`,
+      );
+      await writeFailedSummaryForError(options, summary, error);
+      logError(formatHarnessError(error));
+      return 1;
+    }
+
+    if (summary?.status && summary.status !== "passed") return 1;
+    return exitCode === 0 ? 0 : exitCode;
+  } catch (error) {
+    logError(formatHarnessError(error));
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const exitCode = await runPrivateServerCli();
+  if (exitCode !== 0) process.exitCode = exitCode;
 }

--- a/packages/screeps-server/test/scripts/private-server-harness.test.ts
+++ b/packages/screeps-server/test/scripts/private-server-harness.test.ts
@@ -22,6 +22,7 @@ import {
   summarizeServerLogDiagnostics,
   updatePollingProgress,
   validateSmokeSummary,
+  writeFailedSummaryForError,
 } from "../../scripts/private-server-harness.js";
 
 describe("private-server harness module", () => {
@@ -550,6 +551,26 @@ describe("private-server harness module", () => {
     expect(summary.finishedGameTime).to.equal(150);
     expect(summary.metrics.polls).to.equal(4);
     expect(summary.metrics.ticksAdvanced).to.equal(50);
+  });
+
+  it("rewrites a passed summary as failed when a post-validation error is caught", async () => {
+    const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "screeps-harness-failed-summary-"));
+    const options = parseHarnessArgs([`--artifactsDir=${artifactsDir}`], {});
+    const summary = createInitialSummary(options, new Date("2026-07-05T00:00:00.000Z"));
+    summary.status = "passed";
+
+    await writeFailedSummaryForError(options, summary, new Error("late smoke cleanup failure"));
+
+    expect(summary.status).to.equal("failed");
+    expect(summary.errors).to.have.length(1);
+    expect(summary.errors[0]).to.include("late smoke cleanup failure");
+
+    const summaryJson = JSON.parse(fs.readFileSync(path.join(artifactsDir, "summary.json"), "utf8"));
+    const summaryMarkdown = fs.readFileSync(path.join(artifactsDir, "summary.md"), "utf8");
+    expect(summaryJson.status).to.equal("failed");
+    expect(summaryJson.errors[0]).to.include("late smoke cleanup failure");
+    expect(summaryMarkdown).to.include("Status: failed");
+    expect(summaryMarkdown).to.include("late smoke cleanup failure");
   });
 
   it("restarts only the Screeps service before post-spawn runtime validation", async () => {

--- a/packages/screeps-server/test/scripts/run-private-server-test.test.ts
+++ b/packages/screeps-server/test/scripts/run-private-server-test.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInitialSummary } from "../../scripts/private-server-harness.js";
+import { runPrivateServerCli } from "../../scripts/run-private-server-test.js";
+
+describe("run-private-server-test CLI", () => {
+  it("returns zero when the harness summary passed and no process exit code is set", async () => {
+    const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "screeps-harness-cli-passed-"));
+
+    const exitCode = await runPrivateServerCli({
+      argv: [`--artifactsDir=${artifactsDir}`],
+      env: {},
+      getProcessExitCode: () => 0,
+      runTest: async (options) => {
+        const summary = createInitialSummary(options, new Date("2026-07-05T00:00:00.000Z"));
+        summary.status = "passed";
+        return summary;
+      },
+      logError: () => {},
+    });
+
+    expect(exitCode).to.equal(0);
+  });
+
+  it("fails and rewrites artifacts when a passed summary would exit nonzero", async () => {
+    const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "screeps-harness-cli-nonzero-"));
+
+    const exitCode = await runPrivateServerCli({
+      argv: [`--artifactsDir=${artifactsDir}`],
+      env: {},
+      getProcessExitCode: () => 1,
+      runTest: async (options) => {
+        const summary = createInitialSummary(options, new Date("2026-07-05T00:00:00.000Z"));
+        summary.status = "passed";
+        return summary;
+      },
+      logError: () => {},
+    });
+
+    expect(exitCode).to.equal(1);
+
+    const summaryJson = JSON.parse(fs.readFileSync(path.join(artifactsDir, "summary.json"), "utf8"));
+    const summaryMarkdown = fs.readFileSync(path.join(artifactsDir, "summary.md"), "utf8");
+    expect(summaryJson.status).to.equal("failed");
+    expect(summaryJson.errors[0]).to.include("passed summary but process.exitCode=1");
+    expect(summaryMarkdown).to.include("Status: failed");
+    expect(summaryMarkdown).to.include("passed summary but process.exitCode=1");
+  });
+});


### PR DESCRIPTION
## Summary
- Makes the private-server smoke CLI fail loudly instead of suppressing thrown harness errors.
- Rewrites a previously passed summary to `Status: failed` if the CLI would otherwise exit nonzero.
- Adds regression coverage for late/post-validation error summary rewriting and CLI passed-summary/nonzero-exit handling.

## Linked issue
Closes #3239

## Changes
- Code changes
  - Added shared harness error formatting/recording helpers.
  - Added `writeFailedSummaryForError(...)` for failed artifact rewrites.
  - Refactored `run-private-server-test.js` into an injectable CLI entrypoint for test coverage.
- Test changes
  - Covered failed rewrite of a passed summary after a caught post-validation error.
  - Covered CLI behavior for passed+zero-exit and passed+nonzero-exit paths.
- Docs changes
  - None; behavior is covered by issue/PR notes and test names.

## Validation
- ✅ `npm run check-versions` (Node 24.18.0)
- ✅ `npm run sync:deps:check` (Node 24.18.0)
- ✅ `npm run typecheck -w @ralphschuler/screeps-server` (Node 24.18.0)
- ✅ `npm run test:packages -w @ralphschuler/screeps-server` (Node 24.18.0)
- ✅ `npm run build` (Node 24.18.0)
- ✅ `npm run lint:all` (Node 24.18.0; existing MODULE_TYPELESS_PACKAGE_JSON warnings only)
- ✅ `npm run check:no-deep-dist-imports` (Node 24.18.0)
- ✅ `npm run check:alliance-safety` (Node 24.18.0)
- ✅ `npm run check:bot-bundle-drift` (Node 24.18.0)
- ✅ `npm test` (Node 24.18.0)
- ✅ `npm run test:server:smoke` rerun passed; summary `Status: passed`, `49 total / 0 failed`, `ticksAdvanced=3057`.
- ⚠️ First `npm run test:server:smoke` attempt via process failed before running because `/bin/sh` does not support `source`; reran via `bash -lc`.
- ⚠️ First real smoke run failed on an actual `screepsmod-testing` assertion (`backend task board contains tasks`) and correctly wrote `Status: failed` plus `summary.errors`; rerun passed.

## Deployment impact
- No bot runtime logic change.
- Deploy path still builds; this changes local/CI smoke harness behavior only.

## Scope notes
- This PR does not make unrelated smoke assertions less flaky; it ensures any nonzero smoke result is reflected in failed artifacts instead of a passed summary.
