### PR TITLE
[codex] Profile live CPU from console stream

### DIFF
--- a/docs/STATS_AND_METRICS.md
+++ b/docs/STATS_AND_METRICS.md
@@ -23,10 +23,10 @@ Stats are output to console as a single JSON object per tick containing the enti
 {"type":"stats","data":{"tick":12345,"cpu":{"used":15.5},"empire":{"rooms":3}}}
 ```
 
-The graphite exporter's console listener subscribes to the Screeps console stream and:
-1. Parses the JSON object
-2. Flattens the nested structure (same as memory mode)
-3. Sends metrics to Grafana Cloud in real-time
+The graphite exporter's console listener and `scripts/live-cpu-profile.mjs --source console` subscribe to the Screeps console stream and:
+1. Parse the JSON object
+2. Flatten or summarize the nested structure (same stats shape as memory mode)
+3. Send metrics to Grafana Cloud or write bounded diagnostics artifacts in real-time
 
 This is the recommended method as it:
 - Provides real-time stats updates (every tick)
@@ -36,7 +36,7 @@ This is the recommended method as it:
 - Uses the same flattening logic as memory mode
 
 ### 2. Memory Polling (Backward Compatibility)
-Stats are also written to `Memory.stats` in a nested object structure. The graphite exporter can poll this via the Screeps API, but this method:
+Stats are also written to `Memory.stats` in a nested object structure. The graphite exporter or `scripts/live-cpu-profile.mjs --source memory` can poll this via the Screeps API, but this method:
 - Has API rate limits (1440 requests/day for `/api/user/memory`)
 - Has higher latency (polling interval)
 - May miss rapid changes between polls

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,8 +5,8 @@ Operate the bot with CPU, bucket, spawn health, room survival, and error rate as
 ## Monitoring sources
 
 - Screeps console output.
-- `Memory.stats` / unified stats package output. Screeps memory polling is rate-limited; use a no-rate-limit API token for bounded live-analysis automation when available.
-- `scripts/live-cpu-profile.mjs` for read-only CPU/bucket/process samples from `Memory.stats`; its logs redact token-bearing API error fragments.
+- `Memory.stats` / unified stats package output. Screeps memory polling is rate-limited; prefer the console WebSocket stream for bounded live-analysis automation.
+- `scripts/live-cpu-profile.mjs` for read-only CPU/bucket/process samples from console stats logs by default, with explicit Memory polling fallback; its logs redact token-bearing API error fragments.
 - Grafana dashboards linked from the root README when available.
 - Private-server artifacts under `packages/screeps-server/artifacts/<mode>/`.
 - GitHub Actions validation artifacts for duplication, complexity, coverage, and smoke tests.
@@ -33,10 +33,10 @@ Operate the bot with CPU, bucket, spawn health, room survival, and error rate as
 
 ## Live CPU profiling
 
-Use the bounded root script for read-only live CPU, bucket, process, room, role, and CPU-detail samples from `Memory.stats`:
+Use the bounded root script for read-only live CPU, bucket, process, room, role, and CPU-detail samples. The default path subscribes once to the Screeps console WebSocket stream and parses the bot's `{"type":"stats","data":...}` logs, avoiding `/api/user/memory` polling limits:
 
 ```bash
-SCREEPS_TOKEN=<read-only-or-no-rate-limit-token> npm run profile:live:cpu
+SCREEPS_TOKEN=<read-only-token-with-console-access> npm run profile:live:cpu
 ```
 
 Override the target safely with CLI flags or env vars when profiling a private server:
@@ -45,12 +45,12 @@ Override the target safely with CLI flags or env vars when profiling a private s
 SCREEPS_TOKEN=<token> npm run profile:live:cpu -- --samples 5 --interval 1000 --shards shard0 --hostname 127.0.0.1 --protocol http --port 21025
 ```
 
-Supported environment variables: `SCREEPS_TOKEN` (required), `SCREEPS_HOSTNAME`, `SCREEPS_PROTOCOL`, `SCREEPS_PORT`, and `SCREEPS_PATH`. The profiler only reads `Memory.stats`; do not paste token-bearing Screeps URLs into issues or logs.
+Supported environment variables: `SCREEPS_TOKEN` (required), `SCREEPS_HOSTNAME`, `SCREEPS_PROTOCOL`, `SCREEPS_PORT`, and `SCREEPS_PATH`. Use `--source memory` only when console stats are unavailable or a no-rate-limit token is configured; do not paste token-bearing Screeps URLs into issues or logs.
 
