### PR TITLE
[codex] Remove stale emergency quick action

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -47580,9 +47580,6 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
 e += cd.button({
-content: "🚨 Emergency Mode",
-command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});\n        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');\n      }"
-}), e += " ", e += cd.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
 }), e += " ", (e += cd.button({

--- a/packages/screeps-bot/src/core/uiCommands.ts
+++ b/packages/screeps-bot/src/core/uiCommands.ts
@@ -228,18 +228,6 @@ export class UICommands {
     let html = `<div style="background: #2b2b2b; padding: 10px; margin: 5px;">`;
     html += `<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>`;
 
-    // Emergency mode button
-    html += createElement.button({
-      content: "🚨 Emergency Mode",
-      command: `() => {
-        const config = global.botConfig.getConfig();
-        global.botConfig.updateConfig({emergencyMode: !config.emergencyMode});
-        return 'Emergency Mode: ' + (!config.emergencyMode ? 'ON' : 'OFF');
-      }`
-    });
-
-    html += " ";
-
     // Toggle debug button
     html += createElement.button({
       content: "🐛 Toggle Debug",

--- a/packages/screeps-bot/test/unit/uiCommands.test.ts
+++ b/packages/screeps-bot/test/unit/uiCommands.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import type { BotConfig } from "../../src/config";
 import { UICommands } from "../../src/core/uiCommands";
 
 describe("UICommands", () => {
@@ -24,5 +25,31 @@ describe("UICommands", () => {
 
     expect(output).to.include(escapedRoomLiteral);
     expect(output).to.not.include(`Game.rooms['${roomName}']`);
+  });
+
+  it("only writes typed BotConfig keys from quick actions", () => {
+    const output = new UICommands().quickActions();
+    const typedBotConfigKeys = new Set<keyof BotConfig>([
+      "pheromone",
+      "war",
+      "nuke",
+      "expansion",
+      "cpu",
+      "market",
+      "spawn",
+      "boost",
+      "debug",
+      "profiling",
+      "visualizations",
+      "lazyLoadConsoleCommands"
+    ]);
+    const updatedConfigKeys = [...output.matchAll(/updateConfig\(\{([A-Za-z_$][\w$]*)\s*:/g)].map(match => match[1]);
+
+    expect(output).to.include("🐛 Toggle Debug");
+    expect(output).to.include("🗑️ Clear Cache");
+    expect(output).to.not.include("Emergency Mode");
+    expect(output).to.not.include("emergencyMode");
+    expect(updatedConfigKeys).to.deep.equal(["debug"]);
+    expect(updatedConfigKeys.every(key => typedBotConfigKeys.has(key as keyof BotConfig))).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary
- Removed the stale Emergency Mode quick-action that wrote `emergencyMode` into bot config without a typed `BotConfig` field or runtime consumer.

## Linked issue
Closes #3233

## Changes
- Quick actions now keep only the typed debug toggle and cache-clear action.
- Added regression coverage that quick-action config writes stay within typed `BotConfig` keys.
- Rebuilt the tracked bot bundle.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run test:unit -w screeps-typescript-starter -- --grep UICommands` ✅
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run test:unit -w screeps-typescript-starter -- --reporter dot` ✅ (`2401 passing`)
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run build:bot` ✅
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run check-versions` ✅
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run sync:deps:check` ✅
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run build` ✅
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run lint:all` ✅

## Deployment impact
- Runtime bundle changes only remove a misleading console UI action. No config schema or Memory migration needed.
- Deploy path remains `npm run push` after merge.

## Scope notes
- This intentionally removes the unimplemented emergency-mode button instead of adding a new emergency-mode feature.
