### PR TITLE
[codex] Document task-board amount telemetry

### DIFF
--- a/docs/STATS_AND_METRICS.md
+++ b/docs/STATS_AND_METRICS.md
@@ -221,6 +221,30 @@ Per-room operational metrics including energy, creeps, hostiles, and danger leve
     energyHarvested: number;        // Energy harvested (rolling avg)
     damageReceived: number;         // Damage from hostiles (rolling avg)
     danger: number;                 // Danger level (0-3)
+    taskBoard?: {
+      tasks: number;                // Total task records
+      open_tasks: number;           // Unassigned task records
+      assigned_tasks: number;       // Task records with active assignment
+      reservations: number;         // Creep reservation records
+      stale_reservations: number;   // Reservations whose creeps/tasks are stale
+      blocked_reservations: number; // Reservations blocked by invalid targets or state
+      amount: number;               // Total requested task amount
+      reserved_amount: number;      // Amount reserved by creeps
+      remaining_amount: number;     // Unreserved amount still needing work
+      delivery_amount: number;      // Requested amount for delivery task types
+      delivery_reserved_amount: number;
+      delivery_remaining_amount: number;
+      critical_delivery_remaining_amount: number; // High-priority delivery remainder
+      by_type: Record<string, {
+        tasks: number;
+        open_tasks: number;
+        assigned_tasks: number;
+        reservations: number;
+        amount: number;
+        reserved_amount: number;
+        remaining_amount: number;
+      }>;
+    };
   }
 }
 ```
@@ -235,7 +259,64 @@ statsManager.recordRoom(room, 0.5, 0.7, {
 });
 ```
 
-**When Updated**: Manually via `recordRoom()` calls, typically in room manager.
+**When Updated**: Manually via `recordRoom()` calls, typically in room manager. `taskBoard` is sampled from `Memory.creepTaskBoard.rooms[roomName]` when room stats are recorded, then published to `Memory.stats` during stats finalization.
+
+#### Task-board amount telemetry
+
+Room task-board stats expose both count backlog and amount backlog under `Memory.stats.rooms[roomName].taskBoard`:
+
+| Field | Meaning |
+| --- | --- |
+| `tasks`, `open_tasks`, `assigned_tasks` | Task counts. Use these to detect scheduler backlog by record count. |
+| `reservations`, `stale_reservations`, `blocked_reservations` | Reservation health by count. |
+| `amount` | Sum of requested task amounts. Missing, invalid, or negative amounts count as `0`. |
+| `reserved_amount` | Sum reserved by creeps for those tasks. |
+| `remaining_amount` | Unreserved amount left, computed per task as `max(0, amount - reserved_amount)`. |
+| `delivery_amount`, `delivery_reserved_amount`, `delivery_remaining_amount` | Amount totals restricted to delivery work (`refillSpawn`, `refillExtension`, `refillTower`, `fillTerminalEnergy`, `storeEnergy`). |
+| `critical_delivery_remaining_amount` | Remaining amount for high-priority delivery tasks only; this is the urgent refill pressure signal. |
+| `by_type` | Per task-type counts and amount totals for finding which task type dominates backlog. |
+
+Example:
+
+```json
+{
+  "taskBoard": {
+    "tasks": 5,
+    "open_tasks": 4,
+    "assigned_tasks": 1,
+    "reservations": 1,
+    "amount": 2300,
+    "reserved_amount": 100,
+    "remaining_amount": 2200,
+    "delivery_amount": 2300,
+    "delivery_reserved_amount": 100,
+    "delivery_remaining_amount": 2200,
+    "critical_delivery_remaining_amount": 200,
+    "by_type": {
+      "storeEnergy": {
+        "tasks": 2,
+        "open_tasks": 2,
+        "assigned_tasks": 0,
+        "reservations": 0,
+        "amount": 2000,
+        "reserved_amount": 0,
+        "remaining_amount": 2000
+      },
+      "refillSpawn": {
+        "tasks": 3,
+        "open_tasks": 2,
+        "assigned_tasks": 1,
+        "reservations": 1,
+        "amount": 300,
+        "reserved_amount": 100,
+        "remaining_amount": 200
+      }
+    }
+  }
+}
+```
+
+Interpretation: `storeEnergy` can dominate `remaining_amount` because it represents bulk storage logistics, while `refillSpawn`/`refillExtension` tasks can dominate immediate survival risk. Use `critical_delivery_remaining_amount` and `by_type.refillSpawn.remaining_amount` to separate urgent refill pressure from low-urgency bulk hauling.
 
 #### Defense-assist diagnostics
 