-By default, the profiler fails closed when every requested shard returns zero samples, which usually means the Memory API is rate-limited or unavailable. Use `--allow-empty` only when you intentionally want degraded artifacts for investigation:
+By default, the profiler fails closed when every requested shard returns zero samples. For console mode, this usually means the bot did not emit stats logs on that shard before `--console-timeout`. For Memory mode, it usually means `/api/user/memory` is rate-limited or unavailable. Use `--allow-empty` only when you intentionally want degraded artifacts for investigation:
 
 ```bash
-SCREEPS_TOKEN=<token> node scripts/live-cpu-profile.mjs --samples 1 --interval 0 --shards shard1 --allow-empty
+SCREEPS_TOKEN=<token> node scripts/live-cpu-profile.mjs --source console --samples 1 --interval 0 --shards shard1 --allow-empty
 ```
 
 For structural live snapshots, deployment gates can fail when Memory reads are unavailable while still writing redacted artifacts:
@@ -88,7 +88,7 @@ Treat these as failures: no tick progression, bot upload failure, missing test m
 - **Global reset loop:** inspect first thrown error in console/harness logs, then add a regression test around initialization.
 - **Global heap switch:** check `Memory.runtimeDiagnostics.global.switchCount`; repeated increments mean heap globals may be stale.
 - **Bucket drain:** disable expensive visuals/planning first, then profile process metrics and hot path pathfinding.
-- **Live Memory API rate limits:** reduce sample count/interval pressure or configure a no-rate-limit `SCREEPS_TOKEN`; do not paste token-bearing Screeps account URLs into issues or logs.
+- **Live Memory API rate limits:** use `scripts/live-cpu-profile.mjs --source console` first; reserve `--source memory` for no-rate-limit tokens or very low-frequency checks. Do not paste token-bearing Screeps account URLs into issues or logs.
 - **Allied target risk:** use shared alliance helpers from core/defense and add tests for `TooAngel`/`TedRoastBeef`.
 
 ## Deploy/version marker

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "quality:duplication": "node scripts/check-duplication-budget.cjs",
     "quality:complexity": "node scripts/analyze-complexity.cjs",
     "quality:baseline": "npm run quality:duplication && npm run quality:complexity",
-    "profile:live:cpu": "node scripts/live-cpu-profile.mjs --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile",
+    "profile:live:cpu": "node scripts/live-cpu-profile.mjs --source console --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile",
     "check:alliance-safety": "node scripts/check-alliance-safety.js",
     "verify": "npm run build && npm run check:bot-bundle-drift && npm run typecheck && npm run lint:all && npm run test:all && npm run check:alliance-safety && npm run check:no-deep-dist-imports && npm audit --omit=dev --audit-level=high",
     "deploy:preflight": "npm run sync:deps:check && npm run check:alliance-safety && npm run build && npm run check:bot-bundle-drift",

--- a/scripts/live-cpu-profile.mjs
+++ b/scripts/live-cpu-profile.mjs
@@ -10,6 +10,8 @@ export { redactScreepsApiMessage };
 
 const DEFAULT_SHARDS = ["shard0", "shard1", "shard2", "shard3"];
 const DEFAULT_MAX_STATS_AGE = 100;
