### PR TITLE
[codex] Add hard-invader affordable defender fallback

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -38997,10 +38997,10 @@ return e.priority >= mv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === 
 }
 
 function zg(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = dg(e), m = r.urgency >= 2 || t.danger >= 3 ? mv.EMERGENCY : mv.HIGH, d = Ro(X(e)), p = function(e) {
+var i, s, c, u = e.energyCapacityAvailable, l = dg(e), m = Ro(X(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(d) ? u : m === mv.EMERGENCY ? l : u, f = function(e, t) {
+}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? mv.EMERGENCY : mv.HIGH, f = d ? u : p === mv.EMERGENCY ? l : u, y = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
@@ -39028,7 +39028,7 @@ return {
 counts: n,
 power: i
 };
-}(e.name, u), y = function(e) {
+}(e.name, u), v = function(e) {
 var t, r, o, n = {};
 try {
 for (var i = a(e.find(FIND_MY_CREEPS)), s = i.next(); !s.done; s = i.next()) {
@@ -39055,7 +39055,7 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), v = function(e, t) {
+}(e), g = function(e, t) {
 var r, n, i = o({}, e);
 try {
 for (var s = a([ "guard", "ranger", "healer" ]), c = s.next(); !c.done; c = s.next()) {
@@ -39074,16 +39074,16 @@ if (r) throw r.error;
 }
 }
 return i;
-}(y, f.power), g = Mo(p, d, {
-guard: Math.max(0, r.guards - n.guards - f.counts.guards),
-ranger: Math.max(0, r.rangers - n.rangers - f.counts.rangers),
-healer: Math.max(0, r.healers - n.healers - f.counts.healers)
-}, v), h = g.counts.guard, R = null !== (i = g.bodies.guard) && void 0 !== i ? i : Xg("guard", p, d);
-if (h > 0 && R) for (var E = 0; E < h; E++) $g(e, "guard", "military", m, p, "guard_defense_".concat(Game.time, "_").concat(E), R);
-var T = g.counts.ranger, C = null !== (s = g.bodies.ranger) && void 0 !== s ? s : Xg("ranger", p, d);
-if (T > 0 && C) for (E = 0; E < T; E++) $g(e, "ranger", "military", m, p, "ranger_defense_".concat(Game.time, "_").concat(E), C);
-var S = g.counts.healer, w = null !== (c = g.bodies.healer) && void 0 !== c ? c : Xg("healer", p, d);
-if (S > 0 && w && (r.urgency >= 1.5 || g.healerFloor > 0)) for (E = 0; E < S; E++) $g(e, "healer", "military", mv.HIGH, p, "healer_defense_".concat(Game.time, "_").concat(E), w);
+}(v, y.power), h = Mo(f, m, {
+guard: Math.max(0, r.guards - n.guards - y.counts.guards),
+ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
+healer: Math.max(0, r.healers - n.healers - y.counts.healers)
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Xg("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) $g(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Xg("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) $g(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Xg("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) $g(e, "healer", "military", mv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
 if (!(t < mv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
@@ -39131,7 +39131,7 @@ return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ran
 }(r, o);
 n && $g(e, n.role, "military", mv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
-}(e, m, l, d), (h > 0 || T > 0 || S > 0) && U.info("Added defender spawn requests: ".concat(h, " guards, ").concat(T, " rangers, ").concat(S, " healers (priority: ").concat(m, ")"), {
+}(e, p, l, m), (R > 0 || C > 0 || w > 0) && U.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }

--- a/packages/screeps-spawn/src/spawnPipeline.ts
+++ b/packages/screeps-spawn/src/spawnPipeline.ts
@@ -259,10 +259,13 @@ function addDefenderRequests(
 ): void {
   const maxEnergy = room.energyCapacityAvailable;
   const emergencyEnergy = getEffectiveRoomEnergyAvailable(room);
-  const priority = needs.urgency >= 2.0 || swarm.danger >= 3 ? SpawnPriority.EMERGENCY : SpawnPriority.HIGH;
-
   const threatProfile = analyzeDefenseAssistThreat(getActualHostileCreeps(room));
-  const defenderEnergy = isHardDefenseThreat(threatProfile)
+  const hardDefenseThreat = isHardDefenseThreat(threatProfile);
+  const priority = hardDefenseThreat || needs.urgency >= 2.0 || swarm.danger >= 3
+    ? SpawnPriority.EMERGENCY
+    : SpawnPriority.HIGH;
+
+  const defenderEnergy = hardDefenseThreat
     ? maxEnergy
     : priority === SpawnPriority.EMERGENCY
       ? emergencyEnergy

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -768,6 +768,33 @@ describe("defense spawn throttling", () => {
     assert.isTrue(defenderRequests.some(request => request.body.cost > room.energyAvailable));
   });
 
+  it("adds an affordable emergency local defender for one hard invader without war posture", () => {
+    const hardInvader = createHostile(createRepeatedParts([TOUGH, 5], [RANGED_ATTACK, 25], [MOVE, 10], [HEAL, 10]));
+    const room = createRoom([hardInvader], "W9N6", 1800, 300, 4);
+    Game.rooms.W9N6 = room;
+    Game.creeps = {
+      worker1: { spawning: false, memory: { role: "harvester", homeRoom: "W9N6" } }
+    } as unknown as typeof Game.creeps;
+
+    populateSpawnQueue(room, { danger: 2, posture: "defense" } as any);
+
+    const defenderRequests = spawnQueue.getPendingRequests("W9N6")
+      .filter(request => request.role === "guard" || request.role === "ranger" || request.role === "healer");
+    const affordableEmergencyDefenders = defenderRequests.filter(request =>
+      request.priority === SpawnPriority.EMERGENCY && request.body.cost <= room.energyAvailable
+    );
+    const next = spawnQueue.getNextRequest("W9N6", room.energyAvailable);
+
+    assert.isTrue(defenderRequests.some(request => request.body.cost > room.energyAvailable));
+    assert.lengthOf(affordableEmergencyDefenders, 1);
+    assert.includeMembers(affordableEmergencyDefenders[0]!.body.parts, [MOVE]);
+    assert.isTrue(
+      affordableEmergencyDefenders[0]!.body.parts.includes(ATTACK) ||
+      affordableEmergencyDefenders[0]!.body.parts.includes(RANGED_ATTACK)
+    );
+    assert.equal(next?.id, affordableEmergencyDefenders[0]!.id);
+  });
+
   it("queues an emergency refuel hauler before defense assists when helper energy is trapped in source containers", () => {
     const hardInvaders = [
       createHostile(createRepeatedParts([RANGED_ATTACK, 14], [MOVE, 25], [HEAL, 11])),


### PR DESCRIPTION
## Summary
- Escalates visible hard local defense threats to emergency priority so affordable fallback defenders can spawn immediately.
- Keeps capacity-sized parity defender requests for hard threats while allowing the queue to skip them for a currently affordable emergency combat body.
- Adds regression coverage for a single 50-part hard invader when the room is not already in war posture.

## Linked issue
Closes #3194

## Changes
- Code: `packages/screeps-spawn/src/spawnPipeline.ts` treats hard local defense threats as emergency defense priority.
- Tests: `packages/screeps-spawn/test/defenseSpawning.test.ts` covers a single hard invader with low current energy and asserts the affordable emergency defender is the next spawnable request.
- Bundle: refreshed `packages/screeps-bot/dist/main.js`.

## Validation
- ✅ `npm run test:spawn -- --grep "one hard invader"` (initially failed before the fix, passes after)
- ✅ `npm run test:spawn`
- ✅ `npm run lint:spawn`
- ✅ `npm run build:spawn`
- ✅ `npm run build`
- ✅ `npm run typecheck`
- ✅ `npm run test:server:smoke`
- ✅ `npm run check:bot-bundle-drift`

## Deployment impact
Affects Screeps runtime spawn planning for local hard-invader defense. Deploy path still builds; smoke passed.

## Scope notes
- Existing smoke artifact passed and no longer shows a hard-invader room blocked by only unspawnable high-priority defender requests (`spawnQueues` diagnostics were empty in this run).
- Smoke still reported one non-critical backend `Unknown module 'main'` notification while status remained passed; left out of scope for #3194.
