### PR TITLE
[codex] Suppress tiny hard-invader rangers

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -38582,7 +38582,7 @@ return Math.max(1, n.length);
 
 function Gg(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : o && pg("guard", hg(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : pg("guard", hg(r), o) ? 1 : 0;
 }
 
 function Lg(e, t) {
@@ -39270,11 +39270,25 @@ requests: c
 }
 
 function uh(e, t) {
-var r, n, i, s, c, u = e.energyCapacityAvailable;
+var r, n, i, s = e.energyCapacityAvailable;
 try {
-var l = 3 * Math.max(3, Math.min(50, Math.floor(u / 100))), m = Pv.getMaxAffordableInTicks(e, l), d = hg(e), p = t.priority >= gv.EMERGENCY || t.bootstrap ? d : Math.max(u, m), f = t.assistTarget && _o(t.roleName) ? t.roleName : null, y = Boolean(f), v = y && t.priority >= gv.EMERGENCY, g = t.assistTarget ? To(t.assistTarget) : null, h = f ? Oo(f, u, g) : null, R = f && v ? null !== (n = null !== (r = Oo(f, d, g)) && void 0 !== r ? r : pg(f, d, g)) && void 0 !== n ? n : h && h.cost <= d ? h : null : null, E = f ? null != R ? R : v ? null : h : null;
-if (y && g && !E && !t.bodyOverride) return null;
-var T = null !== (c = null !== (s = null !== (i = t.bodyOverride) && void 0 !== i ? i : E) && void 0 !== s ? s : function(e, t) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = Pv.getMaxAffordableInTicks(e, c), l = hg(e), m = t.priority >= gv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && _o(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= gv.EMERGENCY, y = t.assistTarget ? To(t.assistTarget) : null, v = d ? Oo(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var n;
+return null !== (n = [ Oo(e, t, r), pg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return function(e, t, r) {
+if (!t) return !1;
+if ("ranger" !== e) return !0;
+if (r && !bo(r)) return !0;
+var o = t.parts.filter(function(e) {
+return e === RANGED_ATTACK;
+}).length;
+return t.parts.length >= 6 && o >= 2;
+}(e, t, r);
+})) && void 0 !== n ? n : null;
+}(d, l, y, v) : null, h = d ? null != g ? g : f ? null : v : null;
+if (f && !h && !t.bodyOverride) return null;
+if (p && y && !h && !t.bodyOverride) return null;
+var R = null !== (i = null !== (n = null !== (r = t.bodyOverride) && void 0 !== r ? r : h) && void 0 !== n ? n : function(e, t) {
 var r, o, n = null;
 try {
 for (var i = a(e.bodies), s = i.next(); !s.done; s = i.next()) {
@@ -39293,14 +39307,14 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, p)) && void 0 !== c ? c : kv({
-maxEnergy: p,
+}(t.def, m)) && void 0 !== i ? i : kv({
+maxEnergy: m,
 role: t.roleName
-}), C = t.bodyOverride ? u : E ? v ? d : u : p;
-if (!T) return null;
-if ("claimer" === t.roleName && !T.parts.includes(CLAIM)) return null;
-if (T.cost > C) return null;
-var S = o(o(o(o(o({}, t.task ? {
+}), E = t.bodyOverride ? s : h ? f ? l : s : m;
+if (!R) return null;
+if ("claimer" === t.roleName && !R.parts.includes(CLAIM)) return null;
+if (R.cost > E) return null;
+var T = o(o(o(o(o({}, t.task ? {
 task: t.task
 } : {}), t.assistTarget ? {
 assistTarget: t.assistTarget
@@ -39316,10 +39330,10 @@ id: "".concat(t.roleName, "_").concat(Game.time, "_").concat(Math.random().toStr
 roomName: e.name,
 role: t.def.role,
 family: t.def.family,
-body: T,
+body: R,
 priority: t.priority,
 targetRoom: t.targetRoom,
-additionalMemory: Object.keys(S).length > 0 ? S : void 0,
+additionalMemory: Object.keys(T).length > 0 ? T : void 0,
 createdAt: Game.time
 };
 } catch (e) {

--- a/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseAssistDemand.ts
@@ -445,7 +445,6 @@ function getAffordableEmergencyAssistFallbackNeed(
 ): number {
   if (role !== "guard") return 0;
   if ((request.urgency ?? 1) < 2) return 0;
-  if (!threatProfile) return 0;
 
   const availableEnergy = getEffectiveRoomEnergyAvailable(helperRoom);
   return getAffordableEmergencyDefenseAssistBody("guard", availableEnergy, threatProfile) ? 1 : 0;

--- a/packages/screeps-spawn/src/spawnIntentCompiler.ts
+++ b/packages/screeps-spawn/src/spawnIntentCompiler.ts
@@ -2,7 +2,10 @@ import { logger } from "@ralphschuler/screeps-core";
 import {
   buildDefenseAssistBody,
   getVisibleDefenseAssistThreatProfile,
-  isDefenseAssistMilitaryRole
+  isDefenseAssistMilitaryRole,
+  isDefenseAssistThreatProfileHard,
+  type DefenseAssistRole,
+  type DefenseAssistThreatProfile
 } from "@ralphschuler/screeps-defense";
 import type { SwarmState } from "@ralphschuler/screeps-memory";
 import { emergencyResponseManager, energyFlowPredictor } from "./botIntegration";
@@ -27,6 +30,8 @@ import { SpawnPriority, type SpawnRequest } from "./spawnQueue";
 
 const TICKS_PER_BODY_PART = 3;
 const CONTROLLER_DOWNGRADE_UPGRADER_PRIORITY_TICKS = 5000;
+const MIN_HARD_DEFENSE_ASSIST_RANGER_PARTS = 6;
+const MIN_HARD_DEFENSE_ASSIST_RANGED_PARTS = 2;
 
 interface SpawnSettingsMemory {
   spawnSettings?: {
@@ -256,6 +261,35 @@ export function createSpawnPlan(room: Room, swarm: SwarmState): SpawnPlan {
   };
 }
 
+function isSafeEmergencyDefenseAssistBody(
+  role: DefenseAssistRole,
+  body: BodyTemplate | null,
+  threatProfile: DefenseAssistThreatProfile | null
+): body is BodyTemplate {
+  if (!body) return false;
+  if (role !== "ranger") return true;
+  if (threatProfile && !isDefenseAssistThreatProfileHard(threatProfile)) return true;
+
+  const rangedParts = body.parts.filter(part => part === RANGED_ATTACK).length;
+  return body.parts.length >= MIN_HARD_DEFENSE_ASSIST_RANGER_PARTS &&
+    rangedParts >= MIN_HARD_DEFENSE_ASSIST_RANGED_PARTS;
+}
+
+function selectAffordableEmergencyDefenseAssistBody(
+  role: DefenseAssistRole,
+  availableEnergy: number,
+  threatProfile: DefenseAssistThreatProfile | null,
+  capacityBody: BodyTemplate | null
+): BodyTemplate | null {
+  const candidates = [
+    buildDefenseAssistBody(role, availableEnergy, threatProfile),
+    getAffordableEmergencyDefenseAssistBody(role, availableEnergy, threatProfile),
+    capacityBody && capacityBody.cost <= availableEnergy ? capacityBody : null
+  ];
+
+  return candidates.find(body => isSafeEmergencyDefenseAssistBody(role, body, threatProfile)) ?? null;
+}
+
 /**
  * Compile one spawn demand into a concrete queue request.
  */
@@ -287,13 +321,17 @@ export function compileSpawnDemandToRequest(room: Room, demand: SpawnDemand): Sp
         )
       : null;
     const affordableDefenseAssistBody = defenseAssistRole && isEmergencyDefenseAssist
-      ? buildDefenseAssistBody(defenseAssistRole, availableEnergy, defenseAssistThreatProfile) ??
-        getAffordableEmergencyDefenseAssistBody(defenseAssistRole, availableEnergy, defenseAssistThreatProfile) ??
-        (defenseAssistCapacityBody && defenseAssistCapacityBody.cost <= availableEnergy ? defenseAssistCapacityBody : null)
+      ? selectAffordableEmergencyDefenseAssistBody(
+          defenseAssistRole,
+          availableEnergy,
+          defenseAssistThreatProfile,
+          defenseAssistCapacityBody
+        )
       : null;
     const defenseAssistBody = defenseAssistRole
       ? affordableDefenseAssistBody ?? (isEmergencyDefenseAssist ? null : defenseAssistCapacityBody)
       : null;
+    if (isEmergencyDefenseAssist && !defenseAssistBody && !demand.bodyOverride) return null;
     if (isDefenseAssistDemand && defenseAssistThreatProfile && !defenseAssistBody && !demand.bodyOverride) return null;
 
     const body =

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -969,6 +969,48 @@ describe("defense spawn throttling", () => {
     }
   });
 
+  it("uses an affordable guard fallback instead of tiny emergency ranger assists for unseen urgent requests", () => {
+    const helper = createRoom([], "W17S29", 300, 300);
+    Game.rooms.W17S29 = helper;
+    Game.creeps = {
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W17S29" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W17S29" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W17S29" } }
+    } as unknown as typeof Game.creeps;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W19S28",
+        guardsNeeded: 0,
+        rangersNeeded: 1,
+        healersNeeded: 0,
+        urgency: 3,
+        createdAt: Game.time,
+        threat: "hard ranged healer"
+      }
+    ];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const requests = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests;
+    const tinyRangerAssist = requests.find(request => request.role === "ranger" &&
+      request.priority >= SpawnPriority.EMERGENCY &&
+      request.additionalMemory?.task === "defenseAssist" &&
+      request.body.parts.length < 6);
+    const rangerAssists = requests.filter(request => request.role === "ranger" &&
+      request.priority >= SpawnPriority.EMERGENCY &&
+      request.additionalMemory?.task === "defenseAssist");
+    const guardFallback = requests.find(request => request.role === "guard" &&
+      request.priority >= SpawnPriority.EMERGENCY &&
+      request.additionalMemory?.task === "defenseAssist");
+
+    assert.isUndefined(tinyRangerAssist);
+    for (const rangerAssist of rangerAssists) {
+      assert.isAtLeast(rangerAssist.body.parts.length, 6);
+      assert.isAtLeast(rangerAssist.body.parts.filter(part => part === RANGED_ATTACK).length, 2);
+    }
+    assert.isOk(guardFallback);
+    assert.isAtMost(guardFallback!.body.cost, helper.energyAvailable);
+  });
+
   it("uses capacity-sized local emergency defenders against visible hard threats", () => {
     const hostile = createHostile(createRepeatedParts([TOUGH, 5], [RANGED_ATTACK, 25], [MOVE, 10], [HEAL, 10]));
     const room = createRoom([hostile], "W1N1", 1800, 300);


### PR DESCRIPTION
## Summary
- Prevent emergency defense-assist ranger bodies from spawning as tiny responses for hard or unseen threats.
- Allow urgent unseen defense requests to still create an affordable guard fallback.
- Add spawn regression coverage and regenerate the deploy bundle.

## Linked issue
Closes #3194

## Changes
- Code changes: filters emergency defense-assist ranger body candidates unless they meet the hard-threat body floor; skips unsafe emergency assist bodies instead of falling back to generic tiny ranger bodies.
- Code changes: permits urgent guard fallback creation when a target threat profile is not visible.
- Test changes: covers unseen urgent hard-invader requests so a helper room gets an affordable guard fallback and no tiny emergency ranger assist.
- Docs changes: none; runtime behavior only.

## Validation
- `npm run test:spawn` — passed, 157 passing.
- `npm run build` — passed.
- `npm run lint:spawn` — passed.
- `npm run sync:deps:check` — passed.
- `npm run test:server:smoke` — passed; smoke status passed, 3066 ticks, screepsmod-testing failed=0.
- `npm run build:bot && npm run check:bot-bundle-drift && git diff --check` — passed after commit with reproducible generated bundle.

## Deployment impact
- Affects screeps.com runtime spawn planning and the generated `packages/screeps-bot/dist/main.js` bundle.
- Expected to unblock the production private-server smoke gate by avoiding tiny hard-invader ranger defenders.

## Scope notes
- Existing Dependabot PRs remain outside this issue because they are not linked to an existing issue.
