### PR TITLE
[codex] Clarify explicit deploy push guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Configure Screeps credentials through environment variables or the package `.env
 
 ```bash
 npm run deploy:preflight
-npm run push
+SCREEPS_HOSTNAME=screeps.com SCREEPS_BRANCH=main npm run push
 ```
 
-`npm run build` is safe build-only mode. `npm run deploy:preflight` runs deploy-gate validation without secrets. `npm run push` sets `DEPLOY=true` and uploads the bundle to the configured Screeps branch.
+`npm run build` is safe build-only mode. `npm run deploy:preflight` runs deploy-gate validation without secrets. `npm run push` sets `DEPLOY=true` and uploads the bundle only when `SCREEPS_HOSTNAME` and `SCREEPS_BRANCH` are explicit; if they are missing, it fails closed and prints the exact command to run.
 
 ## Documentation
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -31,14 +31,16 @@ The deploy path is `npm run push` / `npm run deploy`. Build-only validation is `
 
    `npm run deploy:preflight` runs dependency sync validation, alliance-safety checks, a full repository build, and a generated bundle drift check so framework package outputs exist and `packages/screeps-bot/dist/main.js` matches the committed artifact before upload.
 
-4. Upload:
+4. Upload with an explicit target:
 
    ```bash
-   npm run push
-   # same as: npm run deploy
+   SCREEPS_HOSTNAME=screeps.com SCREEPS_BRANCH=main npm run push
+   # same target guard applies to: npm run deploy
    ```
 
-`npm run build` prints deploy configuration but does not upload. `npm run push` sets `DEPLOY=true` and uploads through the Screeps API.
+   If `SCREEPS_HOSTNAME` and `SCREEPS_BRANCH` are already exported in the shell, `npm run push` is equivalent. Without both explicit variables, the deploy guard fails before upload and prints the exact command to run.
+
+`npm run build` prints deploy configuration but does not upload. `npm run push` sets `DEPLOY=true` and uploads through the Screeps API only when `SCREEPS_HOSTNAME` and `SCREEPS_BRANCH` are explicit.
 
 ## GitHub Actions deploy
 
