### PR TITLE
[codex] Separate generated artifact outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,5 +125,26 @@ performance-baselines/strategic/collected-metrics*.json
 
 # Local agent scratch/debug files
 tmp/
+.tmp/
 *-debug.ts
 *_debug.ts
+
+# Generated Screeps/live-analysis artifacts
+# Historical curated artifacts under artifacts/ remain tracked. New generated
+# live/postdeploy/refinement outputs stay local unless intentionally force-added.
+artifacts/agent/
+artifacts/subagents/
+artifacts/autonomous-live-*/
+artifacts/code-refinement-*.md
+artifacts/code-refinement-*/
+artifacts/cpu-profile*/
+artifacts/deploy-*/
+artifacts/issue-*
+artifacts/live-500-*/
+artifacts/live-analysis-*
+artifacts/postdeploy-*/
+artifacts/postdeploy-*.stderr.txt
+artifacts/postdeploy-*.stdout.json
+artifacts/postdeploy-*.log
+artifacts/triage-scout-*.md
+packages/screeps-server/artifacts/

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -12,6 +12,12 @@ Operate the bot with CPU, bucket, spawn health, room survival, and error rate as
 - GitHub Actions validation artifacts for duplication, complexity, coverage, and smoke tests.
 - [Global runtime diagnostics](global-runtime-diagnostics.md) for global resets and stale heap switches.
 
+## Artifact hygiene
+
+Generated local live/deploy/refinement outputs are ignored by default so routine diagnostics do not dirty `git status`. Prefer `.tmp/artifacts/...` for new local collectors and keep long-lived evidence in docs or an explicitly reviewed path. Historical curated files already tracked under `artifacts/` remain tracked; force-add a generated artifact only when a PR intentionally needs that exact evidence file.
+
+Current ignored generated paths include `.tmp/`, `artifacts/live-500-*`, `artifacts/live-analysis-*`, `artifacts/postdeploy-*`, `artifacts/deploy-*`, `artifacts/issue-*`, `artifacts/cpu-profile*`, `artifacts/code-refinement-*`, `artifacts/agent/`, `artifacts/subagents/`, and `packages/screeps-server/artifacts/`.
+
 ## Key health checks
 
 | Signal | Healthy expectation | Investigate when |

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "quality:duplication": "node scripts/check-duplication-budget.cjs",
     "quality:complexity": "node scripts/analyze-complexity.cjs",
     "quality:baseline": "npm run quality:duplication && npm run quality:complexity",
-    "profile:live:cpu": "node scripts/live-cpu-profile.mjs --source console --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile",
+    "profile:live:cpu": "node scripts/live-cpu-profile.mjs --source console --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir .tmp/artifacts/cpu-profile",
     "check:alliance-safety": "node scripts/check-alliance-safety.js",
     "verify": "npm run build && npm run check:bot-bundle-drift && npm run typecheck && npm run lint:all && npm run test:all && npm run check:alliance-safety && npm run check:no-deep-dist-imports && npm audit --omit=dev --audit-level=high",
     "deploy:preflight": "npm run sync:deps:check && npm run check:alliance-safety && npm run build && npm run check:bot-bundle-drift",