+const DEFAULT_SOURCE = "console";
+const VALID_SOURCES = new Set(["console", "memory"]);
 
 export function formatHelp() {
   return `Usage: node scripts/live-cpu-profile.mjs [options]
@@ -23,18 +25,20 @@ Options:
   --protocol <http|https>    Screeps API protocol (default SCREEPS_PROTOCOL or https)
   --port <n>                 Screeps API port (default SCREEPS_PORT or 443)
   --max-stats-age <ticks>    Maximum api.time - Memory.stats.tick age allowed (default ${DEFAULT_MAX_STATS_AGE})
+  --source <console|memory>  Stats source: console WebSocket stream or Memory polling (default ${DEFAULT_SOURCE})
+  --console-timeout <ms>     Max wait for console stats samples (default max(15000, samples * max(interval, 1000) + 5000))
   --allow-empty              Allow zero-sample degraded artifact collection (default fail closed)
   --allow-stale              Allow stale/missing stats artifacts as degraded instead of failed
   --help, -h                 Show this help
 
 Environment:
-  SCREEPS_TOKEN              Required API token; read-only Memory.stats access is enough
+  SCREEPS_TOKEN              Required API token; console source only needs console WebSocket access
   SCREEPS_HOSTNAME           Default hostname override
   SCREEPS_PROTOCOL           Default protocol override
   SCREEPS_PORT               Default port override
   SCREEPS_PATH               API path override (default /)
 
-Read-only: fetches api.time and Memory.stats.`;
+Read-only: console source subscribes once to user console logs and fetches api.time; memory source polls api.time and Memory.stats.`;
 }
 
 export function parseArgs(argv) {
@@ -47,6 +51,8 @@ export function parseArgs(argv) {
     protocol: process.env.SCREEPS_PROTOCOL || "https",
     port: Number(process.env.SCREEPS_PORT || 443),
     maxStatsAge: DEFAULT_MAX_STATS_AGE,
+    source: DEFAULT_SOURCE,
+    consoleTimeout: null,
     allowEmpty: false,
     allowStale: false
   };
@@ -62,6 +68,8 @@ export function parseArgs(argv) {
     else if (arg === "--protocol" && next) args.protocol = next, i++;
     else if (arg === "--port" && next) args.port = Number(next), i++;
     else if (arg === "--max-stats-age" && next) args.maxStatsAge = Number(next), i++;
+    else if (arg === "--source" && next) args.source = next, i++;
+    else if (arg === "--console-timeout" && next) args.consoleTimeout = Number(next), i++;
     else if (arg === "--allow-empty") args.allowEmpty = true;
     else if (arg === "--allow-stale") args.allowStale = true;
     else if (arg === "--help" || arg === "-h") {
@@ -81,6 +89,11 @@ export function parseArgs(argv) {
     throw new Error("--port must be between 1 and 65535");
   }
   if (!Number.isFinite(args.maxStatsAge) || args.maxStatsAge < 1) throw new Error("--max-stats-age must be >= 1");
+  if (!VALID_SOURCES.has(args.source)) throw new Error("--source must be console or memory");
+  if (args.consoleTimeout === null) {
+    args.consoleTimeout = Math.max(15000, args.samples * Math.max(args.interval, 1000) + 5000);
+  }
+  if (!Number.isFinite(args.consoleTimeout) || args.consoleTimeout < 1) throw new Error("--console-timeout must be >= 1");
   return args;
 }
 
@@ -277,18 +290,290 @@ export function evaluateTelemetryHealth(summary, { allowEmpty = false, allowStal
   };
 }
 
-async function fetchStats(api, shard) {
-  const response = await api.memory.get("stats", shard);
-  const stats = response?.data ?? response;
+function unwrapMemoryResponse(response) {
+  return response?.data ?? response;
+}
+
+async function fetchStats(apiClient, shard) {
+  const stats = unwrapMemoryResponse(await apiClient.memoryGet("stats", shard));
   if (!stats || stats.ok === 1 && !stats.cpu) return null;
   return stats;
 }
 
-async function fetchGameTick(api, shard) {
-  const response = await api.time(shard);
+async function fetchGameTick(apiClient, shard) {
+  const response = await apiClient.gameTime(shard);
   const tick = Number(response?.time ?? response?.gameTime);
   if (!Number.isFinite(tick)) throw new Error(`api.time returned invalid tick for ${shard}`);
   return tick;
+}
+
+async function fetchGameTicks(apiClient, shards) {
+  const gameTicksByShard = Object.fromEntries(shards.map(shard => [shard, null]));
+  const timeErrorsByShard = Object.fromEntries(shards.map(shard => [shard, []]));
+  await Promise.all(shards.map(async shard => {
+    try {
+      gameTicksByShard[shard] = await fetchGameTick(apiClient, shard);
+    } catch (error) {
+      const message = redactScreepsApiMessage(error instanceof Error ? error.message : String(error));
+      timeErrorsByShard[shard].push({ message });
+      console.warn(`WARN ${shard} api.time: ${message}`);
+    }
+  }));
+  return { gameTicksByShard, timeErrorsByShard };
+}
+
+function decodeConsoleLine(line) {
+  return String(line ?? "")
+    .replace(/&quot;|&#34;|&#x22;/gi, '"')
+    .replace(/&#39;|&#x27;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&amp;/gi, "&");
+}
+
+export function parseConsoleStatsLine(line) {
+  const trimmed = decodeConsoleLine(line).trim();
+  if (!trimmed.startsWith("{")) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || parsed.type !== "stats" || !parsed.data || typeof parsed.data !== "object" || Array.isArray(parsed.data)) {
+    return null;
+  }
+
+  if (!isFiniteNumber(parsed.data.tick) && isFiniteNumber(parsed.tick)) {
+    return { ...parsed.data, tick: parsed.tick };
+  }
+  return parsed.data;
+}
+
+export function extractConsoleStatsSamples(event, requestedShards = DEFAULT_SHARDS) {
+  const data = event?.data ?? {};
+  const eventShard = typeof data.shard === "string" && data.shard ? data.shard : null;
+  const shard = eventShard ?? (requestedShards.length === 1 ? requestedShards[0] : null);
+  if (!shard || !requestedShards.includes(shard)) return [];
+
+  const logs = Array.isArray(data.messages?.log) ? data.messages.log : [];
+  const results = Array.isArray(data.messages?.results) ? data.messages.results : [];
+  return [...logs, ...results]
+    .flatMap(line => String(line ?? "").split(/\r?\n/))
+    .map(line => parseConsoleStatsLine(line))
+    .filter(Boolean)
+    .map(stats => ({ shard, stats }));
+}
+
+function hasRequestedSamples(byShard, shards, samples) {
+  return shards.every(shard => (byShard[shard]?.length ?? 0) >= samples);
+}
+
+async function subscribeConsole(socket, onConsole) {
+  if (!socket) throw new Error("Screeps API client does not expose a WebSocket console stream");
+  if (typeof socket.subscribeUserConsole === "function") return socket.subscribeUserConsole(onConsole);
+  if (typeof socket.subscribe === "function") return socket.subscribe("console", onConsole);
+  throw new Error("Screeps API socket does not support console subscription");
+}
+
+function disconnectSocket(socket) {
+  if (!socket) return;
+  if (typeof socket.disconnect === "function") socket.disconnect();
+  else if (typeof socket.close === "function") socket.close();
+}
+
+function remainingTimeoutMs(deadline) {
+  return Math.max(1, deadline - Date.now());
+}
+
+async function withTimeout(promise, ms, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms);
+      })
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function collectConsoleSamples(apiClient, args) {
+  const byShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
+  const errorsByShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
+  let finished = false;
+  let finish;
+  let status = "timeout";
+  const result = new Promise(resolve => {
+    finish = nextStatus => {
+      if (finished) return;
+      finished = true;
+      status = nextStatus;
+      resolve();
+    };
+  });
+
+  const onConsole = event => {
+    const data = event?.data ?? {};
+    const eventShard = typeof data.shard === "string" && data.shard ? data.shard : null;
+    const targetShards = eventShard && args.shards.includes(eventShard) ? [eventShard] : (!eventShard && args.shards.length === 1 ? [args.shards[0]] : []);
+    if (data.error) {
+      const message = redactScreepsApiMessage(data.error);
+      for (const shard of targetShards.length > 0 ? targetShards : args.shards) {
+        errorsByShard[shard].push({ sample: byShard[shard].length + 1, source: "console", message });
+      }
+    }
+
+    for (const { shard, stats } of extractConsoleStatsSamples(event, args.shards)) {
+      if (byShard[shard].length < args.samples) byShard[shard].push(stats);
+    }
+
+    if (hasRequestedSamples(byShard, args.shards, args.samples)) finish("complete");
+  };
+
+  const deadline = Date.now() + args.consoleTimeout;
+  try {
+    await withTimeout(
+      subscribeConsole(apiClient.socket, onConsole),
+      remainingTimeoutMs(deadline),
+      `Timed out waiting for Screeps console subscription after ${args.consoleTimeout}ms`
+    );
+    if (!finished) {
+      await withTimeout(
+        apiClient.socket.connect(),
+        remainingTimeoutMs(deadline),
+        `Timed out connecting to Screeps console WebSocket after ${args.consoleTimeout}ms`
+      );
+    }
+    if (!finished) {
+      try {
+        await withTimeout(
+          result,
+          remainingTimeoutMs(deadline),
+          `Timed out waiting for Screeps console stats samples after ${args.consoleTimeout}ms`
+        );
+      } catch (error) {
+        if (!String(error instanceof Error ? error.message : error).startsWith("Timed out")) throw error;
+        finish("timeout");
+      }
+    }
+  } catch (error) {
+    const message = redactScreepsApiMessage(error instanceof Error ? error.message : String(error));
+    status = message.startsWith("Timed out") ? "timeout" : "error";
+    for (const shard of args.shards) {
+      errorsByShard[shard].push({ sample: byShard[shard].length + 1, source: "console", message });
+    }
+  } finally {
+    disconnectSocket(apiClient.socket);
+  }
+
+  const { gameTicksByShard, timeErrorsByShard } = await fetchGameTicks(apiClient, args.shards);
+  return {
+    source: "console",
+    status,
+    apiMethods: ["api.auth/me", "socket.subscribeUserConsole", "api.time|api.gameTime"],
+    byShard,
+    errorsByShard,
+    gameTicksByShard,
+    timeErrorsByShard
+  };
+}
+
+async function collectMemorySamples(apiClient, args) {
+  const byShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
+  const errorsByShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
+  for (let sample = 1; sample <= args.samples; sample++) {
+    await Promise.all(args.shards.map(async shard => {
+      try {
+        const stats = await fetchStats(apiClient, shard);
+        if (stats) byShard[shard].push(stats);
+      } catch (error) {
+        const message = redactScreepsApiMessage(error instanceof Error ? error.message : String(error));
+        errorsByShard[shard].push({ sample, message });
+        console.warn(`WARN ${shard}: ${message}`);
+      }
+    }));
+    if (sample < args.samples && args.interval > 0) await sleep(args.interval);
+  }
+
+  const { gameTicksByShard, timeErrorsByShard } = await fetchGameTicks(apiClient, args.shards);
+  return {
+    source: "memory",
+    status: "complete",
+    apiMethods: ["api.memory.get|api.userMemoryGet", "api.time|api.gameTime"],
+    byShard,
+    errorsByShard,
+    gameTicksByShard,
+    timeErrorsByShard
+  };
+}
+
+export function createLiveApiClient(apiModule, args, token) {
+  const options = {
+    token,
+    protocol: args.protocol,
+    hostname: args.hostname,
+    port: args.port,
+    path: process.env.SCREEPS_PATH || "/"
+  };
+
+  const LegacyApi = apiModule?.ScreepsAPI ?? apiModule?.default?.ScreepsAPI;
+  if (typeof LegacyApi === "function") {
+    const api = new LegacyApi(options);
+    return {
+      transport: "ScreepsAPI",
+      socket: api.socket,
+      memoryGet: (memoryPath, shard) => api.memory.get(memoryPath, shard),
+      gameTime: shard => api.time(shard)
+    };
+  }
+
+  const HttpClient = apiModule?.ScreepsHttpClient ?? apiModule?.default?.ScreepsHttpClient;
+  if (typeof HttpClient === "function") {
+    const api = new HttpClient(options);
+    return {
+      transport: "ScreepsHttpClient",
+      socket: api.socket,
+      memoryGet: (memoryPath, shard) => api.userMemoryGet(memoryPath, shard),
+      gameTime: shard => api.gameTime(shard)
+    };
+  }
+
+  throw new Error("screeps-api module did not expose a supported API client");
+}
+
+function buildSummary(args, collection) {
+  const summary = {
+    generated_at: new Date().toISOString(),
+    hostname: args.hostname,
+    source: collection.source,
+    collection_status: collection.status,
+    api_policy: {
+      read_only: true,
+      methods_used: collection.apiMethods,
+      state_changing_endpoints_used: false
+    },
+    samples_requested: args.samples,
+    interval_ms: args.interval,
+    console_timeout_ms: args.consoleTimeout,
+    allow_empty: args.allowEmpty,
+    allow_stale: args.allowStale,
+    max_stats_age: args.maxStatsAge,
+    shards: Object.fromEntries(Object.entries(collection.byShard).map(([shard, samples]) => [shard, summarizeShard(samples, collection.errorsByShard[shard] || [], {
+      gameTick: collection.gameTicksByShard[shard],
+      maxStatsAge: args.maxStatsAge,
+      timeErrors: collection.timeErrorsByShard[shard] || []
+    })]))
+  };
+  summary.health = evaluateTelemetryHealth(summary, { allowEmpty: args.allowEmpty, allowStale: args.allowStale });
+  if (collection.source === "console" && summary.health.total_samples === 0) {
+    summary.health.message = summary.health.message.replace("Memory.stats telemetry is unavailable", "console stats telemetry is unavailable");
+  }
+  return summary;
 }
 
 function printSummary(summary) {
@@ -312,58 +597,13 @@ async function main() {
   const args = parseArgs(process.argv);
   if (!process.env.SCREEPS_TOKEN) throw new Error("SCREEPS_TOKEN is required");
 
-  const { ScreepsAPI } = createRequire(import.meta.url)("screeps-api");
-  const api = new ScreepsAPI({
-    token: process.env.SCREEPS_TOKEN,
-    protocol: args.protocol,
-    hostname: args.hostname,
-    port: args.port,
-    path: process.env.SCREEPS_PATH || "/"
-  });
-
-  const byShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
-  const errorsByShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
-  const gameTicksByShard = Object.fromEntries(args.shards.map(shard => [shard, null]));
-  const timeErrorsByShard = Object.fromEntries(args.shards.map(shard => [shard, []]));
-  for (let sample = 1; sample <= args.samples; sample++) {
-    await Promise.all(args.shards.map(async shard => {
-      try {
-        const stats = await fetchStats(api, shard);
-        if (stats) byShard[shard].push(stats);
-      } catch (error) {
-        const message = redactScreepsApiMessage(error instanceof Error ? error.message : String(error));
-        errorsByShard[shard].push({ sample, message });
-        console.warn(`WARN ${shard}: ${message}`);
-      }
-    }));
-    if (sample < args.samples && args.interval > 0) await sleep(args.interval);
-  }
-
-  await Promise.all(args.shards.map(async shard => {
-    try {
-      gameTicksByShard[shard] = await fetchGameTick(api, shard);
-    } catch (error) {
-      const message = redactScreepsApiMessage(error instanceof Error ? error.message : String(error));
-      timeErrorsByShard[shard].push({ message });
-      console.warn(`WARN ${shard} api.time: ${message}`);
-    }
-  }));
-
-  const summary = {
-    generated_at: new Date().toISOString(),
-    hostname: args.hostname,
-    samples_requested: args.samples,
-    interval_ms: args.interval,
-    allow_empty: args.allowEmpty,
-    allow_stale: args.allowStale,
-    max_stats_age: args.maxStatsAge,
-    shards: Object.fromEntries(Object.entries(byShard).map(([shard, samples]) => [shard, summarizeShard(samples, errorsByShard[shard] || [], {
-      gameTick: gameTicksByShard[shard],
-      maxStatsAge: args.maxStatsAge,
-      timeErrors: timeErrorsByShard[shard] || []
-    })]))
-  };
-  summary.health = evaluateTelemetryHealth(summary, { allowEmpty: args.allowEmpty, allowStale: args.allowStale });
+  const apiModule = createRequire(import.meta.url)("screeps-api");
+  const apiClient = createLiveApiClient(apiModule, args, process.env.SCREEPS_TOKEN);
+  const collection = args.source === "memory"
+    ? await collectMemorySamples(apiClient, args)
+    : await collectConsoleSamples(apiClient, args);
+  const summary = buildSummary(args, collection);
+  summary.api_policy.transport = apiClient.transport;
 
   fs.mkdirSync(args.outDir, { recursive: true });
   const outPath = path.join(args.outDir, `live-cpu-profile-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);