--- a/docs/STATS_SYSTEM_OVERVIEW.md
+++ b/docs/STATS_SYSTEM_OVERVIEW.md
@@ -138,6 +138,7 @@ Per-room metrics:
 - Energy harvested
 - Damage received
 - Danger level
+- Task-board backlog counts, reservations, and amount-aware delivery pressure
 
 ### Subsystem Statistics
 CPU tracking for major subsystems:
@@ -237,6 +238,16 @@ Memory.stats = {
       brain: { danger, posture_code, colony_level_code },
       pheromones: { expand, harvest, build, upgrade, defense, war, siege, logistics, nukeTarget },
       metrics: { ... },
+      taskBoard: {
+        tasks, open_tasks, assigned_tasks,
+        reservations, stale_reservations, blocked_reservations,
+        amount, reserved_amount, remaining_amount,
+        delivery_amount, delivery_reserved_amount, delivery_remaining_amount,
+        critical_delivery_remaining_amount,
+        by_type: {
+          [taskType]: { tasks, open_tasks, assigned_tasks, reservations, amount, reserved_amount, remaining_amount }
+        }
+      },
       profiler: { avg_cpu, peak_cpu, samples }
     }
   },
@@ -255,6 +266,21 @@ Memory.stats = {
   }
 }
 ```
+
+### Room Task-Board Amount Telemetry
+
+`Memory.stats.rooms[roomName].taskBoard` summarizes creep task-board pressure without polling raw `Memory.creepTaskBoard`:
+
+- `tasks`, `open_tasks`, `assigned_tasks`: task-count backlog. These are counts, not energy/work amounts.
+- `reservations`, `stale_reservations`, `blocked_reservations`: reservation health by count.
+- `amount`: total requested work/energy amount across all tasks.
+- `reserved_amount`: amount already reserved by creeps.
+- `remaining_amount`: unreserved amount, computed as `max(0, amount - reserved_amount)` per task.
+- `delivery_amount`, `delivery_reserved_amount`, `delivery_remaining_amount`: same totals restricted to delivery tasks (`refillSpawn`, `refillExtension`, `refillTower`, `fillTerminalEnergy`, `storeEnergy`).
+- `critical_delivery_remaining_amount`: unreserved amount for high-priority delivery tasks.
+- `by_type`: per-task-type counts and amount totals for isolating the source of backlog.
+
+Interpretation: a room can have high `remaining_amount` because large `storeEnergy` tasks are waiting, while urgent spawn/extension refills dominate `critical_delivery_remaining_amount`. Compare `remaining_amount`, `delivery_remaining_amount`, `critical_delivery_remaining_amount`, and `by_type` before treating the room as generally starved.
 
 ### Programmatic Access
 ```typescript
@@ -294,6 +320,9 @@ Memory.stats.empire.rooms
 Memory.stats.rooms.W1N1.rcl
 Memory.stats.roles.harvester.count
 Memory.stats.rooms.W1N1.pheromones.harvest
+Memory.stats.rooms.W1N1.taskBoard.remaining_amount
+Memory.stats.rooms.W1N1.taskBoard.critical_delivery_remaining_amount
+Memory.stats.rooms.W1N1.taskBoard.by_type.refillSpawn.remaining_amount
 ```
 
 ## Migration from Legacy Stats


### PR DESCRIPTION
## Summary
- Documented the `Memory.stats.rooms.*.taskBoard` amount telemetry schema.
- Added guidance for interpreting count backlog vs amount backlog and urgent delivery pressure.

## Linked issue
Closes #3246

## Changes
- Updated `docs/STATS_SYSTEM_OVERVIEW.md` with room task-board telemetry fields and access examples.
- Updated `docs/STATS_AND_METRICS.md` with the current task-board schema, field descriptions, and a `storeEnergy` vs refill pressure example.
- No runtime code changes.

## Validation
- ✅ `npm run build:docs`
- ✅ `npm run check-versions`
- ✅ Independent reviewer checked docs against `packages/@ralphschuler/screeps-stats/src/unifiedStats.ts`; must-fix notes addressed.

## Deployment impact
- Documentation-only. No Screeps runtime behavior changes expected.
- Deploy path remains unchanged.

## Scope notes
- Did not modify stats code or task-board telemetry behavior.