--- a/packages/screeps-server/scripts/export-live-structural-snapshot.js
+++ b/packages/screeps-server/scripts/export-live-structural-snapshot.js
@@ -14,7 +14,7 @@ const require = createRequire(import.meta.url);
 const { ScreepsAPI } = require("screeps-api");
 
 function printHelp() {
-  console.log(`Usage: node packages/screeps-server/scripts/export-live-structural-snapshot.js [options]\n\nOptions:\n  --shard <name>              Screeps shard (default shard1)\n  --rooms <list>              Comma-separated extra/source rooms to include\n  --maxRooms <n>              Maximum derived rooms to export (default 30)\n  --out <path>                Output JSON path (default packages/screeps-server/artifacts/cpu-benchmark/live-snapshot.json)\n  --hostname <host>           Screeps hostname (default screeps.com)\n  --protocol <proto>          Protocol (default https)\n  --port <n>                  Port (default 443)\n  --fail-on-memory-errors     Exit nonzero when read-only Memory paths fail\n\nRequires SCREEPS_TOKEN. Read-only endpoints only.`);
+  console.log(`Usage: node packages/screeps-server/scripts/export-live-structural-snapshot.js [options]\n\nOptions:\n  --shard <name>              Screeps shard (default shard1)\n  --rooms <list>              Comma-separated extra/source rooms to include\n  --maxRooms <n>              Maximum derived rooms to export (default 30)\n  --out <path>                Output JSON path (default .tmp/artifacts/live-structural-snapshot.json)\n  --hostname <host>           Screeps hostname (default screeps.com)\n  --protocol <proto>          Protocol (default https)\n  --port <n>                  Port (default 443)\n  --fail-on-memory-errors     Exit nonzero when read-only Memory paths fail\n\nRequires SCREEPS_TOKEN. Read-only endpoints only.`);
 }
 
 function parseOptions(argv = process.argv.slice(2), env = process.env) {
@@ -30,7 +30,7 @@ function parseOptions(argv = process.argv.slice(2), env = process.env) {
     shard: args.get("shard") ?? env.SHARD ?? "shard1",
     rooms,
     maxRooms,
-    out: args.get("out") ?? "packages/screeps-server/artifacts/cpu-benchmark/live-snapshot.json",
+    out: args.get("out") ?? ".tmp/artifacts/live-structural-snapshot.json",
     hostname: args.get("hostname") ?? env.SCREEPS_HOSTNAME ?? "screeps.com",
     protocol: args.get("protocol") ?? env.SCREEPS_PROTOCOL ?? "https",
     port: Number(args.get("port") ?? env.SCREEPS_PORT ?? 443),

--- a/scripts/live-cpu-profile.mjs
+++ b/scripts/live-cpu-profile.mjs
@@ -20,7 +20,7 @@ Options:
   --samples <n>              Number of samples (default 20)
   --interval <ms>            Delay between samples (default 3000)
   --shards <list>            Comma-separated shards (default shard0,shard1,shard2,shard3)
-  --out-dir <path>           Output directory (default artifacts/cpu-profile)
+  --out-dir <path>           Output directory (default .tmp/artifacts/cpu-profile)
   --hostname <host>          Screeps hostname (default SCREEPS_HOSTNAME or screeps.com)
   --protocol <http|https>    Screeps API protocol (default SCREEPS_PROTOCOL or https)
   --port <n>                 Screeps API port (default SCREEPS_PORT or 443)
@@ -46,7 +46,7 @@ export function parseArgs(argv) {
     samples: 20,
     interval: 3000,
     shards: DEFAULT_SHARDS,
-    outDir: "artifacts/cpu-profile",
+    outDir: ".tmp/artifacts/cpu-profile",
     hostname: process.env.SCREEPS_HOSTNAME || "screeps.com",
     protocol: process.env.SCREEPS_PROTOCOL || "https",
     port: Number(process.env.SCREEPS_PORT || 443),

--- a/scripts/test/artifact-hygiene.test.mjs
+++ b/scripts/test/artifact-hygiene.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function checkIgnored(paths) {
+  const result = spawnSync("git", ["check-ignore", "--stdin"], {
+    cwd: new URL("../..", import.meta.url),
+    input: `${paths.join("\n")}\n`,
+    encoding: "utf8"
+  });
+  return result.stdout.trim().split("\n").filter(Boolean);
+}
+
+test("generated live and deploy artifacts are ignored by default", () => {
+  const generatedPaths = [
+    ".tmp/live-comment.md",
+    "artifacts/agent/open-issues.json",
+    "artifacts/subagents/issue-triage.md",
+    "artifacts/autonomous-live-20260707T000000Z/summary.json",
+    "artifacts/code-refinement-20260707-pr9999.md",
+    "artifacts/code-refinement-20260707-pr9999/report.json",
+    "artifacts/cpu-profile/live-cpu-profile.json",
+    "artifacts/cpu-profile-20260707T000000Z/live-cpu-profile.json",
+    "artifacts/deploy-3303-20260707T000000Z/push.log",
+    "artifacts/issue-3224-check/log.txt",
+    "artifacts/live-500-2026-07-07T00-00-00Z/summary.md",
+    "artifacts/live-analysis-20260707T000000Z/summary.json",
+    "artifacts/live-analysis-current.json",
+    "artifacts/postdeploy-3303-verify/summary.json",
+    "artifacts/postdeploy-3303-verify-20260707T000000Z.stderr.txt",
+    "artifacts/postdeploy-3303-verify-20260707T000000Z.stdout.json",
+    "artifacts/triage-scout-20260707.md",
+    "packages/screeps-server/artifacts/smoke/summary.json"
+  ];
+
+  assert.deepEqual(checkIgnored(generatedPaths), generatedPaths);
+});
+
+test("curated artifact notes and docs remain addable without force", () => {
+  const curatedPaths = [
+    "artifacts/curated-evidence-note.md",
+    "artifacts/review/evidence.md",
+    "docs/operations/artifact-policy.md"
+  ];
+
+  assert.deepEqual(checkIgnored(curatedPaths), []);
+});

--- a/scripts/test/live-cpu-profile-cli.test.mjs
+++ b/scripts/test/live-cpu-profile-cli.test.mjs
@@ -434,6 +434,6 @@ test("allow-stale does not hide api.time freshness failures", () => {
 test("root package exposes a bounded read-only live CPU profile script", () => {
   assert.equal(
     rootPackage.scripts["profile:live:cpu"],
-    "node scripts/live-cpu-profile.mjs --source console --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir artifacts/cpu-profile"
+    "node scripts/live-cpu-profile.mjs --source console --samples 20 --interval 3000 --shards shard0,shard1,shard2,shard3 --out-dir .tmp/artifacts/cpu-profile"
   );
 });


### PR DESCRIPTION
## Summary
- Separates generated live/deploy/refinement outputs from curated repository artifacts with targeted ignore rules.
- Moves default local live CPU and structural snapshot outputs under `.tmp/artifacts/...`.
- Documents the artifact policy and adds regression coverage for generated-vs-curated artifact paths.

## Linked issue
Closes #3224

## Changes
- Code/config changes
  - Added `.gitignore` entries for generated `.tmp/`, live analysis, postdeploy/deploy, CPU profile, issue-run, agent/subagent, and private-server artifact outputs.
  - Updated `profile:live:cpu` and live CPU profiler default output directory to `.tmp/artifacts/cpu-profile`.
  - Updated live structural snapshot default output path to `.tmp/artifacts/live-structural-snapshot.json`.
- Test changes
  - Added `scripts/test/artifact-hygiene.test.mjs` to verify generated paths are ignored and curated paths remain addable.
  - Updated the live CPU profiler package-script assertion.
- Docs changes
  - Added an artifact hygiene policy to `docs/operations/README.md`.

## Validation
- ✅ `node --test scripts/test/artifact-hygiene.test.mjs scripts/test/live-cpu-profile-cli.test.mjs scripts/test/export-live-structural-snapshot-redaction.test.mjs`
- ✅ `npm run check-versions` under Node 24.18.0
- ✅ `npm run sync:deps:check` under Node 24.18.0
- ✅ `npm run test:scripts` under Node 24.18.0
- ✅ `npm run build` under Node 24.18.0
- ✅ `npm run check:bot-bundle-drift` under Node 24.18.0
- ✅ `npm run lint:all` under Node 24.18.0
- ✅ `git diff --check`

## Deployment impact
No bot runtime behavior change. Deploy path still builds; only local diagnostic output defaults and repository hygiene rules change.

## Scope notes
Historical curated files already tracked under `artifacts/` remain tracked. New generated evidence under ignored prefixes can still be intentionally force-added, but long-lived evidence should prefer docs or reviewed paths.
