### PR TITLE
[codex] Avoid Memory polling in structural snapshots

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -59,10 +59,16 @@ By default, the profiler fails closed when every requested shard returns zero sa
 SCREEPS_TOKEN=<token> node scripts/live-cpu-profile.mjs --source console --samples 1 --interval 0 --shards shard1 --allow-empty
 ```
 
-For structural live snapshots, deployment gates can fail when Memory reads are unavailable while still writing redacted artifacts:
+For structural live snapshots, pass explicit rooms when possible. The default stats path reads one console WebSocket stats sample and skips `/api/user/memory` when those explicit rooms are enough; use `--stats-source memory --memory-paths all` only with no-rate-limit credentials or intentionally low-frequency checks:
 
 ```bash
-SCREEPS_TOKEN=<token> node packages/screeps-server/scripts/export-live-structural-snapshot.js --shard shard1 --rooms W18S28,W18S27 --fail-on-memory-errors
+SCREEPS_TOKEN=<token> node packages/screeps-server/scripts/export-live-structural-snapshot.js --shard shard1 --rooms W18S28,W18S27 --console-timeout 15000
+```
+
+Deployment gates can still fail when requested Memory reads are unavailable while writing redacted artifacts:
+
+```bash
+SCREEPS_TOKEN=<token> node packages/screeps-server/scripts/export-live-structural-snapshot.js --shard shard1 --rooms W18S28,W18S27 --stats-source memory --memory-paths all --fail-on-memory-errors
 ```
 
 ## Runtime triage
@@ -94,7 +100,7 @@ Treat these as failures: no tick progression, bot upload failure, missing test m
 - **Global reset loop:** inspect first thrown error in console/harness logs, then add a regression test around initialization.
 - **Global heap switch:** check `Memory.runtimeDiagnostics.global.switchCount`; repeated increments mean heap globals may be stale.
 - **Bucket drain:** disable expensive visuals/planning first, then profile process metrics and hot path pathfinding.
-- **Live Memory API rate limits:** use `scripts/live-cpu-profile.mjs --source console` first; reserve `--source memory` for no-rate-limit tokens or very low-frequency checks. Do not paste token-bearing Screeps account URLs into issues or logs.
+- **Live Memory API rate limits:** use `scripts/live-cpu-profile.mjs --source console` first, and use structural snapshots with `--rooms ...` so they can rely on console stats plus room-object endpoints. Reserve Memory modes for no-rate-limit tokens or very low-frequency checks. Do not paste token-bearing Screeps account URLs into issues or logs.
 - **Allied target risk:** use shared alliance helpers from core/defense and add tests for `TooAngel`/`TedRoastBeef`.
 
 ## Deploy/version marker

--- a/packages/screeps-server/scripts/cpu-benchmark-model.js
+++ b/packages/screeps-server/scripts/cpu-benchmark-model.js
@@ -371,6 +371,8 @@ export function summarizeMemoryForSnapshot(memory) {
   const statsRooms = {};
   for (const [roomName, stats] of Object.entries(safeObject(memory.stats?.rooms))) {
     if (!isRoomName(roomName)) continue;
+    const taskBoard = safeObject(stats?.taskBoard ?? stats?.task_board);
+    const defense = safeObject(stats?.defense);
     statsRooms[roomName] = {
       rcl: toNumber(stats?.rcl, undefined),
       creeps: toNumber(stats?.creeps, undefined),
@@ -378,6 +380,22 @@ export function summarizeMemoryForSnapshot(memory) {
       remoteAssigned: toNumber(stats?.remote?.assigned, undefined),
       avgCpu: toNumber(stats?.profiler?.avg_cpu ?? stats?.profiler?.avgCpu, undefined),
       spawnQueueTotal: toNumber(stats?.spawn_queue?.total ?? stats?.spawnQueue?.total, undefined),
+      taskBoard: Object.keys(taskBoard).length > 0 ? {
+        tasks: toNumber(taskBoard.tasks, undefined),
+        openTasks: toNumber(taskBoard.openTasks ?? taskBoard.open_tasks, undefined),
+        assignedTasks: toNumber(taskBoard.assignedTasks ?? taskBoard.assigned_tasks, undefined),
+        reservations: toNumber(taskBoard.reservations, undefined),
+        staleReservations: toNumber(taskBoard.staleReservations ?? taskBoard.stale_reservations, undefined),
+        blockedReservations: toNumber(taskBoard.blockedReservations ?? taskBoard.blocked_reservations, undefined),
+        remainingAmount: toNumber(taskBoard.remainingAmount ?? taskBoard.remaining_amount, undefined),
+        criticalDeliveryRemainingAmount: toNumber(taskBoard.criticalDeliveryRemainingAmount ?? taskBoard.critical_delivery_remaining_amount, undefined),
+      } : undefined,
+      defense: Object.keys(defense).length > 0 ? {
+        towers: toNumber(defense.towers, undefined),
+        towerEnergy: toNumber(defense.towerEnergy ?? defense.tower_energy, undefined),
+        towerEnergyPercent: toNumber(defense.towerEnergyPercent ?? defense.tower_energy_percent, undefined),
+        towerReserveDeficit: toNumber(defense.towerReserveDeficit ?? defense.tower_reserve_deficit, undefined),
+      } : undefined,
     };
   }
 
@@ -394,7 +412,7 @@ export function summarizeMemoryForSnapshot(memory) {
   };
 }
 
-export function buildStructuralSnapshot({ hostname, shard, tick, myUserName, memory, roomResponses, roomStatus = {} }) {
+export function buildStructuralSnapshot({ hostname, shard, tick, myUserName, memory, roomResponses, roomStatus = {}, apiMethods, statsSource, apiTransport }) {
   const sourceRooms = Object.keys(roomResponses).sort();
   const roomMapping = translateRoomNames(sourceRooms);
   const rooms = sourceRooms.map((sourceName) => {
@@ -417,7 +435,9 @@ export function buildStructuralSnapshot({ hostname, shard, tick, myUserName, mem
       user: myUserName,
       apiPolicy: {
         readOnly: true,
-        methodsUsed: ["api.time", "api.memory.get", "api.raw.game.roomObjects", "api.raw.game.roomStatus", "api.me"],
+        methodsUsed: apiMethods ? [...new Set(apiMethods)] : ["api.time", "api.memory.get", "api.raw.game.roomObjects", "api.raw.game.roomStatus", "api.me"],
+        statsSource,
+        transport: apiTransport,
         stateChangingEndpointsUsed: false,
       },
       permanentAlliesNeverHostile: PERMANENT_ALLIES.slice(),

--- a/packages/screeps-server/scripts/export-live-structural-snapshot.js
+++ b/packages/screeps-server/scripts/export-live-structural-snapshot.js
@@ -8,13 +8,31 @@ import {
   safeObject,
   writeJson,
 } from "./cpu-benchmark-model.js";
+import { collectConsoleSamples } from "../../../scripts/live-cpu-profile.mjs";
 import { formatScreepsApiError, redactScreepsApiMessage } from "../../../scripts/live-redaction.mjs";
 
+const DEFAULT_MEMORY_PATHS = ["stats", "creeps", "rooms", "creepTaskBoard", "defenseRequests", "clusters", "empire"];
+const DEFAULT_STATS_SOURCE = "console";
+const VALID_STATS_SOURCES = new Set(["console", "memory", "none"]);
+
 const require = createRequire(import.meta.url);
-const { ScreepsAPI } = require("screeps-api");
+const screepsApiModule = require("screeps-api");
 
 function printHelp() {
-  console.log(`Usage: node packages/screeps-server/scripts/export-live-structural-snapshot.js [options]\n\nOptions:\n  --shard <name>              Screeps shard (default shard1)\n  --rooms <list>              Comma-separated extra/source rooms to include\n  --maxRooms <n>              Maximum derived rooms to export (default 30)\n  --out <path>                Output JSON path (default .tmp/artifacts/live-structural-snapshot.json)\n  --hostname <host>           Screeps hostname (default screeps.com)\n  --protocol <proto>          Protocol (default https)\n  --port <n>                  Port (default 443)\n  --fail-on-memory-errors     Exit nonzero when read-only Memory paths fail\n\nRequires SCREEPS_TOKEN. Read-only endpoints only.`);
+  console.log(`Usage: node packages/screeps-server/scripts/export-live-structural-snapshot.js [options]\n\nOptions:\n  --shard <name>              Screeps shard (default shard1)\n  --rooms <list>              Comma-separated extra/source rooms to include\n  --maxRooms <n>              Maximum derived rooms to export (default 30)\n  --out <path>                Output JSON path (default .tmp/artifacts/live-structural-snapshot.json)\n  --hostname <host>           Screeps hostname (default screeps.com)\n  --protocol <proto>          Protocol (default https)\n  --port <n>                  Port (default 443)\n  --stats-source <mode>       stats source: console, memory, or none (default console)\n  --console-timeout <ms>      Max wait for one console stats sample (default 15000)\n  --memory-paths <list>       Comma-separated Memory paths, all, none, or auto (default auto)\n  --fail-on-memory-errors     Exit nonzero when read-only Memory paths fail\n\nRequires SCREEPS_TOKEN. Read-only endpoints only. Default console stats + explicit rooms avoids /api/user/memory polling.`);
+}
+
+export function parseMemoryPathsOption(value) {
+  const raw = String(value ?? "auto").trim();
+  if (!raw || raw === "auto") return "auto";
+  if (raw === "none") return [];
+  if (raw === "all") return DEFAULT_MEMORY_PATHS.slice();
+
+  const paths = raw.split(",").map((path) => path.trim()).filter(Boolean);
+  if (paths.length === 0) return [];
+  const invalid = paths.filter((path) => !DEFAULT_MEMORY_PATHS.includes(path));
+  if (invalid.length > 0) throw new Error(`--memory-paths contains unsupported path(s): ${invalid.join(", ")}`);
+  return [...new Set(paths)];
 }
 
 function parseOptions(argv = process.argv.slice(2), env = process.env) {
@@ -26,6 +44,10 @@ function parseOptions(argv = process.argv.slice(2), env = process.env) {
     .filter(Boolean);
   const maxRooms = Number(args.get("maxRooms") ?? 30);
   if (!Number.isInteger(maxRooms) || maxRooms < 1) throw new Error("--maxRooms must be a positive integer");
+  const statsSource = String(args.get("stats-source") ?? DEFAULT_STATS_SOURCE);
+  if (!VALID_STATS_SOURCES.has(statsSource)) throw new Error("--stats-source must be console, memory, or none");
+  const consoleTimeout = Number(args.get("console-timeout") ?? 15000);
+  if (!Number.isFinite(consoleTimeout) || consoleTimeout < 1) throw new Error("--console-timeout must be >= 1");
   return {
     shard: args.get("shard") ?? env.SHARD ?? "shard1",
     rooms,
@@ -34,6 +56,9 @@ function parseOptions(argv = process.argv.slice(2), env = process.env) {
     hostname: args.get("hostname") ?? env.SCREEPS_HOSTNAME ?? "screeps.com",
     protocol: args.get("protocol") ?? env.SCREEPS_PROTOCOL ?? "https",
     port: Number(args.get("port") ?? env.SCREEPS_PORT ?? 443),
+    statsSource,
+    consoleTimeout,
+    memoryPaths: parseMemoryPathsOption(args.get("memory-paths")),
     failOnMemoryErrors: args.has("fail-on-memory-errors") && args.get("fail-on-memory-errors") !== "false",
   };
 }
@@ -71,12 +96,11 @@ export function evaluateStructuralSnapshotHealth(snapshot, { failOnMemoryErrors 
   };
 }
 
-async function fetchMemory(api, shard) {
-  const paths = ["stats", "creeps", "rooms", "creepTaskBoard", "defenseRequests", "clusters", "empire"];
+async function fetchMemory(api, shard, paths = DEFAULT_MEMORY_PATHS) {
   const memory = {};
   for (const memoryPath of paths) {
     try {
-      memory[memoryPath] = unwrapMemory(await api.memory.get(memoryPath, shard));
+      memory[memoryPath] = unwrapMemory(await api.memoryGet(memoryPath, shard));
     } catch (error) {
       memory[memoryPath] = {};
       memory.__errors = [...(memory.__errors ?? []), redactedSnapshotError({ type: "memory", path: memoryPath }, error)];
@@ -85,38 +109,148 @@ async function fetchMemory(api, shard) {
   return memory;
 }
 
-async function exportSnapshot(options) {
-  if (!process.env.SCREEPS_TOKEN) throw new Error("SCREEPS_TOKEN is required for read-only live snapshot export");
+function consoleApiClient(api) {
+  return {
+    socket: api.socket,
+    gameTime: (shard) => api.time(shard),
+    memoryGet: (memoryPath, shard) => api.memoryGet(memoryPath, shard),
+  };
+}
 
-  const api = new ScreepsAPI({
+export function createSnapshotApi(apiModule, options) {
+  const clientOptions = {
     token: process.env.SCREEPS_TOKEN,
     protocol: options.protocol,
     hostname: options.hostname,
     port: options.port,
     path: process.env.SCREEPS_PATH || "/",
+  };
+
+  const LegacyApi = apiModule?.ScreepsAPI ?? apiModule?.default?.ScreepsAPI;
+  if (typeof LegacyApi === "function") {
+    const api = new LegacyApi(clientOptions);
+    return {
+      transport: "ScreepsAPI",
+      methods: {
+        me: "api.me",
+        time: "api.time",
+        roomStatus: "api.raw.game.roomStatus",
+        roomObjects: "api.raw.game.roomObjects",
+      },
+      socket: api.socket,
+      me: () => api.me(),
+      time: (shard) => api.time(shard),
+      memoryGet: (memoryPath, shard) => api.memory.get(memoryPath, shard),
+      roomStatus: (roomName, shard) => api.raw.game.roomStatus(roomName, shard),
+      roomObjects: (roomName, shard) => api.raw.game.roomObjects(roomName, shard),
+    };
+  }
+
+  const HttpClient = apiModule?.ScreepsHttpClient ?? apiModule?.default?.ScreepsHttpClient;
+  if (typeof HttpClient === "function") {
+    const api = new HttpClient(clientOptions);
+    return {
+      transport: "ScreepsHttpClient",
+      methods: {
+        me: "api.me",
+        time: "api.gameTime",
+        roomStatus: "api.gameRoomStatus",
+        roomObjects: "api.gameRoomObjects",
+      },
+      socket: api.socket,
+      me: () => api.me(),
+      time: (shard) => api.gameTime(shard),
+      memoryGet: (memoryPath, shard) => api.userMemoryGet(memoryPath, shard),
+      roomStatus: (roomName, shard) => api.gameRoomStatus(roomName, shard),
+      roomObjects: (roomName, shard) => api.gameRoomObjects(roomName, shard),
+    };
+  }
+
+  throw new Error("screeps-api module did not expose a supported API client");
+}
+
+function consoleErrorsForSnapshot(collection, shard) {
+  const errors = [
+    ...(collection.errorsByShard?.[shard] ?? []).map((error) => ({ type: "consoleStats", path: "stats", message: error.message })),
+    ...(collection.timeErrorsByShard?.[shard] ?? []).map((error) => ({ type: "consoleStatsTime", path: "stats", message: error.message })),
+  ];
+  return errors.filter((error) => error.message);
+}
+
+async function fetchConsoleStatsMemory(api, options) {
+  const collection = await collectConsoleSamples(consoleApiClient(api), {
+    shards: [options.shard],
+    samples: 1,
+    interval: 0,
+    consoleTimeout: options.consoleTimeout,
+    maxStatsAge: 100,
   });
+  const latestStats = collection.byShard?.[options.shard]?.at(-1);
+  return {
+    memory: latestStats ? { stats: latestStats } : {},
+    errors: consoleErrorsForSnapshot(collection, options.shard),
+    apiMethods: collection.apiMethods,
+  };
+}
+
+function resolveMemoryPaths(options, memory) {
+  if (Array.isArray(options.memoryPaths)) return options.memoryPaths;
+  if (options.statsSource === "memory") return DEFAULT_MEMORY_PATHS.slice();
+  const roomsAlreadyKnown = deriveCandidateRooms(memory, options.rooms, options.maxRooms).length > 0;
+  if (roomsAlreadyKnown) return [];
+  return DEFAULT_MEMORY_PATHS.filter((path) => !(path === "stats" && (memory.stats || options.statsSource === "none")));
+}
+
+export async function collectSnapshotMemory(api, options) {
+  let memory = {};
+  const errors = [];
+  const apiMethods = [];
+
+  if (options.statsSource === "console") {
+    const consoleStats = await fetchConsoleStatsMemory(api, options);
+    memory = { ...memory, ...consoleStats.memory };
+    errors.push(...consoleStats.errors);
+    apiMethods.push(...consoleStats.apiMethods);
+  }
+
+  const paths = resolveMemoryPaths(options, memory).filter((path) => !Object.prototype.hasOwnProperty.call(memory, path));
+  if (paths.length > 0) {
+    const memoryResult = await fetchMemory(api, options.shard, paths);
+    memory = { ...memory, ...memoryResult };
+    errors.push(...(memoryResult.__errors ?? []));
+    apiMethods.push("api.memory.get");
+  }
+
+  return { memory, errors, apiMethods };
+}
+
+async function exportSnapshot(options) {
+  if (!process.env.SCREEPS_TOKEN) throw new Error("SCREEPS_TOKEN is required for read-only live snapshot export");
+
+  const api = createSnapshotApi(screepsApiModule, options);
 
   const me = await api.me();
   const myUserName = me?.username || me?.name || "unknown";
   const time = await api.time(options.shard);
   const tick = Number(time?.time ?? time?.gameTime ?? 0);
-  const memory = await fetchMemory(api, options.shard);
+  const memoryCollection = await collectSnapshotMemory(api, options);
+  const memory = memoryCollection.memory;
   const rooms = deriveCandidateRooms(memory, options.rooms, options.maxRooms);
-  if (rooms.length === 0) throw new Error("No rooms derived from live Memory; pass --rooms to include explicit rooms");
+  if (rooms.length === 0) throw new Error("No rooms derived from live snapshot sources; pass --rooms to include explicit rooms");
 
   const roomResponses = {};
   const roomStatus = {};
-  const errors = [...(memory.__errors ?? [])];
+  const errors = [...memoryCollection.errors];
   for (const roomName of rooms) {
     try {
-      roomStatus[roomName] = await api.raw.game.roomStatus(roomName, options.shard);
+      roomStatus[roomName] = await api.roomStatus(roomName, options.shard);
     } catch (error) {
       const message = formatScreepsApiError(error);
       roomStatus[roomName] = { ok: 0, error: message };
       errors.push(redactedSnapshotError({ type: "roomStatus", room: roomName }, error));
     }
     try {
-      roomResponses[roomName] = await api.raw.game.roomObjects(roomName, options.shard);
+      roomResponses[roomName] = await api.roomObjects(roomName, options.shard);
     } catch (error) {
       roomResponses[roomName] = { objects: [], users: {} };
       errors.push(redactedSnapshotError({ type: "roomObjects", room: roomName }, error));
@@ -131,6 +265,15 @@ async function exportSnapshot(options) {
     memory: safeObject(memory),
     roomResponses,
     roomStatus,
+    apiMethods: [
+      api.methods.me,
+      ...memoryCollection.apiMethods,
+      api.methods.time,
+      api.methods.roomStatus,
+      api.methods.roomObjects,
+    ],
+    apiTransport: api.transport,
+    statsSource: options.statsSource,
   });
   snapshot.errors = errors;
   writeJson(options.out, snapshot);

--- a/scripts/test/export-live-structural-snapshot-redaction.test.mjs
+++ b/scripts/test/export-live-structural-snapshot-redaction.test.mjs
@@ -2,11 +2,15 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  collectSnapshotMemory,
+  createSnapshotApi,
   evaluateStructuralSnapshotHealth,
   formatStructuralSnapshotCliError,
+  parseMemoryPathsOption,
   parseOptions,
   redactedSnapshotError
 } from "../../packages/screeps-server/scripts/export-live-structural-snapshot.js";
+import { buildStructuralSnapshot } from "../../packages/screeps-server/scripts/cpu-benchmark-model.js";
 
 const RATE_LIMIT_MESSAGE = [
   "Rate limit exceeded, retry after 123ms or disable rate limiting using this link:",
@@ -62,8 +66,15 @@ test("structural snapshot top-level CLI errors redact non-Error token fragments"
   assert.equal(message.includes("token=<redacted>"), true);
 });
 
-test("structural snapshot parser supports deploy-gate memory error failure flag", () => {
-  const options = parseOptions(["--shard", "shard3", "--rooms", "W1N1,W2N2", "--fail-on-memory-errors"], {
+test("structural snapshot parser supports deploy-gate and source flags", () => {
+  const options = parseOptions([
+    "--shard", "shard3",
+    "--rooms", "W1N1,W2N2",
+    "--stats-source", "memory",
+    "--console-timeout", "2500",
+    "--memory-paths", "stats,rooms",
+    "--fail-on-memory-errors"
+  ], {
     SCREEPS_HOSTNAME: "screeps.com",
     SCREEPS_PROTOCOL: "https",
     SCREEPS_PORT: "443"
@@ -71,7 +82,24 @@ test("structural snapshot parser supports deploy-gate memory error failure flag"
 
   assert.equal(options.shard, "shard3");
   assert.deepEqual(options.rooms, ["W1N1", "W2N2"]);
+  assert.equal(options.statsSource, "memory");
+  assert.equal(options.consoleTimeout, 2500);
+  assert.deepEqual(options.memoryPaths, ["stats", "rooms"]);
   assert.equal(options.failOnMemoryErrors, true);
+});
+
+test("structural snapshot parser defaults to console stats with automatic Memory policy", () => {
+  const options = parseOptions(["--shard", "shard1", "--rooms", "W1N1"], {});
+
+  assert.equal(options.statsSource, "console");
+  assert.equal(options.consoleTimeout, 15000);
+  assert.equal(options.memoryPaths, "auto");
+});
+
+test("structural snapshot memory path parser rejects unsupported paths", () => {
+  assert.deepEqual(parseMemoryPathsOption("none"), []);
+  assert.deepEqual(parseMemoryPathsOption("all"), ["stats", "creeps", "rooms", "creepTaskBoard", "defenseRequests", "clusters", "empire"]);
+  assert.throws(() => parseMemoryPathsOption("stats,unknown"), /unsupported path/);
 });
 
 test("structural snapshot health fails only when requested memory errors are present", () => {
@@ -93,4 +121,144 @@ test("structural snapshot health fails only when requested memory errors are pre
   assert.equal(degraded.ok, true);
   assert.equal(degraded.status, "degraded");
   assert.equal(degraded.memory_errors, 1);
+});
+
+test("structural snapshot API wrapper supports the current ScreepsHttpClient module shape", async () => {
+  const previousToken = process.env.SCREEPS_TOKEN;
+  process.env.SCREEPS_TOKEN = "test-token";
+  try {
+    class FakeHttpClient {
+      constructor(options) {
+        this.options = options;
+        this.socket = { kind: "socket" };
+      }
+      async me() { return { username: "TedRoastBeef" }; }
+      async gameTime(shard) { return { time: shard === "shard1" ? 123 : 0 }; }
+      async userMemoryGet(path, shard) { return { data: { path, shard } }; }
+      async gameRoomStatus(roomName, shard) { return { roomName, shard, status: "normal" }; }
+      async gameRoomObjects(roomName, shard) { return { objects: [{ roomName, shard }], users: {} }; }
+    }
+
+    const api = createSnapshotApi({ ScreepsHttpClient: FakeHttpClient }, {
+      hostname: "screeps.com",
+      protocol: "https",
+      port: 443
+    });
+
+    assert.equal(api.transport, "ScreepsHttpClient");
+    assert.deepEqual(api.methods, {
+      me: "api.me",
+      time: "api.gameTime",
+      roomStatus: "api.gameRoomStatus",
+      roomObjects: "api.gameRoomObjects"
+    });
+    assert.deepEqual(await api.me(), { username: "TedRoastBeef" });
+    assert.deepEqual(await api.time("shard1"), { time: 123 });
+    assert.deepEqual(await api.memoryGet("stats", "shard1"), { data: { path: "stats", shard: "shard1" } });
+    assert.deepEqual(await api.roomStatus("W1N1", "shard1"), { roomName: "W1N1", shard: "shard1", status: "normal" });
+    assert.deepEqual(await api.roomObjects("W1N1", "shard1"), { objects: [{ roomName: "W1N1", shard: "shard1" }], users: {} });
+  } finally {
+    if (previousToken === undefined) delete process.env.SCREEPS_TOKEN;
+    else process.env.SCREEPS_TOKEN = previousToken;
+  }
+});
+
+test("structural snapshot memory mode fetches requested Memory paths", async () => {
+  const memoryCalls = [];
+  const api = {
+    async memoryGet(path, shard) {
+      memoryCalls.push([path, shard]);
+      return { data: { marker: path } };
+    }
+  };
+
+  const options = parseOptions(["--shard", "shard1", "--stats-source", "memory", "--memory-paths", "all"], {});
+  const result = await collectSnapshotMemory(api, options);
+
+  assert.deepEqual(memoryCalls, [
+    ["stats", "shard1"],
+    ["creeps", "shard1"],
+    ["rooms", "shard1"],
+    ["creepTaskBoard", "shard1"],
+    ["defenseRequests", "shard1"],
+    ["clusters", "shard1"],
+    ["empire", "shard1"]
+  ]);
+  assert.equal(result.memory.stats.marker, "stats");
+  assert.equal(result.memory.creepTaskBoard.marker, "creepTaskBoard");
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.apiMethods, ["api.memory.get"]);
+});
+
+test("structural snapshot uses console stats without Memory API calls when explicit rooms are supplied", async () => {
+  const memoryCalls = [];
+  let disconnected = false;
+  const api = {
+    socket: {
+      async subscribeUserConsole(handler) {
+        this.handler = handler;
+      },
+      async connect() {
+        this.handler({
+          data: {
+            shard: "shard1",
+            messages: {
+              log: ['{&quot;type&quot;:&quot;stats&quot;,&quot;data&quot;:{&quot;tick&quot;:500,&quot;cpu&quot;:{&quot;used&quot;:7,&quot;bucket&quot;:9000},&quot;rooms&quot;:{&quot;W1N1&quot;:{&quot;rcl&quot;:5,&quot;taskBoard&quot;:{&quot;tasks&quot;:3,&quot;openTasks&quot;:1},&quot;defense&quot;:{&quot;towers&quot;:1}}}}}']
+            }
+          }
+        });
+      },
+      disconnect() {
+        disconnected = true;
+      }
+    },
+    time: async () => ({ time: 501 }),
+    memory: {
+      async get(path) {
+        memoryCalls.push(path);
+        throw new Error("memory should not be read for explicit-room console snapshots");
+      }
+    }
+  };
+
+  const options = parseOptions(["--shard", "shard1", "--rooms", "W1N1", "--console-timeout", "100"], {});
+  const result = await collectSnapshotMemory(api, options);
+
+  assert.equal(disconnected, true);
+  assert.deepEqual(memoryCalls, []);
+  assert.equal(result.memory.stats.tick, 500);
+  assert.equal(result.memory.stats.rooms.W1N1.taskBoard.openTasks, 1);
+  assert.equal(result.errors.length, 0);
+  assert.equal(result.apiMethods.includes("api.memory.get"), false);
+});
+
+test("structural snapshot source policy records console methods and compact stats summaries", () => {
+  const snapshot = buildStructuralSnapshot({
+    hostname: "screeps.com",
+    shard: "shard1",
+    tick: 501,
+    myUserName: "TedRoastBeef",
+    memory: {
+      stats: {
+        tick: 500,
+        cpu: { used: 7, bucket: 9000 },
+        rooms: {
+          W1N1: {
+            rcl: 5,
+            creeps: 12,
+            taskBoard: { tasks: 3, openTasks: 1, reservations: 2, remainingAmount: 150 },
+            defense: { towers: 1, towerEnergy: 600, towerEnergyPercent: 0.8 }
+          }
+        }
+      }
+    },
+    roomResponses: { W1N1: { objects: [], users: {} } },
+    apiMethods: ["api.me", "socket.subscribeUserConsole", "api.time", "api.raw.game.roomObjects", "api.raw.game.roomStatus"],
+    statsSource: "console"
+  });
+
+  assert.equal(snapshot.source.apiPolicy.statsSource, "console");
+  assert.equal(snapshot.source.apiPolicy.methodsUsed.includes("api.memory.get"), false);
+  assert.equal(snapshot.memorySummary.stats.rooms.W1N1.taskBoard.openTasks, 1);
+  assert.equal(snapshot.memorySummary.stats.rooms.W1N1.defense.towers, 1);
 });


### PR DESCRIPTION
## Summary
- Makes live structural snapshots use console-stream `Memory.stats` by default instead of unconditional `/api/user/memory` polling.
- Keeps explicit Memory mode available with `--stats-source memory --memory-paths all` for no-rate-limit credentials.
- Supports current `screeps-api` `ScreepsHttpClient` shape and records actual read-only method metadata.

## Linked issue
Refs #3121

## Changes
- Code: add `--stats-source`, `--console-timeout`, and `--memory-paths` policy for structural snapshots.
- Code: summarize compact task-board/defense stats from console `Memory.stats` in structural artifacts.
- Tests: cover console/no-Memory snapshots, memory-mode paths, current `ScreepsHttpClient` wrapper, parser flags, and API policy metadata.
- Docs: update operations guide for console-first structural snapshots and memory fallback.

## Validation
- ✅ `node --test scripts/test/live-cpu-profile-cli.test.mjs scripts/test/live-cpu-profile-redaction.test.mjs scripts/test/export-live-structural-snapshot-redaction.test.mjs`
- ✅ `npm run test:scripts`
- ✅ `npm run check-versions`
- ✅ `npm run sync:deps:check`
- ✅ `npm run lint:all`
- ✅ `npm run build:docs`
- ✅ `npm run build`
- ✅ Live read-only structural snapshot: `node packages/screeps-server/scripts/export-live-structural-snapshot.js --shard shard1 --rooms W18S28,W18S27 --console-timeout 15000 --out .tmp/artifacts/issue-3121-structural-console-verify-20260708T010618Z.json` produced `health=healthy`, `memoryErrors=0`, and no `api.memory.get` method.

## Deployment impact
- No bot runtime behavior change; deploy bundle still builds.
- Improves post-deploy/live diagnostic path by reducing Memory API rate-limit pressure.

## Scope notes
- This is a repo-side stage for #3121, not a full closure of every raw Memory diagnostic need.
- Raw `creepTaskBoard` / `defenseRequests` / `clusters` Memory reads still require explicit Memory mode or a future compact console diagnostics payload.
