### PR TITLE
[codex] Cache remote creep counts per tick

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -37794,70 +37794,71 @@ function Dv(e, t, r, o, n) {
 return Js(e, t, r, o, n);
 }
 
-var Fv = new Map, Bv = -1, Wv = null;
+var Fv = new Map, Bv = -1, Wv = null, Hv = null;
 
-function Hv() {
-Bv === Game.time && Wv === Game.creeps || (Fv.clear(), Bv = Game.time, Wv = Game.creeps);
+function Kv() {
+Bv === Game.time && Wv === Game.creeps || (Fv.clear(), Hv = null, Bv = Game.time,
+Wv = Game.creeps);
 }
 
-function Kv(e) {
+function Yv(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Yv(e, t) {
+function Vv(e, t) {
 var r;
-void 0 === t && (t = !1), Hv();
+void 0 === t && (t = !1), Kv();
 var o = t ? "".concat(e, "_active") : e, n = Fv.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Kv(c);
+var u = Yv(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
 return Fv.set(o, a), a;
 }
 
-function Vv(e, t, r) {
-var o, n, i = 0;
-try {
-for (var s = a(Object.values(Game.creeps)), c = s.next(); !c.done; c = s.next()) {
-var u = c.value.memory;
-u.homeRoom === e && u.role === t && u.targetRoom === r && i++;
-}
-} catch (e) {
-o = {
-error: e
-};
-} finally {
-try {
-c && !c.done && (n = s.return) && n.call(s);
-} finally {
-if (o) throw o.error;
-}
-}
-return i;
+function qv(e, t, r) {
+return "".concat(e).concat("").concat(t).concat("").concat(r);
 }
 
-function qv(e) {
+function jv(e, t, r) {
+var o;
+return null !== (o = function() {
+var e;
+if (Kv(), Hv) return Hv;
+var t = new Map;
+for (var r in Game.creeps) {
+var o = Game.creeps[r].memory, n = o.homeRoom, a = o.role, i = o.targetRoom;
+if (n && a && i) {
+var s = qv(n, a, i);
+t.set(s, (null !== (e = t.get(s)) && void 0 !== e ? e : 0) + 1);
+}
+}
+return Hv = t, t;
+}().get(qv(e, t, r))) && void 0 !== o ? o : 0;
+}
+
+function zv(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var jv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var Qv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function zv(e) {
-return jv.includes(e);
+function Xv(e) {
+return Qv.includes(e);
 }
 
-function Qv(e) {
+function Zv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Xv(e, t, r, o) {
+function Jv(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37871,7 +37872,7 @@ var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
 if (r) return Dv(e, t, Er(r).length, o, {
-reserved: Qv(r)
+reserved: Zv(r)
 }).recommendedHaulers;
 var n = Dv(e, t, 2, o, {
 reserved: !1
@@ -37884,7 +37885,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: qv
+filter: zv
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37895,7 +37896,7 @@ return 2;
 }
 }
 
-function Zv(e, t) {
+function $v(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37905,13 +37906,13 @@ return null;
 }
 }
 
-function Jv() {
+function eg() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function $v(e) {
-var t = Jv(), r = function(e) {
+function tg(e) {
+var t = eg(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37923,14 +37924,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function eg(e) {
+function rg(e) {
 var t = ft.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Jv();
+var r = eg();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function tg(e) {
+function og(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37938,11 +37939,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function rg(e) {
+function ng(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function og() {
+function ag() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37952,9 +37953,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var ng = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var ig = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function ag(e, t) {
+function sg(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37966,7 +37967,7 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(og()), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(ag()), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Nv.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
@@ -37987,7 +37988,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function ig() {
+function cg() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -38008,7 +38009,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function sg(e, t) {
+function ug(e, t) {
 var r, o, n, c, u = ft.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -38018,15 +38019,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !ag(e.roomName, "claim");
+return !sg(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || tg(t));
+return !(!r || r.my || r.owner || r.reservation || og(t));
 }
-return !eg(e);
+return !rg(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -38037,11 +38038,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = ig().filter(function(e) {
-return !ag(e, "claim");
+var r, o, n = cg().filter(function(e) {
+return !sg(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = Jv();
+var r, o, n = Game.rooms[e], a = eg();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -38052,7 +38053,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && ng.has(e.type);
+return e.hits > 0 && ig.has(e.type);
 });
 });
 }(n));
@@ -38064,7 +38065,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = Zv(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = $v(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -38079,14 +38080,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(ig()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(cg()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !ag(e.roomName, "claim");
+return !e.claimed && !sg(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -38098,20 +38099,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Jv();
+var l = eg();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !ag(p, "claim")) {
+if (!t.has(p) && !sg(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || $v(y)) continue;
-if (tg(f)) continue;
+if (y.owner || tg(y)) continue;
+if (og(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !ag(p, "reserve")) return p;
-} else if (!eg(p) && !ag(p, "reserve")) return p;
+if ((!v || g < 3e3) && !sg(p, "reserve")) return p;
+} else if (!rg(p) && !sg(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -38133,34 +38134,34 @@ task: "reserve"
 } : null;
 }
 
-function cg(e) {
+function lg(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function ug(e) {
-return cg(e) ? hv.EMERGENCY : hv.HIGH;
+function mg(e) {
+return lg(e) ? hv.EMERGENCY : hv.HIGH;
 }
 
-function lg(e, t, r) {
+function dg(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!rg(e)) return !1;
+if (!ng(e)) return !1;
 var a = e.name === t ? r : ft.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function mg(e, t, r) {
+function pg(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return lg(e, t, r);
+return dg(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Zv(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = $v(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -38168,18 +38169,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function dg(e, t) {
+function fg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !lg(n, e, t)) return null;
+if (!n || !dg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !rg(e);
+return !ng(e);
 }).filter(function(e) {
-return !tg(e);
+return !og(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -38200,7 +38201,7 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(og()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(ag()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 i += Nv.getPendingRequests(d).filter(function(t) {
 var r;
@@ -38219,12 +38220,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (cg(e) ? 3 : 1);
+}(e.name) < (lg(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = Zv(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = $v(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -38232,10 +38233,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (mg(u.room, e, t) === e) return {
+if (pg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: ug(u.room)
+priority: mg(u.room)
 };
 }
 } catch (e) {
@@ -38252,7 +38253,7 @@ if (r) throw r.error;
 return null;
 }
 
-function pg(e, t) {
+function yg(e, t) {
 if (t <= 0) return null;
 try {
 var r = Mv({
@@ -38265,26 +38266,26 @@ return null;
 }
 }
 
-function fg(e, t, r) {
-return "healer" === e || "ranger" === e && bo(r) ? null : pg(e, t);
+function vg(e, t, r) {
+return "healer" === e || "ranger" === e && bo(r) ? null : yg(e, t);
 }
 
-var yg, vg, gg = new Map;
+var gg, hg, Rg = new Map;
 
-function hg(e) {
+function Eg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Rg(e) {
+function Tg(e) {
 var t, r;
-r = Game.time, yg === Game && vg === r || (gg.clear(), yg = Game, vg = r);
+r = Game.time, gg === Game && hg === r || (Rg.clear(), gg = Game, hg = r);
 var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}(), n = gg.get(e.name);
+}(), n = Rg.get(e.name);
 if (n && n.fallbackEnabled === o) return n.value;
 var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
@@ -38295,7 +38296,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += hg(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Eg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38316,7 +38317,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += hg(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Eg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38330,38 +38331,38 @@ if (o) throw o.error;
 }
 return i;
 }(e)) : i;
-return gg.set(e.name, {
+return Rg.set(e.name, {
 fallbackEnabled: o,
 value: s
 }), s;
 }
 
-function Eg(e) {
+function Cg(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Tg(e) {
+function Sg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? X(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function Cg(e) {
+function wg(e) {
 var t = e.defenseRequests;
-return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Eg);
+return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Cg);
 }
 
-var Sg = [ "guard", "ranger", "healer" ];
+var xg = [ "guard", "ranger", "healer" ];
 
-function wg(e, t) {
+function bg(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-var xg = null;
+var Og = null;
 
-function bg() {
+function kg() {
 var e = Nv.getRevision();
-return xg && xg.game === Game && xg.creeps === Game.creeps && xg.tick === Game.time && xg.queueRevision === e ? xg : xg = {
+return Og && Og.game === Game && Og.creeps === Game.creeps && Og.tick === Game.time && Og.queueRevision === e ? Og : Og = {
 game: Game,
 creeps: Game.creeps,
 tick: Game.time,
@@ -38374,8 +38375,8 @@ canSpawn: new Map
 };
 }
 
-function Og(e) {
-var t = bg(), r = Game.rooms[e], o = t.threats.get(e);
+function Mg(e) {
+var t = kg(), r = Game.rooms[e], o = t.threats.get(e);
 if (o && o.room === r) return o.threatProfile;
 var n = To(e);
 return t.threats.set(e, {
@@ -38384,27 +38385,27 @@ threatProfile: n
 }), n;
 }
 
-function kg(e) {
-return Game.rooms[e.roomName] ? null !== Og(e.roomName) : Tg(e);
+function Ag(e) {
+return Game.rooms[e.roomName] ? null !== Mg(e.roomName) : Sg(e);
 }
 
-function Mg(e) {
+function _g(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ci ? e.targetRoom : void 0;
 }
 
-function Ag(e, t) {
+function Ug(e, t) {
 var r, o;
 return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === ci && e.targetRoom === t;
 }
 
-function _g(e, t, r) {
+function Ng(e, t, r) {
 var o = vo(r), n = e[t];
 e[t] = n ? ho(n, o) : o;
 }
 
-function Ug(e) {
-var t = bg(), r = t.assigned.get(e);
+function Pg(e) {
+var t = kg(), r = t.assigned.get(e);
 if (r) return r;
 var o = function(e) {
 var t, r, o, n, i, s, c = {
@@ -38415,12 +38416,12 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = d.memory, f = null !== (i = p.role) && void 0 !== i ? i : "";
-if (_o(f) && Mg(p) === e) {
+if (_o(f) && _g(p) === e) {
 c[f]++;
 var y = (null !== (s = d.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-y.length > 0 && _g(u, f, y);
+y.length > 0 && Ng(u, f, y);
 }
 }
 } catch (e) {
@@ -38437,7 +38438,7 @@ if (t) throw t.error;
 for (var v in Game.rooms) try {
 for (var g = (o = void 0, a(Nv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-_o(R.role) && Ag(R, e) && (c[R.role]++, _g(u, R.role, R.body.parts));
+_o(R.role) && Ug(R, e) && (c[R.role]++, Ng(u, R.role, R.body.parts));
 }
 } catch (e) {
 o = {
@@ -38458,8 +38459,8 @@ power: u
 return t.assigned.set(e, o), o;
 }
 
-function Ng(e) {
-var t = bg(), r = t.canSpawn.get(e.name);
+function Ig(e) {
+var t = kg(), r = t.canSpawn.get(e.name);
 if (r && r.room === e) return r.value;
 var o = function(e) {
 var t;
@@ -38471,20 +38472,20 @@ value: o
 }), o;
 }
 
-function Pg(e, t) {
-var r, o, n = bg(), i = function(e, t) {
+function Gg(e, t) {
+var r, o, n = kg(), i = function(e, t) {
 var r, o, n, a, i;
 return [ t.name, e.roomName, t.energyCapacityAvailable, Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0), Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0), null !== (a = e.urgency) && void 0 !== a ? a : "", null !== (i = e.createdAt) && void 0 !== i ? i : "" ].join(":");
 }(e, t), s = n.helperPlans.get(i);
 if (s) return s;
-var c = Og(e.roomName), u = Ug(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Ao(d, c, function(e, t) {
+var c = Mg(e.roomName), u = Pg(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Ao(d, c, function(e, t) {
 return {
-guard: Math.max(0, wg(e, "guard") - t.guard),
-ranger: Math.max(0, wg(e, "ranger") - t.ranger),
-healer: Math.max(0, wg(e, "healer") - t.healer)
+guard: Math.max(0, bg(e, "guard") - t.guard),
+ranger: Math.max(0, bg(e, "ranger") - t.ranger),
+healer: Math.max(0, bg(e, "healer") - t.healer)
 };
 }(e, l), m), f = function(e, t) {
-var r, o, n, i, s = bg(), c = s.capableHelpers.get(e);
+var r, o, n, i, s = kg(), c = s.capableHelpers.get(e);
 if (c) return c;
 var u = {
 guard: 0,
@@ -38494,8 +38495,8 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.rooms)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d.name !== e && Ng(d)) try {
-for (var p = (n = void 0, a(Sg)), f = p.next(); !f.done; f = p.next()) {
+if (d.name !== e && Ig(d)) try {
+for (var p = (n = void 0, a(xg)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
 Oo(y, d.energyCapacityAvailable, t) && u[y]++;
 }
@@ -38525,7 +38526,7 @@ if (r) throw r.error;
 return s.capableHelpers.set(e, u), u;
 }(e.roomName, c), y = {};
 try {
-for (var v = a(Sg), g = v.next(); !g.done; g = v.next()) {
+for (var v = a(xg), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 y[h] = Oo(h, d, c);
 }
@@ -38552,8 +38553,8 @@ helperBodies: y
 return n.helperPlans.set(i, R), R;
 }
 
-function Ig(e, t, r) {
-var o = wg(e, t);
+function Lg(e, t, r) {
+var o = bg(e, t);
 if (!_o(t)) return o;
 if (!r.threatProfile) return o;
 var n = r.assignedCounts[t] + r.aggregatePlan.counts[t], a = o > 0 ? function(e, t, r) {
@@ -38568,27 +38569,27 @@ return Math.min(8, Math.max(1, i, s, u, l));
 return Math.max(o, n, a, i);
 }
 
-function Gg(e, t, r) {
-void 0 === r && (r = Pg(e, t));
+function Dg(e, t, r) {
+void 0 === r && (r = Gg(e, t));
 var o = r.aggregatePlan.counts.guard + r.aggregatePlan.counts.ranger + r.aggregatePlan.counts.healer;
 if (o > 0) return o;
-var n = Sg.filter(function(t) {
-return !(Ig(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
+var n = xg.filter(function(t) {
+return !(Lg(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
 });
 return Math.max(1, n.length);
 }
 
-function Lg(e, t, r, o) {
+function Fg(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : fg("guard", Rg(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : vg("guard", Tg(r), o) ? 1 : 0;
 }
 
-function Dg(e, t) {
+function Bg(e, t) {
 if (!function(e) {
 return _o(e);
 }(t)) return null;
 var r = Game.rooms[e];
-if (!r || !Ng(r)) return null;
+if (!r || !Ig(r)) return null;
 var o = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38615,15 +38616,15 @@ if (t) throw t.error;
 var n = function(e, t) {
 var r;
 void 0 === t && (t = {});
-var o = Cg(e), n = function(e) {
+var o = wg(e), n = function(e) {
 return e.map(function(e) {
 var t, r, o, n, a;
 return [ e.roomName, Math.max(0, null !== (t = e.guardsNeeded) && void 0 !== t ? t : 0), Math.max(0, null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.healersNeeded) && void 0 !== o ? o : 0), null !== (n = e.urgency) && void 0 !== n ? n : "", null !== (a = e.createdAt) && void 0 !== a ? a : "" ].join(":");
 }).join("|");
-}(o), a = bg();
+}(o), a = kg();
 if ((null === (r = a.activeRequests) || void 0 === r ? void 0 : r.signature) === n) return t.prune && Array.isArray(e.defenseRequests) && a.activeRequests.requests.length !== o.length && (e.defenseRequests = a.activeRequests.requests),
 a.activeRequests.requests;
-var i = o.filter(kg);
+var i = o.filter(Ag);
 return a.activeRequests = {
 signature: n,
 requests: i
@@ -38634,17 +38635,17 @@ prune: !0
 }).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var o = Pg(e, r);
+var o = Gg(e, r);
 return {
 request: e,
 plan: o,
-helperNeed: Math.max(Ig(e, t, o), Lg(e, t, r, o.threatProfile))
+helperNeed: Math.max(Lg(e, t, o), Fg(e, t, r, o.threatProfile))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
 return function(e, t) {
-return _o(t) ? Ug(e).counts[t] : 0;
+return _o(t) ? Pg(e).counts[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38654,7 +38655,7 @@ return f !== y ? f - y : (null !== (m = t.request.createdAt) && void 0 !== m ? m
 }), s = n[0];
 return s ? function(e, t, r, o) {
 var n;
-void 0 === o && (o = Pg(r, t));
+void 0 === o && (o = Gg(r, t));
 var a = function(e, t) {
 var r = function() {
 var e, t = Memory;
@@ -38674,25 +38675,25 @@ targetRoom: r.roomName,
 task: ci,
 priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? hv.EMERGENCY : hv.HIGH,
 defenseSquadId: ui(e, r.roomName, a.createdAt),
-defenseSquadSize: Gg(r, t, o),
+defenseSquadSize: Dg(r, t, o),
 defenseSquadCreatedAt: a.createdAt
 };
 }(e, r, s.request, s.plan) : null;
 }
 
-var Fg = "defenseRefuel", Bg = {
+var Wg = "defenseRefuel", Hg = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Wg(e, t) {
+function Kg(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < Bg.cost);
-}(n) ? Rg(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < Hg.cost);
+}(n) ? Tg(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38731,7 +38732,7 @@ if (t) throw t.error;
 try {
 for (var m = a(Nv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Fg && s++;
+"hauler" === p.role && f === Wg && s++;
 }
 } catch (e) {
 o = {
@@ -38746,23 +38747,23 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Fg,
+task: Wg,
 priority: hv.EMERGENCY,
-body: Bg
+body: Hg
 } : null : null;
 }
 
-function Hg(e) {
+function Yg(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !$v(t.controller) && !tg(t) : !eg(e);
+return t ? !!t.controller && !tg(t.controller) && !og(t) : !rg(e);
 }
 
-function Kg(e) {
+function Vg(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !$v(t.controller) : !eg(e);
+return (null == t ? void 0 : t.controller) ? !tg(t.controller) : !rg(e);
 }
 
-function Yg(e, t, r) {
+function qg(e, t, r) {
 var o = Sv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
@@ -38791,13 +38792,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Vg(e, t, r) {
+function jg(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Hg(l) && Vv(e, t, l) < Xv(e, l, t, Game.rooms[l])) return l;
+if (Yg(l) && jv(e, t, l) < Jv(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -38813,7 +38814,7 @@ if (o) throw o.error;
 return null;
 }
 
-function qg(e, t, r, o) {
+function zg(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
 var p = Sv[t];
@@ -38835,11 +38836,11 @@ return "military" === (null === (t = Sv[o]) || void 0 === t ? void 0 : t.family)
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Yv(e), y)) return !1;
+}(t, Vv(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (zv(t)) return !("remoteWorker" === t && function(e, t) {
-Hv();
+if (Xv(t)) return !("remoteWorker" === t && function(e, t) {
+Kv();
 var r = "".concat(e, ":").concat(t), o = Fv.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
@@ -38848,14 +38849,14 @@ var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
 return Fv.set(r, n), n;
-}(e, t) >= Yg(e, t, r)) && null !== Vg(e, t, r);
+}(e, t) >= qg(e, t, r)) && null !== jg(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Kg(R)) {
+if (Vg(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = X(E).filter(function(e) {
@@ -38863,7 +38864,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && Vv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && jv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38880,9 +38881,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Yv(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== dg(e, r);
-if (C >= Yg(e, t, r)) return !1;
+var C = null !== (u = Vv(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== fg(e, r);
+if (C >= qg(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38894,14 +38895,14 @@ var r = ft.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = Zv(e, o);
+var a = $v(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== sg(e, r);
+if ("claimer" === t) return null !== ug(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38965,16 +38966,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function jg(e) {
+function Qg(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function zg(e) {
-return 0 === jg(Yv(e, !0));
+function Xg(e) {
+return 0 === Qg(Vv(e, !0));
 }
 
-function Qg(e) {
+function Zg(e) {
 var t = Er(e);
 return [ {
 role: "harvester",
@@ -38997,14 +38998,14 @@ minCount: 1
 } ];
 }
 
-function Xg(e, t) {
-var r, o, n, i, s = Yv(e, !0);
-if (0 === jg(s)) return !0;
+function Jg(e, t) {
+var r, o, n, i, s = Vv(e, !0);
+if (0 === Qg(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Yv(e, !1), u = Qg(t);
+var c = Vv(e, !1), u = Zg(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -39024,36 +39025,36 @@ if (r) throw r.error;
 return !1;
 }
 
-var Zg = [ "guard", "ranger", "healer" ];
+var $g = [ "guard", "ranger", "healer" ];
 
-function Jg(e, t, r) {
+function eh(e, t, r) {
 void 0 === r && (r = 1), e[t] += r, e.total += r;
 }
 
-function $g(e, t) {
+function th(e, t) {
 var r, o;
 return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === ci ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
 }
 
-function eh(e) {
+function rh(e) {
 var t;
-return _o(e.role) && void 0 !== $g(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
+return _o(e.role) && void 0 !== th(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
 }
 
-function th(e, t) {
+function oh(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function rh(e, t) {
+function nh(e, t) {
 return 0 === t.length ? e : ho(e, vo(t));
 }
 
-function oh(e, t) {
-e.assignedPower = rh(e.assignedPower, t);
+function ah(e, t) {
+e.assignedPower = nh(e.assignedPower, t);
 }
 
-function nh(e, t) {
+function ih(e, t) {
 var r, o;
 if (void 0 !== t.defenseAssistReleasedAt) {
 var n = null !== (r = t.defenseAssistReleaseReason) && void 0 !== r ? r : "unknown";
@@ -39063,10 +39064,10 @@ e.released.lastReason = n);
 }
 }
 
-function ah(e, t) {
+function sh(e, t) {
 e.parityPercent = e.targetScore > 0 ? Math.min(100, t.score / e.targetScore * 100) : 0,
 e.blockReason = function(e) {
-var t = Zg.filter(function(t) {
+var t = $g.filter(function(t) {
 return e.queued[t] > 0;
 });
 if (t.length > 0 && t.every(function(t) {
@@ -39078,19 +39079,19 @@ return e.requested.total > 0 && 0 === r ? "no-local-assist" : "none";
 }(e);
 }
 
-function ih(e) {
+function ch(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function sh(e, t, r) {
-var n = Yg(e.name, r.roleName, t);
+function uh(e, t, r) {
+var n = qg(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function ch(e, t, r, o, n) {
+function lh(e, t, r, o, n) {
 if (n && ("larvaWorker" === r || "harvester" === r)) return hv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
@@ -39112,23 +39113,23 @@ return e >= 90 ? hv.HIGH : e >= 60 ? hv.NORMAL : hv.LOW;
 }(o);
 }
 
-function uh(e, t) {
+function mh(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-ih(e);
-var l = Yv(e.name), m = zg(e.name), d = [];
-if (Xg(e.name, e)) {
+ch(e);
+var l = Vv(e.name), m = Xg(e.name), d = [];
+if (Jg(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === jg(Yv(e, !0))) return _.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Qg(Vv(e, !0))) return _.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Yv(e, !1), c = Qg(t);
+var s = Vv(e, !1), c = Zg(t);
 _.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -39143,7 +39144,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = qg(e, m.role, r, !0);
+var p = zg(e, m.role, r, !0);
 if (_.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -39174,17 +39175,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = Sv[p]) && qg(e.name, p, t, !0) ? (d.push(sh(e, t, {
+return p && (g = Sv[p]) && zg(e.name, p, t, !0) ? (d.push(uh(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: ch(e, 0, p, g.priority, m),
+priority: lh(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
 for (var f = a(Object.entries(Sv)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Wg(e.name, p);
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Kg(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -39195,7 +39196,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Dg(e.name, p);
+var E = Bg(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -39209,8 +39210,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (qg(e.name, p, t, m)) {
-var T = zv(p), C = T ? Vg(e.name, p, t) : null, S = "claimer" === p ? sg(e.name, t) : null, w = "pioneer" === p ? dg(e.name, t) : null;
+}); else if (zg(e.name, p, t, m)) {
+var T = Xv(p), C = T ? jg(e.name, p, t) : null, S = "claimer" === p ? ug(e.name, t) : null, w = "pioneer" === p ? fg(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -39220,11 +39221,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(sh(e, t, {
+}) : d.push(uh(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: ch(e, 0, p, g.priority, m),
+priority: lh(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -39246,7 +39247,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = lh(e, l.value);
+var m = dh(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -39267,12 +39268,12 @@ requests: c
 };
 }
 
-function lh(e, t) {
+function dh(e, t) {
 var r, n, i, s = e.energyCapacityAvailable;
 try {
-var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = Iv.getMaxAffordableInTicks(e, c), l = Rg(e), m = t.priority >= hv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && _o(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= hv.EMERGENCY, y = t.assistTarget ? To(t.assistTarget) : null, v = d ? Oo(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = Iv.getMaxAffordableInTicks(e, c), l = Tg(e), m = t.priority >= hv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && _o(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= hv.EMERGENCY, y = t.assistTarget ? To(t.assistTarget) : null, v = d ? Oo(d, s, y) : null, g = d && f ? function(e, t, r, o) {
 var n;
-return null !== (n = [ Oo(e, t, r), fg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return null !== (n = [ Oo(e, t, r), vg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
 return function(e, t, r) {
 if (!t) return !1;
 if ("ranger" !== e) return !0;
@@ -39341,30 +39342,30 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var mh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), dh = new Set([ "guard", "ranger", "healer" ]);
+var ph = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), fh = new Set([ "guard", "ranger", "healer" ]);
 
-function ph() {
+function yh() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function fh(e) {
+function vh(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function yh(e) {
+function gh(e) {
 var t;
 return e.priority >= hv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function vh(e) {
+function hh(e) {
 var t;
 return e.priority >= hv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function gh(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Rg(e), m = Eo(X(e)), d = function(e) {
+function Rh(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Tg(e), m = Eo(X(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
 }(m), p = d || r.urgency >= 2 || t.danger >= 3 ? hv.EMERGENCY : hv.HIGH, f = d ? u : p === hv.EMERGENCY ? l : u, y = function(e, t) {
@@ -39376,9 +39377,9 @@ healers: 0
 try {
 for (var s = a(Nv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || hh(u, e) && ("guard" === u.role && (n.guards++,
-Eh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Eh(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Eh(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Eh(u, e) && ("guard" === u.role && (n.guards++,
+Ch(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Ch(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Ch(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -39406,7 +39407,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Eh(n, u, l);
+0 !== l.length && Ch(n, u, l);
 }
 }
 }
@@ -39445,26 +39446,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - y.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - y.counts.healers)
-}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Rh("guard", f, m);
-if (R > 0 && E) for (var T = 0; T < R; T++) Ch(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
-var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Rh("ranger", f, m);
-if (C > 0 && S) for (T = 0; T < C; T++) Ch(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
-var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Rh("healer", f, m);
-if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) Ch(e, "healer", "military", hv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Th("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) wh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Th("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) wh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Th("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) wh(e, "healer", "military", hv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
 if (!(t < hv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !dh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !fh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
 for (var i = a(Nv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < hv.EMERGENCY || dh.has(c.role) && hh(c, e.name) && c.body.cost <= t && n++;
+c.priority < hv.EMERGENCY || fh.has(c.role) && Eh(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39481,7 +39482,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = pg(t, e);
+var r = yg(t, e);
 return r ? {
 role: t,
 body: r
@@ -39496,35 +39497,35 @@ var r = vo(t.body.parts).score - vo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Ch(e, n.role, "military", hv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && wh(e, n.role, "military", hv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, p, l, m), (R > 0 || C > 0 || w > 0) && _.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function hh(e, t) {
+function Eh(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Rh(e, t, r) {
+function Th(e, t, r) {
 return r ? Oo(e, t, r) : null;
 }
 
-function Eh(e, t, r) {
+function Ch(e, t, r) {
 var o = vo(r);
 e[t] = e[t] ? ho(e[t], o) : o;
 }
 
-function Th(e, t, r) {
+function Sh(e, t, r) {
 return Nv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Ch(e, t, r, o, n, a, i, s, c) {
+function wh(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
 var u = null != i ? i : Mv({
@@ -39552,7 +39553,7 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Sh(e, t, r) {
+function xh(e, t, r) {
 if (void 0 === r && (r = e.energyAvailable), t.priority >= hv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
@@ -39564,20 +39565,20 @@ if (o / e.energyCapacityAvailable < .5) return !0;
 return t.priority === hv.NORMAL && o / e.energyCapacityAvailable < .3 && Iv.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function wh(e, t) {
+function bh(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-ih(e);
+ch(e);
 var s = Nv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Xg(e.name, e), u = zg(e.name) && !Nv.hasEmergencySpawns(e.name), l = ao(e), m = so(e);
+var c = Jg(e.name, e), u = Xg(e.name) && !Nv.hasEmergencySpawns(e.name), l = ao(e), m = so(e);
 if (c) {
-s > 0 && Nv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && gh(e, t, l, m);
+s > 0 && Nv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Rh(e, t, l, m);
 try {
-for (var d = a(uh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(mh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 Nv.addRequest(f);
 }
@@ -39592,7 +39593,7 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && gh(e, t, l, m), function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Rh(e, t, l, m), function(e) {
 var t, r, o = Gv.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
@@ -39611,11 +39612,11 @@ for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Th(e.name, "powerHarvester", f), g = Th(e.name, "healer", f), h = Th(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Ch(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Sh(e.name, "powerHarvester", f), g = Sh(e.name, "healer", f), h = Sh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) wh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Ch(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) wh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Ch(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) wh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -39644,12 +39645,12 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Nv.getPendingRequests(e.name).map(fh));
+var c = new Set(Nv.getPendingRequests(e.name).map(vh));
 try {
-for (var u = a(uh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= hv.HIGH, p = "claimer" === m.role && ph(), f = yh(m), y = vh(m);
-if (mh.has(m.role) || d || p || f || y) {
-var v = fh(m);
+for (var u = a(mh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= hv.HIGH, p = "claimer" === m.role && yh(), f = gh(m), y = hh(m);
+if (ph.has(m.role) || d || p || f || y) {
+var v = vh(m);
 c.has(v) || (Nv.addRequest(m), c.add(v));
 }
 }
@@ -39667,7 +39668,7 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(uh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+for (var y = a(mh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
 Nv.addRequest(f);
 } catch (e) {
 n = {
@@ -39690,12 +39691,12 @@ subsystem: "SpawnPipeline"
 var r = function(e) {
 var t, r, o = Nv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Rg(e);
+var n = 0, i = Tg(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Nv.getNextRequest(e.name, i);
 if (!l) break;
-if (Sh(e, l, i)) {
+if (xh(e, l, i)) {
 _.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
@@ -39724,9 +39725,9 @@ return n;
 }(e), o = Nv.getQueueStats(e.name), n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T = Game.rooms[e];
 if (!T) return [];
-var C = Rg(T), S = new Map, w = new Map, x = function(e, t) {
+var C = Tg(T), S = new Map, w = new Map, x = function(e, t) {
 var r;
-w.set(e, rh(null !== (r = w.get(e)) && void 0 !== r ? r : {
+w.set(e, nh(null !== (r = w.get(e)) && void 0 !== r ? r : {
 partCount: 0,
 attack: 0,
 ranged: 0,
@@ -39802,7 +39803,7 @@ return function(e, t, r) {
 var o, n, i, s = To(e.targetRoom);
 e.targetScore = null !== (i = null == s ? void 0 : s.total.score) && void 0 !== i ? i : 0;
 try {
-for (var c = a(Zg), u = c.next(); !u.done; u = c.next()) {
+for (var c = a($g), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Oo(l, t.energyCapacityAvailable, s);
 m ? (e.bodyCost[l] = m.cost, e.affordable[l] = m.cost <= r) : e.affordable[l] = !1;
 }
@@ -39822,15 +39823,15 @@ if (o) throw o.error;
 try {
 for (var O = a(function(e, t) {
 void 0 === t && (t = {});
-var r = Cg(e), o = r.filter(Tg);
+var r = wg(e), o = r.filter(Sg);
 return t.prune && Array.isArray(e.defenseRequests) && o.length !== r.length && (e.defenseRequests = o),
 o;
 }(Memory)), k = O.next(); !k.done; k = O.next()) if ((I = k.value).roomName !== e) {
 var M = b(I.roomName, null !== (f = I.urgency) && void 0 !== f ? f : 0);
 try {
-for (var A = (o = void 0, a(Zg)), _ = A.next(); !_.done; _ = A.next()) {
+for (var A = (o = void 0, a($g)), _ = A.next(); !_.done; _ = A.next()) {
 var U = _.value;
-Jg(M.requested, U, th(I, U));
+eh(M.requested, U, oh(I, U));
 }
 } catch (e) {
 o = {
@@ -39858,9 +39859,9 @@ if (t) throw t.error;
 try {
 for (var N = a(Nv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
 var I;
-eh(I = P.value) && (D = $g(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Jg((M = b(D)).queued, I.role),
+rh(I = P.value) && (D = th(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (eh((M = b(D)).queued, I.role),
 M.bodyCost[I.role] = Math.max(null !== (v = M.bodyCost[I.role]) && void 0 !== v ? v : 0, I.body.cost),
-M.affordable[I.role] = I.body.cost <= C, oh(M, I.body.parts));
+M.affordable[I.role] = I.body.cost <= C, ah(M, I.body.parts));
 }
 } catch (e) {
 c = {
@@ -39876,13 +39877,13 @@ if (c) throw c.error;
 try {
 for (var G = a(Object.values(Game.creeps)), L = G.next(); !L.done; L = G.next()) {
 var D, F = L.value, B = null !== (g = F.memory) && void 0 !== g ? g : {};
-if (B.homeRoom === e && _o(U = null !== (h = B.role) && void 0 !== h ? h : "") && (D = $g(B))) {
+if (B.homeRoom === e && _o(U = null !== (h = B.role) && void 0 !== h ? h : "") && (D = th(B))) {
 M = b(D);
 var W = (null !== (R = F.body) && void 0 !== R ? R : []).filter(function(e) {
 return e.hits > 0;
 });
-F.spawning ? Jg(M.spawning, U) : void 0 === B.defenseAssistReleasedAt && F.room.name === e ? (Jg(M.staged, U),
-x(D, W)) : F.room.name === D ? Jg(M.arrived, U) : Jg(M.moving, U), nh(M, B), oh(M, W);
+F.spawning ? eh(M.spawning, U) : void 0 === B.defenseAssistReleasedAt && F.room.name === e ? (eh(M.staged, U),
+x(D, W)) : F.room.name === D ? eh(M.arrived, U) : eh(M.moving, U), ih(M, B), ah(M, W);
 }
 }
 } catch (e) {
@@ -39898,7 +39899,7 @@ if (l) throw l.error;
 }
 var H = s([], i(S.values()), !1);
 try {
-for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) ah(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : go());
+for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) sh(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : go());
 } catch (e) {
 d = {
 error: e
@@ -39928,7 +39929,7 @@ defenseAssist: n
 }(e, t);
 }
 
-var xh = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, bh = /^(\d{1,2})\|(.+)$/, Oh = M("SS2TerminalComms"), kh = function() {
+var Oh = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, kh = /^(\d{1,2})\|(.+)$/, Mh = M("SS2TerminalComms"), Ah = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -39988,11 +39989,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(xh);
+var t = e.match(Oh);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(bh);
+var i = a.match(kh);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -40027,7 +40028,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-Oh.warn("Missing packet in multi-packet message", {
+Mh.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -40043,7 +40044,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), Oh.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), Mh.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -40067,7 +40068,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && Oh.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && Mh.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -40079,7 +40080,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return Oh.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return Mh.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -40087,14 +40088,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), Oh.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), Mh.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (Oh.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (Mh.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -40119,7 +40120,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-Oh.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+Mh.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -40131,7 +40132,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-Oh.info("Completed sending multi-packet message", {
+Mh.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -40139,25 +40140,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? Oh.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? Mh.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (Oh.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (Mh.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else Oh.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else Mh.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else Oh.warn("Terminal not found for queue item, removing from queue", {
+} else Mh.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -40191,7 +40192,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && Oh.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && Mh.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -40201,7 +40202,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-Oh.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+Mh.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -40292,7 +40293,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (Oh.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (Mh.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -40314,7 +40315,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return Oh.error("Error parsing JSON", {
+return Mh.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -40325,7 +40326,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), Mh = [ {
+}(), _h = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -40345,7 +40346,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Ah = function() {
+} ], Uh = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -40392,9 +40393,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), _h = new Ah;
+}(), Nh = new Uh;
 
-function Uh(e) {
+function Ph(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -40402,19 +40403,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function Nh(e, t) {
+function Ih(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Ph(e, t) {
+function Gh(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var Ih = {
+var Lh = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -40425,9 +40426,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, Gh = function() {
+}, Dh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Ih), e);
+void 0 === e && (e = {}), this.config = o(o({}, Lh), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -40448,7 +40449,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = _h.getSwarmState(r.toRoom);
+var o = Nh.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return _.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -40461,7 +40462,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = _h.getSwarmState(c);
+var l = Nh.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -40531,9 +40532,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(Nh), u = n.filter(function(e) {
+}).sort(Ih), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Ph), l = [], m = [], d = function(t) {
+}).sort(Gh), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -40555,11 +40556,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return Uh({
+return Ph({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + Uh({
+}) + Ph({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -40658,7 +40659,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), Lh = new Gh, Dh = {
+}(), Fh = new Dh, Bh = {
 1: {
 guards: 1,
 rangers: 1,
@@ -40679,14 +40680,14 @@ siegeUnits: 1
 }
 };
 
-function Fh(e) {
+function Wh(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function Bh(e) {
+function Hh(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -40709,9 +40710,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function Wh(e) {
+function Kh(e) {
 var t, r, o;
-Bh(e);
+Hh(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -40735,20 +40736,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Hh(e) {
+function Yh(e) {
 var t;
-Bh(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Wh(e);
+Hh(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Kh(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function Kh(e) {
-return !!Hh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function Vh(e) {
+return !!Yh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-Bh(e);
+Hh(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -40759,12 +40760,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = Wh(e);
+var d = Kh(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function Yh(e, t) {
+function qh(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -40785,20 +40786,20 @@ if (r) throw r.error;
 return n;
 }
 
-function Vh(e, t) {
+function jh(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Dh[r]) && void 0 !== t ? t : Dh[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Bh[r]) && void 0 !== t ? t : Bh[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = Yh(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = qh(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: Fh(r),
+targetComposition: Wh(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -40810,7 +40811,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function qh(e) {
+function zh(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return _.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -40830,9 +40831,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function jh(e) {
+function Qh(e) {
 var t = e.members.length;
-Bh(e), e.members.length < t && _.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+Hh(e), e.members.length < t && _.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -40846,7 +40847,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && Kh(e) && (e.state = "moving", _.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && Vh(e) && (e.state = "moving", _.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -40875,7 +40876,7 @@ subsystem: "Squad"
 }
 }
 
-var zh = {
+var Xh = {
 harassment: {
 composition: {
 harassers: 3,
@@ -40962,7 +40963,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Qh(e, t) {
+function Zh(e, t) {
 var r, o, n, a;
 if (!t) return _.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -40977,8 +40978,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Xh(e, t) {
-var r, o, n, i = zh[t], s = 0;
+function Jh(e, t) {
+var r, o, n, i = Xh[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -41004,7 +41005,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var Zh, Jh, $h, eR = {
+var $h, eR, tR, rR = {
 move: 50,
 work: 100,
 carry: 50,
@@ -41013,11 +41014,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, tR = new Map;
+}, oR = new Map;
 
-function rR(e, t) {
+function nR(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (tR.has(m)) _.debug("Squad ".concat(m, " already forming"), {
+if (oR.has(m)) _.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -41029,7 +41030,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = zh[p].composition;
+d = Xh[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -41044,19 +41045,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (tR.set(m, y), function(e, t, r, o) {
+v ? (oR.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = zh[s].useBoosts;
+i = Xh[s].useBoosts;
 }
 var c = hv.NORMAL;
 "siege" === t.type ? c = hv.HIGH : "defense" === t.type && (c = hv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = oR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + eR[t];
-}, 0), m = i ? aR(r) : [], d = {
+var u = aR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + rR[t];
+}, 0), m = i ? sR(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -41099,42 +41100,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function oR(e, t, r) {
+function aR(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return nR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return iR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return nR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return iR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return nR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return iR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return nR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return iR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return nR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return iR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return nR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return iR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function nR(e, t, r) {
+function iR(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + eR[t];
+return e + rR[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + eR[t];
+return e + rR[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function aR(e) {
+function sR(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -41165,45 +41166,45 @@ return [];
 }
 }
 
-function iR(e) {
-return tR.has(e);
+function cR(e) {
+return oR.has(e);
 }
 
-function sR(e) {
-return Hh(e) || Kh(e);
+function uR(e) {
+return Yh(e) || Vh(e);
 }
 
-(Zh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, Zh[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-Zh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (Jh = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-Jh[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, Jh[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-Jh[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, ($h = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-$h[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, $h[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-$h[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, $h[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+($h = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, $h[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+$h[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (eR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+eR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, eR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+eR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (tR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+tR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, tR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+tR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, tR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var cR = {
+var lR = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function uR(e, t) {
-var r = cR[t], o = _h.getClusters();
+function mR(e, t) {
+var r = lR[t], o = Nh.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function lR(e, t, r) {
+function dR(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = _h.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = Nh.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: uR(e, i.danger),
+reservedEnergy: mR(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -41293,7 +41294,7 @@ success: !1
 });
 }
 
-var mR = {
+var pR = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -41303,7 +41304,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function dR(e, t, r) {
+function fR(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -41334,7 +41335,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function pR(e, t, r, o) {
+function yR(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -41344,7 +41345,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function fR(e, t) {
+function vR(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -41365,19 +41366,19 @@ if (r) throw r.error;
 return n;
 }
 
-function yR() {
-var e = _h.getEmpire();
+function gR() {
+var e = Nh.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function vR(e) {
-yR()[e.id] = e;
+function hR(e) {
+gR()[e.id] = e;
 }
 
-function gR(e) {
+function RR(e) {
 e.lastUpdate = Game.time;
-var t = _h.getCluster(e.clusterId);
-if (!t) return e.state = "failed", vR(e), void _.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = Nh.getCluster(e.clusterId);
+if (!t) return e.state = "failed", hR(e), void _.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -41387,12 +41388,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (sR(r) || iR(e) || rR(0, r), sR(r));
+return !!r && (uR(r) || cR(e) || nR(0, r), uR(r));
 }) && (e.state = "executing", _.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", _.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), vR(e);
+})), hR(e);
 }(e, t);
 break;
 
@@ -41403,7 +41404,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (jh(o), qh(o)) {
+if (Qh(o), zh(o)) {
 _.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -41432,7 +41433,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = _h.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = Nh.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -41459,12 +41460,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", _.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), vR(e);
+})), hR(e);
 }(e, t);
 }
 }
 
-function hR(e, t, r) {
+function ER(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -41483,11 +41484,11 @@ score: n.score + o.score
 }
 }
 
-function RR(e, t, r) {
+function TR(e, t, r) {
 return Oo(e, t, r);
 }
 
-function ER(e, t) {
+function CR(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -41500,11 +41501,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function TR(e) {
+function SR(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function CR(e, t, r) {
+function wR(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -41517,8 +41518,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function SR(e, t, r) {
-var o = RR(t, e.energyCapacityAvailable, r);
+function xR(e, t, r) {
+var o = TR(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -41526,16 +41527,16 @@ var a = vo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function wR(e, t, r, o) {
+function bR(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = SR(e, t, o);
-if (s !== SR(n, t, o)) return s ? -1 : 1;
+var a, i, s = xR(e, t, o);
+if (s !== xR(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function xR(e, t) {
+function OR(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -41619,21 +41620,21 @@ if (r) throw r.error;
 return u;
 }
 
-function bR(e, t) {
+function kR(e, t) {
 return {
-guard: Math.max(0, ER(e, "guard") - t.counts.guard),
-ranger: Math.max(0, ER(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, ER(e, "healer") - t.counts.healer)
+guard: Math.max(0, CR(e, "guard") - t.counts.guard),
+ranger: Math.max(0, CR(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, CR(e, "healer") - t.counts.healer)
 };
 }
 
-function OR(e) {
+function MR(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function kR(e, t) {
+function AR(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return OR(e.role);
+return MR(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -41646,12 +41647,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function MR(e) {
+function _R(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ci ? e.targetRoom : void 0;
 }
 
-function AR(e) {
+function UR(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -41663,7 +41664,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-OR(m) && MR(l) === e && !u.spawning && hR(i, m, u.body.filter(function(e) {
+MR(m) && _R(l) === e && !u.spawning && ER(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -41681,7 +41682,7 @@ if (t) throw t.error;
 return i;
 }
 
-function _R(e, t, r) {
+function NR(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -41711,16 +41712,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: kR(e, r)
+pendingAssist: AR(e, r)
 };
 }
 }
 
-function UR(e, t) {
+function PR(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = RR(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = TR(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -41741,7 +41742,7 @@ subsystem: "Cluster"
 }
 }
 
-function NR(e, t, r) {
+function IR(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -41783,20 +41784,20 @@ exitAccess: a
 };
 }
 
-function PR(e, t) {
+function GR(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function IR(e, t, r) {
+function LR(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function GR(e) {
+function DR(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function LR(e, t) {
+function FR(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -41807,7 +41808,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function DR(e, t, r) {
+function BR(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -41818,8 +41819,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = GR(g);
-h && (mi(g) || LR(v, h) && (t.assignedCreeps.includes(v.name) || PR(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = DR(g);
+h && (mi(g) || FR(v, h) && (t.assignedCreeps.includes(v.name) || GR(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -41856,7 +41857,7 @@ return e.distance - t.distance;
 });
 }
 
-function FR(e, t) {
+function WR(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -41881,21 +41882,21 @@ if (r) throw r.error;
 return i;
 }
 
-function BR(e) {
+function HR(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var WR = {
+var KR = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, HR = function() {
+}, YR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, WR), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, KR), e);
 }
 return e.prototype.run = function() {
-var e = _h.getClusters();
+var e = Nh.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -41914,7 +41915,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: Mh.map(function(t) {
+steps: _h.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -41970,7 +41971,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-Lh.processCluster(t);
+Fh.processCluster(t);
 break;
 
 case "squads":
@@ -42002,7 +42003,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = NR(e, new RoomPosition(s, c, e.name), "defense");
+var u = IR(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -42051,9 +42052,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = _h.getSwarmState(i);
+var i = n.value, s = Nh.getSwarmState(i);
 if (s) {
-var c = uR(i, s.danger);
+var c = mR(i, s.danger);
 c > 0 && Game.time % 100 == 0 && _.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -42084,7 +42085,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = _h.getSwarmState(m);
+var m = l.value, d = Nh.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -42116,7 +42117,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += BR(l.controller.level));
+}).length, i += HR(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -42233,7 +42234,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-jh(i), "gathering" !== i.state || sR(i) || iR(i.id) || rR(0, i), qh(i) && (i.state = "dissolving");
+Qh(i), "gathering" !== i.state || uR(i) || cR(i.id) || nR(0, i), zh(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -42258,7 +42259,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Vh(e, s);
+var s = i.value, c = jh(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -42275,7 +42276,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(yR()).filter(function(e) {
+var t = (a = e.id, Object.values(gR()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -42286,22 +42287,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, mR), n), m = [], d = _h.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, pR), n), m = [], d = Nh.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = dR(f, y, d);
+var g = fR(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = fR(e, f);
+var h = vR(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = pR(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = yR(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Qh(f, {
+var C = Zh(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -42336,29 +42337,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Xh(e, n.doctrine) ? function(e, t, r) {
+Jh(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = _h.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = Nh.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return _.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return _.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = dR(e, o, r);
+var n = fR(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (_.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return _.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (_h.getEmpire().knownRooms || {})[t], n = null != r ? r : Qh(t, {
+var o = (Nh.getEmpire().knownRooms || {})[t], n = null != r ? r : Zh(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Xh(e, n)) return _.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!Jh(e, n)) return _.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -42371,7 +42372,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-vR(i);
+hR(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -42385,13 +42386,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = Yh(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = qh(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: Fh(n),
+targetComposition: Wh(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -42406,8 +42407,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), vR(i), rR(0, c), i.state = "forming", i.lastUpdate = Game.time,
-vR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), hR(i), nR(0, c), i.state = "forming", i.lastUpdate = Game.time,
+hR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 _.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), _.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -42426,11 +42427,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(tR.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(oR.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (_.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), tR.delete(c));
+}), oR.delete(c));
 }
 } catch (t) {
 e = {
@@ -42444,10 +42445,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = yR();
-for (var t in e) gR(e[t]);
+var e = gR();
+for (var t in e) RR(e[t]);
 !function() {
-var e = yR();
+var e = gR();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -42525,14 +42526,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = _h.getCluster(t, e);
+var t = "cluster_".concat(e), r = Nh.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return _.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = _h.getCluster(e);
+var o = Nh.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), _.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), _.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -42561,7 +42562,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && lR(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && dR(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -42578,7 +42579,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = _h.getSwarmState(t);
+var n, a, i = Nh.getSwarmState(t);
 if (!i) return "continue";
 if (co(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -42619,7 +42620,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = To(g), f[g] = AR(g);
+p[g] = To(g), f[g] = UR(g);
 }
 } catch (e) {
 r = {
@@ -42635,7 +42636,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = _R(E, m, t);
+d[E] = NR(E, m, t);
 }
 } catch (e) {
 n = {
@@ -42654,13 +42655,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = CR(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = wR(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = xR(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = OR(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Ao(T, R, bR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Ao(T, R, kR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = wR(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = bR(h, b, g.roomName, R), M = 0; M < O; M++) {
 var A = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -42672,7 +42673,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(A.roomName, "_").con
 roomName: A.roomName,
 role: b,
 family: "military",
-priority: TR(g.urgency),
+priority: SR(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -42718,7 +42719,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) UR(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) PR(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -42745,7 +42746,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = FR(f, DR(e, f, t)), v = y.reduce(function(e, t) {
+var y = WR(f, BR(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -42758,7 +42759,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), IR(f, R.role, PR(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), LR(f, R.role, GR(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -42825,19 +42826,19 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), KR = new HR, YR = /^([WE])(\d+)([NS])(\d+)$/;
+}(), VR = new YR, qR = /^([WE])(\d+)([NS])(\d+)$/;
 
-function VR(e) {
-return YR.test(e);
+function jR(e) {
+return qR.test(e);
 }
 
-var qR = {
+var zR = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, jR = function() {
+}, QR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, qR), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, zR), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
@@ -42905,7 +42906,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (VR(x)) {
+if (e.isAlly(x)) f.add(x); else if (jR(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -42977,7 +42978,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), zR = new jR, QR = function() {
+}(), XR = new QR, ZR = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -43054,9 +43055,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), XR = new QR, ZR = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), JR = new ZR, $R = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function JR(e, t) {
+function eE(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -43079,13 +43080,13 @@ if (r) throw r.error;
 return n;
 }
 
-function $R(e) {
+function tE(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function eE(e, t, r) {
-if (!$R(e)) return 0;
-var o = JR(e.name, t);
+function rE(e, t, r) {
+if (!tE(e)) return 0;
+var o = eE(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
 return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += $s(e.mineralType),
@@ -43094,7 +43095,7 @@ n += oc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLeve
 n += ac(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function tE(e, t) {
+function oE(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -43104,13 +43105,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && ZR.has(e.type);
+return e.hits > 0 && $R.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function rE(e, t, r) {
+function nE(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -43120,7 +43121,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function oE(e) {
+function aE(e) {
 return function(e) {
 var t = ee(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -43131,8 +43132,8 @@ isSK: te(t.x) && te(t.y)
 }(e);
 }
 
-function nE(e) {
-var t = oE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function iE(e) {
+var t = aE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -43151,14 +43152,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var aE = {
+var sE = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, iE = function() {
+}, cE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, aE), e);
+void 0 === e && (e = {}), this.config = o(o({}, sE), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -43249,7 +43250,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = oE(e);
+var t = aE(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -43261,14 +43262,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return nE(sE(e));
+return iE(uE(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = nE(sE(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = iE(uE(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function sE(e) {
+function uE(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = X(e), c = Z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -43300,11 +43301,11 @@ swamps: d
 };
 }
 
-var cE = new iE, uE = /^([WE])(\d+)([NS])(\d+)$/, lE = {
+var lE = new cE, mE = /^([WE])(\d+)([NS])(\d+)$/, dE = {
 allies: []
-}, mE = function() {
+}, pE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, lE), e);
+void 0 === e && (e = {}), this.config = o(o({}, dE), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -43324,7 +43325,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!uE.test(e)) return !1;
+if (!mE.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -43432,7 +43433,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return uE.test(e);
+return mE.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -43459,7 +43460,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), dE = new mE, pE = {
+}(), fE = new pE, yE = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -43472,9 +43473,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, fE = function() {
+}, vE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, pE), e);
+void 0 === e && (e = {}), this.config = o(o({}, yE), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = ft.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -43487,7 +43488,7 @@ t.updateExpansionQueue(o);
 }), qi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), qi.measureSubsystem("empire:warTargets", function() {
-dE.updateWarTargets(o);
+fE.updateWarTargets(o);
 }), qi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), qi.measureSubsystem("empire:gclTracking", function() {
@@ -43495,13 +43496,13 @@ t.trackGCLProgress(o);
 }), s && qi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (qi.measureSubsystem("empire:intelRefresh", function() {
-cE.refreshRoomIntel(o);
+lE.refreshRoomIntel(o);
 }), qi.measureSubsystem("empire:roomDiscovery", function() {
-cE.discoverNearbyRooms(o);
+lE.discoverNearbyRooms(o);
 })), s && qi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (qi.measureSubsystem("empire:clusterHealth", function() {
-XR.monitorClusterHealth();
+JR.monitorClusterHealth();
 }), qi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -43584,22 +43585,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = tE(f, u);
+var y = Boolean(Game.rooms[f]), v = oE(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = JR(f, t);
+var g = eE(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = rE(h, u, y);
+var h = e.knownRooms[f], R = nE(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? eE(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? rE(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -43643,10 +43644,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && $R(a)) {
-var i = JR(a.name, t);
+if (a && tE(a)) {
+var i = eE(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = eE(a, t, r);
+var s = rE(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -43966,13 +43967,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), yE = new fE;
+}(), gE = new vE;
 
-function vE(e) {
+function hE(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var gE = {
+var RE = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -43980,10 +43981,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, hE = function() {
+}, EE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, gE), e);
+this.config = o(o({}, RE), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -44127,7 +44128,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, vE(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, hE(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -44302,7 +44303,7 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), RE = new hE, EE = function() {
+}(), TE = new EE, CE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Xs(o(o({}, Gs), e), {
 getEmpire: function() {
@@ -44338,7 +44339,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), TE = new EE, CE = function() {
+}(), SE = new CE, wE = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = ft.getEmpire();
@@ -44356,9 +44357,9 @@ lastScan: 0
 var e = ft.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), SE = new (function(e) {
+}(), xE = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new CE) || this;
+return void 0 === t && (t = {}), e.call(this, t, new wE) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -44370,22 +44371,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ar() ], t);
 }(_i));
 
-function wE() {
+function bE() {
 return global;
 }
 
-function xE(e) {
+function OE(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function bE(e) {
+function kE(e) {
 return Number(null != e ? e : 0);
 }
 
-var OE = function() {
+var ME = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = wE();
+var e = bE();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -44393,12 +44394,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return wE()._pixelGenerationMemory;
+return bE()._pixelGenerationMemory;
 }, e;
-}(), kE = function(e) {
+}(), AE = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new OE) || this;
+var r = e.call(this, t, new ME) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -44415,7 +44416,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(xE).length : Object.values(null != t ? t : {}).filter(xE).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(OE).length : Object.values(null != t ? t : {}).filter(OE).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -44426,9 +44427,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (bE(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (bE(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = bE(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = bE(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (kE(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (kE(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = kE(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = kE(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -44450,9 +44451,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ar() ], t);
-}(Ni), ME = new kE;
+}(Ni), _E = new AE;
 
-function AE(e, t) {
+function UE(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !j(e.controller.owner.username)) return {
 lost: !0,
@@ -44474,7 +44475,7 @@ lost: !1
 };
 }
 
-function _E(e, t, r) {
+function NE(e, t, r) {
 var o, n = ft.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -44488,20 +44489,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var UE = Rt().cpu.bucketThresholds.highMode + 1800, NE = {
+var PE = Rt().cpu.bucketThresholds.highMode + 1800, IE = {
 updateInterval: 250,
-minBucket: UE,
+minBucket: PE,
 maxSitesPerRemotePerTick: 2
 };
 
-function PE(e, t) {
+function GE(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var IE = function() {
+var LE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, NE), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, IE), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -44518,8 +44519,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = AE(l);
-m.lost && m.reason && _E(e, u, m.reason);
+var m = UE(l);
+m.lost && m.reason && NE(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -44537,10 +44538,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = PE("remoteInfrastructure.intent", function() {
+var i = GE("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-PE("remoteInfrastructure.execute", function() {
+GE("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -44706,13 +44707,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = PE("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = GE("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = PE("remoteInfrastructure.roomSnapshot", function() {
+u[t] = GE("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -44745,7 +44746,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = PE("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = GE("remoteInfrastructure.calculateRemoteRoads", function() {
 return ha(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -44774,14 +44775,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = PE("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = GE("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? PE("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? GE("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -44798,7 +44799,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? PE("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? GE("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -44816,7 +44817,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return PE("remoteInfrastructure.findSources", function() {
+return GE("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -44913,10 +44914,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ rr("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Wt.LOW,
 interval: 1e3,
-minBucket: UE,
+minBucket: PE,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), GE = new IE, LE = new (function(e) {
+}(), DE = new LE, FE = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -44928,7 +44929,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ar() ], t);
-}(Mf)), DE = function() {
+}(Mf)), BE = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -45018,7 +45019,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ar() ], e);
-}(), FE = new DE, BE = new (function() {
+}(), WE = new BE, HE = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -45048,7 +45049,7 @@ registerProcesses: function() {
 var e;
 Qu.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), Oi(FE, bs, _s, ns, yE, dc, RE, GE, Ts, SE, ME, TE, qc, Zc, LE, zR, Bc, KR, Ci),
+}), Oi(WE, bs, _s, ns, gE, dc, TE, DE, Ts, xE, _E, SE, qc, Zc, FE, XR, Bc, VR, Ci),
 function() {
 var e, t, r = Rt().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -45103,7 +45104,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return KR.run();
+return VR.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -45144,9 +45145,9 @@ Qu.info("Registered ".concat(bi.getProcesses().length, " processes with kernel")
 subsystem: "ProcessRegistry"
 });
 }
-}), WE = "_ownedRooms", HE = "_ownedRoomsTick";
+}), KE = "_ownedRooms", YE = "_ownedRoomsTick";
 
-function KE(e) {
+function VE(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -45156,13 +45157,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var YE = ju("NativeCallsTracker");
+var qE = ju("NativeCallsTracker");
 
-function VE(e, t, r) {
+function jE(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) YE.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) qE.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -45178,7 +45179,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-YE.warn("Failed to wrap method", {
+qE.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -45188,30 +45189,30 @@ error: String(e)
 }
 }
 
-var qE, jE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], zE = "shard1", QE = {
+var zE, QE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], XE = "shard1", ZE = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, XE = {
+}, JE = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, ZE = {
+}, $E = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function JE() {
+function eT() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function $E() {
+function tT() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: jE,
+targetShards: QE,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -45221,11 +45222,11 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = jE),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = QE),
 Memory.interShardOperation;
 }
 
-function eT() {
+function rT() {
 return Tf({
 version: 1,
 shards: {},
@@ -45239,32 +45240,32 @@ checksum: 0
 });
 }
 
-function tT(e, t) {
+function oT(e, t) {
 void 0 === t && (t = [ "footprintOperation" ]), Cf(e, {
 updatedSections: t
 });
 }
 
-function rT() {
-var e, t, r, o, n, i, s, c = eT(), u = JE();
+function nT() {
+var e, t, r, o, n, i, s, c = rT(), u = eT();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: jE,
+targetShards: QE,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : jE,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : QE,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && oT() ? "established" : "unreached",
+status: p === u && aT() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -45282,7 +45283,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === zE ? "core" : "frontier",
+role: u === XE ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -45299,24 +45300,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), tT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), oT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function oT() {
+function aT() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function nT() {
+function iT() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function aT(e, t) {
+function sT(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -45335,7 +45336,7 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(nT()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(iT()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 s += Nv.getPendingRequests(p.name).filter(function(r) {
 var o;
@@ -45356,7 +45357,7 @@ if (n) throw n.error;
 return s;
 }
 
-function iT(e) {
+function cT(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -45400,7 +45401,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = eT().shards[JE()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = rT().shards[eT()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -45410,8 +45411,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function sT(e, t) {
-if (!(aT("scout", t) >= 1)) {
+function uT(e, t) {
+if (!(sT("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -45454,7 +45455,7 @@ id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: ZE,
+body: $E,
 priority: hv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
@@ -45466,13 +45467,13 @@ task: "interShardPortalScout"
 }
 }
 
-function cT(e, t, r) {
-aT("interShardClaimer", t) >= 1 || Nv.addRequest({
+function lT(e, t, r) {
+sT("interShardClaimer", t) >= 1 || Nv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: QE,
+body: ZE,
 priority: hv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
@@ -45486,13 +45487,13 @@ workflowState: "movingToPortal"
 });
 }
 
-function uT(e, t, r) {
-aT("interShardScout", t) >= 1 || Nv.addRequest({
+function mT(e, t, r) {
+sT("interShardScout", t) >= 1 || Nv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: ZE,
+body: $E,
 priority: hv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
@@ -45506,14 +45507,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function lT(e, t, r) {
+function dT(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (aT("interShardPioneer", t.shard) >= 3 || Nv.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (sT("interShardPioneer", t.shard) >= 3 || Nv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: XE,
+body: JE,
 priority: hv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
@@ -45527,16 +45528,16 @@ workflowState: "movingToPortal"
 }));
 }
 
-function mT(e) {
+function pT(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = JE(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = eT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : jE), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : QE), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
 var f = InterShardMemory.getRemote(p), y = f ? yf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
@@ -45571,7 +45572,7 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(nT()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(iT()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 n += Nv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
@@ -45592,7 +45593,7 @@ return n;
 }() < o;
 }
 
-(qE = {
+(zE = {
 optimizeBody: Mv,
 spawnQueue: {
 addRequest: function(e) {
@@ -45604,10 +45605,10 @@ LOW: hv.LOW,
 NORMAL: hv.NORMAL,
 HIGH: hv.HIGH
 }
-}).optimizeBody && (_f.optimizeBody = qE.optimizeBody), qE.spawnQueue && (_f.spawnQueue = qE.spawnQueue),
-qE.spawnPriorities && (_f.spawnPriorities = o(o({}, _f.spawnPriorities), qE.spawnPriorities));
+}).optimizeBody && (_f.optimizeBody = zE.optimizeBody), zE.spawnQueue && (_f.spawnQueue = zE.spawnQueue),
+zE.spawnPriorities && (_f.spawnPriorities = o(o({}, _f.spawnPriorities), zE.spawnPriorities));
 
-var dT, pT = function() {
+var fT, yT = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -45651,7 +45652,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function fT(e) {
+function vT(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -45672,7 +45673,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function yT(e, t, r) {
+function gT(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -45738,16 +45739,16 @@ return u;
 });
 }
 
-function vT(e) {
+function hT(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(dT || (dT = {}));
+}(fT || (fT = {}));
 
-var gT = function() {
+var RT = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -45785,8 +45786,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = yT(h.pos, T.pos, this.logger);
-if (vT(C)) {
+var T = E.value, C = gT(h.pos, T.pos, this.logger);
+if (hT(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -45813,8 +45814,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, M = yT(k, u.pos, this.logger);
-vT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, M = gT(k, u.pos, this.logger);
+hT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -45853,8 +45854,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = yT(e, t, this.logger);
-if (vT(n)) {
+var n = gT(e, t, this.logger);
+if (hT(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -45864,7 +45865,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), hT = function() {
+}(), ET = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -45874,7 +45875,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = fT(s);
+var c = vT(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -45900,7 +45901,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), RT = function() {
+}(), TT = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -45949,7 +45950,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), ET = {
+}(), CT = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -45962,7 +45963,7 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, TT = {
+}, ST = {
 getCachedPath: function(e, t) {
 var r = yr(e, t), o = bt.get(r, {
 namespace: fr
@@ -45989,7 +45990,7 @@ direction: a
 }
 return t;
 }
-}, CT = {
+}, wT = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
 void 0 === o && (o = Km.MEDIUM), ed.register({
@@ -46002,13 +46003,13 @@ skippable: o !== Km.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, ST = new gT(TT, ET), wT = new hT(ET, CT, ST), xT = new RT(ET, TT, ST, ul.moveTo);
+}, xT = new RT(ST, CT), bT = new ET(CT, wT, xT), OT = new TT(CT, ST, xT, ul.moveTo);
 
-function bT(e, t, r, o) {
-return xT.moveToWithRemoteCache(e, t, r, o);
+function kT(e, t, r, o) {
+return OT.moveToWithRemoteCache(e, t, r, o);
 }
 
-var OT, kT = function() {
+var MT, AT = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -46021,12 +46022,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), MT = function() {
+}(), _T = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 Yt.on(e, t);
 }, e;
-}(), AT = function() {
+}(), UT = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -46071,28 +46072,28 @@ m.length > 0 && vr(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), _T = function() {
+}(), NT = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return fT(e);
+return vT(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-ST.precacheRemoteRoutes(e, t);
+xT.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), UT = new pT(new kT, new MT, new AT, new _T), NT = {
+}(), PT = new yT(new AT, new _T, new UT, new NT), IT = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, PT = function() {
+}, GT = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, NT), e);
+this.config = o(o({}, IT), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -46186,123 +46187,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new PT, (OT = {})[FIND_STRUCTURES] = {
+new GT, (MT = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, OT[FIND_MY_STRUCTURES] = {
+}, MT[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, OT[FIND_HOSTILE_STRUCTURES] = {
+}, MT[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, OT[FIND_SOURCES_ACTIVE] = {
+}, MT[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, OT[FIND_SOURCES] = {
+}, MT[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, OT[FIND_MINERALS] = {
+}, MT[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, OT[FIND_DEPOSITS] = {
+}, MT[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, OT[FIND_MY_CONSTRUCTION_SITES] = {
+}, MT[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, OT[FIND_CONSTRUCTION_SITES] = {
+}, MT[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, OT[FIND_CREEPS] = {
+}, MT[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, OT[FIND_MY_CREEPS] = {
+}, MT[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, OT[FIND_HOSTILE_CREEPS] = {
+}, MT[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, OT[FIND_DROPPED_RESOURCES] = {
+}, MT[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, OT[FIND_TOMBSTONES] = {
+}, MT[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, OT[FIND_RUINS] = {
+}, MT[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, OT[FIND_FLAGS] = {
+}, MT[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, OT[FIND_MY_SPAWNS] = {
+}, MT[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, OT[FIND_HOSTILE_SPAWNS] = {
+}, MT[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, OT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, MT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, OT[FIND_NUKES] = {
+}, MT[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, OT[FIND_POWER_CREEPS] = {
+}, MT[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, OT[FIND_MY_POWER_CREEPS] = {
+}, MT[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, OT[FIND_HOSTILE_POWER_CREEPS] = {
+}, MT[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, OT[FIND_EXIT_TOP] = {
+}, MT[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, OT[FIND_EXIT_RIGHT] = {
+}, MT[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, OT[FIND_EXIT_BOTTOM] = {
+}, MT[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, OT[FIND_EXIT_LEFT] = {
+}, MT[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, OT[FIND_EXIT] = {
+}, MT[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var IT = new pe({}, ft), GT = new Se({}, ft);
+var LT = new pe({}, ft), DT = new Se({}, ft);
 
-function LT(e) {
+function FT(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -46310,11 +46311,11 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var DT = !1;
+var BT = !1;
 
-function FT() {
+function WT() {
 var e, t;
-DT || (Nu({
+BT || (Nu({
 level: (t = Rt()).debug ? mu.DEBUG : mu.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
@@ -46401,7 +46402,7 @@ return Ru.getLabOverflow(e);
 }), qi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) YE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) qE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -46415,7 +46416,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-YE.warn("Failed to wrap PathFinder.search", {
+qE.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -46423,11 +46424,11 @@ error: String(e)
 }
 }
 }
-}(), VE(e = Creep.prototype, "moveTo", "moveTo"), VE(e, "move", "move"), VE(e, "harvest", "harvest"),
-VE(e, "transfer", "transfer"), VE(e, "withdraw", "withdraw"), VE(e, "build", "build"),
-VE(e, "repair", "repair"), VE(e, "upgradeController", "upgradeController"), VE(e, "attack", "attack"),
-VE(e, "rangedAttack", "rangedAttack"), VE(e, "heal", "heal"), VE(e, "dismantle", "dismantle"),
-VE(e, "say", "say")), function(e) {
+}(), jE(e = Creep.prototype, "moveTo", "moveTo"), jE(e, "move", "move"), jE(e, "harvest", "harvest"),
+jE(e, "transfer", "transfer"), jE(e, "withdraw", "withdraw"), jE(e, "build", "build"),
+jE(e, "repair", "repair"), jE(e, "upgradeController", "upgradeController"), jE(e, "attack", "attack"),
+jE(e, "rangedAttack", "rangedAttack"), jE(e, "heal", "heal"), jE(e, "dismantle", "dismantle"),
+jE(e, "say", "say")), function(e) {
 void 0 === e && (e = Lt);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, kt.L1, {
@@ -46614,15 +46615,15 @@ room: e.homeRoom
 }), _.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(bi, ft, hy), UT.initializePathCacheEvents(), wT.initialize(Km.MEDIUM), Xl = bT,
-He.initialize(), LE.initialize(), DT = !0), ft.initialize();
-var r = BE.configureForCurrentTick();
+}(bi, ft, hy), PT.initializePathCacheEvents(), bT.initialize(Km.MEDIUM), Xl = kT,
+He.initialize(), FE.initialize(), BT = !0), ft.initialize();
+var r = HE.configureForCurrentTick();
 "critical" === r && Game.time % 10 == 0 && Qu.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = $E();
-if (!1 !== r.enabled && (r.lastRun = Game.time, rT(), function() {
-var e, t, r, o, n = eT(), a = n.footprintOperation, i = JE(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = tT();
+if (!1 !== r.enabled && (r.lastRun = Game.time, nT(), function() {
+var e, t, r, o, n = rT(), a = n.footprintOperation, i = eT(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -46635,15 +46636,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, tT(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, oT(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = $E();
+var e, t, r, n, i, s, c = tT();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : jE), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === zE ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : QE), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === XE ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -46661,7 +46662,7 @@ d && Game.cpu.setShardLimits(m) === OK && _.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !oT())) try {
+}(), !aT())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
 "interShardClaimer" !== c && "interShardScout" !== c || zf(s), "interShardPioneer" === c && jf(s);
@@ -46688,17 +46689,17 @@ subsystem: "SwarmBot"
 Game.time % 10 == 0 && Qu.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: DT
+systemsInitialized: BT
 }
-}), BE.ensureProcessesRegistered(), qi.startTick(), tl.clear(), BE.startEventTick();
+}), HE.ensureProcessesRegistered(), qi.startTick(), tl.clear(), HE.startEventTick();
 var i = function(e) {
-var t = e.cache[WE], r = e.cache[HE];
+var t = e.cache[KE], r = e.cache[YE];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[WE] = o, e.cache[HE] = e.tick, o;
+return e.cache[KE] = o, e.cache[YE] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -46735,15 +46736,15 @@ if (e) throw e.error;
 }
 }), qi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = $E();
+var e, t, r, o = tT();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = rT();
+var n = nT();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : jE), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : QE), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== JE()) try {
+if (d !== eT()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
 var f = yf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
@@ -46764,20 +46765,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = nT().sort(function(e, t) {
+var i = iT().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : jE), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : QE), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== JE()) {
+if (u !== eT()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = iT(u);
+var m = cT(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? lT(i, l, m) : mT() ? cT(i, u, m) : (uT(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (sT(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? dT(i, l, m) : pT() ? lT(i, u, m) : (mT(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (uT(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -46794,8 +46795,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = eT();
-d.footprintOperation = n, tT(d);
+var d = rT();
+d.footprintOperation = n, oT(d);
 }
 }
 })(), function() {
@@ -46803,8 +46804,8 @@ var e, t, r, o = Game.cpu.bucket < Rt().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if (null === (r = s.controller) || void 0 === r ? void 0 : r.my) if (!o || LT(s)) {
-var c = wh(s, ft.getOrInitSwarmState(s.name));
+if (null === (r = s.controller) || void 0 === r ? void 0 : r.my) if (!o || FT(s)) {
+var c = bh(s, ft.getOrInitSwarmState(s.name));
 qi.recordSpawnQueue(s.name, c.stats, c.spawned), qi.recordDefenseAssist(s.name, c.defenseAssist);
 } else qi.recordDefenseAssist(s.name, []);
 }
@@ -46823,11 +46824,11 @@ if (e) throw e.error;
 }), ul.preTick(), qi.measureSubsystem("processSync", function() {
 ay.syncCreepProcesses(), iv.syncRoomProcesses();
 }), qi.measureSubsystem("kernel", function() {
-BE.runProcesses();
+HE.runProcesses();
 }), qi.measureSubsystem("eventQueue", function() {
-BE.processQueuedEvents();
+HE.processQueuedEvents();
 }), qi.measureSubsystem("ss2PacketQueue", function() {
-kh.processQueue();
+Ah.processQueue();
 }), bi.hasCpuBudget() && qi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
@@ -46848,7 +46849,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), KE({
+}), VE({
 hasCpuBudget: bi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && qi.measureSubsystem("visualizations", function() {
@@ -46858,8 +46859,8 @@ var r, o;
 if (Rt().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = IT.getConfig(), s = GT.getConfig();
-IT.setConfig(n.roomVisualizerConfig), n.renderMap && GT.setConfig(n.mapVisualizerConfig);
+var i = LT.getConfig(), s = DT.getConfig();
+LT.setConfig(n.roomVisualizerConfig), n.renderMap && DT.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -46870,7 +46871,7 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-IT.draw(m);
+LT.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
 Qu.error("Visualization error in ".concat(m.name, ": ").concat(d), {
@@ -46892,14 +46893,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-GT.draw();
+DT.draw();
 } catch (e) {
 d = e instanceof Error ? e.message : String(e), Qu.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-IT.setConfig(i), GT.setConfig(s);
+LT.setConfig(i), DT.setConfig(s);
 }
 }
 }
@@ -46984,7 +46985,7 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), ul.reconcileTraffic(), KE({
+}), ul.reconcileTraffic(), VE({
 hasCpuBudget: bi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && qi.measureSubsystem("scheduledTasks", function() {
@@ -46996,7 +46997,7 @@ return e.set(t.id, t), e;
 qi.finalizeTick(), Qu.flush();
 }
 
-var BT = function() {
+var HT = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Rt().visualizations;
@@ -47004,25 +47005,25 @@ return Et({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = IT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = LT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-IT.toggle(o);
-var n = IT.getConfig()[o];
+LT.toggle(o);
+var n = LT.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = GT.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = DT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-GT.toggle(o);
-var n = GT.getConfig()[o];
+DT.toggle(o);
+var n = DT.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = GT.getConfig();
+var e = DT.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -47145,15 +47146,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), WT = function() {
+}(), KT = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = LE.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = FE.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = LE.getAllShards();
+var e, t, r = FE.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -47175,9 +47176,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (LE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (FE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = LE.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = FE.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -47202,16 +47203,16 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = LE.getOptimalPortalRoute(e, t);
+var r, o = FE.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (LE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (FE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (LE.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (FE.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
 var e, t, r = Nf.getActiveRequests();
@@ -47235,7 +47236,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = LE.getCurrentShardState();
+var e, t, r = FE.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -47256,7 +47257,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = LE.getActiveTransferTasks();
+var e, t, r, o = FE.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -47277,16 +47278,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = LE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+var e = FE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
 return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(hf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = LE.getMemoryStats();
+var e = FE.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return LE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return FE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = eT().footprintOperation;
+var e, t, r, o = rT().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -47392,9 +47393,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), HT = new WT;
+}(), YT = new KT;
 
-function KT(e) {
+function VT(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -47424,7 +47425,7 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? KT(e.metadata.usage) : void 0
+params: e.metadata.usage ? VT(e.metadata.usage) : void 0
 };
 });
 return ud({
@@ -47636,39 +47637,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var YT = new cv, VT = new BT, qT = new uv, jT = new Xu, zT = new sv, QT = new lv, XT = new mv, ZT = "__screepsGlobalRuntimeDiagnostics";
+var qT = new cv, jT = new HT, zT = new uv, QT = new Xu, XT = new sv, ZT = new lv, JT = new mv, $T = "__screepsGlobalRuntimeDiagnostics";
 
-function JT() {
+function eC() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function $T(e, t) {
+function tC(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function eC(e, t) {
+function rC(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function tC(e) {
+function oC(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function rC(e) {
+function nC(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: $T(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: $T(n.switchCount, 0),
-lastTick: eC(n.lastTick, Game.time),
-lastResetTick: eC(n.lastResetTick, Game.time),
-lastSwitchTick: tC(n.lastSwitchTick),
-lastSwitchPreviousTick: tC(n.lastSwitchPreviousTick),
-lastWarningTick: tC(n.lastWarningTick)
+resetCount: tC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: tC(n.switchCount, 0),
+lastTick: rC(n.lastTick, Game.time),
+lastResetTick: rC(n.lastResetTick, Game.time),
+lastSwitchTick: oC(n.lastSwitchTick),
+lastSwitchPreviousTick: oC(n.lastSwitchPreviousTick),
+lastWarningTick: oC(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -47682,13 +47683,13 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var oC = ju("Main");
+var aC = ju("Main");
 
 vt.register(), function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-qr.initialize(), zr(YT), zr(VT), zr(qT), zr(jT), zr(zT), zr(QT), zr(XT), zr(Su),
-zr(wu), zr(xu), zr(HT), zr(eo), zr(fc), zr(Kc), global.tooangel = Wc;
+qr.initialize(), zr(qT), zr(jT), zr(zT), zr(QT), zr(XT), zr(ZT), zr(JT), zr(Su),
+zr(wu), zr(xu), zr(YT), zr(eo), zr(fc), zr(Kc), global.tooangel = Wc;
 var e = global;
 e.botConfig = {
 getConfig: Rt,
@@ -47703,12 +47704,12 @@ try {
 vt.run(), function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : JT, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[ZT];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : eC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[$T];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[ZT] = s, function(e, t) {
-var r, o = rC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[$T] = s, function(e, t) {
+var r, o = nC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -47726,7 +47727,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = rC(e.heapId);
+var n, a = nC(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -47747,14 +47748,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = rC(s.heapId);
+var u = nC(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 }({
-logger: oC
-}), FT();
+logger: aC
+}), WT();
 } catch (e) {
-throw oC.error("Critical error in main loop: ".concat(String(e)), {
+throw aC.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-spawn/src/creepCounts.ts
+++ b/packages/screeps-spawn/src/creepCounts.ts
@@ -12,11 +12,13 @@ type CreepCountCacheValue = Map<string, number> | number;
 const creepCountCache = new Map<string, CreepCountCacheValue>();
 let creepCountCacheTick = -1;
 let creepCountCacheRef: Record<string, Creep> | null = null;
+let remoteCreepCountIndex: Map<string, number> | null = null;
 
 function ensureCurrentCreepCountCache(): void {
   if (creepCountCacheTick === Game.time && creepCountCacheRef === Game.creeps) return;
 
   creepCountCache.clear();
+  remoteCreepCountIndex = null;
   creepCountCacheTick = Game.time;
   creepCountCacheRef = Game.creeps;
 }
@@ -72,14 +74,35 @@ export function countCreepsOfRole(roomName: string, role: string): number {
   return count;
 }
 
+const REMOTE_COUNT_KEY_SEPARATOR = "\u001f";
+
+function getRemoteCreepCountKey(homeRoom: string, role: string, targetRoom: string): string {
+  return `${homeRoom}${REMOTE_COUNT_KEY_SEPARATOR}${role}${REMOTE_COUNT_KEY_SEPARATOR}${targetRoom}`;
+}
+
+function getRemoteCreepCountIndex(): Map<string, number> {
+  ensureCurrentCreepCountCache();
+
+  if (remoteCreepCountIndex) return remoteCreepCountIndex;
+
+  const counts = new Map<string, number>();
+  for (const name in Game.creeps) {
+    const creep = Game.creeps[name];
+    const memory = creep.memory as unknown as SwarmCreepMemory;
+    const homeRoom = memory.homeRoom;
+    const role = memory.role;
+    const targetRoom = memory.targetRoom;
+    if (!homeRoom || !role || !targetRoom) continue;
+
+    const cacheKey = getRemoteCreepCountKey(homeRoom, role, targetRoom);
+    counts.set(cacheKey, (counts.get(cacheKey) ?? 0) + 1);
+  }
+
+  remoteCreepCountIndex = counts;
+  return counts;
+}
+
 /** Count remote creeps for one home room, role, and assigned target room. */
 export function countRemoteCreepsByTargetRoom(homeRoom: string, role: string, targetRoom: string): number {
-  let count = 0;
-  for (const creep of Object.values(Game.creeps)) {
-    const memory = creep.memory as unknown as SwarmCreepMemory;
-    if (memory.homeRoom === homeRoom && memory.role === role && memory.targetRoom === targetRoom) {
-      count++;
-    }
-  }
-  return count;
+  return getRemoteCreepCountIndex().get(getRemoteCreepCountKey(homeRoom, role, targetRoom)) ?? 0;
 }

--- a/packages/screeps-spawn/test/creepCounts.test.ts
+++ b/packages/screeps-spawn/test/creepCounts.test.ts
@@ -61,4 +61,45 @@ describe("spawn creep count helpers", () => {
 
     expect(countRemoteCreepsByTargetRoom("E1N1", "remoteHarvester", "E2N1")).to.equal(2);
   });
+
+  it("reuses one same-tick remote count index across target queries", () => {
+    let memoryReads = 0;
+    const createTrackedCreep = (memory: Partial<CreepMemory>): Creep =>
+      Object.defineProperty({ spawning: false }, "memory", {
+        get: () => {
+          memoryReads += 1;
+          return memory;
+        }
+      }) as Creep;
+
+    Game.creeps = {
+      remoteA: createTrackedCreep({ role: "remoteHarvester", homeRoom: "E1N1", targetRoom: "E2N1" }),
+      remoteB: createTrackedCreep({ role: "remoteHarvester", homeRoom: "E1N1", targetRoom: "E2N1" }),
+      remoteC: createTrackedCreep({ role: "remoteHarvester", homeRoom: "E1N1", targetRoom: "E3N1" }),
+      remoteD: createTrackedCreep({ role: "remoteHarvester", homeRoom: "E4N1", targetRoom: "E2N1" }),
+      guard: createTrackedCreep({ role: "remoteGuard", homeRoom: "E1N1", targetRoom: "E2N1" })
+    };
+
+    expect(countRemoteCreepsByTargetRoom("E1N1", "remoteHarvester", "E2N1")).to.equal(2);
+    expect(countRemoteCreepsByTargetRoom("E1N1", "remoteHarvester", "E3N1")).to.equal(1);
+    expect(countRemoteCreepsByTargetRoom("E1N1", "remoteGuard", "E2N1")).to.equal(1);
+    expect(memoryReads).to.equal(Object.keys(Game.creeps).length);
+  });
+
+  it("invalidates the remote count index when Game.creeps changes or the tick advances", () => {
+    Game.creeps = {
+      remoteA: createCreep({ role: "remoteHarvester", homeRoom: "E1N1", targetRoom: "E2N1" })
+    };
+    expect(countRemoteCreepsByTargetRoom("E1N1", "remoteHarvester", "E2N1")).to.equal(1);
+
+    Game.creeps = {
+      ...Game.creeps,
+      remoteB: createCreep({ role: "remoteHarvester", homeRoom: "E1N1", targetRoom: "E2N1" })
+    };
+    expect(countRemoteCreepsByTargetRoom("E1N1", "remoteHarvester", "E2N1")).to.equal(2);
+
+    Game.creeps.remoteC = createCreep({ role: "remoteHarvester", homeRoom: "E1N1", targetRoom: "E2N1" });
+    Game.time += 1;
+    expect(countRemoteCreepsByTargetRoom("E1N1", "remoteHarvester", "E2N1")).to.equal(3);
+  });
 });


### PR DESCRIPTION
## Summary
- Cache remote creep counts once per tick in `@ralphschuler/screeps-spawn`.
- Reuse the indexed counts for repeated `(homeRoom, role, targetRoom)` spawn-demand queries.
- Update the tracked bot bundle so bundle drift stays clean.

## Linked issue
Closes #3147

## Changes
- Code: added a tick/ref-scoped remote creep count index in `packages/screeps-spawn/src/creepCounts.ts`.
- Tests: added coverage proving same-tick reuse plus invalidation on `Game.creeps` reference change and tick advance.
- Bundle: regenerated `packages/screeps-bot/dist/main.js`.

## Validation
- PASS (expected RED before implementation): `npm test -w @ralphschuler/screeps-spawn -- --grep "spawn creep count helpers"` failed with `expected 15 to equal 5`.
- PASS: `npm test -w @ralphschuler/screeps-spawn -- --grep "spawn creep count helpers"`.
- PASS: `npm test -w @ralphschuler/screeps-spawn`.
- PASS: `npm run lint -w @ralphschuler/screeps-spawn`.
- PASS: `npm run build -w @ralphschuler/screeps-spawn`.
- PASS on Node 24.18.0: `npm run check-versions`.
- PASS on Node 24.18.0: `npm run sync:deps:check`.
- PASS on Node 24.18.0: `npm run build`.
- PASS on Node 24.18.0: `npm run lint:spawn`.
- PASS on Node 24.18.0: `npm test -w @ralphschuler/screeps-spawn`.
- PASS on Node 24.18.0: `npm run check:alliance-safety`.
- PASS on Node 24.18.0: `npm test`.
- PASS after commit: `npm run check:bot-bundle-drift`.

## Deployment impact
- Runtime-affecting spawn CPU optimization; no config or Memory migration.
- Deploy path remains `npm run push`/`npm run deploy`; tracked bundle was regenerated.

## Scope notes
- This PR only addresses #3147 remote role count caching.
- Other `Game.creeps` scans in spawn/defense demand code remain separate existing backlog work and are not changed here.