--- a/scripts/test/live-cpu-profile-cli.test.mjs
+++ b/scripts/test/live-cpu-profile-cli.test.mjs
@@ -3,7 +3,16 @@ import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-import { evaluateStatsFreshness, evaluateTelemetryHealth, formatHelp, parseArgs, summarizeShard } from "../live-cpu-profile.mjs";
+import {
+  collectConsoleSamples,
+  evaluateStatsFreshness,
+  evaluateTelemetryHealth,
+  extractConsoleStatsSamples,
+  formatHelp,
+  parseArgs,
+  parseConsoleStatsLine,
+  summarizeShard
+} from "../live-cpu-profile.mjs";
 
 const rootPackage = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
 
@@ -19,6 +28,8 @@ test("parseArgs honors documented CLI flags", () => {
     "--protocol", "http",
     "--port", "21025",
     "--max-stats-age", "25",
+    "--source", "memory",
+    "--console-timeout", "1200",
     "--allow-empty",
     "--allow-stale"
   ]);
@@ -32,6 +43,8 @@ test("parseArgs honors documented CLI flags", () => {
     protocol: "http",
     port: 21025,
     maxStatsAge: 25,
+    source: "memory",
+    consoleTimeout: 1200,
     allowEmpty: true,
     allowStale: true
   });