@@ -87,7 +89,7 @@ Build-only mode creates `packages/screeps-bot/dist/main.js`, checks bundle size,
    npm run test:server:smoke
    ```
 
-4. Deploy with `npm run push`.
+4. Deploy with `SCREEPS_HOSTNAME=screeps.com SCREEPS_BRANCH=main npm run push` or with both variables already exported.
 5. Monitor console/errors/stats for at least one creep lifecycle or the incident-specific window.
 
 ## Safety

--- a/packages/screeps-bot/rollup.config.js
+++ b/packages/screeps-bot/rollup.config.js
@@ -53,6 +53,16 @@ const cfg = {
 
 // Check if we have valid credentials (either token or email+password)
 const hasValidCredentials = cfg.token || (cfg.email && cfg.password);
+const explicitDeployCommand = `SCREEPS_HOSTNAME=${cfg.hostname} SCREEPS_BRANCH=${cfg.branch} npm run push`;
+
+if (shouldDeploy && (!explicitHostname || !explicitBranch)) {
+  console.error("\nERROR: DEPLOY=true requires explicit SCREEPS_HOSTNAME and SCREEPS_BRANCH.");
+  console.error("This safety guard prevents accidental uploads to an implicit target.");
+  console.error("Use an explicit deploy target, for example:");
+  console.error(`  ${explicitDeployCommand}`);
+  console.error("For private/community servers, replace both values explicitly.");
+  process.exit(1);
+}
 
 // Debug logging for deployment troubleshooting
 console.log("=== Screeps Deploy Configuration ===");
@@ -62,11 +72,6 @@ console.log("Credentials type:", cfg.token ? "token" : cfg.email && cfg.password
 console.log("Target server:", cfg.hostname);
 console.log("Target branch:", cfg.branch);
 console.log("====================================");
-
-if (shouldDeploy && (!explicitHostname || !explicitBranch)) {
-  console.error("\nERROR: DEPLOY=true requires explicit SCREEPS_HOSTNAME and SCREEPS_BRANCH.");
-  process.exit(1);
-}
 
 if (shouldDeploy && !hasValidCredentials) {
   console.error("\nERROR: DEPLOY=true was set, but Screeps credentials are not configured.");

--- a/scripts/test/deploy-workflow.test.mjs
+++ b/scripts/test/deploy-workflow.test.mjs
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const explicitProductionPushCommand = "SCREEPS_HOSTNAME=screeps.com SCREEPS_BRANCH=main npm run push";
 const workflow = readFileSync(new URL("../../.github/workflows/deploy.yml", import.meta.url), "utf8");
 const rootPackage = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
+const deployDocs = readFileSync(new URL("../../docs/deployment/README.md", import.meta.url), "utf8");
 
 function parseDeployTargets() {
   const matrixBlock = workflow.match(/matrix:\n(?<block>[\s\S]*?)\n\s{4}env:/)?.groups?.block;
@@ -29,6 +34,42 @@ function stepBlock(name) {
   const next = workflow.indexOf("\n      - name:", start + 1);
   return workflow.slice(start, next === -1 ? workflow.length : next);
 }
+
+test("local push guard fails closed with an exact explicit target command", () => {
+  assert.equal(
+    rootPackage.scripts.push,
+    "DEPLOY=true npm run push -w screeps-typescript-starter",
+    "root push should be the guarded deploy entry point",
+  );
+  assert.match(
+    deployDocs,
+    new RegExp(explicitProductionPushCommand.replaceAll(".", "\\.")),
+    "deployment docs should show the canonical explicit production push command",
+  );
+
+  const env = {
+    ...process.env,
+    DEPLOY: "true",
+    SCREEPS_TOKEN: "fake-token-for-guard-test",
+  };
+  delete env.SCREEPS_HOSTNAME;
+  delete env.SCREEPS_BRANCH;
+  delete env.SCREEPS_USER;
+  delete env.SCREEPS_PASS;
+
+  const result = spawnSync(process.execPath, ["-e", "import('./packages/screeps-bot/rollup.config.js')"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 1, `deploy guard should reject missing explicit target:\n${output}`);
+  assert.match(output, /DEPLOY=true requires explicit SCREEPS_HOSTNAME and SCREEPS_BRANCH/);
+  assert.match(output, new RegExp(explicitProductionPushCommand.replaceAll(".", "\\.")));
+  assert.doesNotMatch(output, /Target server:/, "guard should fail before printing default target server");
+  assert.doesNotMatch(output, /Target branch:/, "guard should fail before printing default target branch");
+});
 
 test("deploy workflow runs preflight before secret-scoped upload", () => {
   assert.equal(


### PR DESCRIPTION
## Summary
- Make the deploy guard fail before printing implicit default target values when `SCREEPS_HOSTNAME` or `SCREEPS_BRANCH` is missing.
- Print a copy-paste explicit production deploy command in the guard failure.
- Update deployment docs and README to show the explicit target command.

## Linked issue
Closes #3124

## Changes
- Code: `packages/screeps-bot/rollup.config.js` now emits an actionable explicit-target guard message before the deploy config summary.
- Tests: `scripts/test/deploy-workflow.test.mjs` covers the explicit env guard, docs command, and no default target output on guard failure.
- Docs: `README.md` and `docs/deployment/README.md` document the explicit local deploy form.

## Validation
- ✅ `node --test scripts/test/deploy-workflow.test.mjs`
- ✅ `npm run test:scripts`
- ✅ `npm run deploy:preflight`
- ✅ `npm run lint:all`
- ✅ `git diff --check -- README.md docs/deployment/README.md packages/screeps-bot/rollup.config.js scripts/test/deploy-workflow.test.mjs`

## Deployment impact
- Deploy runtime upload path remains `npm run push` / `npm run deploy` with explicit `SCREEPS_HOSTNAME` and `SCREEPS_BRANCH`.
- No Screeps bot runtime behavior changes.

## Scope notes
- Existing high-priority #3049 is not directly implementable as written on current `main`; no Docker validation matrix or named Dockerfiles remain.
- Existing #3121 remains blocked by Screeps Memory API rate limiting/no-rate-limit token capability.
