### PR TITLE
[codex] Reuse roles structure cache for mineral containers

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/context.ts
@@ -354,15 +354,14 @@ function getTombstones(cache: RoomCache): Tombstone[] {
  */
 function getMineralContainers(cache: RoomCache): StructureContainer[] {
   if (cache._mineralContainers === undefined) {
-    cache._mineralContainers = cache.room.find(FIND_STRUCTURES, {
-      filter: s => {
-        if (s.structureType !== STRUCTURE_CONTAINER) return false;
-        const container = s ;
-        // Check for any non-energy resources
-        const resources = Object.keys(container.store) as ResourceConstant[];
-        return resources.some(r => r !== RESOURCE_ENERGY && container.store.getUsedCapacity(r) > 0);
-      }
-    }) ;
+    ensureAllStructuresLoaded(cache);
+    cache._mineralContainers = cache.allStructures.filter((s): s is StructureContainer => {
+      if (s.structureType !== STRUCTURE_CONTAINER) return false;
+      const container = s as StructureContainer;
+      // Check for any non-energy resources
+      const resources = Object.keys(container.store) as ResourceConstant[];
+      return resources.some(r => r !== RESOURCE_ENERGY && container.store.getUsedCapacity(r) > 0);
+    });
   }
   return cache._mineralContainers;
 }

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -250,6 +250,67 @@ describe("Behavior Contracts", () => {
     expect(findCounts.get(FIND_STRUCTURES)).to.equal(1);
   });
 
+  it("reuses cached structures for regular and mineral containers", () => {
+    const room = createMockRoom("W1N1");
+    const energyContainer = {
+      id: "energy-container" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      pos: { x: 10, y: 10, roomName: room.name },
+      store: makeEnergyStore(500, 2000)
+    } as unknown as StructureContainer;
+    const mineralContainer = {
+      id: "mineral-container" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      pos: { x: 20, y: 20, roomName: room.name },
+      store: {
+        [RESOURCE_ENERGY]: 0,
+        [RESOURCE_HYDROGEN]: 100,
+        getUsedCapacity: (resource?: ResourceConstant) => {
+          if (resource === undefined) return 100;
+          if (resource === RESOURCE_HYDROGEN) return 100;
+          return 0;
+        },
+        getFreeCapacity: () => 1900,
+        getCapacity: () => 2000
+      }
+    } as unknown as StructureContainer;
+    const road = {
+      id: "road" as Id<StructureRoad>,
+      structureType: STRUCTURE_ROAD,
+      pos: { x: 15, y: 15, roomName: room.name }
+    } as unknown as StructureRoad;
+    const structures = [energyContainer, mineralContainer, road] as Structure[];
+    const findCounts = new Map<FindConstant, number>();
+    (room as unknown as { find: Room["find"] }).find = ((type: FindConstant, opts?: { filter?: (structure: Structure) => boolean }) => {
+      findCounts.set(type, (findCounts.get(type) ?? 0) + 1);
+      if (type !== FIND_STRUCTURES) return [];
+      return opts?.filter ? structures.filter(opts.filter) : structures;
+    }) as Room["find"];
+    const creep = createMockCreep("hauler1", {
+      room,
+      memory: { role: "hauler", homeRoom: room.name, working: false }
+    });
+
+    Game.rooms[room.name] = room;
+    Game.creeps[creep.name] = creep;
+    clearRoomCaches();
+
+    const ctx = createRuntimeContext(creep);
+
+    expect(ctx.containers).to.deep.equal([energyContainer, mineralContainer]);
+    expect(ctx.mineralContainers).to.deep.equal([mineralContainer]);
+    expect(ctx.mineralContainers).to.deep.equal([mineralContainer]);
+    expect(findCounts.get(FIND_STRUCTURES)).to.equal(1);
+
+    findCounts.clear();
+    clearRoomCaches();
+    const mineralFirstContext = createRuntimeContext(creep);
+
+    expect(mineralFirstContext.mineralContainers).to.deep.equal([mineralContainer]);
+    expect(mineralFirstContext.containers).to.deep.equal([energyContainer, mineralContainer]);
+    expect(findCounts.get(FIND_STRUCTURES)).to.equal(1);
+  });
+
   it("keeps builder, upgrader, and hauler critical energy delivery priority aligned", () => {
     const extension = {
       id: "extension1",

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -22862,14 +22862,12 @@ e._tombstones;
 var e;
 },
 get mineralContainers() {
-return void 0 === (e = i)._mineralContainers && (e._mineralContainers = e.room.find(FIND_STRUCTURES, {
-filter: function(e) {
+return void 0 === (e = i)._mineralContainers && (rl(e), e._mineralContainers = e.allStructures.filter(function(e) {
 if (e.structureType !== STRUCTURE_CONTAINER) return !1;
 var t = e;
 return Object.keys(t.store).some(function(e) {
 return e !== RESOURCE_ENERGY && t.store.getUsedCapacity(e) > 0;
 });
-}
 })), e._mineralContainers;
 var e;
 }


### PR DESCRIPTION
## Summary
- Reuses the roles room-context `allStructures` cache when deriving `mineralContainers`.
- Prevents duplicate `FIND_STRUCTURES` scans when hauler behavior accesses regular and mineral container views in the same room/tick.

## Linked issue
Refs #3176

This is a focused stage for the existing issue, not a full closure of every remaining Game/room scan candidate.

## Changes
- Code: `getMineralContainers` now calls the existing lazy `ensureAllStructuresLoaded` path and filters cached structures.
- Tests: added behavior-contract coverage for both access orders (`containers` then `mineralContainers`, and reverse) proving one structure scan.
- Build artifact: refreshed `packages/screeps-bot/dist/main.js` with the source change.

## Validation
- `npm test -w @ralphschuler/screeps-roles -- --grep "reuses cached structures"` (Node 24) — pass
- `npm test -w @ralphschuler/screeps-roles` (Node 24) — pass, 178 passing
- `npm run lint:roles` (Node 24) — pass; existing module-type warning only
- `npm run build:roles` (Node 24) — pass
- `npm run build:bot` (Node 24) — pass; bundle size 1324KB / 2048KB
- `npm run sync:deps:check` (Node 24) — pass
- `npm run check-versions` (Node 24) — pass
- `git diff --check` — pass

## Deployment impact
Runtime CPU improvement only: haulers/roles reuse a per-tick room structure scan for mineral-container lookup. Screeps deploy path remains unchanged.

## Scope notes
Remaining `Object.values(Game.rooms)` and other room-scan candidates from #3176 stay open for later stages in the same existing issue.