@@ -49,13 +62,16 @@ test("help documents all flags and Screeps env vars", () => {
     "--protocol <http|https>",
     "--port <n>",
     "--max-stats-age <ticks>",
+    "--source <console|memory>",
+    "--console-timeout <ms>",
     "--allow-empty",
     "--allow-stale",
     "SCREEPS_TOKEN",
     "SCREEPS_HOSTNAME",
     "SCREEPS_PROTOCOL",
     "SCREEPS_PORT",
-    "SCREEPS_PATH"
+    "SCREEPS_PATH",
+    "WebSocket"
   ]) {
     assert.match(help, new RegExp(text.replace(/[|]/g, "\\|")));
   }
@@ -76,8 +92,121 @@ test("rejects invalid arguments", () => {
   assert.throws(() => parseArgs(["node", "script", "--port", "not-a-number"]), /--port must be a number/);
   assert.throws(() => parseArgs(["node", "script", "--port", "0"]), /--port must be between 1 and 65535/);
   assert.throws(() => parseArgs(["node", "script", "--max-stats-age", "0"]), /--max-stats-age must be >= 1/);
+  assert.throws(() => parseArgs(["node", "script", "--source", "file"]), /--source must be console or memory/);
+  assert.throws(() => parseArgs(["node", "script", "--console-timeout", "0"]), /--console-timeout must be >= 1/);
   assert.throws(() => parseArgs(["node", "script", "--protocol", "ftp"]), /--protocol must be http or https/);
   assert.throws(() => parseArgs(["node", "script", "--shards", ","]), /--shards must include at least one shard/);
+});
+
+test("parseConsoleStatsLine extracts typed stats payloads", () => {
+  const stats = parseConsoleStatsLine('{"type":"stats","tick":123,"data":{"cpu":{"used":5,"bucket":9000}}}');
+  const escaped = parseConsoleStatsLine("{&#x22;type&#x22;:&#x22;stats&#x22;,&#x22;data&#x22;:{&#x22;tick&#x22;:124}}");
+
+  assert.deepEqual(stats, { tick: 123, cpu: { used: 5, bucket: 9000 } });
+  assert.deepEqual(escaped, { tick: 124 });
+  assert.equal(parseConsoleStatsLine("not json"), null);
+  assert.equal(parseConsoleStatsLine('{"type":"log","data":{}}'), null);
+});
+
+test("extractConsoleStatsSamples filters console stats by requested shard", () => {
+  const samples = extractConsoleStatsSamples(
+    {
+      data: {
+        shard: "shard1",
+        messages: {
+          log: [
+            "plain log\n{\"type\":\"stats\",\"data\":{\"tick\":200,\"cpu\":{\"used\":7,\"bucket\":8000}}}"
+          ],
+          results: ['{"type":"stats","data":{"tick":201,"cpu":{"used":8,"bucket":8100}}}']
+        }
+      }
+    },
+    ["shard1"]
+  );
+
+  assert.deepEqual(samples, [
+    { shard: "shard1", stats: { tick: 200, cpu: { used: 7, bucket: 8000 } } },
+    { shard: "shard1", stats: { tick: 201, cpu: { used: 8, bucket: 8100 } } }
+  ]);
+  assert.deepEqual(extractConsoleStatsSamples({ data: { shard: "shard3", messages: { log: samples } } }, ["shard1"]), []);
+});
+
+test("collectConsoleSamples uses the console stream without Memory polling", async () => {
+  let disconnected = false;
+  const fakeSocket = {
+    async subscribeUserConsole(handler) {
+      this.handler = handler;
+    },
+    async connect() {
+      this.handler({
+        data: {
+          shard: "shard1",
+          messages: { log: ['{"type":"stats","data":{"tick":300,"cpu":{"used":4,"bucket":9000}}}'] }
+        }
+      });
+      this.handler({
+        data: {
+          shard: "shard1",
+          messages: { log: ['{"type":"stats","data":{"tick":301,"cpu":{"used":6,"bucket":8800}}}'] }
+        }
+      });
+    },
+    disconnect() {
+      disconnected = true;
+    }
+  };
+  const apiClient = {
+    socket: fakeSocket,
+    gameTime: async shard => ({ time: shard === "shard1" ? 302 : 0 }),
+    memoryGet: async () => {
+      throw new Error("memory should not be read");
+    }
+  };
+
+  const collection = await collectConsoleSamples(apiClient, {
+    shards: ["shard1"],
+    samples: 2,
+    interval: 0,
+    consoleTimeout: 100,
+    maxStatsAge: 10
+  });
+
+  assert.equal(collection.source, "console");
+  assert.equal(collection.status, "complete");
+  assert.equal(disconnected, true);
+  assert.deepEqual(collection.apiMethods, ["api.auth/me", "socket.subscribeUserConsole", "api.time|api.gameTime"]);
+  assert.deepEqual(collection.byShard.shard1.map(stats => stats.tick), [300, 301]);
+  assert.equal(collection.gameTicksByShard.shard1, 302);
+});
+
+test("collectConsoleSamples returns bounded timeout errors before subscription completes", async () => {
+  const fakeSocket = {
+    async subscribeUserConsole() {
+      return new Promise(() => {});
+    },
+    connect() {
+      throw new Error("connect should not be called after subscription timeout");
+    },
+    disconnect() {}
+  };
+  const apiClient = {
+    socket: fakeSocket,
+    gameTime: async () => ({ time: 400 })
+  };
+
+  const started = Date.now();
+  const collection = await collectConsoleSamples(apiClient, {
+    shards: ["shard1"],
+    samples: 1,
+    interval: 0,
+    consoleTimeout: 5,
+    maxStatsAge: 10
+  });
+
+  assert.equal(collection.status, "timeout");
+  assert.equal(collection.byShard.shard1.length, 0);
+  assert.match(collection.errorsByShard.shard1[0].message, /Timed out waiting for Screeps console subscription/);
+  assert.ok(Date.now() - started < 250);
 });
 
 test("summarizeShard aggregates CPU stats and sorted top rows", () => {
@@ -305,6 +434,6 @@ test("allow-stale does not hide api.time freshness failures", () => {
 test("root package exposes a bounded read-only live CPU profile script", () => {
   assert.equal(
     rootPackage.scripts["profile:live:cpu"],
-    "node scripts/live-cpu-profile.mjs --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile"
+    "node scripts/live-cpu-profile.mjs --source console --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile"
   );
 });


### PR DESCRIPTION
## Summary
- Switch the bounded live CPU profiler default source from `/api/user/memory` polling to the Screeps console WebSocket stats stream.
- Support current `screeps-api` v2 `ScreepsHttpClient` plus the legacy `ScreepsAPI` shape.
- Decode Screeps console HTML entities before parsing `{"type":"stats","data":...}` payloads.

## Linked issue
Refs #3121

## Changes
- Code changes
  - Add `--source console|memory` and `--console-timeout` to `scripts/live-cpu-profile.mjs`.
  - Add bounded console subscription/connect/sample collection using `socket.subscribeUserConsole` and one `api.time` read per shard.
  - Preserve explicit `--source memory` fallback for compatibility.
- Test changes
  - Cover console stats parsing, escaped console payloads, result/log parsing, no Memory polling in console mode, and subscription timeout bounding.
- Docs changes
  - Update operations/stats docs to prefer console-stream profiling and document Memory polling as fallback.

## Validation
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run check-versions`
- PASS: `npm run sync:deps:check`
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node --test scripts/test/live-cpu-profile-cli.test.mjs`
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run test:scripts`
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run lint:all`
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run build`
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run check:bot-bundle-drift`
- PASS: `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run test:server:smoke`
- PASS: live read-only console profile on `screeps.com` shard1 collected a fresh CPU/bucket/process sample via console stream only: `artifacts/issue-3121-console-verify-final-20260707T230243Z/live-cpu-profile-2026-07-07T23-02-47-060Z.json`
- NOTE: `npm run check-versions` failed under the shell's default Node 22.22.2, then passed after `nvm use 24`.
- NOTE: a full `npm run test:all` attempt timed out at 600s while entering private-server smoke; `test:scripts` and `test:server:smoke` were then run separately and passed.

## Deployment impact
- No runtime bot behavior changes.
- Changes deployment tooling/docs only. Screeps deploy path still builds.
- After merge, deploying is still safe and keeps the generated bot bundle unchanged.

## Scope notes
- This stage fixes live CPU/profile collection without `/api/user/memory` polling.
- Structural snapshot task-board/defense/cluster Memory reads still use the existing Memory API path and remain future scope inside #3121.
