### PR TITLE
[codex] Reuse economy GameObjectCache owned rooms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9595,6 +9595,7 @@
       "version": "0.1.0",
       "license": "Unlicense",
       "dependencies": {
+        "@ralphschuler/screeps-cache": "*",
         "@ralphschuler/screeps-core": "*",
         "@ralphschuler/screeps-kernel": "*",
         "@ralphschuler/screeps-memory": "*",

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5965,31 +5965,45 @@ function br(e) {
 xr(e);
 }
 
-var Or = [];
+function Or() {
+var e;
+return null !== (e = bt.get("ownedRooms", {
+namespace: "game",
+ttl: 0,
+compute: function() {
+return Object.values(Game.rooms).filter(function(e) {
+var t;
+return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
+});
+}
+})) && void 0 !== e ? e : [];
+}
 
-function kr(e, t, r) {
-Or.some(function(o) {
+var kr = [];
+
+function Mr(e, t, r) {
+kr.some(function(o) {
 return o.target === r && o.methodName === t && o.metadata.name === e.name;
-}) || Or.push({
+}) || kr.push({
 metadata: e,
 methodName: t,
 target: r
 });
 }
 
-var Mr, Ar = "General";
-
-function _r(e, t) {
-return e === t ? 0 : e === Ar ? -1 : t === Ar ? 1 : e.localeCompare(t);
-}
+var Ar, _r = "General";
 
 function Ur(e, t) {
-var r = t.metadata;
-e.push("  ".concat(Pr(r.name, r.usage))), e.push("    ".concat(r.description)),
-Nr(e, r.examples, "      ", "    Examples:", !1), e.push("");
+return e === t ? 0 : e === _r ? -1 : t === _r ? 1 : e.localeCompare(t);
 }
 
-function Nr(e, t, r, o, n) {
+function Nr(e, t) {
+var r = t.metadata;
+e.push("  ".concat(Ir(r.name, r.usage))), e.push("    ".concat(r.description)),
+Pr(e, r.examples, "      ", "    Examples:", !1), e.push("");
+}
+
+function Pr(e, t, r, o, n) {
 var i, s;
 if (void 0 === o && (o = "Examples:"), void 0 === n && (n = !0), t && 0 !== t.length) {
 n && e.push(""), e.push(o);
@@ -6012,11 +6026,11 @@ if (i) throw i.error;
 }
 }
 
-function Pr(e, t) {
+function Ir(e, t) {
 return null != t ? t : "".concat(e, "()");
 }
 
-function Ir(e) {
+function Gr(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return e.metadata.name.localeCompare(t.metadata.name);
 });
@@ -6025,26 +6039,26 @@ return e.metadata.name.localeCompare(t.metadata.name);
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(Mr || (Mr = {}));
+}(Ar || (Ar = {}));
 
-var Gr, Lr = (Gr = "console", {
+var Lr, Dr = (Lr = "console", {
 debug: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Gr, "]"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Lr, "]"), e ], i(t), !1));
 },
 info: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Gr, "]"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Lr, "]"), e ], i(t), !1));
 },
 warn: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Gr, "] WARN:"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Lr, "] WARN:"), e ], i(t), !1));
 },
 error: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Gr, "] ERROR:"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Lr, "] ERROR:"), e ], i(t), !1));
 }
-}), Dr = {
+}), Fr = {
 getProcesses: function() {
 return [];
 },
@@ -6074,7 +6088,7 @@ getRemainingCpu: function() {
 return 0;
 },
 resetStats: function() {}
-}, Fr = {
+}, Br = {
 run: function() {},
 getMetricSeries: function(e) {
 return null;
@@ -6082,7 +6096,7 @@ return null;
 getLatestStats: function() {
 return {};
 }
-}, Br = {
+}, Wr = {
 getSnapshot: function() {
 return {};
 },
@@ -6102,7 +6116,7 @@ return {};
 postureCodeToName: function(e) {
 return "unknown";
 }
-}, Wr = {
+}, Hr = {
 setEnabled: function(e) {},
 isEnabled: function() {
 return !1;
@@ -6112,7 +6126,7 @@ getConfig: function() {
 return {};
 },
 toggle: function(e) {}
-}, Hr = {
+}, Kr = {
 setEnabled: function(e) {},
 isEnabled: function() {
 return !1;
@@ -6121,16 +6135,6 @@ getConfig: function() {
 return {};
 },
 toggle: function(e) {}
-}, Kr = {
-getProcessInfo: function(e) {
-return null;
-},
-listProcesses: function() {
-return [];
-},
-getStats: function() {
-return {};
-}
 }, Yr = {
 getProcessInfo: function(e) {
 return null;
@@ -6141,26 +6145,36 @@ return [];
 getStats: function() {
 return {};
 }
-}, Vr = function() {
+}, Vr = {
+getProcessInfo: function(e) {
+return null;
+},
+listProcesses: function() {
+return [];
+},
+getStats: function() {
+return {};
+}
+}, qr = function() {
 function e() {
 this.commands = new Map, this.initialized = !1, this.lazyLoadEnabled = !1, this.commandsRegistered = !1,
 this.commandsExposed = !1;
 }
 return e.prototype.register = function(e, t) {
 var r;
-this.commands.has(e.name) && Lr.warn('Command "'.concat(e.name, '" is already registered, overwriting'), {
+this.commands.has(e.name) && Dr.warn('Command "'.concat(e.name, '" is already registered, overwriting'), {
 subsystem: "CommandRegistry"
 }), this.commands.set(e.name, {
 metadata: o(o({}, e), {
 category: null !== (r = e.category) && void 0 !== r ? r : "General"
 }),
 handler: t
-}), Lr.debug('Registered command "'.concat(e.name, '"'), {
+}), Dr.debug('Registered command "'.concat(e.name, '"'), {
 subsystem: "CommandRegistry"
 });
 }, e.prototype.unregister = function(e) {
 var t = this.commands.delete(e);
-return t && Lr.debug('Unregistered command "'.concat(e, '"'), {
+return t && Dr.debug('Unregistered command "'.concat(e, '"'), {
 subsystem: "CommandRegistry"
 }), t;
 }, e.prototype.getCommand = function(e) {
@@ -6216,20 +6230,20 @@ try {
 return o.handler.apply(o, s([], i(t), !1));
 } catch (t) {
 var n = t instanceof Error ? t.message : String(t);
-return Lr.error('Error executing command "'.concat(e, '": ').concat(n), {
+return Dr.error('Error executing command "'.concat(e, '": ').concat(n), {
 subsystem: "CommandRegistry"
 }), "Error: ".concat(n);
 }
 }, e.prototype.generateHelp = function() {
 return function(e) {
-var t, r, o, n, i = [ "=== Available Console Commands ===", "" ], s = Array.from(e.keys()).sort(_r);
+var t, r, o, n, i = [ "=== Available Console Commands ===", "" ], s = Array.from(e.keys()).sort(Ur);
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = e.get(l);
 if (m && 0 !== m.length) {
 i.push("--- ".concat(l, " ---"));
 try {
-for (var d = (o = void 0, a(Ir(m))), p = d.next(); !p.done; p = d.next()) Ur(i, p.value);
+for (var d = (o = void 0, a(Gr(m))), p = d.next(); !p.done; p = d.next()) Nr(i, p.value);
 } catch (e) {
 o = {
 error: e
@@ -6260,8 +6274,8 @@ return i.join("\n");
 this.lazyLoadEnabled && !this.commandsRegistered && this.triggerLazyLoad();
 var t = this.commands.get(e);
 return t ? function(e) {
-var t, r = e.metadata, o = [ "=== ".concat(r.name, " ==="), "", "Description: ".concat(r.description), "Usage: ".concat(Pr(r.name, r.usage)), "Category: ".concat(null !== (t = r.category) && void 0 !== t ? t : Ar) ];
-return Nr(o, r.examples, "  "), o.join("\n");
+var t, r = e.metadata, o = [ "=== ".concat(r.name, " ==="), "", "Description: ".concat(r.description), "Usage: ".concat(Ir(r.name, r.usage)), "Category: ".concat(null !== (t = r.category) && void 0 !== t ? t : _r) ];
+return Pr(o, r.examples, "  "), o.join("\n");
 }(t) : 'Command "'.concat(e, '" not found. Use help() to see available commands.');
 }, e.prototype.exposeToGlobal = function() {
 var e, t, r = this, o = global;
@@ -6281,7 +6295,7 @@ s && !s.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-this.commandsExposed = !0, Lr.debug("Exposed ".concat(this.commands.size, " commands to global scope"), {
+this.commandsExposed = !0, Dr.debug("Exposed ".concat(this.commands.size, " commands to global scope"), {
 subsystem: "CommandRegistry"
 }), o.help = function(e) {
 return r.lazyLoadEnabled && !r.commandsRegistered && r.triggerLazyLoad(), e ? r.generateCommandHelp(e) : r.generateHelp();
@@ -6298,15 +6312,15 @@ category: "System"
 for (var t = [], r = 0; r < arguments.length; r++) t[r] = arguments[r];
 var o = t[0];
 return void 0 !== o ? e.generateCommandHelp(String(o)) : e.generateHelp();
-}), this.initialized = !0, Lr.info("Command registry initialized", {
+}), this.initialized = !0, Dr.info("Command registry initialized", {
 subsystem: "CommandRegistry"
 }));
 }, e.prototype.enableLazyLoading = function(e) {
-this.lazyLoadEnabled = !0, this.registrationCallback = e, Lr.info("Console commands lazy loading enabled", {
+this.lazyLoadEnabled = !0, this.registrationCallback = e, Dr.info("Console commands lazy loading enabled", {
 subsystem: "CommandRegistry"
 });
 }, e.prototype.triggerLazyLoad = function() {
-!this.commandsRegistered && this.registrationCallback && (Lr.debug("Lazy loading console commands on first access", {
+!this.commandsRegistered && this.registrationCallback && (Dr.debug("Lazy loading console commands on first access", {
 subsystem: "CommandRegistry"
 }), this.commandsRegistered = !0, this.registrationCallback(), this.exposeToGlobal());
 }, e.prototype.getCommandCount = function() {
@@ -6319,25 +6333,25 @@ this.commandsExposed = !1, this.registrationCallback = void 0;
 }, e.prototype.clear = function() {
 this.reset();
 }, e;
-}(), qr = new Vr;
+}(), jr = new qr;
 
-function jr(e) {
+function zr(e) {
 return function(t, r, o) {
-if ("object" != typeof r) kr(e, String(r), t); else {
+if ("object" != typeof r) Mr(e, String(r), t); else {
 var n = r, a = String(n.name);
 n.addInitializer(function() {
-"object" == typeof this && null !== this && kr(e, a, Object.getPrototypeOf(this));
+"object" == typeof this && null !== this && Mr(e, a, Object.getPrototypeOf(this));
 });
 }
 };
 }
 
-function zr(e) {
+function Qr(e) {
 var t, r;
 try {
 for (var o = a(function(e) {
 var t = Object.getPrototypeOf(e);
-return Or.filter(function(e) {
+return kr.filter(function(e) {
 return function(e, t) {
 return null !== t && (e === t || Object.getPrototypeOf(e) === t || e === Object.getPrototypeOf(t));
 }(e.target, t);
@@ -6346,7 +6360,7 @@ return null !== t && (e === t || Object.getPrototypeOf(e) === t || e === Object.
 var i = n.value, s = e[i.methodName];
 if ("function" == typeof s) {
 var c = s.bind(e);
-qr.register(i.metadata, c), Lr.debug('Registered decorated command "'.concat(i.metadata.name, '"'), {
+jr.register(i.metadata, c), Dr.debug('Registered decorated command "'.concat(i.metadata.name, '"'), {
 subsystem: "CommandRegistry"
 });
 }
@@ -6368,22 +6382,22 @@ if (t) throw t.error;
 function e() {}
 e.prototype.setLogLevel = function(e) {
 return void 0 === {
-debug: Mr.DEBUG,
-info: Mr.INFO,
-warn: Mr.WARN,
-error: Mr.ERROR,
-none: Mr.NONE
+debug: Ar.DEBUG,
+info: Ar.INFO,
+warn: Ar.WARN,
+error: Ar.ERROR,
+none: Ar.NONE
 }[e.toLowerCase()] ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : "Log level set to: ".concat(e.toUpperCase());
 }, e.prototype.toggleDebug = function() {
 var e = !{}.debug;
-return e ? Mr.DEBUG : Mr.INFO, "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
-}, n([ jr({
+return e ? Ar.DEBUG : Ar.INFO, "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
+}, n([ zr({
 name: "setLogLevel",
 description: "Set the log level for the bot",
 usage: "setLogLevel(level)",
 examples: [ "setLogLevel('debug')", "setLogLevel('info')", "setLogLevel('warn')", "setLogLevel('error')", "setLogLevel('none')" ],
 category: "Logging"
-}) ], e.prototype, "setLogLevel", null), n([ jr({
+}) ], e.prototype, "setLogLevel", null), n([ zr({
 name: "toggleDebug",
 description: "Toggle debug mode on/off (affects log level and debug features)",
 usage: "toggleDebug()",
@@ -6395,19 +6409,8 @@ function e() {}
 e.prototype.toggleVisualizations = function() {
 return "Visualizations: ".concat({}.visualizations ? "DISABLED" : "ENABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t, r, o = null === (t = Wr.getConfig) || void 0 === t ? void 0 : t.call(Wr);
-if (!o) return "RoomVisualizer.getConfig is not implemented";
-var n = Object.keys(o).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof o[e];
-});
-if (!n.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(n.join(", "));
-var a = e;
-Wr.toggle && Wr.toggle(String(a));
-var i = null === (r = Wr.getConfig) || void 0 === r ? void 0 : r.call(Wr), s = null == i ? void 0 : i[a];
-return "Room visualization '".concat(e, "': ").concat(s ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t, r, o = null === (t = Hr.getConfig) || void 0 === t ? void 0 : t.call(Hr);
-if (!o) return "MapVisualizer.getConfig is not implemented";
+if (!o) return "RoomVisualizer.getConfig is not implemented";
 var n = Object.keys(o).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof o[e];
 });
@@ -6415,9 +6418,20 @@ if (!n.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(n.
 var a = e;
 Hr.toggle && Hr.toggle(String(a));
 var i = null === (r = Hr.getConfig) || void 0 === r ? void 0 : r.call(Hr), s = null == i ? void 0 : i[a];
+return "Room visualization '".concat(e, "': ").concat(s ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t, r, o = null === (t = Kr.getConfig) || void 0 === t ? void 0 : t.call(Kr);
+if (!o) return "MapVisualizer.getConfig is not implemented";
+var n = Object.keys(o).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof o[e];
+});
+if (!n.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(n.join(", "));
+var a = e;
+Kr.toggle && Kr.toggle(String(a));
+var i = null === (r = Kr.getConfig) || void 0 === r ? void 0 : r.call(Kr), s = null == i ? void 0 : i[a];
 return "Map visualization '".concat(e, "': ").concat(s ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e, t = null === (e = Hr.getConfig) || void 0 === e ? void 0 : e.call(Hr);
+var e, t = null === (e = Kr.getConfig) || void 0 === e ? void 0 : e.call(Kr);
 return t ? Object.entries(t).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -6487,55 +6501,55 @@ return c;
 }, e.prototype.clearVisCache = function(e) {
 return require("../visuals/visualizationManager").visualizationManager.clearCache(e),
 e ? "Visualization cache cleared for room: ".concat(e) : "All visualization caches cleared";
-}, n([ jr({
+}, n([ zr({
 name: "toggleVisualizations",
 description: "Toggle all visualizations on/off",
 usage: "toggleVisualizations()",
 examples: [ "toggleVisualizations()" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualizations", null), n([ jr({
+}) ], e.prototype, "toggleVisualizations", null), n([ zr({
 name: "toggleVisualization",
 description: "Toggle a specific room visualization feature",
 usage: "toggleVisualization(key)",
 examples: [ "toggleVisualization('showPheromones')", "toggleVisualization('showPaths')", "toggleVisualization('showCombat')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualization", null), n([ jr({
+}) ], e.prototype, "toggleVisualization", null), n([ zr({
 name: "toggleMapVisualization",
 description: "Toggle a specific map visualization feature",
 usage: "toggleMapVisualization(key)",
 examples: [ "toggleMapVisualization('showRoomStatus')", "toggleMapVisualization('showConnections')", "toggleMapVisualization('showThreats')", "toggleMapVisualization('showExpansion')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleMapVisualization", null), n([ jr({
+}) ], e.prototype, "toggleMapVisualization", null), n([ zr({
 name: "showMapConfig",
 description: "Show current map visualization configuration",
 usage: "showMapConfig()",
 examples: [ "showMapConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showMapConfig", null), n([ jr({
+}) ], e.prototype, "showMapConfig", null), n([ zr({
 name: "setVisMode",
 description: "Set visualization mode preset (debug, presentation, minimal, performance)",
 usage: "setVisMode(mode)",
 examples: [ "setVisMode('debug')", "setVisMode('presentation')", "setVisMode('minimal')", "setVisMode('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "setVisMode", null), n([ jr({
+}) ], e.prototype, "setVisMode", null), n([ zr({
 name: "toggleVisLayer",
 description: "Toggle a specific visualization layer",
 usage: "toggleVisLayer(layer)",
 examples: [ "toggleVisLayer('pheromones')", "toggleVisLayer('paths')", "toggleVisLayer('defense')", "toggleVisLayer('economy')", "toggleVisLayer('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisLayer", null), n([ jr({
+}) ], e.prototype, "toggleVisLayer", null), n([ zr({
 name: "showVisPerf",
 description: "Show visualization performance metrics",
 usage: "showVisPerf()",
 examples: [ "showVisPerf()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisPerf", null), n([ jr({
+}) ], e.prototype, "showVisPerf", null), n([ zr({
 name: "showVisConfig",
 description: "Show current visualization configuration",
 usage: "showVisConfig()",
 examples: [ "showVisConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisConfig", null), n([ jr({
+}) ], e.prototype, "showVisConfig", null), n([ zr({
 name: "clearVisCache",
 description: "Clear visualization cache",
 usage: "clearVisCache(roomName?)",
@@ -6545,7 +6559,7 @@ category: "Visualization"
 }(), function() {
 function e() {}
 e.prototype.showStats = function() {
-var e, t = null === (e = Fr.getLatestStats) || void 0 === e ? void 0 : e.call(Fr);
+var e, t = null === (e = Br.getLatestStats) || void 0 === e ? void 0 : e.call(Br);
 return t ? t ? "=== SwarmBot Stats (Tick ".concat(t.tick, ") ===\nCPU: ").concat(t.cpuUsed.toFixed(2), "/").concat(t.cpuLimit, " (Bucket: ").concat(t.cpuBucket, ")\nGCL: ").concat(t.gclLevel, " (").concat((100 * t.gclProgress).toFixed(1), "%)\nGPL: ").concat(t.gplLevel, "\nCreeps: ").concat(t.totalCreeps, "\nRooms: ").concat(t.totalRooms, "\n").concat(t.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks." : "MemorySegmentStats.getLatestStats is not implemented";
@@ -6561,7 +6575,7 @@ return "=== Room.find() Cache Statistics ===\nCached Rooms: ".concat(e.rooms, "\
 return (0, require("../utils/roomFindCache").clearRoomFindCache)(), "Room.find() cache cleared and statistics reset";
 }, e.prototype.toggleProfiling = function() {
 var e = !{}.profiling;
-return Br.setEnabled && Br.setEnabled(e), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
+return Wr.setEnabled && Wr.setEnabled(e), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.cpuBreakdown = function(e) {
 var t, r, o, n, i, s, c, u, l = Memory.stats;
 if (!l) return "No stats available. Stats collection may be disabled.";
@@ -6673,7 +6687,7 @@ d.push("");
 }
 return d.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n, i = null === (n = Br.validateBudgets) || void 0 === n ? void 0 : n.call(Br);
+var e, t, r, o, n, i = null === (n = Wr.validateBudgets) || void 0 === n ? void 0 : n.call(Wr);
 if (!i) return "unifiedStats.validateBudgets is not implemented";
 var s = "=== CPU Budget Report (Tick ".concat(i.tick, ") ===\n");
 if (s += "Rooms Evaluated: ".concat(i.roomsEvaluated, "\n"), s += "Within Budget: ".concat(i.roomsWithinBudget, "\n"),
@@ -6722,7 +6736,7 @@ if (r) throw r.error;
 }
 return s;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n, i = null === (n = Br.detectAnomalies) || void 0 === n ? void 0 : n.call(Br);
+var e, t, r, o, n, i = null === (n = Wr.detectAnomalies) || void 0 === n ? void 0 : n.call(Wr);
 if (!i) return "unifiedStats.detectAnomalies is not implemented";
 if (0 === i.length) return "✓ No CPU anomalies detected";
 var s = "=== CPU Anomalies Detected: ".concat(i.length, " ===\n\n"), c = i.filter(function(e) {
@@ -6772,7 +6786,7 @@ return s;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n, i, s, c;
 void 0 === e && (e = !1);
-var u = null === (i = Br.getCurrentSnapshot) || void 0 === i ? void 0 : i.call(Br);
+var u = null === (i = Wr.getCurrentSnapshot) || void 0 === i ? void 0 : i.call(Wr);
 if (!u) return "unifiedStats.getCurrentSnapshot is not implemented";
 var l = "=== CPU Profile (Tick ".concat(u.tick, ") ===\n");
 l += "Total: ".concat(u.cpu.used.toFixed(2), " / ").concat(u.cpu.limit, " (").concat(u.cpu.percent.toFixed(1), "%)\n"),
@@ -6783,7 +6797,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 l += "Top ".concat(d.length, " Rooms by CPU:\n");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (c = null === (s = Br.postureCodeToName) || void 0 === s ? void 0 : s.call(Br, y.brain.postureCode)) && void 0 !== c ? c : "unknown";
+var y = f.value, v = null !== (c = null === (s = Wr.postureCodeToName) || void 0 === s ? void 0 : s.call(Wr, y.brain.postureCode)) && void 0 !== c ? c : "unknown";
 l += "  ".concat(y.name, " (RCL").concat(y.rcl, ", ").concat(v, "): avg ").concat(y.profiler.avgCpu.toFixed(3), " | peak ").concat(y.profiler.peakCpu.toFixed(3), " | samples ").concat(y.profiler.samples, "\n");
 }
 } catch (e) {
@@ -6820,61 +6834,61 @@ if (o) throw o.error;
 }
 }
 return l;
-}, n([ jr({
+}, n([ zr({
 name: "showStats",
 description: "Show current bot statistics from memory segment",
 usage: "showStats()",
 examples: [ "showStats()" ],
 category: "Statistics"
-}) ], e.prototype, "showStats", null), n([ jr({
+}) ], e.prototype, "showStats", null), n([ zr({
 name: "cacheStats",
 description: "Show object cache statistics (hits, misses, hit rate, CPU savings)",
 usage: "cacheStats()",
 examples: [ "cacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "cacheStats", null), n([ jr({
+}) ], e.prototype, "cacheStats", null), n([ zr({
 name: "resetCacheStats",
 description: "Reset cache statistics counters (for benchmarking)",
 usage: "resetCacheStats()",
 examples: [ "resetCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "resetCacheStats", null), n([ jr({
+}) ], e.prototype, "resetCacheStats", null), n([ zr({
 name: "roomFindCacheStats",
 description: "Show room.find() cache statistics (hits, misses, hit rate)",
 usage: "roomFindCacheStats()",
 examples: [ "roomFindCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "roomFindCacheStats", null), n([ jr({
+}) ], e.prototype, "roomFindCacheStats", null), n([ zr({
 name: "clearRoomFindCache",
 description: "Clear all room.find() cache entries and reset stats",
 usage: "clearRoomFindCache()",
 examples: [ "clearRoomFindCache()" ],
 category: "Statistics"
-}) ], e.prototype, "clearRoomFindCache", null), n([ jr({
+}) ], e.prototype, "clearRoomFindCache", null), n([ zr({
 name: "toggleProfiling",
 description: "Toggle CPU profiling on/off",
 usage: "toggleProfiling()",
 examples: [ "toggleProfiling()" ],
 category: "Statistics"
-}) ], e.prototype, "toggleProfiling", null), n([ jr({
+}) ], e.prototype, "toggleProfiling", null), n([ zr({
 name: "cpuBreakdown",
 description: "Show detailed CPU breakdown by process, room, creep, and subsystem",
 usage: "cpuBreakdown(type?)",
 examples: [ "cpuBreakdown() // Show all breakdowns", "cpuBreakdown('process') // Show only process breakdown", "cpuBreakdown('room') // Show only room breakdown", "cpuBreakdown('creep') // Show only creep breakdown", "cpuBreakdown('subsystem') // Show only subsystem breakdown" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBreakdown", null), n([ jr({
+}) ], e.prototype, "cpuBreakdown", null), n([ zr({
 name: "cpuBudget",
 description: "Show CPU budget status and violations for all rooms",
 usage: "cpuBudget()",
 examples: [ "cpuBudget()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBudget", null), n([ jr({
+}) ], e.prototype, "cpuBudget", null), n([ zr({
 name: "cpuAnomalies",
 description: "Detect and show CPU usage anomalies (spikes and sustained high usage)",
 usage: "cpuAnomalies()",
 examples: [ "cpuAnomalies()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuAnomalies", null), n([ jr({
+}) ], e.prototype, "cpuAnomalies", null), n([ zr({
 name: "cpuProfile",
 description: "Show comprehensive CPU profiling breakdown by room and subsystem",
 usage: "cpuProfile(showAll?)",
@@ -6885,11 +6899,11 @@ category: "Statistics"
 function e() {}
 e.prototype.showConfig = function() {
 var e = {}, t = {
-level: Mr.INFO,
+level: Ar.INFO,
 categories: {}
 };
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(Mr[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
-}, n([ jr({
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(Ar[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+}, n([ zr({
 name: "showConfig",
 description: "Show current bot configuration",
 usage: "showConfig()",
@@ -6899,11 +6913,11 @@ category: "Configuration"
 }(), function() {
 function e() {}
 e.prototype.showKernelStats = function() {
-var e, t, r, o, n, i, s, c, u, l, m, d, p, f = null === (n = Dr.getStatsSummary) || void 0 === n ? void 0 : n.call(Dr);
+var e, t, r, o, n, i, s, c, u, l, m, d, p, f = null === (n = Fr.getStatsSummary) || void 0 === n ? void 0 : n.call(Fr);
 if (!f) return "kernel.getStatsSummary is not implemented";
-var y = null !== (s = null === (i = Dr.getConfig) || void 0 === i ? void 0 : i.call(Dr)) && void 0 !== s ? s : {
+var y = null !== (s = null === (i = Fr.getConfig) || void 0 === i ? void 0 : i.call(Fr)) && void 0 !== s ? s : {
 targetCpuUsage: 0
-}, v = null !== (u = null === (c = Dr.getBucketMode) || void 0 === c ? void 0 : c.call(Dr)) && void 0 !== u ? u : "normal", g = "=== Kernel Stats ===\nBucket Mode: ".concat(v.toUpperCase(), "\nCPU Bucket: ").concat(Game.cpu.bucket, "\nCPU Limit: ").concat((null !== (m = null === (l = Dr.getCpuLimit) || void 0 === l ? void 0 : l.call(Dr)) && void 0 !== m ? m : 0).toFixed(2), " (").concat((100 * y.targetCpuUsage).toFixed(0), "% of ").concat(Game.cpu.limit, ")\nRemaining CPU: ").concat((null !== (p = null === (d = Dr.getRemainingCpu) || void 0 === d ? void 0 : d.call(Dr)) && void 0 !== p ? p : 0).toFixed(2), "\n\nProcesses: ").concat(f.totalProcesses, " total (").concat(f.activeProcesses, " active, ").concat(f.suspendedProcesses, " suspended)\nTotal CPU Used: ").concat(f.totalCpuUsed.toFixed(3), "\nAvg CPU/Process: ").concat(f.avgCpuPerProcess.toFixed(4), "\nAvg Health Score: ").concat(f.avgHealthScore.toFixed(1), "/100\n\nTop CPU Consumers:");
+}, v = null !== (u = null === (c = Fr.getBucketMode) || void 0 === c ? void 0 : c.call(Fr)) && void 0 !== u ? u : "normal", g = "=== Kernel Stats ===\nBucket Mode: ".concat(v.toUpperCase(), "\nCPU Bucket: ").concat(Game.cpu.bucket, "\nCPU Limit: ").concat((null !== (m = null === (l = Fr.getCpuLimit) || void 0 === l ? void 0 : l.call(Fr)) && void 0 !== m ? m : 0).toFixed(2), " (").concat((100 * y.targetCpuUsage).toFixed(0), "% of ").concat(Game.cpu.limit, ")\nRemaining CPU: ").concat((null !== (p = null === (d = Fr.getRemainingCpu) || void 0 === d ? void 0 : d.call(Fr)) && void 0 !== p ? p : 0).toFixed(2), "\n\nProcesses: ").concat(f.totalProcesses, " total (").concat(f.activeProcesses, " active, ").concat(f.suspendedProcesses, " suspended)\nTotal CPU Used: ").concat(f.totalCpuUsed.toFixed(3), "\nAvg CPU/Process: ").concat(f.avgCpuPerProcess.toFixed(4), "\nAvg Health Score: ").concat(f.avgHealthScore.toFixed(1), "/100\n\nTop CPU Consumers:");
 try {
 for (var h = a(f.topCpuProcesses), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
@@ -6939,7 +6953,7 @@ if (r) throw r.error;
 }
 return g;
 }, e.prototype.listProcesses = function() {
-var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E = Dr.getProcesses();
+var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E = Fr.getProcesses();
 if (0 === E.length) return "No processes registered with kernel.";
 var T = "=== Registered Processes ===\n";
 T += "ID | Name | Priority | Frequency | State | Runs | Avg CPU | Health | Errors\n",
@@ -6965,15 +6979,15 @@ if (e) throw e.error;
 }
 return T;
 }, e.prototype.suspendProcess = function(e) {
-var t = Dr.suspendProcess(e);
+var t = Fr.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = Dr.resumeProcess(e);
+var t = Fr.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return Dr.resetStats ? (Dr.resetStats(), "Kernel statistics reset.") : "Kernel.resetStats is not implemented";
+return Fr.resetStats ? (Fr.resetStats(), "Kernel statistics reset.") : "Kernel.resetStats is not implemented";
 }, e.prototype.showProcessHealth = function() {
-var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S = Dr.getProcesses();
+var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S = Fr.getProcesses();
 if (0 === S.length) return "No processes registered with kernel.";
 var w = s([], i(S), !1).sort(function(e, t) {
 var r, o, n, a;
@@ -6996,13 +7010,13 @@ O && !O.done && (t = b.return) && t.call(b);
 if (e) throw e.error;
 }
 }
-var N = null !== (C = null === (T = Dr.getStatsSummary) || void 0 === T ? void 0 : T.call(Dr)) && void 0 !== C ? C : {
+var N = null !== (C = null === (T = Fr.getStatsSummary) || void 0 === T ? void 0 : T.call(Fr)) && void 0 !== C ? C : {
 avgHealthScore: 0,
 suspendedProcesses: 0
 };
 return (x += "\nAverage Health: ".concat(N.avgHealthScore.toFixed(1), "/100")) + "\nSuspended Processes: ".concat(N.suspendedProcesses);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = Dr.getProcesses().filter(function(e) {
+var e, t, r = Fr.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -7010,7 +7024,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Dr.resumeProcess(s.id) && o++;
+Fr.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -7025,7 +7039,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r, o = null === (r = Kr.getStats) || void 0 === r ? void 0 : r.call(Kr);
+var e, t, r, o = null === (r = Yr.getStats) || void 0 === r ? void 0 : r.call(Yr);
 if (!o) return "creepProcessManager.getStats is not implemented";
 var n = "=== Creep Process Stats ===\nTotal Creeps: ".concat(o.totalCreeps, "\nRegistered Processes: ").concat(o.registeredCreeps, "\n\nCreeps by Priority:");
 try {
@@ -7046,7 +7060,7 @@ if (e) throw e.error;
 }
 return n;
 }, e.prototype.showRoomStats = function() {
-var e, t, r, o = null === (r = Yr.getStats) || void 0 === r ? void 0 : r.call(Yr);
+var e, t, r, o = null === (r = Vr.getStats) || void 0 === r ? void 0 : r.call(Vr);
 if (!o) return "roomProcessManager.getStats is not implemented";
 var n = "=== Room Process Stats ===\nTotal Rooms: ".concat(o.totalRooms, "\nRegistered Processes: ").concat(o.registeredRooms, "\nOwned Rooms: ").concat(o.ownedRooms, "\n\nRooms by Priority:");
 try {
@@ -7067,7 +7081,7 @@ if (e) throw e.error;
 }
 return n;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o, n, c, u, l, m, d = Dr.getProcesses().filter(function(e) {
+var t, r, o, n, c, u, l, m, d = Fr.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (d = d.filter(function(t) {
@@ -7096,7 +7110,7 @@ if (t) throw t.error;
 }
 return p + "\nTotal: ".concat(d.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r, o, n, c, u, l, m = Dr.getProcesses().filter(function(e) {
+var e, t, r, o, n, c, u, l, m = Fr.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === m.length) return "No room processes registered.";
@@ -7122,67 +7136,67 @@ if (e) throw e.error;
 }
 }
 return d + "\nTotal: ".concat(m.length, " room processes");
-}, n([ jr({
+}, n([ zr({
 name: "showKernelStats",
 description: "Show kernel statistics including CPU usage and process info",
 usage: "showKernelStats()",
 examples: [ "showKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showKernelStats", null), n([ jr({
+}) ], e.prototype, "showKernelStats", null), n([ zr({
 name: "listProcesses",
 description: "List all registered kernel processes",
 usage: "listProcesses()",
 examples: [ "listProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "listProcesses", null), n([ jr({
+}) ], e.prototype, "listProcesses", null), n([ zr({
 name: "suspendProcess",
 description: "Suspend a kernel process by ID",
 usage: "suspendProcess(processId)",
 examples: [ "suspendProcess('empire:manager')", "suspendProcess('cluster:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "suspendProcess", null), n([ jr({
+}) ], e.prototype, "suspendProcess", null), n([ zr({
 name: "resumeProcess",
 description: "Resume a suspended kernel process",
 usage: "resumeProcess(processId)",
 examples: [ "resumeProcess('empire:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "resumeProcess", null), n([ jr({
+}) ], e.prototype, "resumeProcess", null), n([ zr({
 name: "resetKernelStats",
 description: "Reset all kernel process statistics",
 usage: "resetKernelStats()",
 examples: [ "resetKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "resetKernelStats", null), n([ jr({
+}) ], e.prototype, "resetKernelStats", null), n([ zr({
 name: "showProcessHealth",
 description: "Show health status of all processes with detailed metrics",
 usage: "showProcessHealth()",
 examples: [ "showProcessHealth()" ],
 category: "Kernel"
-}) ], e.prototype, "showProcessHealth", null), n([ jr({
+}) ], e.prototype, "showProcessHealth", null), n([ zr({
 name: "resumeAllProcesses",
 description: "Resume all suspended processes (use with caution)",
 usage: "resumeAllProcesses()",
 examples: [ "resumeAllProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "resumeAllProcesses", null), n([ jr({
+}) ], e.prototype, "resumeAllProcesses", null), n([ zr({
 name: "showCreepStats",
 description: "Show statistics about creep processes managed by the kernel",
 usage: "showCreepStats()",
 examples: [ "showCreepStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showCreepStats", null), n([ jr({
+}) ], e.prototype, "showCreepStats", null), n([ zr({
 name: "showRoomStats",
 description: "Show statistics about room processes managed by the kernel",
 usage: "showRoomStats()",
 examples: [ "showRoomStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showRoomStats", null), n([ jr({
+}) ], e.prototype, "showRoomStats", null), n([ zr({
 name: "listCreepProcesses",
 description: "List all creep processes with their details",
 usage: "listCreepProcesses(role?)",
 examples: [ "listCreepProcesses()", "listCreepProcesses('harvester')" ],
 category: "Kernel"
-}) ], e.prototype, "listCreepProcesses", null), n([ jr({
+}) ], e.prototype, "listCreepProcesses", null), n([ zr({
 name: "listRoomProcesses",
 description: "List all room processes with their details",
 usage: "listRoomProcesses()",
@@ -7192,16 +7206,16 @@ category: "Kernel"
 }(), function() {
 function e() {}
 e.prototype.listCommands = function() {
-return qr.generateHelp();
+return jr.generateHelp();
 }, e.prototype.commandHelp = function(e) {
-return qr.generateCommandHelp(e);
-}, n([ jr({
+return jr.generateCommandHelp(e);
+}, n([ zr({
 name: "listCommands",
 description: "List all available commands (alias for help)",
 usage: "listCommands()",
 examples: [ "listCommands()" ],
 category: "System"
-}) ], e.prototype, "listCommands", null), n([ jr({
+}) ], e.prototype, "listCommands", null), n([ zr({
 name: "commandHelp",
 description: "Get detailed help for a specific command",
 usage: "commandHelp(commandName)",
@@ -7210,13 +7224,13 @@ category: "System"
 }) ], e.prototype, "commandHelp", null);
 }();
 
-var Qr, Xr = {
+var Xr, Zr = {
 maxPredictionTicks: 100,
 safetyMargin: .9,
 enableLogging: !1
-}, Zr = function() {
+}, Jr = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Xr), e);
+void 0 === e && (e = {}), this.config = o(o({}, Zr), e);
 }
 return e.prototype.findMyCreeps = function(e, t) {
 return e.find(FIND_MY_CREEPS).filter(t);
@@ -7378,24 +7392,24 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), Jr = new Zr, $r = function() {
+}(), $r = new Jr, eo = function() {
 function e() {}
 return e.prototype.predictEnergy = function(e, t) {
 void 0 === t && (t = 50);
 var r = Game.rooms[e];
 return r ? r.controller && r.controller.my ? function(e, t) {
 return [ "=== Energy Prediction: ".concat(e, " ==="), "Current Energy: ".concat(t.current), "Predicted (".concat(t.ticks, " ticks): ").concat(Math.round(t.predicted)), "Net Flow: ".concat(t.netFlow.toFixed(2), " energy/tick"), "", "Income Breakdown (per tick):", "  Harvesters: ".concat(t.income.harvesters.toFixed(2)), "  Static Miners: ".concat(t.income.miners.toFixed(2)), "  Links: ".concat(t.income.links.toFixed(2)), "  Total: ".concat(t.income.total.toFixed(2)), "", "Consumption Breakdown (per tick):", "  Upgraders: ".concat(t.consumption.upgraders.toFixed(2)), "  Builders: ".concat(t.consumption.builders.toFixed(2)), "  Towers: ".concat(t.consumption.towers.toFixed(2)), "  Spawning: ".concat(t.consumption.spawning.toFixed(2)), "  Repairs: ".concat(t.consumption.repairs.toFixed(2)), "  Total: ".concat(t.consumption.total.toFixed(2)), "" ].join("\n");
-}(e, Jr.predictEnergyInTicks(r, t)) : "Room ".concat(e, " is not owned by you") : "Room ".concat(e, " is not visible");
+}(e, $r.predictEnergyInTicks(r, t)) : "Room ".concat(e, " is not owned by you") : "Room ".concat(e, " is not visible");
 }, e.prototype.showIncome = function(e) {
 var t = Game.rooms[e];
 return t ? function(e, t) {
 return [ "=== Energy Income: ".concat(e, " ==="), "Harvesters: ".concat(t.harvesters.toFixed(2), " energy/tick"), "Static Miners: ".concat(t.miners.toFixed(2), " energy/tick"), "Links: ".concat(t.links.toFixed(2), " energy/tick"), "Total: ".concat(t.total.toFixed(2), " energy/tick"), "" ].join("\n");
-}(e, Jr.calculateEnergyIncome(t)) : "Room ".concat(e, " is not visible");
+}(e, $r.calculateEnergyIncome(t)) : "Room ".concat(e, " is not visible");
 }, e.prototype.showConsumption = function(e) {
 var t = Game.rooms[e];
 return t ? function(e, t) {
 return [ "=== Energy Consumption: ".concat(e, " ==="), "Upgraders: ".concat(t.upgraders.toFixed(2), " energy/tick"), "Builders: ".concat(t.builders.toFixed(2), " energy/tick"), "Towers: ".concat(t.towers.toFixed(2), " energy/tick"), "Spawning: ".concat(t.spawning.toFixed(2), " energy/tick"), "Repairs: ".concat(t.repairs.toFixed(2), " energy/tick"), "Total: ".concat(t.total.toFixed(2), " energy/tick"), "" ].join("\n");
-}(e, Jr.calculateEnergyConsumption(t)) : "Room ".concat(e, " is not visible");
+}(e, $r.calculateEnergyConsumption(t)) : "Room ".concat(e, " is not visible");
 }, e.prototype.canAfford = function(e, t, r) {
 void 0 === r && (r = 50);
 var o, n = Game.rooms[e];
@@ -7403,14 +7417,14 @@ return n ? (o = {
 roomName: e,
 cost: t,
 ticks: r,
-canAfford: Jr.canAffordInTicks(n, t, r),
-predicted: Jr.predictEnergyInTicks(n, r).predicted,
-delay: Jr.getRecommendedSpawnDelay(n, t)
+canAfford: $r.canAffordInTicks(n, t, r),
+predicted: $r.predictEnergyInTicks(n, r).predicted,
+delay: $r.getRecommendedSpawnDelay(n, t)
 }).canAfford ? "✓ Room ".concat(o.roomName, " CAN afford ").concat(o.cost, " energy within ").concat(o.ticks, " ticks (predicted: ").concat(Math.round(o.predicted), ")") : o.delay >= 999 ? "✗ Room ".concat(o.roomName, " CANNOT afford ").concat(o.cost, " energy (negative energy flow)") : "✗ Room ".concat(o.roomName, " CANNOT afford ").concat(o.cost, " energy within ").concat(o.ticks, " ticks (would need ").concat(o.delay, " ticks)") : "Room ".concat(e, " is not visible");
 }, e.prototype.getSpawnDelay = function(e, t) {
 var r = Game.rooms[e];
 if (!r) return "Room ".concat(e, " is not visible");
-var o = Jr.getRecommendedSpawnDelay(r, t), n = r.energyAvailable, a = o > 0 && o < 999 ? Jr.predictEnergyInTicks(r, o) : void 0;
+var o = $r.getRecommendedSpawnDelay(r, t), n = r.energyAvailable, a = o > 0 && o < 999 ? $r.predictEnergyInTicks(r, o) : void 0;
 return function(e) {
 var t;
 return 0 === e.delay ? "✓ Room ".concat(e.roomName, " can spawn ").concat(e.cost, " energy body NOW (current: ").concat(e.current, ")") : e.delay >= 999 ? "✗ Room ".concat(e.roomName, " has negative energy flow, cannot spawn ").concat(e.cost, " energy body") : "Room ".concat(e.roomName, " needs to wait ").concat(e.delay, " ticks to spawn ").concat(e.cost, " energy body (current: ").concat(e.current, ", predicted: ").concat(Math.round(null !== (t = e.predicted) && void 0 !== t ? t : 0), ")");
@@ -7421,54 +7435,54 @@ delay: o,
 current: n,
 predicted: null == a ? void 0 : a.predicted
 });
-}, n([ jr({
+}, n([ zr({
 name: "economy.energy.predict",
 description: "Predict energy availability for a room in N ticks",
 usage: "economy.energy.predict(roomName, ticks)",
 examples: [ "economy.energy.predict('W1N1', 50)", "economy.energy.predict('E1S1', 100)" ],
 category: "Economy"
-}) ], e.prototype, "predictEnergy", null), n([ jr({
+}) ], e.prototype, "predictEnergy", null), n([ zr({
 name: "economy.energy.income",
 description: "Show energy income breakdown for a room",
 usage: "economy.energy.income(roomName)",
 examples: [ "economy.energy.income('W1N1')" ],
 category: "Economy"
-}) ], e.prototype, "showIncome", null), n([ jr({
+}) ], e.prototype, "showIncome", null), n([ zr({
 name: "economy.energy.consumption",
 description: "Show energy consumption breakdown for a room",
 usage: "economy.energy.consumption(roomName)",
 examples: [ "economy.energy.consumption('W1N1')" ],
 category: "Economy"
-}) ], e.prototype, "showConsumption", null), n([ jr({
+}) ], e.prototype, "showConsumption", null), n([ zr({
 name: "economy.energy.canAfford",
 description: "Check if a room can afford a certain energy cost within N ticks",
 usage: "economy.energy.canAfford(roomName, cost, ticks)",
 examples: [ "economy.energy.canAfford('W1N1', 1000, 50)", "economy.energy.canAfford('E1S1', 500, 25)" ],
 category: "Economy"
-}) ], e.prototype, "canAfford", null), n([ jr({
+}) ], e.prototype, "canAfford", null), n([ zr({
 name: "economy.energy.spawnDelay",
 description: "Get recommended spawn delay for a body cost",
 usage: "economy.energy.spawnDelay(roomName, cost)",
 examples: [ "economy.energy.spawnDelay('W1N1', 1000)", "economy.energy.spawnDelay('E1S1', 500)" ],
 category: "Economy"
 }) ], e.prototype, "getSpawnDelay", null), e;
-}(), eo = new $r, to = new Set([ ATTACK, RANGED_ATTACK, WORK, HEAL, CLAIM ]);
+}(), to = new eo, ro = new Set([ ATTACK, RANGED_ATTACK, WORK, HEAL, CLAIM ]);
 
-function ro(e) {
+function oo(e) {
 return 0 === e.find(FIND_MY_SPAWNS).length || e.energyCapacityAvailable <= 0;
 }
 
-function oo(e) {
-var t, r, o, n = null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = X(e);
-return Boolean(null === (o = e.controller) || void 0 === o ? void 0 : o.my) && n <= 3 && ro(e) && a.length > 0;
-}
-
 function no(e) {
-var t;
-return Boolean(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && ro(e) && X(e).length > 0;
+var t, r, o, n = null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = X(e);
+return Boolean(null === (o = e.controller) || void 0 === o ? void 0 : o.my) && n <= 3 && oo(e) && a.length > 0;
 }
 
 function ao(e) {
+var t;
+return Boolean(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && oo(e) && X(e).length > 0;
+}
+
+function io(e) {
 var t, r, o, n, i, s, c = {
 guards: 0,
 rangers: 0,
@@ -7477,8 +7491,8 @@ urgency: 1,
 reasons: []
 }, u = null !== (s = null === (i = e.controller) || void 0 === i ? void 0 : i.level) && void 0 !== s ? s : 1, l = X(e);
 if (0 === l.length) return c;
-var m = oo(e);
-no(e) && (c.guards = Math.max(1, c.guards), c.urgency = Math.max(c.urgency, 3),
+var m = no(e);
+ao(e) && (c.guards = Math.max(1, c.guards), c.urgency = Math.max(c.urgency, 3),
 c.reasons.push("Hostile present with no local spawn capacity (RCL ".concat(u, ")"))),
 m && (c.guards = Math.max(1, c.guards), c.urgency = Math.max(c.urgency, 1.5), c.reasons.push("Hostile present in bootstrap defense gap (RCL ".concat(u, ")")));
 var d = 0, p = 0, f = 0, y = 0, v = 0;
@@ -7539,38 +7553,38 @@ subsystem: "Defense"
 }), c;
 }
 
-function io(e, t) {
+function so(e, t) {
 var r;
 return (null !== (r = e.body) && void 0 !== r ? r : []).some(function(e) {
 return e.hits > 0 && t.includes(e.type);
 });
 }
 
-function so(e) {
+function co(e) {
 var t = e.find(FIND_MY_CREEPS);
 return {
 guards: t.filter(function(e) {
-return !e.spawning && "guard" === e.memory.role && io(e, [ ATTACK, RANGED_ATTACK ]);
+return !e.spawning && "guard" === e.memory.role && so(e, [ ATTACK, RANGED_ATTACK ]);
 }).length,
 rangers: t.filter(function(e) {
-return !e.spawning && "ranger" === e.memory.role && io(e, [ RANGED_ATTACK ]);
+return !e.spawning && "ranger" === e.memory.role && so(e, [ RANGED_ATTACK ]);
 }).length,
 healers: t.filter(function(e) {
-return !e.spawning && "healer" === e.memory.role && io(e, [ HEAL ]);
+return !e.spawning && "healer" === e.memory.role && so(e, [ HEAL ]);
 }).length
 };
 }
 
-function co(e, t) {
+function uo(e, t) {
 var r, o, n = function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && to.has(e.type);
+return e.hits > 0 && ro.has(e.type);
 });
 });
-}(e), a = oo(e), i = no(e);
+}(e), a = no(e), i = ao(e);
 if (t.danger < 2 && !n && !a && !i) return !1;
-var s = ao(e), c = so(e), u = Math.max(0, s.guards - c.guards) + Math.max(0, s.rangers - c.rangers) + Math.max(0, s.healers - c.healers);
+var s = io(e), c = co(e), u = Math.max(0, s.guards - c.guards) + Math.max(0, s.rangers - c.rangers) + Math.max(0, s.healers - c.healers);
 if (u <= 0) return !1;
 if (n) return !0;
 var l = e.find(FIND_MY_SPAWNS);
@@ -7585,9 +7599,9 @@ var m = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.l
 return t.danger >= 2 && (u >= 2 || m <= 3);
 }
 
-function uo(e, t) {
-if (!co(e, t)) return null;
-var r = ao(e), o = so(e), n = {
+function lo(e, t) {
+if (!uo(e, t)) return null;
+var r = io(e), o = co(e), n = {
 roomName: e.name,
 guardsNeeded: Math.max(0, r.guards - o.guards),
 rangersNeeded: Math.max(0, r.rangers - o.rangers),
@@ -7601,38 +7615,38 @@ subsystem: "Defense"
 }), n;
 }
 
-var lo = ((Qr = {})[MOVE] = 50, Qr[WORK] = 100, Qr[CARRY] = 50, Qr[ATTACK] = 80,
-Qr[RANGED_ATTACK] = 150, Qr[HEAL] = 250, Qr[CLAIM] = 600, Qr[TOUGH] = 10, Qr);
+var mo = ((Xr = {})[MOVE] = 50, Xr[WORK] = 100, Xr[CARRY] = 50, Xr[ATTACK] = 80,
+Xr[RANGED_ATTACK] = 150, Xr[HEAL] = 250, Xr[CLAIM] = 600, Xr[TOUGH] = 10, Xr);
 
-function mo(e) {
+function po(e) {
 return "string" == typeof e ? e : e.type;
 }
 
-function po(e) {
+function fo(e) {
 if ("string" != typeof e && void 0 !== e.boost) return String(e.boost);
 }
 
-function fo(e) {
+function yo(e) {
 return "string" == typeof e || e.hits > 0;
 }
 
-function yo(e, t, r) {
+function vo(e, t, r) {
 var o, n;
 if (!t) return 1;
 var a = globalThis.BOOSTS, i = null === (n = null === (o = null == a ? void 0 : a[e]) || void 0 === o ? void 0 : o[t]) || void 0 === n ? void 0 : n[r];
 return "number" == typeof i && i > 0 ? i : 1;
 }
 
-function vo(e) {
+function go(e) {
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (fo(m)) {
+if (yo(m)) {
 c++;
-var d = mo(m), p = po(m);
-d === ATTACK && (o += 30 * yo(d, p, "attack")), d === RANGED_ATTACK && (n += 10 * yo(d, p, "rangedAttack")),
-d === HEAL && (i += 12 * yo(d, p, "heal")), d === WORK && (s += 50 * yo(d, p, "dismantle"));
+var d = po(m), p = fo(m);
+d === ATTACK && (o += 30 * vo(d, p, "attack")), d === RANGED_ATTACK && (n += 10 * vo(d, p, "rangedAttack")),
+d === HEAL && (i += 12 * vo(d, p, "heal")), d === WORK && (s += 50 * vo(d, p, "dismantle"));
 }
 }
 } catch (e) {
@@ -7656,7 +7670,7 @@ score: o + n + i + s + 2 * c
 };
 }
 
-function go() {
+function ho() {
 return {
 partCount: 0,
 attack: 0,
@@ -7667,7 +7681,7 @@ score: 0
 };
 }
 
-function ho(e, t) {
+function Ro(e, t) {
 return {
 partCount: e.partCount + t.partCount,
 attack: e.attack + t.attack,
@@ -7678,7 +7692,7 @@ score: e.score + t.score
 };
 }
 
-function Ro(e, t) {
+function Eo(e, t) {
 return {
 partCount: e.partCount * t,
 attack: e.attack * t,
@@ -7689,7 +7703,7 @@ score: e.score * t
 };
 }
 
-function Eo(e) {
+function To(e) {
 var t, r;
 if (0 === e.length) return null;
 var o = null, n = {
@@ -7702,7 +7716,7 @@ score: 0
 };
 try {
 for (var i = a(e), s = i.next(); !s.done; s = i.next()) {
-var c = vo(s.value.body);
+var c = go(s.value.body);
 n.partCount += c.partCount, n.attack += c.attack, n.ranged += c.ranged, n.heal += c.heal,
 n.dismantle += c.dismantle, n.score += c.score, (!o || c.score > o.score) && (o = c);
 }
@@ -7724,17 +7738,17 @@ total: n
 };
 }
 
-function To(e) {
+function Co(e) {
 var t = Game.rooms[e];
-return t ? Eo(X(t)) : null;
+return t ? To(X(t)) : null;
 }
 
-function Co(e, t, r) {
+function So(e, t, r) {
 var o = function(e) {
 if (0 === e.length || e.length > 50 || !e.includes(MOVE)) return null;
 var t = function(e) {
 return e.reduce(function(e, t) {
-return e + lo[t];
+return e + mo[t];
 }, 0);
 }(e);
 return {
@@ -7751,7 +7765,7 @@ return e.parts.join(",") === n;
 }
 }
 
-function So(e) {
+function wo(e) {
 var t, r, o, n = [];
 try {
 for (var i = a([ TOUGH, WORK, ATTACK, RANGED_ATTACK, HEAL, MOVE ]), s = i.next(); !s.done; s = i.next()) for (var c = s.value, u = null !== (o = e[c]) && void 0 !== o ? o : 0, l = 0; l < u; l++) n.push(c);
@@ -7769,33 +7783,33 @@ if (t) throw t.error;
 return n;
 }
 
-function wo(e, t) {
-var r = vo(t.parts).score - vo(e.parts).score;
+function xo(e, t) {
+var r = go(t.parts).score - go(e.parts).score;
 return 0 !== r ? r : t.cost - e.cost;
 }
 
-function xo(e) {
+function bo(e) {
 return Boolean(e && (e.partCount >= 25 || e.score >= 250));
 }
 
-function bo(e) {
-return Boolean(e && (xo(e.strongest) || xo(e.total)));
+function Oo(e) {
+return Boolean(e && (bo(e.strongest) || bo(e.total)));
 }
 
-function Oo(e, t, r) {
+function ko(e, t, r) {
 var o, n, a = function(e, t) {
 return "guard" === e ? function(e) {
-for (var t, r, o = [], n = 1; n <= 25; n++) Co(o, So(((t = {})[ATTACK] = n, t[MOVE] = n,
-t)), e), Co(o, So(((r = {})[TOUGH] = n, r[ATTACK] = n, r[MOVE] = n, r)), e);
+for (var t, r, o = [], n = 1; n <= 25; n++) So(o, wo(((t = {})[ATTACK] = n, t[MOVE] = n,
+t)), e), So(o, wo(((r = {})[TOUGH] = n, r[ATTACK] = n, r[MOVE] = n, r)), e);
 return o;
 }(t) : "ranger" === e ? function(e) {
-for (var t, r, o = [], n = 1; n <= 25; n++) Co(o, So(((t = {})[RANGED_ATTACK] = n,
-t[MOVE] = n, t)), e), Co(o, So(((r = {})[TOUGH] = Math.ceil(n / 2), r[RANGED_ATTACK] = n,
+for (var t, r, o = [], n = 1; n <= 25; n++) So(o, wo(((t = {})[RANGED_ATTACK] = n,
+t[MOVE] = n, t)), e), So(o, wo(((r = {})[TOUGH] = Math.ceil(n / 2), r[RANGED_ATTACK] = n,
 r[MOVE] = n, r)), e);
 return o;
 }(t) : function(e) {
-for (var t, r, o = [], n = 1; n <= 25; n++) Co(o, So(((t = {})[HEAL] = n, t[MOVE] = n,
-t)), e), Co(o, So(((r = {})[TOUGH] = Math.ceil(n / 2), r[HEAL] = n, r[MOVE] = n,
+for (var t, r, o = [], n = 1; n <= 25; n++) So(o, wo(((t = {})[HEAL] = n, t[MOVE] = n,
+t)), e), So(o, wo(((r = {})[TOUGH] = Math.ceil(n / 2), r[HEAL] = n, r[MOVE] = n,
 r)), e);
 return o;
 }(t);
@@ -7803,7 +7817,7 @@ return o;
 if (0 === a.length) return null;
 var c = null == r ? void 0 : r.strongest;
 if (c && c.score > 0) {
-var u = bo(r) ? a.filter(function(t) {
+var u = Oo(r) ? a.filter(function(t) {
 return function(e, t) {
 var r = t.filter(function(e) {
 return e === ATTACK || e === RANGED_ATTACK || e === HEAL || e === WORK;
@@ -7815,18 +7829,18 @@ if (0 === u.length) return null;
 var l = u.filter(function(e) {
 return function(e, t) {
 if (!t || t.score <= 0) return !0;
-var r = vo(e);
+var r = go(e);
 return r.partCount >= t.partCount && r.score >= t.score;
 }(e.parts, c);
 }).sort(function(e, t) {
-return e.cost - t.cost || wo(e, t);
+return e.cost - t.cost || xo(e, t);
 });
-return l.length > 0 ? l[0] : null !== (o = s([], i(u), !1).sort(wo)[0]) && void 0 !== o ? o : null;
+return l.length > 0 ? l[0] : null !== (o = s([], i(u), !1).sort(xo)[0]) && void 0 !== o ? o : null;
 }
-return null !== (n = s([], i(a), !1).sort(wo)[0]) && void 0 !== n ? n : null;
+return null !== (n = s([], i(a), !1).sort(xo)[0]) && void 0 !== n ? n : null;
 }
 
-function ko(e, t, r) {
+function Mo(e, t, r) {
 var o, n, i = function(e) {
 var t, r, o = {
 partCount: 0,
@@ -7840,7 +7854,7 @@ if (!e) return o;
 try {
 for (var n = a([ "guard", "ranger", "healer" ]), i = n.next(); !i.done; i = n.next()) {
 var s = e[i.value];
-s && (o = ho(o, s));
+s && (o = Ro(o, s));
 }
 } catch (e) {
 t = {
@@ -7858,7 +7872,7 @@ return o;
 try {
 for (var s = a([ "guard", "ranger", "healer" ]), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t[u];
-l && e[u] > 0 && (i = ho(i, Ro(l, e[u])));
+l && e[u] > 0 && (i = Ro(i, Eo(l, e[u])));
 }
 } catch (e) {
 o = {
@@ -7874,7 +7888,7 @@ if (o) throw o.error;
 return i;
 }
 
-function Mo(e, t, r, o) {
+function Ao(e, t, r, o) {
 if (!t || t.heal <= 0) return 0;
 var n = e.total.attack + e.total.ranged;
 if (!(o > 0 || e.total.heal > 0 || r >= 3) || n <= 0) return o;
@@ -7882,7 +7896,7 @@ var a = Math.ceil(.5 * n);
 return Math.max(1, o, Math.ceil(a / t.heal));
 }
 
-function Ao(e, t, r, o, n) {
+function _o(e, t, r, o, n) {
 var i, s, c;
 void 0 === r && (r = {}), void 0 === n && (n = 12);
 var u = {
@@ -7892,8 +7906,8 @@ healer: 0
 }, l = {}, m = {};
 try {
 for (var d = a([ "guard", "ranger", "healer" ]), p = d.next(); !p.done; p = d.next()) {
-var f = Oo(C = p.value, e, t);
-f && (l[C] = f, m[C] = vo(f.parts), u[C] = Math.max(0, Math.floor(null !== (c = r[C]) && void 0 !== c ? c : 0)));
+var f = ko(C = p.value, e, t);
+f && (l[C] = f, m[C] = go(f.parts), u[C] = Math.max(0, Math.floor(null !== (c = r[C]) && void 0 !== c ? c : 0)));
 }
 } catch (e) {
 i = {
@@ -7909,7 +7923,7 @@ if (i) throw i.error;
 if (!t) return {
 counts: u,
 bodies: l,
-totalPower: ko(u, m, o),
+totalPower: Mo(u, m, o),
 healerFloor: 0,
 targetScore: 0,
 capped: !1
@@ -7927,7 +7941,7 @@ return (null !== (n = null === (o = e[r]) || void 0 === o ? void 0 : o.score) &&
 return u.guard + u.ranger + u.healer;
 }, R = function(e) {
 return !!m[e] && (h() >= n ? (g = !0, !1) : (u[e]++, !0));
-}, E = ko(u, m, o);
+}, E = Mo(u, m, o);
 if (0 === h() && E.score > y) return {
 counts: u,
 bodies: l,
@@ -7937,12 +7951,12 @@ targetScore: y,
 capped: !1
 };
 v && 0 === h() && R(v);
-for (var T = Mo(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Mo(t, m.healer, u.guard + u.ranger, u.healer);
-for (E = ko(u, m, o); E.score <= y; ) {
+for (var T = Ao(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Ao(t, m.healer, u.guard + u.ranger, u.healer);
+for (E = Mo(u, m, o); E.score <= y; ) {
 var C;
 if (!R(C = null != v ? v : "healer")) break;
-for (T = Mo(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Mo(t, m.healer, u.guard + u.ranger, u.healer);
-E = ko(u, m, o);
+for (T = Ao(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Ao(t, m.healer, u.guard + u.ranger, u.healer);
+E = Mo(u, m, o);
 }
 return {
 counts: u,
@@ -7954,11 +7968,11 @@ capped: g
 };
 }
 
-function _o(e) {
+function Uo(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function Uo(e, t) {
+function No(e, t) {
 var r, o, n;
 void 0 === t && (t = {});
 var i = null === (n = t.scoreWorkPartThreats) || void 0 === n || n, s = 0, c = 0, u = 0, l = 0;
@@ -8012,7 +8026,7 @@ isDismantler: R
 };
 }
 
-function No(e) {
+function Po(e) {
 var t, r, o = X(e);
 if (0 === o.length) return {
 roomName: e.name,
@@ -8037,7 +8051,7 @@ return "undefined" == typeof Memory || !1 !== (null === (e = Memory.defenseSetti
 }();
 try {
 for (var f = a(o), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = Uo(v, {
+var v = y.value, g = No(v, {
 scoreWorkPartThreats: p
 });
 i += g.dps, s += v.hits, n += g.scoreContribution, g.isBoosted && c++, g.isHealer && u++,
@@ -8069,7 +8083,7 @@ return e + ((i = s / o.length) <= 5 ? 600 : i >= 20 ? 150 : 600 - 30 * (i - 5));
 }, 0), E = i > 1.5 * R, T = Math.min(100, Math.max(0, (i - R) / 10)), C = function(e, t, r) {
 if (Array.isArray(e)) {
 var o = e.reduce(function(e, t) {
-return e + Lo(t.body.filter(function(e) {
+return e + Do(t.body.filter(function(e) {
 return e.hits > 0;
 }).map(function(e) {
 return e.type;
@@ -8078,12 +8092,12 @@ return e.type;
 return 300 * Math.ceil(o / 30);
 }
 if (void 0 === t || void 0 === r) {
-var n = Wo("guard"), a = Wo("ranger"), i = Ho(n), s = Ho(a), c = (i.avgDps + s.avgDps) / 2, u = (i.avgCost + s.avgCost) / 2;
+var n = Ho("guard"), a = Ho("ranger"), i = Ko(n), s = Ko(a), c = (i.avgDps + s.avgDps) / 2, u = (i.avgCost + s.avgCost) / 2;
 t = null != t ? t : c, r = null != r ? r : u;
 }
 return t <= 0 && (t = 300, r = 1300), Math.ceil(e / t) * r;
 }(i), S = Math.max(1, function(e) {
-return 0 === e || e < Po ? 0 : e < Io ? 1 : e < Go ? 2 : 3;
+return 0 === e || e < Io ? 0 : e < Go ? 1 : e < Lo ? 2 : 3;
 }(n));
 return h = n < 100 ? "monitor" : n < 500 && !E ? "defend" : E && n < 1e3 ? "assist" : n > 1e3 || c > 3 ? "safemode" : "defend",
 e.find(FIND_NUKES).length > 0 && (n += 500, h = "safemode", S = 3), {
@@ -8105,9 +8119,9 @@ recommendedResponse: h
 };
 }
 
-var Po = 100, Io = 500, Go = 1e3;
+var Io = 100, Go = 500, Lo = 1e3;
 
-function Lo(e) {
+function Do(e) {
 var t, r, o = 0;
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
@@ -8128,7 +8142,7 @@ if (t) throw t.error;
 return o;
 }
 
-function Do(e) {
+function Fo(e) {
 var t, r = ((t = {})[MOVE] = 50, t[WORK] = 100, t[CARRY] = 50, t[ATTACK] = 80, t[RANGED_ATTACK] = 150,
 t[HEAL] = 250, t[CLAIM] = 600, t[TOUGH] = 10, t);
 return e.reduce(function(e, t) {
@@ -8136,26 +8150,26 @@ return e + r[t];
 }, 0);
 }
 
-function Fo(e) {
+function Bo(e) {
 return {
 parts: e,
-cost: Do(e),
-dps: Lo(e)
+cost: Fo(e),
+dps: Do(e)
 };
 }
 
-var Bo = {
-guard: [ Fo([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ]), Fo([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), Fo([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), Fo([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ],
-ranger: [ Fo([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ]), Fo([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ]), Fo([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), Fo([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ]
+var Wo = {
+guard: [ Bo([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ]), Bo([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), Bo([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), Bo([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ],
+ranger: [ Bo([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ]), Bo([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ]), Bo([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), Bo([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ]
 };
 
-function Wo(e) {
-return s([], i(Bo[e]), !1).sort(function(e, t) {
+function Ho(e) {
+return s([], i(Wo[e]), !1).sort(function(e, t) {
 return e.cost - t.cost;
 });
 }
 
-function Ho(e) {
+function Ko(e) {
 if (0 === e.length) return {
 dpsPerEnergy: 300 / 1300,
 avgCost: 1300,
@@ -8173,23 +8187,23 @@ avgDps: n
 };
 }
 
-function Ko(e, t, r) {
-var o = qo(t) - qo(e);
+function Yo(e, t, r) {
+var o = jo(t) - jo(e);
 if (0 !== o) return o;
 if (!r) return 0;
-var n = Vo(e) - Vo(t);
-return 0 !== n ? n : Yo(e) - Yo(t);
-}
-
-function Yo(e) {
-return "number" == typeof e.hits ? e.hits : 1 / 0;
+var n = qo(e) - qo(t);
+return 0 !== n ? n : Vo(e) - Vo(t);
 }
 
 function Vo(e) {
-return "number" != typeof e.hits || "number" != typeof e.hitsMax || e.hitsMax <= 0 ? 1 : e.hits / e.hitsMax;
+return "number" == typeof e.hits ? e.hits : 1 / 0;
 }
 
 function qo(e) {
+return "number" != typeof e.hits || "number" != typeof e.hitsMax || e.hitsMax <= 0 ? 1 : e.hits / e.hitsMax;
+}
+
+function jo(e) {
 var t = 0;
 return t += 100 * e.getActiveBodyparts(HEAL), t += 50 * e.getActiveBodyparts(RANGED_ATTACK),
 t += 40 * e.getActiveBodyparts(ATTACK), t += 60 * e.getActiveBodyparts(CLAIM), (t += 30 * e.getActiveBodyparts(WORK)) > 0 && e.body.some(function(e) {
@@ -8197,19 +8211,19 @@ return e.boost;
 }) && (t += 20), t;
 }
 
-function jo(e) {
+function zo(e) {
 return e.hits < e.hitsMax;
 }
 
-function zo(e) {
+function Qo(e) {
 return e.hits < .8 * e.hitsMax && e.structureType !== STRUCTURE_WALL && e.structureType !== STRUCTURE_RAMPART;
 }
 
-function Qo(e) {
+function Xo(e) {
 return !e.isCombatPosture;
 }
 
-function Xo(e) {
+function Zo(e) {
 var t, r = e.hostiles.length > 0 ? function(e, t) {
 var r, o;
 void 0 === t && (t = {});
@@ -8217,7 +8231,7 @@ var n = !1 !== t.preferWoundedTargets, i = null;
 try {
 for (var s = a(e), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-(!i || Ko(u, i, n) < 0) && (i = u);
+(!i || Yo(u, i, n) < 0) && (i = u);
 }
 } catch (e) {
 r = {
@@ -8246,7 +8260,7 @@ var t = function(e) {
 return function(e) {
 return "siege" !== e.posture || !1 !== e.allowSiegeHealing;
 }(e) ? e.tower.pos.findClosestByRange(FIND_MY_CREEPS, {
-filter: jo
+filter: zo
 }) : null;
 }(e);
 if (t) return {
@@ -8259,8 +8273,8 @@ return void 0 !== e.repairReserveEnergy ? Math.max(0, Math.min(TOWER_CAPACITY, e
 }(e);
 }(e)) return null;
 var r = function(e) {
-return Qo(e) ? e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
-filter: zo
+return Xo(e) ? e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
+filter: Qo
 }) : null;
 }(e);
 if (r) return {
@@ -8268,7 +8282,7 @@ type: "repair",
 target: r
 };
 var o = function(e) {
-return !Qo(e) || e.hostiles.length > 0 ? null : e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
+return !Xo(e) || e.hostiles.length > 0 ? null : e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
 filter: function(t) {
 return function(e, t) {
 return function(e) {
@@ -8287,7 +8301,7 @@ type: "idle"
 };
 }
 
-function Zo(e, t) {
+function Jo(e, t) {
 var r, o, n = null !== (r = {
 1: 0,
 2: 3e5,
@@ -8308,7 +8322,7 @@ var a = null !== (o = {
 return Math.floor(n * a);
 }
 
-var Jo = [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_FACTORY, STRUCTURE_POWER_SPAWN, STRUCTURE_NUKER, STRUCTURE_OBSERVER ], $o = [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE ], en = [ {
+var $o = [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_FACTORY, STRUCTURE_POWER_SPAWN, STRUCTURE_NUKER, STRUCTURE_OBSERVER ], en = [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE ], tn = [ {
 x: -2,
 y: 0
 }, {
@@ -8538,7 +8552,7 @@ x: 6,
 y: 4
 } ];
 
-function tn(e) {
+function rn(e) {
 return [ {
 x: e.x - 1,
 y: e.y - 1
@@ -8566,7 +8580,7 @@ y: e.y + 1
 } ];
 }
 
-function rn(e, t, r) {
+function on(e, t, r) {
 var o, n, i = [];
 try {
 for (var s = a(r), c = s.next(); !c.done; c = s.next()) for (var u = c.value, l = 1; l <= t; l++) switch (u) {
@@ -8611,7 +8625,7 @@ if (o) throw o.error;
 return i;
 }
 
-function on(e, t) {
+function nn(e, t) {
 return e.filter(function(e) {
 return t.includes(e.structureType);
 }).map(function(e) {
@@ -8622,17 +8636,17 @@ y: e.y
 });
 }
 
-function nn(e, t) {
+function an(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, Math.floor(e)) : t;
 }
 
-function an() {
+function sn() {
 return "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES;
 }
 
-var sn = function() {
+var cn = function() {
 function e(e, t, r, o) {
-void 0 === r && (r = 10), void 0 === o && (o = an()), this.initialRoomSiteCount = e,
+void 0 === r && (r = 10), void 0 === o && (o = sn()), this.initialRoomSiteCount = e,
 this.initialGlobalSiteCount = t, this.roomLimit = r, this.globalLimit = o, this.createdSites = 0,
 this.createdByStructureType = {};
 }
@@ -8673,7 +8687,7 @@ return null !== (t = this.createdByStructureType[e]) && void 0 !== t ? t : 0;
 return void 0 === e && (e = {}), !(this.remainingGlobalSites <= 0) && (!0 === e.bypassRoomLimit || this.remainingRoomSites > 0);
 }, e.prototype.capRequested = function(e, t) {
 void 0 === t && (t = {});
-var r = nn(e, 0);
+var r = an(e, 0);
 if (r <= 0 || this.remainingGlobalSites <= 0) return 0;
 var o = !0 === t.bypassRoomLimit ? this.remainingGlobalSites : Math.min(this.remainingRoomSites, this.remainingGlobalSites);
 return Math.min(r, o);
@@ -8685,7 +8699,7 @@ return e !== OK ? 0 : (this.recordPlacement(t), 1);
 }, e;
 }();
 
-function cn(e, t, r) {
+function un(e, t, r) {
 void 0 === r && (r = {});
 var o = function() {
 for (var o = [], n = 0; n < arguments.length; n++) o[n] = arguments[n];
@@ -8721,7 +8735,7 @@ return "function" == typeof n ? n.bind(e) : n;
 });
 }
 
-function un(e) {
+function ln(e) {
 var t = Number.isFinite(e) ? e : 1;
 return {
 1: {
@@ -8818,15 +8832,15 @@ powerSpawn: 1
 }[Math.min(8, Math.max(1, Math.floor(t)))];
 }
 
-function ln(e, t) {
+function mn(e, t) {
 return "".concat(e, ",").concat(t);
 }
 
-function mn(e, t) {
+function dn(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function dn(e) {
+function pn(e) {
 return e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_LINK;
@@ -8834,8 +8848,8 @@ return e.structureType === STRUCTURE_LINK;
 });
 }
 
-function pn(e) {
-var t, r, o, n, i, s, c = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, u = null !== (i = un(c)[STRUCTURE_LINK]) && void 0 !== i ? i : 0, l = [];
+function fn(e) {
+var t, r, o, n, i, s, c = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, u = null !== (i = ln(c)[STRUCTURE_LINK]) && void 0 !== i ? i : 0, l = [];
 if (!(null === (s = e.controller) || void 0 === s ? void 0 : s.my) || c < 5 || u <= 0) return {
 roomName: e.name,
 rcl: c,
@@ -8847,7 +8861,7 @@ var t, r, o, n, i = new Set, s = e.find(FIND_STRUCTURES);
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-l.structureType !== STRUCTURE_LINK && i.add(ln(l.pos.x, l.pos.y));
+l.structureType !== STRUCTURE_LINK && i.add(mn(l.pos.x, l.pos.y));
 }
 } catch (e) {
 t = {
@@ -8863,7 +8877,7 @@ if (t) throw t.error;
 try {
 for (var m = a(e.find(FIND_MY_CONSTRUCTION_SITES)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-i.add(ln(p.pos.x, p.pos.y));
+i.add(mn(p.pos.x, p.pos.y));
 }
 } catch (e) {
 o = {
@@ -8882,14 +8896,14 @@ return function(a, i, s, c, u, l) {
 if (i && !(t.length >= r)) {
 var m = function(e, t, r, o, n, a, i) {
 for (var s = [], c = e.getTerrain(), u = t.x - o; u <= t.x + o; u += 1) for (var l = t.y - o; l <= t.y + o; l += 1) {
-var m = mn({
+var m = dn({
 x: u,
 y: l
 }, t);
 if (!(m < r || m > o || u < 1 || u > 48 || l < 1 || l > 48 || c.get(u, l) === TERRAIN_MASK_WALL)) {
-var d = ln(u, l);
+var d = mn(u, l);
 if (!n.has(d) && !a.has(d)) {
-var p = i ? mn({
+var p = i ? dn({
 x: u,
 y: l
 }, i) : 0;
@@ -8915,20 +8929,20 @@ roomName: e.name,
 role: a,
 targetId: i.id,
 priority: u
-}), n.add(ln(m.x, m.y)));
+}), n.add(mn(m.x, m.y)));
 }
 };
 }(e, l, u, m, d);
 v("controller", f, 2, 2, 400, null != p ? p : y);
 var g = null != p ? p : f, h = function(e, t) {
 return e.find(FIND_SOURCES).slice().sort(function(e, r) {
-return mn(r.pos, t.pos) - mn(e.pos, t.pos);
+return dn(r.pos, t.pos) - dn(e.pos, t.pos);
 });
 }(e, g), R = p && c >= 6 ? 1 : 0, E = y && c >= 8 ? 1 : 0, T = Math.max(0, u - l.length - R - E);
 try {
 for (var C = a(h.slice(0, T)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
-v("source", w, 1, 1, 300 + mn(w.pos, g.pos), null != p ? p : f);
+v("source", w, 1, 1, 300 + dn(w.pos, g.pos), null != p ? p : f);
 }
 } catch (e) {
 t = {
@@ -8950,15 +8964,15 @@ placements: l
 };
 }
 
-function fn(e, t) {
+function yn(e, t) {
 var r;
 return null !== (r = function(e, t) {
 return function(e, t) {
-var r, o = ln(t.x, t.y);
+var r, o = mn(t.x, t.y);
 return null === (r = e.find(function(e) {
-return ln(e.x, e.y) === o;
+return mn(e.x, e.y) === o;
 })) || void 0 === r ? void 0 : r.role;
-}(pn(e).placements, t);
+}(fn(e).placements, t);
 }(e, t.pos)) && void 0 !== r ? r : function(e, t) {
 return e.controller && t.pos.getRangeTo(e.controller) <= 2 ? "controller" : e.storage && t.pos.getRangeTo(e.storage) <= 2 ? "storage" : e.find(FIND_MY_SPAWNS).some(function(e) {
 return t.pos.getRangeTo(e) <= 2;
@@ -8968,27 +8982,27 @@ return t.pos.getRangeTo(e) <= 2;
 }(e, t);
 }
 
-function yn(e, t) {
+function vn(e, t) {
 return "".concat(e, ",").concat(t);
 }
 
-function vn(e, t) {
+function gn(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function gn(e, t) {
-var r = yn(e.pos.x, e.pos.y);
-return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
-}
-
 function hn(e, t) {
-var r = yn(e.pos.x, e.pos.y);
+var r = vn(e.pos.x, e.pos.y);
 return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
 }
 
-function Rn(e, t, r, o, n, a, i, s) {
+function Rn(e, t) {
+var r = vn(e.pos.x, e.pos.y);
+return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
+}
+
+function En(e, t, r, o, n, a, i, s) {
 if (!(r < 1 || r > 48 || o < 1 || o > 48)) {
-var c = yn(r, o), u = a.has(c), l = i.has(c);
+var c = vn(r, o), u = a.has(c), l = i.has(c);
 if (!u && !l) {
 if (t.getTerrain().get(r, o) === TERRAIN_MASK_WALL) return;
 if (s.has(c)) return;
@@ -9005,20 +9019,20 @@ distanceToHub: Math.max(Math.abs(r - n.x), Math.abs(o - n.y))
 }
 }
 
-function En(e, t) {
+function Tn(e, t) {
 return 0 === t.length ? 0 : Math.min.apply(Math, s([], i(t.map(function(t) {
-return vn(e, t);
+return gn(e, t);
 })), !1));
 }
 
-var Tn = "spawn", Cn = "extension", Sn = "road", wn = "rampart", xn = "container", bn = "tower", On = "storage", kn = "link", Mn = "terminal", An = "extractor", _n = "lab", Un = "factory", Nn = "nuker", Pn = "observer", In = "powerSpawn", Gn = [ Tn, Cn, bn, On, kn, Mn, An, _n, Un, Nn, Pn, In ];
+var Cn = "spawn", Sn = "extension", wn = "road", xn = "rampart", bn = "container", On = "tower", kn = "storage", Mn = "link", An = "terminal", _n = "extractor", Un = "lab", Nn = "factory", Pn = "nuker", In = "observer", Gn = "powerSpawn", Ln = [ Cn, Sn, On, kn, Mn, An, _n, Un, Nn, Pn, In, Gn ];
 
-function Ln(e) {
+function Dn(e) {
 return Math.min(8, Math.max(1, Math.floor(Number.isFinite(e) ? e : 1)));
 }
 
-function Dn(e) {
-var t, r, o, n, i = Ln(e);
+function Fn(e) {
+var t, r, o, n, i = Dn(e);
 if ("undefined" != typeof CONTROLLER_STRUCTURES) {
 var s = {};
 try {
@@ -9039,13 +9053,13 @@ if (t) throw t.error;
 }
 return s;
 }
-return un(i);
+return ln(i);
 }
 
-function Fn(e) {
-var t, r, o, n = Dn(e), i = {};
+function Bn(e) {
+var t, r, o, n = Fn(e), i = {};
 try {
-for (var s = a(Gn), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Ln), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (o = n[u]) && void 0 !== o ? o : 0;
 l > 0 && (i[u] = l);
 }
@@ -9063,10 +9077,10 @@ if (t) throw t.error;
 return i;
 }
 
-var Bn = {
+var Wn = {
 x: 0,
 y: 0
-}, Wn = {
+}, Hn = {
 name: "seedNest",
 rcl: 1,
 type: "spread",
@@ -9076,8 +9090,8 @@ x: 25,
 y: 25
 },
 structures: [ {
-x: Bn.x,
-y: Bn.y,
+x: Wn.x,
+y: Wn.y,
 structureType: STRUCTURE_SPAWN
 }, {
 x: -2,
@@ -9100,12 +9114,12 @@ x: -2,
 y: -2,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s([], i(tn(Bn)), !1),
+roads: s([], i(rn(Wn)), !1),
 ramparts: []
-}, Hn = {
+}, Kn = {
 x: 0,
 y: 0
-}, Kn = {
+}, Yn = {
 name: "foragingExpansion",
 rcl: 3,
 type: "spread",
@@ -9207,7 +9221,7 @@ x: -3,
 y: -3,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s(s(s(s([], i(tn(Hn)), !1), [ {
+roads: s(s(s(s([], i(rn(Kn)), !1), [ {
 x: -2,
 y: -1
 }, {
@@ -9231,7 +9245,7 @@ y: 2
 }, {
 x: 1,
 y: 2
-} ], !1), i(rn(Hn, 3, [ "north", "south", "east", "west" ])), !1), [ {
+} ], !1), i(on(Kn, 3, [ "north", "south", "east", "west" ])), !1), [ {
 x: 3,
 y: 3
 }, {
@@ -9242,10 +9256,10 @@ x: 3,
 y: 4
 } ], !1),
 ramparts: []
-}, Yn = {
+}, Vn = {
 x: 0,
 y: 0
-}, Vn = {
+}, qn = {
 name: "matureColony",
 rcl: 5,
 type: "spread",
@@ -9423,7 +9437,7 @@ x: 1,
 y: 5,
 structureType: STRUCTURE_LINK
 } ],
-roads: s(s(s([], i(tn(Yn)), !1), [ {
+roads: s(s(s([], i(rn(Vn)), !1), [ {
 x: 3,
 y: -1
 }, {
@@ -9471,8 +9485,8 @@ y: 2
 }, {
 x: 1,
 y: 2
-} ], !1), i(rn(Yn, 3, [ "north", "south", "east", "west" ])), !1),
-ramparts: on([ {
+} ], !1), i(on(Vn, 3, [ "north", "south", "east", "west" ])), !1),
+ramparts: nn([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_SPAWN
@@ -9497,7 +9511,7 @@ x: 1,
 y: 5,
 structureType: STRUCTURE_LINK
 } ], [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_LINK ])
-}, qn = {
+}, jn = {
 name: "fortifiedHive",
 rcl: 7,
 type: "spread",
@@ -9647,13 +9661,13 @@ x: 3,
 y: -1,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s(s(s(s([], i(tn({
+roads: s(s(s(s([], i(rn({
 x: 0,
 y: 0
-})), !1), i(tn({
+})), !1), i(rn({
 x: -5,
 y: -1
-})), !1), i(tn({
+})), !1), i(rn({
 x: 5,
 y: -1
 })), !1), [ {
@@ -9693,7 +9707,7 @@ y: 2
 x: 1,
 y: 2
 } ], !1),
-ramparts: on([ {
+ramparts: nn([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_SPAWN
@@ -9746,7 +9760,7 @@ x: -1,
 y: 5,
 structureType: STRUCTURE_POWER_SPAWN
 } ], [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_NUKER, STRUCTURE_POWER_SPAWN ])
-}, jn = {
+}, zn = {
 name: "compactBunker",
 rcl: 8,
 type: "bunker",
@@ -10179,7 +10193,7 @@ y: 3
 x: 3,
 y: 3
 } ],
-ramparts: s(s([], i(on([ {
+ramparts: s(s([], i(nn([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_STORAGE
@@ -10292,7 +10306,7 @@ y: -2
 } ]), !1)
 };
 
-function zn(e, t, r) {
+function Qn(e, t, r) {
 for (var o = e.getTerrain(), n = -1; n <= 1; n++) for (var a = -1; a <= 1; a++) {
 var i = t + n, s = r + a;
 if (i < 1 || i > 48 || s < 1 || s > 48) return !1;
@@ -10301,7 +10315,7 @@ if (o.get(i, s) === TERRAIN_MASK_WALL) return !1;
 return !0;
 }
 
-function Qn(e, t, r) {
+function Xn(e, t, r) {
 var o, n, i, s, c, u = e.getTerrain(), l = null !== (c = r.minSpaceRadius) && void 0 !== c ? c : 7, m = 0, d = 0;
 if (t.x < l || t.x > 49 - l || t.y < l || t.y > 49 - l) return {
 fits: !1,
@@ -10361,7 +10375,7 @@ totalTiles: d
 };
 }
 
-function Xn(e, t) {
+function Zn(e, t) {
 var r, o, n, i, s, c = e.controller;
 if (!c) return null;
 var u = e.find(FIND_SOURCES), l = c.pos.x, m = c.pos.y;
@@ -10383,7 +10397,7 @@ for (var f = Math.round(l / (u.length + 1)), y = Math.round(m / (u.length + 1)),
 for (var R = -h; R <= h; R++) for (var E = -h; E <= h; E++) if (!(Math.abs(R) !== h && Math.abs(E) !== h && h > 0)) {
 var T = f + R, C = y + E;
 if (!(T < v || T > 49 - v || C < v || C > 49 - v)) {
-var S = new RoomPosition(T, C, e.name), w = Qn(e, S, t);
+var S = new RoomPosition(T, C, e.name), w = Xn(e, S, t);
 if (w.fits) {
 var x = 1e3, b = S.getRangeTo(c);
 b >= 4 && b <= 8 ? x += 100 : b < 4 ? x -= 50 : b > 12 && (x -= 30);
@@ -10425,8 +10439,8 @@ return t.score - e.score;
 return null;
 }
 
-function Zn(e, t) {
-var r, o = un(t), n = {}, a = e.structures.filter(function(e) {
+function Jn(e, t) {
+var r, o = ln(t), n = {}, a = e.structures.filter(function(e) {
 var t, r, a = e.structureType, i = null !== (t = o[a]) && void 0 !== t ? t : 0, s = null !== (r = n[a]) && void 0 !== r ? r : 0;
 return !(s >= i || (n[a] = s + 1, 0));
 }), c = null !== (r = o[STRUCTURE_EXTENSION]) && void 0 !== r ? r : 0;
@@ -10436,9 +10450,9 @@ return e.structureType === STRUCTURE_EXTENSION;
 }).length;
 if (r <= 0) return e;
 var o = function() {
-for (var e = [], t = 0; t < Math.min(80, en.length); t++) e.push({
-x: en[t].x,
-y: en[t].y,
+for (var e = [], t = 0; t < Math.min(80, tn.length); t++) e.push({
+x: tn[t].x,
+y: tn[t].y,
 structureType: STRUCTURE_EXTENSION
 });
 return e;
@@ -10451,7 +10465,7 @@ return s(s([], i(e), !1), i(a), !1);
 }(a, c)), a;
 }
 
-function Jn(e) {
+function $n(e) {
 switch (e) {
 case STRUCTURE_SPAWN:
 return 100;
@@ -10479,18 +10493,18 @@ return 20;
 }
 }
 
-function $n(e, t, r) {
+function ea(e, t, r) {
 return !(t < 1 || t > 48 || r < 1 || r > 48) && e.getTerrain().get(t, r) !== TERRAIN_MASK_WALL;
 }
 
-function ea(e, t, r, o, n) {
-if (void 0 === n && (n = 6), $n(e, t, r) && !o.has("".concat(t, ",").concat(r))) return {
+function ta(e, t, r, o, n) {
+if (void 0 === n && (n = 6), ea(e, t, r) && !o.has("".concat(t, ",").concat(r))) return {
 x: t,
 y: r
 };
 for (var a = 1; a <= n; a++) for (var i = -a; i <= a; i++) for (var s = -a; s <= a; s++) if (Math.abs(i) === a || Math.abs(s) === a) {
 var c = t + i, u = r + s;
-if ($n(e, c, u) && !o.has("".concat(c, ",").concat(u))) return {
+if (ea(e, c, u) && !o.has("".concat(c, ",").concat(u))) return {
 x: c,
 y: u
 };
@@ -10498,13 +10512,13 @@ y: u
 return null;
 }
 
-var ta = {
+var ra = {
 recalculateInterval: 1e3,
 maxPathOps: 2e3,
 includeRemoteRoads: !0
-}, ra = new Map, oa = new Map;
+}, oa = new Map, na = new Map;
 
-function na(e) {
+function aa(e) {
 var t, r, o, n, i = Game.rooms[e], s = new PathFinder.CostMatrix;
 if (!i) return s;
 var c = i.find(FIND_STRUCTURES);
@@ -10544,11 +10558,11 @@ if (o) throw o.error;
 return s;
 }
 
-function aa(e) {
+function ia(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function ia(e) {
+function sa(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(r, 10),
@@ -10556,12 +10570,12 @@ y: parseInt(o, 10)
 };
 }
 
-function sa(e, t) {
+function ca(e, t) {
 var r, o, n;
 try {
 for (var i = a(t), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-e.has(c.roomName) || e.set(c.roomName, new Set), null === (n = e.get(c.roomName)) || void 0 === n || n.add(aa(c));
+e.has(c.roomName) || e.set(c.roomName, new Set), null === (n = e.get(c.roomName)) || void 0 === n || n.add(ia(c));
 }
 } catch (e) {
 r = {
@@ -10576,7 +10590,7 @@ if (r) throw r.error;
 }
 }
 
-function ca(e, t, r, o) {
+function ua(e, t, r, o) {
 return PathFinder.search(e, {
 pos: t,
 range: 0
@@ -10585,18 +10599,18 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return e === r && na(e);
+return e === r && aa(e);
 }
 });
 }
 
-function ua(e, t, r) {
+function la(e, t, r) {
 t.incomplete || function(e, t, r) {
 var o, n;
 try {
 for (var i = a(t), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.roomName === r && e.add(aa(c));
+c.roomName === r && e.add(ia(c));
 }
 } catch (e) {
 o = {
@@ -10612,7 +10626,7 @@ if (o) throw o.error;
 }(e, t.path, r);
 }
 
-function la(e, t, r, o, n) {
+function ma(e, t, r, o, n) {
 var i, s;
 try {
 for (var c = a(function(e, t, r, o) {
@@ -10624,7 +10638,7 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return e === r && na(e);
+return e === r && aa(e);
 }
 });
 if (!c.incomplete) try {
@@ -10649,7 +10663,7 @@ if (n) throw n.error;
 return s;
 }(t, r, o, n)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-e.add(aa(l));
+e.add(ia(l));
 }
 } catch (e) {
 i = {
@@ -10664,20 +10678,20 @@ if (i) throw i.error;
 }
 }
 
-function ma(e, t, r) {
+function da(e, t, r) {
 var n, i, s, c, u, l, m;
 void 0 === r && (r = {});
-var d = o(o({}, ta), r), p = function(e, t, r) {
+var d = o(o({}, ra), r), p = function(e, t, r) {
 var o, n, a, i = null === (o = e.storage) || void 0 === o ? void 0 : o.pos, s = i ? "".concat(i.x, ",").concat(i.y) : "none", c = null !== (a = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== a ? a : 0;
 return [ e.name, "anchor:".concat(t.x, ",").concat(t.y), "storage:".concat(s), "rcl:".concat(c), "ops:".concat(r.maxPathOps), "remote:".concat(r.includeRemoteRoads ? 1 : 0) ].join("|");
 }(e, t, d), f = function(e, t) {
-var r = ra.get(e);
+var r = oa.get(e);
 if (r && Game.time - r.lastCalculated < t) return r;
 }(p, d.recalculateInterval);
 if (f) return f;
 var y = new Set, v = null !== (l = null === (u = e.controller) || void 0 === u ? void 0 : u.level) && void 0 !== l ? l : 0, g = e.find(FIND_SOURCES), h = e.controller, R = e.storage, E = e.find(FIND_MINERALS)[0], T = null !== (m = null == R ? void 0 : R.pos) && void 0 !== m ? m : t;
 try {
-for (var C = a(g), S = C.next(); !S.done; S = C.next()) la(y, T, S.value.pos, e.name, d.maxPathOps);
+for (var C = a(g), S = C.next(); !S.done; S = C.next()) ma(y, T, S.value.pos, e.name, d.maxPathOps);
 } catch (e) {
 n = {
 error: e
@@ -10689,10 +10703,10 @@ S && !S.done && (i = C.return) && i.call(C);
 if (n) throw n.error;
 }
 }
-if (h && la(y, T, h.pos, e.name, d.maxPathOps), E && v >= 6 && la(y, T, E.pos, e.name, d.maxPathOps),
+if (h && ma(y, T, h.pos, e.name, d.maxPathOps), E && v >= 6 && ma(y, T, E.pos, e.name, d.maxPathOps),
 !R) {
 try {
-for (var w = a(g), x = w.next(); !x.done; x = w.next()) la(y, t, x.value.pos, e.name, d.maxPathOps);
+for (var w = a(g), x = w.next(); !x.done; x = w.next()) ma(y, t, x.value.pos, e.name, d.maxPathOps);
 } catch (e) {
 s = {
 error: e
@@ -10704,7 +10718,7 @@ x && !x.done && (c = w.return) && c.call(w);
 if (s) throw s.error;
 }
 }
-h && la(y, t, h.pos, e.name, d.maxPathOps);
+h && ma(y, t, h.pos, e.name, d.maxPathOps);
 }
 var b = {
 roomName: e.name,
@@ -10712,13 +10726,13 @@ positions: y,
 lastCalculated: Game.time
 };
 return function(e, t) {
-ra.set(e, t);
+oa.set(e, t);
 }(p, b), _.debug("Calculated road network for ".concat(e.name, ": ").concat(y.size, " positions"), {
 subsystem: "RoadNetwork"
 }), b;
 }
 
-function da(e) {
+function pa(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return null;
 var r = parseInt(t[2], 10), o = parseInt(t[4], 10);
@@ -10728,14 +10742,14 @@ y: "N" === t[3] ? o : -o - 1
 };
 }
 
-function pa(e, t) {
-var r = da(e), o = da(t);
+function fa(e, t) {
+var r = pa(e), o = pa(t);
 if (!r || !o) return null;
 var n = o.x - r.x, a = o.y - r.y;
 return Math.abs(n) + Math.abs(a) !== 1 ? null : 1 === n ? "right" : -1 === n ? "left" : 1 === a ? "top" : -1 === a ? "bottom" : null;
 }
 
-function fa(e, t) {
+function ya(e, t) {
 var r = [], o = Game.map.getRoomTerrain(e);
 switch (t) {
 case "top":
@@ -10756,7 +10770,7 @@ for (a = 0; a < 50; a++) o.get(49, a) !== TERRAIN_MASK_WALL && r.push(new RoomPo
 return r;
 }
 
-function ya(e, t) {
+function va(e, t) {
 var r, o;
 if (0 === t.length) return null;
 var n = t[0], i = e.getRangeTo(n);
@@ -10779,11 +10793,11 @@ if (r) throw r.error;
 return n;
 }
 
-function va(e, t) {
+function ga(e, t) {
 return e.x <= t || e.x >= 49 - t || e.y <= t || e.y >= 49 - t;
 }
 
-function ga(e, t, r, o) {
+function ha(e, t, r, o) {
 var n = new RoomPosition(25, 25, r), a = PathFinder.search(t, {
 pos: n,
 range: 20
@@ -10792,16 +10806,16 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return na(e);
+return aa(e);
 }
 });
-a.incomplete || sa(e, a.path);
+a.incomplete || ca(e, a.path);
 }
 
-function ha(e, t, r) {
+function Ra(e, t, r) {
 var n, i;
 void 0 === r && (r = {});
-var s = o(o({}, ta), r), c = new Map;
+var s = o(o({}, ra), r), c = new Map;
 if (!s.includeRemoteRoads) return c;
 var u = function(e) {
 var t, r = e.storage, o = e.find(FIND_MY_SPAWNS)[0];
@@ -10812,20 +10826,20 @@ try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 try {
-var p = pa(e.name, d);
+var p = fa(e.name, d);
 if (p) {
-var f = fa(e.name, p);
+var f = ya(e.name, p);
 if (0 === f.length) _.warn("No valid exit positions found in ".concat(e.name, " towards ").concat(d), {
 subsystem: "RoadNetwork"
 }); else {
-var y = ya(u, f);
+var y = va(u, f);
 if (y) {
-var v = ca(u, y, e.name, s.maxPathOps);
-v.incomplete || sa(c, v.path);
+var v = ua(u, y, e.name, s.maxPathOps);
+v.incomplete || ca(c, v.path);
 }
 }
 }
-ga(c, u, d, s.maxPathOps);
+ha(c, u, d, s.maxPathOps);
 } catch (e) {
 var g = e instanceof Error ? e.message : String(e);
 _.warn("Failed to calculate remote road to ".concat(d, ": ").concat(g), {
@@ -10847,9 +10861,9 @@ if (n) throw n.error;
 return c;
 }
 
-var Ra = [ "top", "bottom", "left", "right" ];
+var Ea = [ "top", "bottom", "left", "right" ];
 
-function Ea(e, t, r, n) {
+function Ta(e, t, r, n) {
 var c, u;
 void 0 === n && (n = []);
 var l = new Set(function(e, t, r, n) {
@@ -10860,9 +10874,9 @@ return "".concat(e.x, ",").concat(e.y);
 }).sort().join(";"), a = s([], i(o), !1).sort().join(",");
 return "".concat(e, "|").concat(t.x, ",").concat(t.y, "|").concat(n, "|").concat(a);
 }(e.name, t, r, n), u = function(e) {
-var t = oa.get(e);
+var t = na.get(e);
 if (t && function(e) {
-return Game.time - e.lastCalculated < ta.recalculateInterval;
+return Game.time - e.lastCalculated < ra.recalculateInterval;
 }(t)) return t.positions;
 }(c);
 if (u) return u;
@@ -10872,7 +10886,7 @@ var n, i, s = t.getTerrain();
 try {
 for (var c = a(o), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = r.x + l.x, d = r.y + l.y;
-m >= 1 && m <= 48 && d >= 1 && d <= 48 && s.get(m, d) !== TERRAIN_MASK_WALL && e.add(aa({
+m >= 1 && m <= 48 && d >= 1 && d <= 48 && s.get(m, d) !== TERRAIN_MASK_WALL && e.add(ia({
 x: m,
 y: d
 }));
@@ -10889,7 +10903,7 @@ if (n) throw n.error;
 }
 }
 }(l, e, t, r), function(e, t, r) {
-var o, n, i = ma(t, r);
+var o, n, i = da(t, r);
 try {
 for (var s = a(i.positions), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
@@ -10912,19 +10926,19 @@ if (u) {
 var l = function(e, t, r) {
 var n, i;
 void 0 === r && (r = {});
-var s = o(o({}, ta), r), c = new Set;
+var s = o(o({}, ra), r), c = new Set;
 try {
-for (var u = a(Ra), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Ea), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-var d = fa(e.name, m);
+var d = ya(e.name, m);
 if (0 === d.length) continue;
-var p = ya(t, d);
+var p = va(t, d);
 if (!p) continue;
-var f = ca(t, p, e.name, s.maxPathOps);
+var f = ua(t, p, e.name, s.maxPathOps);
 f.incomplete ? _.warn("Incomplete path when calculating exit road for ".concat(m, " in ").concat(e.name, " (target exit: ").concat(p.x, ",").concat(p.y, "). Path length: ").concat(f.path.length), {
 subsystem: "RoadNetwork"
-}) : ua(c, f, e.name);
+}) : la(c, f, e.name);
 } catch (t) {
 var y = t instanceof Error ? t.message : String(t);
 _.warn("Failed to calculate exit road for ".concat(m, " in ").concat(e.name, ": ").concat(y), {
@@ -10965,7 +10979,7 @@ if (r) throw r.error;
 }(l, e), function(e, t, r) {
 var o, n;
 if (0 !== r.length) {
-var i = ha(t, r).get(t.name);
+var i = Ra(t, r).get(t.name);
 if (i) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
@@ -10984,7 +10998,7 @@ if (o) throw o.error;
 }
 }
 }(l, e, n), function(e, t) {
-oa.set(e, t);
+na.set(e, t);
 }(c, {
 roomName: e.name,
 positions: l,
@@ -11005,7 +11019,7 @@ return e.structureType === STRUCTURE_ROAD;
 try {
 for (var l = a(c), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-va(d.pos, t) && s.add(aa(d.pos));
+ga(d.pos, t) && s.add(ia(d.pos));
 }
 } catch (e) {
 r = {
@@ -11021,7 +11035,7 @@ if (r) throw r.error;
 try {
 for (var p = a(u), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-va(y.pos, t) && s.add(aa(y.pos));
+ga(y.pos, t) && s.add(ia(y.pos));
 }
 } catch (e) {
 n = {
@@ -11055,9 +11069,9 @@ if (c) throw c.error;
 return l;
 }
 
-var Ta = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], Ca = new Set(Ta);
+var Ca = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], Sa = new Set(Ca);
 
-var Sa = {
+var wa = {
 id: "EXT10_DIAMOND",
 name: "EXT10 diamond extension pod",
 members: [ {
@@ -11093,7 +11107,7 @@ dy: 2
 } ].map(function(e, t) {
 return {
 id: "extension-".concat(t + 1),
-structureType: Cn,
+structureType: Sn,
 dx: e.dx,
 dy: e.dy,
 minRcl: 2,
@@ -11145,12 +11159,12 @@ minRcl: 2,
 priority: 50 - t
 };
 })
-}, wa = {
+}, xa = {
 id: "HUB_CORE",
 name: "Storage-centered hub core",
 members: [ {
 id: "spawn-1",
-structureType: Tn,
+structureType: Cn,
 dx: -2,
 dy: 0,
 minRcl: 1,
@@ -11161,7 +11175,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "storage",
-structureType: On,
+structureType: kn,
 dx: 0,
 dy: 0,
 minRcl: 4,
@@ -11172,7 +11186,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "hub-link",
-structureType: kn,
+structureType: Mn,
 dx: -1,
 dy: -1,
 minRcl: 5,
@@ -11183,7 +11197,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "terminal",
-structureType: Mn,
+structureType: An,
 dx: 0,
 dy: 1,
 minRcl: 6,
@@ -11194,7 +11208,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "factory",
-structureType: Un,
+structureType: Nn,
 dx: 1,
 dy: 1,
 minRcl: 7,
@@ -11205,7 +11219,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "spawn-2",
-structureType: Tn,
+structureType: Cn,
 dx: 2,
 dy: 0,
 minRcl: 7,
@@ -11216,7 +11230,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "spawn-3",
-structureType: Tn,
+structureType: Cn,
 dx: 0,
 dy: -2,
 minRcl: 8,
@@ -11227,7 +11241,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "tower-1",
-structureType: bn,
+structureType: On,
 dx: -2,
 dy: -2,
 minRcl: 3,
@@ -11238,7 +11252,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-2",
-structureType: bn,
+structureType: On,
 dx: 2,
 dy: -2,
 minRcl: 5,
@@ -11249,7 +11263,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-3",
-structureType: bn,
+structureType: On,
 dx: -2,
 dy: 2,
 minRcl: 7,
@@ -11326,12 +11340,12 @@ dy: 0,
 minRcl: 1,
 priority: 97
 } ]
-}, xa = {
+}, ba = {
 id: "SOURCE_MINING",
 name: "Anchored source mining support",
 members: [ {
 id: "container",
-structureType: xn,
+structureType: bn,
 dx: 0,
 dy: 0,
 minRcl: 2,
@@ -11341,7 +11355,7 @@ group: "source",
 fallback: "nearSource"
 }, {
 id: "source-link",
-structureType: kn,
+structureType: Mn,
 dx: 1,
 dy: 0,
 minRcl: 5,
@@ -11358,12 +11372,12 @@ dy: 1,
 minRcl: 1,
 priority: 60
 } ]
-}, ba = {
+}, Oa = {
 id: "CONTROLLER_STAMP",
 name: "Controller upgrading support",
 members: [ {
 id: "controller-container",
-structureType: xn,
+structureType: bn,
 dx: 0,
 dy: 0,
 minRcl: 2,
@@ -11373,7 +11387,7 @@ group: "controller",
 fallback: "nearController"
 }, {
 id: "controller-link",
-structureType: kn,
+structureType: Mn,
 dx: 1,
 dy: 0,
 minRcl: 5,
@@ -11396,7 +11410,7 @@ dy: 1,
 minRcl: 1,
 priority: 54
 } ]
-}, Oa = {
+}, ka = {
 id: "LAB3_TO_LAB10",
 name: "Expandable compact lab cluster",
 members: [ {
@@ -11452,7 +11466,7 @@ priority: 211
 } ].map(function(e, t) {
 return {
 id: "lab-".concat(t + 1),
-structureType: _n,
+structureType: Un,
 dx: e.dx,
 dy: e.dy,
 minRcl: e.minRcl,
@@ -11494,12 +11508,12 @@ dy: -1,
 minRcl: 6,
 priority: 86
 } ]
-}, ka = {
+}, Ma = {
 id: "DEFENSE_TOWER_PAIR",
 name: "Late-game defended tower group",
 members: [ {
 id: "tower-4",
-structureType: bn,
+structureType: On,
 dx: 0,
 dy: 0,
 minRcl: 8,
@@ -11510,7 +11524,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-5",
-structureType: bn,
+structureType: On,
 dx: 1,
 dy: 0,
 minRcl: 8,
@@ -11521,7 +11535,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-6",
-structureType: bn,
+structureType: On,
 dx: 0,
 dy: 1,
 minRcl: 8,
@@ -11556,12 +11570,12 @@ dy: -1,
 minRcl: 8,
 priority: 77
 } ]
-}, Ma = {
+}, Aa = {
 id: "LATE_GAME_HEAVY",
 name: "Protected late-game heavy structures",
 members: [ {
 id: "power-spawn",
-structureType: In,
+structureType: Gn,
 dx: 0,
 dy: 0,
 minRcl: 8,
@@ -11572,7 +11586,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "nuker",
-structureType: Nn,
+structureType: Pn,
 dx: 2,
 dy: 0,
 minRcl: 8,
@@ -11583,7 +11597,7 @@ fallback: "protectedFlexible",
 rampart: !0
 }, {
 id: "observer",
-structureType: Pn,
+structureType: In,
 dx: -2,
 dy: 0,
 minRcl: 8,
@@ -11618,12 +11632,12 @@ dy: 0,
 minRcl: 8,
 priority: 67
 } ]
-}, Aa = {
+}, _a = {
 id: "MINERAL_STAMP",
 name: "Fixed mineral extractor support",
 members: [ {
 id: "extractor",
-structureType: An,
+structureType: _n,
 dx: 0,
 dy: 0,
 minRcl: 6,
@@ -11633,7 +11647,7 @@ group: "mineral",
 fallback: "none"
 }, {
 id: "mineral-container",
-structureType: xn,
+structureType: bn,
 dx: 1,
 dy: 0,
 minRcl: 6,
@@ -11651,11 +11665,11 @@ priority: 52
 } ]
 };
 
-function _a(e) {
+function Ua(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function Ua(e, t, r) {
+function Na(e, t, r) {
 return t >= 1 && t <= 48 && r >= 1 && r <= 48 && !function(e, t, r) {
 var o = "undefined" == typeof TERRAIN_MASK_WALL ? 1 : TERRAIN_MASK_WALL;
 return 0 !== (function(e, t, r) {
@@ -11665,11 +11679,11 @@ return e.terrain instanceof Map ? null !== (o = e.terrain.get("".concat(t, ",").
 }(e, t, r);
 }
 
-function Na(e) {
-return e === Tn || e === bn || e === On || e === Mn || e === Un || e === kn || e === _n || e === In || e === Nn || e === Pn;
+function Pa(e) {
+return e === Cn || e === On || e === kn || e === An || e === Nn || e === Mn || e === Un || e === Gn || e === Pn || e === In;
 }
 
-function Pa(e, t, r) {
+function Ia(e, t, r) {
 var o, n, a, i;
 if (r.localAnchor) return r.localAnchor;
 switch (r.fallback) {
@@ -11687,14 +11701,14 @@ return t.anchor;
 }
 }
 
-function Ia(e, t, r, o) {
-return !!Ua(e, r, o) && !function(e) {
-return new Set(e.structures.map(_a));
+function Ga(e, t, r, o) {
+return !!Na(e, r, o) && !function(e) {
+return new Set(e.structures.map(Ua));
 }(t).has("".concat(r, ",").concat(o));
 }
 
-function Ga(e, t, r, o, n) {
-var i = Pa(e, t, r), s = Math.max(Math.abs(i.x - o), Math.abs(i.y - n)), c = Math.max(Math.abs(t.anchor.x - o), Math.abs(t.anchor.y - n)), u = e.controller ? Math.max(Math.abs(e.controller.x - o), Math.abs(e.controller.y - n)) : 0, l = function(e, t, r) {
+function La(e, t, r, o, n) {
+var i = Ia(e, t, r), s = Math.max(Math.abs(i.x - o), Math.abs(i.y - n)), c = Math.max(Math.abs(t.anchor.x - o), Math.abs(t.anchor.y - n)), u = e.controller ? Math.max(Math.abs(e.controller.x - o), Math.abs(e.controller.y - n)) : 0, l = function(e, t, r) {
 var o, n;
 if (!e || 0 === e.length) return 0;
 var i = 1 / 0;
@@ -11735,9 +11749,9 @@ if (o) throw o.error;
 }
 return i;
 }(t, o, n), d = Math.min(o, n, 49 - o, 49 - n), p = 1e3 - 18 * s - 2 * c + m + 2 * Math.min(d, 10);
-return r.structureType === bn && (p += 4 * Math.max(0, 14 - Math.min(c, u))), r.structureType === Cn && (p += m + 2 * Math.max(0, 16 - c)),
-r.structureType === kn && (p += 4 * Math.max(0, 10 - Math.min(l, u, c))), r.structureType === _n && (p += 8 * Math.max(0, 8 - c)),
-r.structureType === An && e.mineral && (p += e.mineral.x === o && e.mineral.y === n ? 1e4 : -1e4),
+return r.structureType === On && (p += 4 * Math.max(0, 14 - Math.min(c, u))), r.structureType === Sn && (p += m + 2 * Math.max(0, 16 - c)),
+r.structureType === Mn && (p += 4 * Math.max(0, 10 - Math.min(l, u, c))), r.structureType === Un && (p += 8 * Math.max(0, 8 - c)),
+r.structureType === _n && e.mineral && (p += e.mineral.x === o && e.mineral.y === n ? 1e4 : -1e4),
 {
 x: o,
 y: n,
@@ -11746,12 +11760,12 @@ reason: "fallback ".concat(r.fallback, " score ").concat(Math.round(p))
 };
 }
 
-function La(e, t, r, o) {
-if (void 0 === o && (o = "global"), r.structureType === An && e.mineral) return Ia(e, t, e.mineral.x, e.mineral.y) ? [ Ga(e, t, r, e.mineral.x, e.mineral.y) ] : [];
-for (var n = Pa(e, t, r), a = "local" === o ? 6 : 22, i = [], s = 0; s <= a; s++) {
+function Da(e, t, r, o) {
+if (void 0 === o && (o = "global"), r.structureType === _n && e.mineral) return Ga(e, t, e.mineral.x, e.mineral.y) ? [ La(e, t, r, e.mineral.x, e.mineral.y) ] : [];
+for (var n = Ia(e, t, r), a = "local" === o ? 6 : 22, i = [], s = 0; s <= a; s++) {
 for (var c = -s; c <= s; c++) for (var u = -s; u <= s; u++) if (!(s > 0 && Math.abs(c) !== s && Math.abs(u) !== s)) {
 var l = n.x + c, m = n.y + u;
-Ia(e, t, l, m) && i.push(Ga(e, t, r, l, m));
+Ga(e, t, l, m) && i.push(La(e, t, r, l, m));
 }
 if ("local" === o && i.length > 0) break;
 }
@@ -11760,38 +11774,38 @@ return t.score - e.score;
 });
 }
 
-function Da(e) {
+function Fa(e) {
 return e.length > 0 ? e[0] : null;
 }
 
-var Fa = "stamp-v1";
+var Ba = "stamp-v1";
 
-function Ba(e) {
+function Wa(e) {
 return Math.max(9, Math.min(40, Math.round(e)));
 }
 
-function Wa(e) {
+function Ha(e) {
 return {
-x: Ba(e.x),
-y: Ba(e.y)
+x: Wa(e.x),
+y: Wa(e.y)
 };
 }
 
-function Ha(e, t) {
+function Ka(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function Ka(e, t) {
+function Ya(e, t) {
 var r;
 return null !== (r = e.counts[t]) && void 0 !== r ? r : 0;
 }
 
-function Ya(e, t) {
-e.counts[t] = Ka(e, t) + 1;
+function Va(e, t) {
+e.counts[t] = Ya(e, t) + 1;
 }
 
-function Va(e, t, r, o, n, a) {
-if (!(a > e.plan.rcl) && Ua(e.facts, t, r) && !e.occupied.has("".concat(t, ",").concat(r))) {
+function qa(e, t, r, o, n, a) {
+if (!(a > e.plan.rcl) && Na(e.facts, t, r) && !e.occupied.has("".concat(t, ",").concat(r))) {
 var i = "".concat(t, ",").concat(r);
 e.roadKeys.has(i) || (e.plan.roads.push({
 x: t,
@@ -11803,13 +11817,13 @@ minRcl: a
 }
 }
 
-function qa(e, t, r) {
+function ja(e, t, r) {
 return void 0 === r && (r = !1), !!function(e, t, r, o) {
 var n, a = null !== (n = e.limits[t]) && void 0 !== n ? n : 0;
-return !(a <= 0 || Ka(e, t) >= a || !Ua(e.facts, r, o) || e.occupied.has("".concat(r, ",").concat(o)));
-}(e, t.structureType, t.x, t.y) && (e.plan.structures.push(t), e.occupied.add(_a(t)),
-Ya(e, t.structureType), (r || Na(t.structureType)) && function(e, t, r, o, n, a) {
-if (!(a > e.plan.rcl) && Ua(e.facts, t, r)) {
+return !(a <= 0 || Ya(e, t) >= a || !Na(e.facts, r, o) || e.occupied.has("".concat(r, ",").concat(o)));
+}(e, t.structureType, t.x, t.y) && (e.plan.structures.push(t), e.occupied.add(Ua(t)),
+Va(e, t.structureType), (r || Pa(t.structureType)) && function(e, t, r, o, n, a) {
+if (!(a > e.plan.rcl) && Na(e.facts, t, r)) {
 var i = "".concat(t, ",").concat(r);
 e.rampartKeys.has(i) || (e.plan.ramparts.push({
 x: t,
@@ -11822,12 +11836,12 @@ minRcl: a
 }(e, t.x, t.y, "".concat(t.source, ":rampart"), t.priority, t.minRcl), !0);
 }
 
-function ja(e, t, r) {
+function za(e, t, r) {
 var o, n, i;
 try {
 for (var s = a(null != t ? t : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== Sn && u.structureType !== wn && Ua(e.facts, u.x, u.y)) {
+if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== wn && u.structureType !== xn && Na(e.facts, u.x, u.y)) {
 var l = "".concat(u.x, ",").concat(u.y);
 if (!e.occupied.has(l)) {
 var m = {
@@ -11839,7 +11853,7 @@ priority: 1e3,
 source: r,
 placedBy: "fixed"
 };
-e.plan.structures.push(m), e.occupied.add(l), Ya(e, u.structureType);
+e.plan.structures.push(m), e.occupied.add(l), Va(e, u.structureType);
 }
 }
 }
@@ -11856,7 +11870,7 @@ if (o) throw o.error;
 }
 }
 
-function za(e, t, r, o) {
+function Qa(e, t, r, o) {
 return {
 structureType: e.structureType,
 priority: e.priority,
@@ -11871,17 +11885,17 @@ minRcl: e.minRcl
 };
 }
 
-function Qa(e, t) {
+function Xa(e, t) {
 var r, o = null !== (r = e.limits[t.structureType]) && void 0 !== r ? r : 0;
-return o > 0 && Ka(e, t.structureType) < o;
+return o > 0 && Ya(e, t.structureType) < o;
 }
 
-function Xa(e, t, r, o) {
-return o.minRcl > e.plan.rcl || !Qa(e, {
+function Za(e, t, r, o) {
+return o.minRcl > e.plan.rcl || !Xa(e, {
 structureType: o.structureType,
 priority: o.priority,
 fallback: o.fallback
-}) || qa(e, {
+}) || ja(e, {
 x: r.x + o.dx,
 y: r.y + o.dy,
 structureType: o.structureType,
@@ -11892,13 +11906,13 @@ placedBy: "stamp"
 }, o.rampart);
 }
 
-function Za(e, t, r) {
+function Ja(e, t, r) {
 var o, n, i, s, c = [], u = !0;
 e.plan.stamps.push(t.id);
 try {
 for (var l = a(t.roads), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-Va(e, r.x + d.dx, r.y + d.dy, "".concat(t.id, ":").concat(d.id), d.priority, d.minRcl);
+qa(e, r.x + d.dx, r.y + d.dy, "".concat(t.id, ":").concat(d.id), d.priority, d.minRcl);
 }
 } catch (e) {
 o = {
@@ -11919,7 +11933,7 @@ return t.priority - e.priority;
 try {
 for (var f = a(p), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-Xa(e, t, r, v) || ((v.required || Qa(e, za(v, t.id, r, "stamp member blocked"))) && c.push(za(v, t.id, r, "preferred stamp tile blocked")),
+Za(e, t, r, v) || ((v.required || Xa(e, Qa(v, t.id, r, "stamp member blocked"))) && c.push(Qa(v, t.id, r, "preferred stamp tile blocked")),
 v.required && (u = !1));
 }
 } catch (e) {
@@ -11939,20 +11953,20 @@ missing: c
 };
 }
 
-function Ja(e, t, r, o, n) {
+function $a(e, t, r, o, n) {
 for (var a = t.x, i = t.y, s = 0; (a !== r.x || i !== r.y) && s < 80 && (a < r.x ? a++ : a > r.x && a--,
-i < r.y ? i++ : i > r.y && i--, a !== r.x || i !== r.y); ) Va(e, a, i, o, 40, n),
+i < r.y ? i++ : i > r.y && i--, a !== r.x || i !== r.y); ) qa(e, a, i, o, 40, n),
 s++;
 }
 
-function $a(e, t, r) {
+function ei(e, t, r) {
 for (var o, n = null, a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) if (0 !== a || 0 !== i) {
 var s = {
 x: t.x + a,
 y: t.y + i
 };
-if (Ua(e.facts, s.x, s.y) && !e.occupied.has("".concat(s.x, ",").concat(s.y))) {
-var c = -Ha(s, r);
+if (Na(e.facts, s.x, s.y) && !e.occupied.has("".concat(s.x, ",").concat(s.y))) {
+var c = -Ka(s, r);
 (!n || c > n.score) && (n = {
 point: s,
 score: c
@@ -11962,9 +11976,9 @@ score: c
 return null !== (o = null == n ? void 0 : n.point) && void 0 !== o ? o : null;
 }
 
-function ei(e, t) {
-if (!Qa(e, t)) return !0;
-var r = Da(La(e.facts, e.plan, t, "local")), o = null != r ? r : Da(La(e.facts, e.plan, t, "global"));
+function ti(e, t) {
+if (!Xa(e, t)) return !0;
+var r = Fa(Da(e.facts, e.plan, t, "local")), o = null != r ? r : Fa(Da(e.facts, e.plan, t, "global"));
 if (!o) return !1;
 var n = function(e, t, r) {
 var o;
@@ -11978,11 +11992,11 @@ source: r,
 placedBy: "fallback"
 };
 }(o, t, t.sourceStamp ? "".concat(t.sourceStamp, ":fallback") : "fallback");
-return !!qa(e, n, Na(t.structureType)) && (function(e, t) {
+return !!ja(e, n, Pa(t.structureType)) && (function(e, t) {
 var r, o;
 if (!function(e, t) {
 return e.roads.some(function(e) {
-return 1 === Ha(e, t);
+return 1 === Ka(e, t);
 });
 }(e.plan, t)) {
 var n = [ {
@@ -12010,12 +12024,12 @@ y: t.y + 1
 x: t.x + 1,
 y: t.y - 1
 } ].sort(function(t, r) {
-return Ha(t, e.plan.anchor) - Ha(r, e.plan.anchor);
+return Ka(t, e.plan.anchor) - Ka(r, e.plan.anchor);
 });
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (Ua(e.facts, c.x, c.y) && !e.occupied.has("".concat(c.x, ",").concat(c.y))) return void Va(e, c.x, c.y, "fallback:road-access", 30, 1);
+if (Na(e.facts, c.x, c.y) && !e.occupied.has("".concat(c.x, ",").concat(c.y))) return void qa(e, c.x, c.y, "fallback:road-access", 30, 1);
 }
 } catch (e) {
 r = {
@@ -12032,24 +12046,24 @@ if (r) throw r.error;
 }(e, n), !0);
 }
 
-function ti(e) {
+function ri(e) {
 switch (e) {
-case Cn:
+case Sn:
 return "nearRoad";
 
-case bn:
+case On:
 return "defenseCoverage";
 
-case On:
-case Mn:
-case Un:
-case In:
+case kn:
+case An:
+case Nn:
+case Gn:
 return "nearStorage";
 
-case _n:
+case Un:
 return "labCluster";
 
-case An:
+case _n:
 return "nearMineral";
 
 default:
@@ -12057,37 +12071,37 @@ return "protectedFlexible";
 }
 }
 
-function ri(e) {
+function oi(e) {
 var t;
 return (null !== (t = function(e) {
 var t;
-return null !== (t = Dn(8)[e]) && void 0 !== t ? t : 0;
+return null !== (t = Fn(8)[e]) && void 0 !== t ? t : 0;
 }(e)) && void 0 !== t ? t : 0) > 0;
 }
 
-function oi(e) {
+function ni(e) {
 return "".concat(e.structureType, ":").concat(e.x, ",").concat(e.y);
 }
 
-function ni(e) {
+function ai(e) {
 switch (e) {
-case Tn:
-case xn:
+case Cn:
+case bn:
 return "P0";
 
-case On:
-case Cn:
 case kn:
+case Sn:
+case Mn:
 return "P1";
 
-case bn:
-case wn:
+case On:
+case xn:
 return "P2";
 
-case Mn:
-case _n:
 case An:
 case Un:
+case _n:
+case Nn:
 return "P3";
 
 default:
@@ -12095,7 +12109,7 @@ return "P4";
 }
 }
 
-function ai(e) {
+function ii(e) {
 switch (e) {
 case "P0":
 return 500;
@@ -12114,7 +12128,7 @@ return 100;
 }
 }
 
-function ii(e, t) {
+function si(e, t) {
 var r, o, n, i, s, c, u, l, m;
 void 0 === t && (t = {});
 var d = null !== (u = t.currentRcl) && void 0 !== u ? u : e.rcl, p = null !== (l = t.existingStructureKeys) && void 0 !== l ? l : new Set, f = null !== (m = t.existingSiteKeys) && void 0 !== m ? m : new Set, y = [];
@@ -12127,11 +12141,11 @@ x: h.x,
 y: h.y,
 structureType: h.structureType,
 minRcl: h.minRcl,
-priority: ni(h.structureType),
-score: ai(ni(h.structureType)) + h.priority,
+priority: ai(h.structureType),
+score: ii(ai(h.structureType)) + h.priority,
 source: h.source
 };
-p.has(oi(R)) || f.has(oi(R)) || y.push(R);
+p.has(ni(R)) || f.has(ni(R)) || y.push(R);
 }
 }
 } catch (e) {
@@ -12151,12 +12165,12 @@ var C = T.value;
 C.minRcl > d || (R = {
 x: C.x,
 y: C.y,
-structureType: Sn,
+structureType: wn,
 minRcl: C.minRcl,
 priority: "P1",
 score: 360 + C.priority,
 source: C.source
-}, p.has(oi(R)) || f.has(oi(R)) || y.push(R));
+}, p.has(ni(R)) || f.has(ni(R)) || y.push(R));
 }
 } catch (e) {
 n = {
@@ -12175,12 +12189,12 @@ var x = w.value;
 x.minRcl > d || (R = {
 x: x.x,
 y: x.y,
-structureType: wn,
+structureType: xn,
 minRcl: x.minRcl,
 priority: "P2",
 score: 300 + x.priority,
 source: x.source
-}, p.has(oi(R)) || f.has(oi(R)) || y.push(R));
+}, p.has(ni(R)) || f.has(ni(R)) || y.push(R));
 }
 } catch (e) {
 s = {
@@ -12198,32 +12212,32 @@ return t.score - e.score || e.structureType.localeCompare(t.structureType);
 }), "number" == typeof t.maxItems ? y.slice(0, t.maxItems) : y;
 }
 
-var si, ci = "defenseAssist";
+var ci, ui = "defenseAssist";
 
-function ui(e, t, r) {
+function li(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function li(e, t) {
+function mi(e, t) {
 Object.assign(e.memory, function(e) {
 var t, r, o = null !== (t = e.createdAt) && void 0 !== t ? t : e.now;
 return {
 assistTarget: e.targetRoom,
 targetRoom: e.targetRoom,
-task: ci,
-defenseSquadId: null !== (r = e.squadId) && void 0 !== r ? r : ui(e.homeRoom, e.targetRoom, o),
+task: ui,
+defenseSquadId: null !== (r = e.squadId) && void 0 !== r ? r : li(e.homeRoom, e.targetRoom, o),
 defenseSquadSize: Math.max(1, e.squadSize),
 defenseSquadCreatedAt: o
 };
 }(t));
 }
 
-function mi(e) {
+function di(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ci ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ui ? e.targetRoom : void 0;
 }
 
-function di(e) {
+function pi(e) {
 return !!function(e, t) {
 if ("retreat" === t.recommendedResponse || "safemode" === t.recommendedResponse) return !0;
 var r = e.room.find(FIND_MY_CREEPS, {
@@ -12251,7 +12265,7 @@ subsystem: "Defense",
 room: e.room.name,
 creep: e.name
 }), !0);
-}(e, No(e.room)) && (function(e) {
+}(e, Po(e.room)) && (function(e) {
 var t, r, o, n, c = e.room.find(FIND_MY_SPAWNS)[0];
 if (c) {
 var u = e.moveTo(c, {
@@ -12309,56 +12323,56 @@ stroke: "#ff0000"
 !function(e) {
 e[e.NONE = 0] = "NONE", e[e.LOW = 1] = "LOW", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL";
-}(si || (si = {}));
+}(ci || (ci = {}));
 
-var pi = function() {
+var fi = function() {
 function e() {
 this.emergencyStates = new Map;
 }
 return e.prototype.assess = function(e, t) {
 var r, o, n = this.emergencyStates.get(e.name), a = this.calculateEmergencyLevel(e, t);
-if (a === si.NONE && !n) return {
-level: si.NONE,
+if (a === ci.NONE && !n) return {
+level: ci.NONE,
 startedAt: Game.time,
 assistanceRequested: !1,
 boostsAllocated: !1,
 lastEscalation: 0
 };
-var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : si.NONE;
+var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : ci.NONE;
 return n ? (o = n).level = a : (o = {
 level: a,
 startedAt: Game.time,
 assistanceRequested: !1,
 boostsAllocated: !1,
 lastEscalation: 0
-}, this.emergencyStates.set(e.name, o)), a === si.NONE ? (n && (_.info("Emergency resolved in ".concat(e.name), {
+}, this.emergencyStates.set(e.name, o)), a === ci.NONE ? (n && (_.info("Emergency resolved in ".concat(e.name), {
 subsystem: "Defense"
 }), this.emergencyStates.delete(e.name)), o) : (n && a > i && (_.warn("Emergency escalated in ".concat(e.name, ": Level ").concat(i, " → ").concat(a), {
 subsystem: "Defense"
 }), o.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, o), o);
 }, e.prototype.calculateEmergencyLevel = function(e, t) {
 var r = X(e);
-if (0 === t.danger && 0 === r.length) return si.NONE;
-var o = ao(e), n = so(e), a = No(e);
+if (0 === t.danger && 0 === r.length) return ci.NONE;
+var o = io(e), n = co(e), a = Po(e);
 if (e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
 }
-}).length > 0) return si.CRITICAL;
+}).length > 0) return ci.CRITICAL;
 var i = r.filter(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && e.boost;
 });
 }), s = Math.max(0, o.guards - n.guards) + Math.max(0, o.rangers - n.rangers) + Math.max(0, o.healers - n.healers);
-return i.length > 0 && s >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers || a.dangerLevel >= 2 && s >= 2 ? si.HIGH : (t.danger >= 2 || a.dangerLevel >= 2) && s >= 1 ? si.MEDIUM : t.danger >= 1 || r.length > 0 ? si.LOW : si.NONE;
+return i.length > 0 && s >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers || a.dangerLevel >= 2 && s >= 2 ? ci.HIGH : (t.danger >= 2 || a.dangerLevel >= 2) && s >= 1 ? ci.MEDIUM : t.danger >= 1 || r.length > 0 ? ci.LOW : ci.NONE;
 }, e.prototype.executeEmergencyResponse = function(e, t, r) {
-r.level >= si.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
-r.level >= si.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
+r.level >= ci.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
+r.level >= ci.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
 r.boostsAllocated = !0), this.updateDefensePosture(e, t, r);
 }, e.prototype.requestDefenseAssistance = function(e, t) {
 var r;
-if (!co(e, t)) return !1;
-var o = uo(e, t);
+if (!uo(e, t)) return !1;
+var o = lo(e, t);
 if (!o) return !1;
 var n = Memory, a = null !== (r = n.defenseRequests) && void 0 !== r ? r : [], c = a.find(function(t) {
 return t.roomName === e.name && Game.time - t.createdAt < 500;
@@ -12378,28 +12392,28 @@ subsystem: "Defense"
 });
 }, e.prototype.updateDefensePosture = function(e, t, r) {
 switch (r.level) {
-case si.CRITICAL:
+case ci.CRITICAL:
 "evacuate" !== t.posture && (t.posture = "war", t.pheromones.war = 100, t.pheromones.defense = 100,
 _.warn("".concat(e.name, " posture: CRITICAL DEFENSE"), {
 subsystem: "Defense"
 }));
 break;
 
-case si.HIGH:
+case ci.HIGH:
 "war" !== t.posture && "evacuate" !== t.posture && (t.posture = "defensive", t.pheromones.defense = 80,
 t.pheromones.war = 40, _.info("".concat(e.name, " posture: HIGH DEFENSE"), {
 subsystem: "Defense"
 }));
 break;
 
-case si.MEDIUM:
+case ci.MEDIUM:
 "eco" !== t.posture && "expand" !== t.posture || (t.posture = "defensive", t.pheromones.defense = 60,
 _.info("".concat(e.name, " posture: MEDIUM DEFENSE"), {
 subsystem: "Defense"
 }));
 break;
 
-case si.LOW:
+case ci.LOW:
 "eco" !== t.posture && "expand" !== t.posture || (t.pheromones.defense = 30, _.debug("".concat(e.name, ": LOW DEFENSE alert"), {
 subsystem: "Defense"
 }));
@@ -12418,13 +12432,13 @@ r.defenseRequests = o;
 return this.emergencyStates.get(e);
 }, e.prototype.hasEmergency = function(e) {
 var t = this.emergencyStates.get(e);
-return void 0 !== t && t.level > si.NONE;
+return void 0 !== t && t.level > ci.NONE;
 }, e.prototype.getActiveEmergencies = function() {
 var e, t, r = [];
 try {
 for (var o = a(this.emergencyStates.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-u.level > si.NONE && r.push({
+u.level > ci.NONE && r.push({
 roomName: c,
 state: u
 });
@@ -12444,27 +12458,27 @@ return r.sort(function(e, t) {
 return t.state.level - e.state.level;
 });
 }, e;
-}(), fi = new pi;
+}(), yi = new fi;
 
-function yi(e) {
+function vi(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === HEAL || e.type === WORK || e.type === CLAIM);
 });
 }
 
-function vi(e, t) {
+function gi(e, t) {
 return e.body.filter(function(e) {
 return e.hits > 0 && e.type === t;
 }).length;
 }
 
-function gi(e) {
+function hi(e) {
 return !!e.body.some(function(e) {
 return e.hits > 0 && e.boost;
-}) || vi(e, WORK) >= 5 || vi(e, HEAL) >= 3;
+}) || gi(e, WORK) >= 5 || gi(e, HEAL) >= 3;
 }
 
-var hi = function() {
+var Ri = function() {
 function e() {}
 return e.prototype.checkSafeMode = function(e, t) {
 var r, o, n, a, i;
@@ -12482,7 +12496,7 @@ subsystem: "Defense"
 }, e.prototype.shouldTriggerSafeMode = function(e, t) {
 var r, o;
 if (t.danger < 2) return !1;
-var n = X(e), i = n.filter(yi), s = function() {
+var n = X(e), i = n.filter(vi), s = function() {
 var e;
 return !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.safeModeDangerousHostilesOnly);
 }(), c = s ? i : n;
@@ -12521,21 +12535,21 @@ return "guard" === t || "ranger" === t || "soldier" === t;
 if (c.length > 3 * p.length) return _.warn("Overwhelmed: ".concat(c.length, " safe-mode-relevant hostiles vs ").concat(p.length, " defenders"), {
 subsystem: "Defense"
 }), !0;
-var f = c.filter(gi);
+var f = c.filter(hi);
 return f.length > 0 && p.length < 2 * f.length && (_.warn("High-impact siege hostiles detected: ".concat(f.length), {
 subsystem: "Defense"
 }), !0);
 }, e;
-}(), Ri = new hi, Ei = {
+}(), Ei = new Ri, Ti = {
 triggerDangerLevel: 3,
 nukeEvacuationLeadTime: 5e3,
 minStorageEnergy: 5e4,
 priorityResources: [ RESOURCE_ENERGY, RESOURCE_POWER, RESOURCE_GHODIUM, RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ACID, RESOURCE_CATALYZED_ZYNTHIUM_ACID, RESOURCE_OPS ],
 maxTransfersPerTick: 2
-}, Ti = function() {
+}, Ci = function() {
 function e(e) {
 void 0 === e && (e = {}), this.evacuations = new Map, this.lastTransferTick = 0,
-this.transfersThisTick = 0, this.config = o(o({}, Ei), e);
+this.transfersThisTick = 0, this.config = o(o({}, Ti), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o;
@@ -12797,9 +12811,9 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), Ci = new Ti;
+}(), Si = new Ci;
 
-function Si(e) {
+function wi(e) {
 var t = Math.floor(e.bucketThresholds.lowMode / 2), r = {
 high: 1,
 medium: Math.max(1, Math.min(e.taskFrequencies.clusterLogic, e.taskFrequencies.pheromoneUpdate)),
@@ -12834,21 +12848,21 @@ maxPriorityBoost: 50
 };
 }
 
-var wi, xi = null, bi = new Proxy({}, {
+var xi, bi = null, Oi = new Proxy({}, {
 get: function(e, t) {
-return xi || (xi = new Xt(Si(Rt().cpu))), xi[t];
+return bi || (bi = new Xt(wi(Rt().cpu))), bi[t];
 },
 set: function(e, t, r) {
-return xi || (xi = new Xt(Si(Rt().cpu))), xi[t] = r, !0;
+return bi || (bi = new Xt(wi(Rt().cpu))), bi[t] = r, !0;
 }
 });
 
-function Oi() {
+function ki() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-ur.apply(void 0, s([ bi ], i(e), !1));
+ur.apply(void 0, s([ Oi ], i(e), !1));
 }
 
-var ki, Mi, Ai = {
+var Mi, Ai, _i = {
 updateInterval: 200,
 minBucket: 0,
 minCreditsForPixels: 5e5,
@@ -12860,11 +12874,11 @@ targetPixelPrice: 2e3,
 maxPixelsPerTransaction: 10,
 purchaseCooldown: 1e3,
 minBaseMineralReserve: 1e4,
-criticalResourceThresholds: (wi = {}, wi[RESOURCE_GHODIUM] = 5e3, wi),
+criticalResourceThresholds: (xi = {}, xi[RESOURCE_GHODIUM] = 5e3, xi),
 enabled: !0
-}, _i = function() {
+}, Ui = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ai), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, _i), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13040,15 +13054,15 @@ this.config.enabled = !1, _.info("Pixel buying disabled", {
 subsystem: "PixelBuying"
 });
 }, e;
-}(), Ui = {
+}(), Ni = {
 enabled: !0,
 fullBucketTicksRequired: 25,
 bucketMax: 1e4,
 cpuCostPerPixel: 1e4,
 minBucketAfterGeneration: 0
-}, Ni = function() {
+}, Pi = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, Ui), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.config = o(o({}, Ni), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13110,7 +13124,7 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), Pi = function(e) {
+}(), Ii = function(e) {
 var t = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.map(function(e) {
@@ -13140,18 +13154,18 @@ for (var o = [], n = 1; n < arguments.length; n++) o[n - 1] = arguments[n];
 return console.log.apply(console, s([ "[".concat(e, "] ERROR:"), r ], i(t.apply(void 0, s([], i(o), !1))), !1));
 }
 };
-}("stats"), Ii = function(e) {
+}("stats"), Gi = function(e) {
 var t, r, o;
 return (null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.swarm) || (null === (o = Memory.swarm) || void 0 === o ? void 0 : o[e]) || {};
 };
 
 !function(e) {
 e.ACTIVE = "active", e.DECAY = "decay", e.INACTIVE = "inactive";
-}(ki || (ki = {})), function(e) {
+}(Mi || (Mi = {})), function(e) {
 e.PHEROMONES = "pheromones", e.PATHS = "paths", e.TARGETS = "targets", e.DEBUG = "debug";
-}(Mi || (Mi = {}));
+}(Ai || (Ai = {}));
 
-var Gi = new (function() {
+var Li = new (function() {
 function e() {
 this.metrics = {
 totalCalls: 0,
@@ -13199,7 +13213,7 @@ moveByPath: 0
 }, e;
 }());
 
-function Li(e, t) {
+function Di(e, t) {
 var r;
 void 0 === t && (t = {});
 var o = null === (r = t.includeCpuUsage) || void 0 === r || r, n = s([], i(e), !1).sort(function(e, t) {
@@ -13208,15 +13222,15 @@ return t.percentUsed - e.percentUsed;
 var r, n, a = "room:".concat(e.target), i = null === (r = t.processes) || void 0 === r ? void 0 : r[a], s = null !== (n = null == i ? void 0 : i.tickModulo) && void 0 !== n ? n : 1, c = s > 1 ? " [runs every ".concat(s, " ticks]") : "", u = "".concat((100 * e.percentUsed).toFixed(1), "%");
 return o ? "".concat(e.target, ": ").concat(u, " (").concat(e.cpuUsed.toFixed(3), "/").concat(e.budgetLimit.toFixed(3), " CPU)").concat(c) : "".concat(e.target, ": ").concat(u).concat(c);
 });
-return Di(n, e.length);
+return Fi(n, e.length);
 }
 
-function Di(e, t) {
+function Fi(e, t) {
 var r = t - e.length;
 return r > 0 && e.push("... ".concat(r, " more omitted")), e.join(", ");
 }
 
-var Fi = {
+var Bi = {
 enabled: !0,
 smoothingFactor: .1,
 trackNativeCalls: !0,
@@ -13238,9 +13252,9 @@ enabled: !0,
 spikeThreshold: 2,
 minSamples: 10
 }
-}, Bi = 1e-9, Wi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
+}, Wi = 1e-9, Hi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
 
-function Hi() {
+function Ki() {
 return {
 tasks: 0,
 openTasks: 0,
@@ -13252,28 +13266,28 @@ remainingAmount: 0
 };
 }
 
-function Ki(e) {
+function Yi(e) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, e) : 0;
 }
 
-function Yi(e) {
+function Vi(e) {
 var t;
 return Object.values(null !== (t = e.reservations) && void 0 !== t ? t : {}).reduce(function(e, t) {
-return e + Ki(null == t ? void 0 : t.amount);
+return e + Yi(null == t ? void 0 : t.amount);
 }, 0);
 }
 
-var Vi = function() {
+var qi = function() {
 function e(e) {
 void 0 === e && (e = {}), this.subsystemMeasurements = new Map, this.cpuDetailMeasurements = new Map,
 this.roomMeasurements = new Map, this.lastSegmentUpdate = 0, this.lastBudgetAlertLogTick = -1 / 0,
 this.lastAnomalyLogTick = -1 / 0, this.segmentRequested = !1, this.skippedProcessesThisTick = 0,
-this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Fi), e),
+this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Bi), e),
 this.currentSnapshot = this.createEmptySnapshot(), this.nativeCallsThisTick = this.createEmptyNativeCalls();
 }
 return e.prototype.initialize = function() {
 void 0 === RawMemory.segments[this.config.segmentId] && (RawMemory.setActiveSegments([ this.config.segmentId ]),
-this.segmentRequested = !0), this.installCpuProfilerGlobal(), Pi.info("Unified stats system initialized", {
+this.segmentRequested = !0), this.installCpuProfilerGlobal(), Ii.info("Unified stats system initialized", {
 subsystem: "Stats"
 });
 }, e.prototype.preserveRoomStats = function() {
@@ -13310,7 +13324,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-Gi.reset();
+Li.reset();
 }
 }, e.prototype.publishIdleTick = function() {
 this.startTick(), this.finalizeTick();
@@ -13346,19 +13360,19 @@ return "critical" === e.severity;
 }), C = R.alerts.filter(function(e) {
 return "warning" === e.severity;
 });
-T.length > 0 && Pi.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Li(T, {
+T.length > 0 && Ii.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Di(T, {
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
-}), C.length > 0 && Pi.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Li(C, {
+}), C.length > 0 && Ii.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Di(C, {
 includeCpuUsage: !1,
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
 }), this.lastBudgetAlertLogTick = Game.time;
 }
-E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Pi.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
-return Di(s([], i(e), !1).sort(function(e, t) {
+E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Ii.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
+return Fi(s([], i(e), !1).sort(function(e, t) {
 return t.multiplier - e.multiplier;
 }).slice(0, 5).map(function(e) {
 return "".concat(e.target, " (").concat(e.type, "): ").concat(e.current.toFixed(3), " CPU (").concat(e.multiplier.toFixed(1), "x baseline)").concat(e.context ? " - ".concat(e.context) : "");
@@ -13458,7 +13472,7 @@ v.staleReservations = null !== (s = null === (i = y.stats) || void 0 === i ? voi
 v.blockedReservations = null !== (u = null === (c = y.stats) || void 0 === c ? void 0 : c.blockedReservations) && void 0 !== u ? u : 0;
 try {
 for (var g = a(Object.values(null !== (l = y.tasks) && void 0 !== l ? l : {})), h = g.next(); !h.done; h = g.next()) {
-var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : Hi(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = Ki(R.amount), w = Yi(R), x = Math.max(0, S - w), b = Wi.has(E);
+var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : Ki(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = Yi(R.amount), w = Vi(R), x = Math.max(0, S - w), b = Hi.has(E);
 v.tasks++, v.reservations += C, v.amount += S, v.reservedAmount += w, v.remainingAmount += x,
 T.tasks++, T.reservations += C, T.amount += S, T.reservedAmount += w, T.remainingAmount += x,
 "open" === R.status ? (v.openTasks++, T.openTasks++) : "assigned" === R.status && (v.assignedTasks++,
@@ -13682,7 +13696,7 @@ this.defenseAssistTelemetry.set(e, r), (null == o ? void 0 : o.defense) && (o.de
 }, e.prototype.recordRoom = function(e, t) {
 var r, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, k, M;
 if (this.config.enabled) {
-var A = Ii(e.name), _ = Object.values(Game.creeps).filter(function(t) {
+var A = Gi(e.name), _ = Object.values(Game.creeps).filter(function(t) {
 return t.room.name === e.name;
 }).length, U = X(e), N = this.getRoomTaskBoardStats(e.name), P = this.getRemoteStats(e.name, A), I = this.getDefenseStats(e, U, A), G = this.defenseAssistTelemetry.get(e.name), L = this.getControllerDowngradeStats(e), D = this.currentSnapshot.rooms[e.name];
 D || (D = {
@@ -13790,7 +13804,7 @@ storageEnergy: W
 };
 }
 }, e.prototype.isWarRoom = function(e) {
-var t = Ii(e);
+var t = Gi(e);
 return !!t && ("war" === t.posture || "siege" === t.posture || t.danger >= 2);
 }, e.prototype.validateBudgets = function() {
 var e, t, r, o = {
@@ -13805,8 +13819,8 @@ try {
 for (var n = a(Object.entries(this.currentSnapshot.rooms)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
 o.roomsEvaluated++;
-var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Bi ? h : Math.abs(v - g) <= Bi ? g : v;
-v + Bi >= h ? (o.roomsOverBudget++, o.alerts.push({
+var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Wi ? h : Math.abs(v - g) <= Wi ? g : v;
+v + Wi >= h ? (o.roomsOverBudget++, o.alerts.push({
 severity: "critical",
 target: u,
 targetType: "room",
@@ -13814,7 +13828,7 @@ cpuUsed: y,
 budgetLimit: f,
 percentUsed: R,
 tick: Game.time
-})) : v + Bi >= g ? (o.alerts.push({
+})) : v + Wi >= g ? (o.alerts.push({
 severity: "warning",
 target: u,
 targetType: "room",
@@ -13848,7 +13862,7 @@ var v = null !== (n = this.roomMeasurements.get(f)) && void 0 !== n ? n : 0;
 if (!((x = y.profiler.avgCpu) < .01)) {
 var g = v / x;
 if (g >= this.config.anomalyDetection.spikeThreshold) {
-var h = Ii(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
+var h = Gi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
 l.push({
 type: "spike",
 target: f,
@@ -14276,7 +14290,7 @@ evictions: 0
 }
 };
 }, e.prototype.finalizePathfindingStats = function() {
-this.currentSnapshot.pathfinding = Gi.getMetrics();
+this.currentSnapshot.pathfinding = Li.getMetrics();
 }, e.prototype.formatCpuDetailsForMemory = function() {
 var e, t, r, n, s = this.getCpuDetailsConfig(), c = {};
 try {
@@ -14672,24 +14686,24 @@ var o = JSON.parse(r);
 Array.isArray(o) && (t = o);
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Pi.error("Failed to parse stats segment: ".concat(n), {
+Ii.error("Failed to parse stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
 t.push(this.currentSnapshot), t.length > this.config.maxHistoryPoints && (t = t.slice(-this.config.maxHistoryPoints));
 var a = JSON.stringify(t);
 if (a.length > e) {
-for (Pi.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
+for (Ii.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
 subsystem: "Stats"
 }); a.length > e && t.length > 1; ) t.shift(), a = JSON.stringify(t);
-if (a.length > e) return void Pi.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
+if (a.length > e) return void Ii.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
 subsystem: "Stats"
 });
 }
 try {
 RawMemory.segments[this.config.segmentId] = a;
 } catch (e) {
-n = e instanceof Error ? e.message : String(e), Pi.error("Failed to save stats segment: ".concat(n), {
+n = e instanceof Error ? e.message : String(e), Ii.error("Failed to save stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
@@ -14706,17 +14720,17 @@ lastUpdate: 0
 }), e.stats.profiler;
 }, e.prototype.logSummary = function() {
 var e, t, r, o, n, i, s, c, u, l, m = this.currentSnapshot;
-Pi.info("=== Unified Stats Summary ==="), Pi.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
-Pi.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
+Ii.info("=== Unified Stats Summary ==="), Ii.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
+Ii.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
 var d = Object.values(m.subsystems).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (d.length > 0) {
-Pi.info("Top Subsystems:");
+Ii.info("Top Subsystems:");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Pi.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
+Ii.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
 }
 } catch (t) {
 e = {
@@ -14734,11 +14748,11 @@ var v = Object.values(m.roles).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (v.length > 0) {
-Pi.info("Top Roles:");
+Ii.info("Top Roles:");
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Pi.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
+Ii.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
 }
 } catch (e) {
 r = {
@@ -14756,11 +14770,11 @@ var E = Object.values(m.processes).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (E.length > 0) {
-Pi.info("Top Processes:");
+Ii.info("Top Processes:");
 try {
 for (var T = a(E), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-Pi.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
+Ii.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
 }
 } catch (e) {
 n = {
@@ -14778,11 +14792,11 @@ var w = Object.values(m.rooms).sort(function(e, t) {
 return t.profiler.avgCpu - e.profiler.avgCpu;
 }).slice(0, 5);
 if (w.length > 0) {
-Pi.info("Top Rooms by CPU:");
+Ii.info("Top Rooms by CPU:");
 try {
 for (var x = a(w), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Pi.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
+Ii.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
 }
 } catch (e) {
 s = {
@@ -14800,11 +14814,11 @@ var k = Object.values(m.creeps).sort(function(e, t) {
 return t.cpu - e.cpu;
 }).slice(0, 5);
 if (k.length > 0) {
-Pi.info("Top Creeps by CPU:");
+Ii.info("Top Creeps by CPU:");
 try {
 for (var M = a(k), A = M.next(); !A.done; A = M.next()) {
 var _ = A.value;
-Pi.info("  ".concat(_.name, " (").concat(_.role, "): ").concat(_.cpu.toFixed(3), " CPU in ").concat(_.currentRoom));
+Ii.info("  ".concat(_.name, " (").concat(_.role, "): ").concat(_.cpu.toFixed(3), " CPU in ").concat(_.currentRoom));
 }
 } catch (e) {
 u = {
@@ -14818,7 +14832,7 @@ if (u) throw u.error;
 }
 }
 }
-this.config.trackNativeCalls && Pi.info("Native calls: ".concat(m.native.total, " total"));
+this.config.trackNativeCalls && Ii.info("Native calls: ".concat(m.native.total, " total"));
 }, e.prototype.postureToCode = function(e) {
 var t;
 return null !== (t = {
@@ -14864,16 +14878,16 @@ lastUpdate: 0
 return o({}, this.currentSnapshot);
 }, e.POSTURE_NAMES = [ "eco", "expand", "defensive", "war", "siege", "evacuate", "nukePrep" ],
 e;
-}(), qi = new Vi, ji = {
+}(), ji = new qi, zi = {
 primarySegment: 90,
 backupSegment: 91,
 retentionPeriod: 1e4,
 updateInterval: 50,
 maxDataPoints: 1e3
-}, zi = function() {
+}, Qi = function() {
 function e(e) {
 void 0 === e && (e = {}), this.statsData = null, this.segmentRequested = !1, this.lastUpdate = 0,
-this.config = o(o({}, ji), e);
+this.config = o(o({}, zi), e);
 }
 return e.prototype.initialize = function() {
 RawMemory.setActiveSegments([ this.config.primarySegment ]), this.segmentRequested = !0;
@@ -14884,12 +14898,12 @@ this.lastUpdate = Game.time);
 }, e.prototype.loadFromSegment = function() {
 var e = RawMemory.segments[this.config.primarySegment];
 if (e && 0 !== e.length) try {
-this.statsData = JSON.parse(e), Pi.debug("Loaded stats from segment", {
+this.statsData = JSON.parse(e), Ii.debug("Loaded stats from segment", {
 subsystem: "Stats"
 });
 } catch (e) {
 var t = e instanceof Error ? e.message : String(e);
-Pi.error("Failed to parse stats segment: ".concat(t), {
+Ii.error("Failed to parse stats segment: ".concat(t), {
 subsystem: "Stats"
 }), this.statsData = this.createDefaultStatsData();
 } else this.statsData = this.createDefaultStatsData();
@@ -14941,7 +14955,7 @@ c["".concat(p, ".energy.capacity")] = d.energyCapacity, c["".concat(p, ".storage
 c["".concat(p, ".terminal.energy")] = d.terminalEnergy, c["".concat(p, ".creeps")] = d.creepCount,
 c["".concat(p, ".controller.progress")] = d.controllerProgress, c["".concat(p, ".controller.progress_total")] = d.controllerProgressTotal,
 c["".concat(p, ".controller.progress_percent")] = d.controllerProgressTotal > 0 ? d.controllerProgress / d.controllerProgressTotal * 100 : 0;
-var f = Ii(d.roomName);
+var f = Gi(d.roomName);
 if (f) {
 if (c["".concat(p, ".brain.danger")] = f.danger, c["".concat(p, ".brain.posture_code")] = this.postureToCode(f.posture),
 c["".concat(p, ".brain.colony_level_code")] = this.colonyLevelToCode(f.colonyLevel),
@@ -15056,7 +15070,7 @@ try {
 this.statsData.lastUpdate = Game.time;
 var i = JSON.stringify(this.statsData);
 if (i.length > n) {
-for (Pi.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
+for (Ii.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
 subsystem: "Stats"
 }); i.length > n && this.statsData.history.length > 10; ) this.statsData.history.shift(),
 i = JSON.stringify(this.statsData);
@@ -15075,7 +15089,7 @@ if (e) throw e.error;
 }
 }
 if (i.length > n) {
-Pi.warn("Stats data still exceeds limit after trimming, clearing history", {
+Ii.warn("Stats data still exceeds limit after trimming, clearing history", {
 subsystem: "Stats"
 }), this.statsData.history = this.statsData.history.slice(-5);
 try {
@@ -15098,7 +15112,7 @@ i = JSON.stringify(this.statsData);
 RawMemory.segments[this.config.primarySegment] = i;
 } catch (e) {
 var p = e instanceof Error ? e.message : String(e);
-Pi.error("Failed to save stats segment: ".concat(p), {
+Ii.error("Failed to save stats segment: ".concat(p), {
 subsystem: "Stats"
 });
 }
@@ -15202,9 +15216,9 @@ fortifiedHive: 4,
 empireDominance: 5
 }[e]) && void 0 !== t ? t : 0;
 }, e;
-}(), Qi = new zi;
+}(), Xi = new Qi;
 
-function Xi(e) {
+function Zi(e) {
 e._metrics || (e._metrics = {
 tasksCompleted: 0,
 energyTransferred: 0,
@@ -15217,15 +15231,15 @@ healingDone: 0
 });
 }
 
-function Zi(e) {
-return Xi(e), e._metrics;
+function Ji(e) {
+return Zi(e), e._metrics;
 }
 
-function Ji(e, t) {
-Zi(e).damageDealt += t;
+function $i(e, t) {
+Ji(e).damageDealt += t;
 }
 
-var $i, es = {
+var es, ts = {
 minBucket: 0,
 minSourceLinkEnergy: 400,
 controllerLinkMaxEnergy: 700,
@@ -15237,18 +15251,18 @@ storageEnergyReserveForSpawnLink: 1e4
 !function(e) {
 e.SOURCE = "source", e.CONTROLLER = "controller", e.STORAGE = "storage", e.SPAWN = "spawn",
 e.UNKNOWN = "unknown";
-}($i || ($i = {}));
+}(es || (es = {}));
 
-var ts, rs, os = function() {
+var rs, os, ns = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, es), e);
+void 0 === e && (e = {}), this.config = o(o({}, ts), e);
 }
 return e.prototype.run = function() {
 var e, t;
 if (!(Game.cpu.bucket < this.config.minBucket)) {
-var r = Object.values(Game.rooms).filter(function(e) {
-var t;
-return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.controller.level >= 5;
+var r = Or().filter(function(e) {
+var t, r;
+return (null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0) >= 5;
 });
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
@@ -15275,13 +15289,13 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (!(t.length < 2)) {
 var r = this.classifyLinks(e, t), o = r.filter(function(e) {
-return e.role === $i.SOURCE;
+return e.role === es.SOURCE;
 }), n = r.filter(function(e) {
-return e.role === $i.CONTROLLER;
+return e.role === es.CONTROLLER;
 }), a = r.filter(function(e) {
-return e.role === $i.STORAGE;
+return e.role === es.STORAGE;
 }), i = r.filter(function(e) {
-return e.role === $i.SPAWN;
+return e.role === es.SPAWN;
 });
 this.executeTransfers(e, o, n, a, i);
 }
@@ -15318,11 +15332,11 @@ try {
 for (var R = (l = void 0, a(f)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.link.store.getFreeCapacity(RESOURCE_ENERGY) < this.config.transferThreshold)) {
-if (T.role === $i.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
+if (T.role === es.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
 h = T;
 break;
 }
-if (T.role !== $i.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
+if (T.role !== es.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
 h = T;
 break;
 }
@@ -15402,25 +15416,25 @@ i.transferEnergy(m, l));
 var t = e.room, r = t.controller, o = t.storage, n = t.find(FIND_SOURCES), a = t.find(FIND_MY_SPAWNS);
 return this.classifyLinkRole(e, r, o, n, a);
 }, e.prototype.classifyLinkRole = function(e, t, r, o, n) {
-return t && e.pos.getRangeTo(t) <= 2 ? $i.CONTROLLER : o.some(function(t) {
+return t && e.pos.getRangeTo(t) <= 2 ? es.CONTROLLER : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 1;
-}) ? $i.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? $i.STORAGE : n.some(function(t) {
+}) ? es.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? es.STORAGE : n.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? $i.SPAWN : o.some(function(t) {
+}) ? es.SPAWN : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? $i.SOURCE : $i.UNKNOWN;
+}) ? es.SOURCE : es.UNKNOWN;
 }, e.prototype.getRolePriority = function(e) {
 switch (e) {
-case $i.CONTROLLER:
+case es.CONTROLLER:
 return 100;
 
-case $i.SPAWN:
+case es.SPAWN:
 return 75;
 
-case $i.STORAGE:
+case es.STORAGE:
 return 50;
 
-case $i.SOURCE:
+case es.SOURCE:
 return 10;
 
 default:
@@ -15436,9 +15450,9 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (r.length < 2) return !1;
 var o = this.classifyLinks(e, r), n = o.some(function(e) {
-return e.role === $i.SOURCE;
+return e.role === es.SOURCE;
 }), a = o.some(function(e) {
-return e.role === $i.CONTROLLER || e.role === $i.STORAGE;
+return e.role === es.CONTROLLER || e.role === es.STORAGE;
 });
 return n && a;
 }, n([ rr("link:manager", "Link Manager", {
@@ -15447,23 +15461,23 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), ns = new os;
+}(), as = new ns;
 
-function as(e) {
+function is(e) {
 return "string" == typeof e.roomName && e.roomName.length > 0;
 }
 
-function is(e) {
+function ss(e) {
 var t, r;
 return Math.max(0, null !== (r = null !== (t = e.remainingAmount) && void 0 !== t ? t : e.amount) && void 0 !== r ? r : 0);
 }
 
-function ss(e, t) {
+function cs(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var cs, us, ls, ms, ds, ps, fs, ys, vs, gs, hs, Rs = {
+var us, ls, ms, ds, ps, fs, ys, vs, gs, hs, Rs, Es = {
 updateInterval: 100,
 priceUpdateInterval: 500,
 minBucket: 2e3,
@@ -15481,14 +15495,14 @@ highPriceMultiplier: 1.1,
 trendChangeThreshold: .05,
 buyOpportunityAdjustment: 1.02,
 sellOpportunityAdjustment: .98,
-sellThresholds: (ts = {}, ts[RESOURCE_ENERGY] = 5e5, ts[RESOURCE_HYDROGEN] = 2e4,
-ts[RESOURCE_OXYGEN] = 2e4, ts[RESOURCE_UTRIUM] = 2e4, ts[RESOURCE_LEMERGIUM] = 2e4,
-ts[RESOURCE_KEANIUM] = 2e4, ts[RESOURCE_ZYNTHIUM] = 2e4, ts[RESOURCE_CATALYST] = 2e4,
-ts),
-buyThresholds: (rs = {}, rs[RESOURCE_ENERGY] = 1e5, rs[RESOURCE_HYDROGEN] = 5e3,
-rs[RESOURCE_OXYGEN] = 5e3, rs[RESOURCE_UTRIUM] = 5e3, rs[RESOURCE_LEMERGIUM] = 5e3,
-rs[RESOURCE_KEANIUM] = 5e3, rs[RESOURCE_ZYNTHIUM] = 5e3, rs[RESOURCE_CATALYST] = 5e3,
+sellThresholds: (rs = {}, rs[RESOURCE_ENERGY] = 5e5, rs[RESOURCE_HYDROGEN] = 2e4,
+rs[RESOURCE_OXYGEN] = 2e4, rs[RESOURCE_UTRIUM] = 2e4, rs[RESOURCE_LEMERGIUM] = 2e4,
+rs[RESOURCE_KEANIUM] = 2e4, rs[RESOURCE_ZYNTHIUM] = 2e4, rs[RESOURCE_CATALYST] = 2e4,
 rs),
+buyThresholds: (os = {}, os[RESOURCE_ENERGY] = 1e5, os[RESOURCE_HYDROGEN] = 5e3,
+os[RESOURCE_OXYGEN] = 5e3, os[RESOURCE_UTRIUM] = 5e3, os[RESOURCE_LEMERGIUM] = 5e3,
+os[RESOURCE_KEANIUM] = 5e3, os[RESOURCE_ZYNTHIUM] = 5e3, os[RESOURCE_CATALYST] = 5e3,
+os),
 trackedResources: [ RESOURCE_ENERGY, RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_UTRIUM, RESOURCE_LEMERGIUM, RESOURCE_KEANIUM, RESOURCE_ZYNTHIUM, RESOURCE_CATALYST, RESOURCE_GHODIUM, RESOURCE_POWER ],
 criticalResources: [ RESOURCE_ENERGY, RESOURCE_GHODIUM ],
 emergencyBuyThreshold: 5e3,
@@ -15506,41 +15520,41 @@ minArbitrageMargin: .05,
 energyOverflowStorageEnter: 8e5,
 energyOverflowStorageExit: 5e5,
 minOverflowEnergySellAmount: 1e3
-}, Es = function() {
+}, Ts = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedEmpireTick = -1, this.cachedEmpire = null,
 this.cachedTick = -1, this.cachedMarketOrders = new Map, this.cachedMarketOrderDealAmounts = new Map,
 this.cachedOwnedRooms = null, this.cachedOwnedTerminalRooms = null, this.cachedReadyOwnedTerminalRooms = null,
-this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, Rs), e);
+this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, Es), e);
 }
 return e.prototype.run = function() {
 var e = this;
 this.lastRun = Game.time, this.cachedEmpireTick = -1, this.cachedEmpire = null,
-ss("market.ensureMemory", function() {
+cs("market.ensureMemory", function() {
 return e.ensureMarketMemory();
-}), Game.time % this.config.priceUpdateInterval === 0 && ss("market.updatePriceTracking", function() {
+}), Game.time % this.config.priceUpdateInterval === 0 && cs("market.updatePriceTracking", function() {
 return e.updatePriceTracking();
-}), ss("market.updateOrderStats", function() {
+}), cs("market.updateOrderStats", function() {
 return e.updateOrderStats();
-}), ss("market.reconcilePendingArbitrage", function() {
+}), cs("market.reconcilePendingArbitrage", function() {
 return e.reconcilePendingArbitrage();
-}), ss("market.handleEmergencyBuying", function() {
+}), cs("market.handleEmergencyBuying", function() {
 return e.handleEmergencyBuying();
-}), ss("market.cancelOldOrders", function() {
+}), cs("market.cancelOldOrders", function() {
 return e.cancelOldOrders();
-}), ss("market.manageExistingOrders", function() {
+}), cs("market.manageExistingOrders", function() {
 return e.manageExistingOrders();
-}), this.canRunActiveTrading() && (ss("market.updateBuyOrders", function() {
+}), this.canRunActiveTrading() && (cs("market.updateBuyOrders", function() {
 return e.updateBuyOrders();
-}), ss("market.handleEnergyOverflowSales", function() {
+}), cs("market.handleEnergyOverflowSales", function() {
 return e.handleEnergyOverflowSales();
-}), ss("market.updateSellOrders", function() {
+}), cs("market.updateSellOrders", function() {
 return e.updateSellOrders();
-}), ss("market.checkArbitrageOpportunities", function() {
+}), cs("market.checkArbitrageOpportunities", function() {
 return e.checkArbitrageOpportunities();
-}), ss("market.executeDeal", function() {
+}), cs("market.executeDeal", function() {
 return e.executeDeal();
-}), Game.time % 200 == 0 && ss("market.balanceResourcesAcrossRooms", function() {
+}), Game.time % 200 == 0 && cs("market.balanceResourcesAcrossRooms", function() {
 return e.balanceResourcesAcrossRooms();
 }));
 }, e.prototype.canRunActiveTrading = function() {
@@ -15571,10 +15585,8 @@ remainingAmount: Math.max(0, e.remainingAmount - n)
 var r;
 t <= 0 || (this.ensureTickCaches(), this.cachedMarketOrderDealAmounts.set(e, (null !== (r = this.cachedMarketOrderDealAmounts.get(e)) && void 0 !== r ? r : 0) + t));
 }, e.prototype.getOwnedRooms = function() {
-return this.ensureTickCaches(), this.cachedOwnedRooms || (this.cachedOwnedRooms = Object.values(Game.rooms).filter(function(e) {
-var t;
-return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
-})), this.cachedOwnedRooms;
+return this.ensureTickCaches(), this.cachedOwnedRooms || (this.cachedOwnedRooms = Or()),
+this.cachedOwnedRooms;
 }, e.prototype.getOwnedTerminalRooms = function() {
 return this.ensureTickCaches(), this.cachedOwnedTerminalRooms || (this.cachedOwnedTerminalRooms = this.getOwnedRooms().filter(function(e) {
 return e.terminal;
@@ -15959,8 +15971,8 @@ energyCreditValue: this.config.energyCreditValue,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}, u.orders.filter(as).map(function(e) {
-var t = Math.min(u.requestedAmount, is(e), u.maxDealAmount);
+}, u.orders.filter(is).map(function(e) {
+var t = Math.min(u.requestedAmount, ss(e), u.maxDealAmount);
 if (!(t <= 0)) {
 var r = u.calcTransactionCost(t, u.sourceRoomName, e.roomName), o = e.price * t - r * u.energyCreditValue;
 return {
@@ -16179,8 +16191,8 @@ maxDealAmount: this.config.maxActiveBuyAmount,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}).orders.filter(as).map(function(e) {
-var t = Math.min(is(e), m.maxDealAmount, m.requestedAmount);
+}).orders.filter(is).map(function(e) {
+var t = Math.min(ss(e), m.maxDealAmount, m.requestedAmount);
 if (!(t <= 0)) {
 var r = m.calcTransactionCost(t, e.roomName, m.destinationRoomName);
 return {
@@ -16449,7 +16461,7 @@ interval: 100,
 minBucket: 2e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), Ts = new Es, Cs = function() {
+}(), Cs = new Ts, Ss = function() {
 function e() {
 this.costCache = new Map, this.COST_CACHE_TTL = 100, this.MAX_HOPS = 3;
 }
@@ -16576,7 +16588,7 @@ if (e) throw e.error;
 var r = e.path.indexOf(t);
 return -1 === r || r === e.path.length - 1 ? null : e.path[r + 1] || null;
 }, e;
-}(), Ss = new Cs, ws = {
+}(), ws = new Ss, xs = {
 minBucket: 0,
 minStorageEnergy: 5e4,
 terminalEnergyTarget: 2e4,
@@ -16591,9 +16603,9 @@ emergencyDangerThreshold: 2,
 emergencyEnergyAmount: 2e4,
 energySurplusThreshold: 5e4,
 mineralSurplusThreshold: 5e3
-}, xs = function() {
+}, bs = function() {
 function e(e) {
-void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, ws), e);
+void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, xs), e);
 }
 return e.prototype.requestTransfer = function(e, t, r, o, n) {
 if (void 0 === n && (n = 3), this.transferQueue.some(function(o) {
@@ -16615,11 +16627,10 @@ subsystem: "Terminal"
 }), !1);
 }, e.prototype.run = function() {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
-var e = Object.values(Game.rooms).filter(function(e) {
-var t;
-return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.terminal && e.terminal.my && e.terminal.isActive();
+var e = Or().filter(function(e) {
+return e.terminal && e.terminal.my && e.terminal.isActive();
 });
-0 !== e.length && (Ss.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
+0 !== e.length && (ws.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
 e.length < 2 || (this.checkEmergencyTransfers(e), this.balanceEnergy(e), this.balanceMinerals(e),
 this.executeTransfers(e)));
 }
@@ -16647,7 +16658,7 @@ var l = u[0];
 if (!c.transferQueue.some(function(e) {
 return e.toRoom === t.name && e.resourceType === RESOURCE_ENERGY && e.isEmergency;
 })) {
-var m = Ss.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
+var m = ws.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
 m && (c.transferQueue.push({
 fromRoom: l.name,
 toRoom: t.name,
@@ -16738,7 +16749,7 @@ var w = C - S;
 if (u && u !== e.name) {
 var x = null === (c = Game.rooms[u]) || void 0 === c ? void 0 : c.terminal;
 if (x && x.store.getFreeCapacity() > w) {
-var b = Ss.findOptimalRoute(e.name, u, w);
+var b = ws.findOptimalRoute(e.name, u, w);
 if (b) {
 this.transferQueue.push({
 fromRoom: e.name,
@@ -16754,7 +16765,7 @@ continue;
 }
 }
 }
-Game.time % 10 == 0 && Ts.sellSurplusFromTerminal(e.name, T, w) && _.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
+Game.time % 10 == 0 && Cs.sellSurplusFromTerminal(e.name, T, w) && _.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
 subsystem: "Terminal"
 });
 }
@@ -16799,7 +16810,7 @@ return r.fromRoom === t.room.name && r.toRoom === e.room.name && r.resourceType 
 })) return "continue";
 var r = Math.min(Math.floor((t.totalEnergy - u.config.energySendThreshold) / 2), u.config.energyRequestThreshold - e.totalEnergy, t.terminal.store.getUsedCapacity(RESOURCE_ENERGY));
 if (r < u.config.minTransferAmount) return "continue";
-var o = Ss.findOptimalRoute(t.room.name, e.room.name, r);
+var o = ws.findOptimalRoute(t.room.name, e.room.name, r);
 if (!o) return "continue";
 var n = o.cost / r;
 if (n > u.config.maxTransferCostRatio) return _.debug("Skipping terminal transfer from ".concat(t.room.name, " to ").concat(e.room.name, ": cost ratio ").concat(n.toFixed(2), " too high"), {
@@ -16934,7 +16945,7 @@ var a = r.terminal;
 if (a.cooldown > 0) return "continue";
 var i = t.toRoom;
 if (t.route && !t.route.isDirect) {
-var c = Ss.getNextHop(t.route, t.fromRoom);
+var c = ws.getNextHop(t.route, t.fromRoom);
 c && (i = c);
 }
 var u = null === (o = Game.rooms[i]) || void 0 === o ? void 0 : o.terminal;
@@ -17098,32 +17109,31 @@ interval: 20,
 minBucket: 0,
 cpuBudget: .1
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), bs = new xs, Os = {
+}(), Os = new bs, ks = {
 minBucket: 0,
 minStorageEnergy: 8e4,
 inputBufferAmount: 2e3,
 outputBufferAmount: 5e3
-}, ks = ((cs = {})[RESOURCE_UTRIUM_BAR] = ((us = {})[RESOURCE_UTRIUM] = 500, us[RESOURCE_ENERGY] = 200,
-us), cs[RESOURCE_LEMERGIUM_BAR] = ((ls = {})[RESOURCE_LEMERGIUM] = 500, ls[RESOURCE_ENERGY] = 200,
-ls), cs[RESOURCE_ZYNTHIUM_BAR] = ((ms = {})[RESOURCE_ZYNTHIUM] = 500, ms[RESOURCE_ENERGY] = 200,
-ms), cs[RESOURCE_KEANIUM_BAR] = ((ds = {})[RESOURCE_KEANIUM] = 500, ds[RESOURCE_ENERGY] = 200,
-ds), cs[RESOURCE_GHODIUM_MELT] = ((ps = {})[RESOURCE_GHODIUM] = 500, ps[RESOURCE_ENERGY] = 200,
-ps), cs[RESOURCE_OXIDANT] = ((fs = {})[RESOURCE_OXYGEN] = 500, fs[RESOURCE_ENERGY] = 200,
-fs), cs[RESOURCE_REDUCTANT] = ((ys = {})[RESOURCE_HYDROGEN] = 500, ys[RESOURCE_ENERGY] = 200,
-ys), cs[RESOURCE_PURIFIER] = ((vs = {})[RESOURCE_CATALYST] = 500, vs[RESOURCE_ENERGY] = 200,
-vs), cs[RESOURCE_BATTERY] = ((gs = {})[RESOURCE_ENERGY] = 600, gs), cs), Ms = ((hs = {})[RESOURCE_BATTERY] = 10,
-hs[RESOURCE_UTRIUM_BAR] = 5, hs[RESOURCE_LEMERGIUM_BAR] = 5, hs[RESOURCE_ZYNTHIUM_BAR] = 5,
-hs[RESOURCE_KEANIUM_BAR] = 5, hs[RESOURCE_GHODIUM_MELT] = 4, hs[RESOURCE_OXIDANT] = 3,
-hs[RESOURCE_REDUCTANT] = 3, hs[RESOURCE_PURIFIER] = 3, hs), As = function() {
+}, Ms = ((us = {})[RESOURCE_UTRIUM_BAR] = ((ls = {})[RESOURCE_UTRIUM] = 500, ls[RESOURCE_ENERGY] = 200,
+ls), us[RESOURCE_LEMERGIUM_BAR] = ((ms = {})[RESOURCE_LEMERGIUM] = 500, ms[RESOURCE_ENERGY] = 200,
+ms), us[RESOURCE_ZYNTHIUM_BAR] = ((ds = {})[RESOURCE_ZYNTHIUM] = 500, ds[RESOURCE_ENERGY] = 200,
+ds), us[RESOURCE_KEANIUM_BAR] = ((ps = {})[RESOURCE_KEANIUM] = 500, ps[RESOURCE_ENERGY] = 200,
+ps), us[RESOURCE_GHODIUM_MELT] = ((fs = {})[RESOURCE_GHODIUM] = 500, fs[RESOURCE_ENERGY] = 200,
+fs), us[RESOURCE_OXIDANT] = ((ys = {})[RESOURCE_OXYGEN] = 500, ys[RESOURCE_ENERGY] = 200,
+ys), us[RESOURCE_REDUCTANT] = ((vs = {})[RESOURCE_HYDROGEN] = 500, vs[RESOURCE_ENERGY] = 200,
+vs), us[RESOURCE_PURIFIER] = ((gs = {})[RESOURCE_CATALYST] = 500, gs[RESOURCE_ENERGY] = 200,
+gs), us[RESOURCE_BATTERY] = ((hs = {})[RESOURCE_ENERGY] = 600, hs), us), As = ((Rs = {})[RESOURCE_BATTERY] = 10,
+Rs[RESOURCE_UTRIUM_BAR] = 5, Rs[RESOURCE_LEMERGIUM_BAR] = 5, Rs[RESOURCE_ZYNTHIUM_BAR] = 5,
+Rs[RESOURCE_KEANIUM_BAR] = 5, Rs[RESOURCE_GHODIUM_MELT] = 4, Rs[RESOURCE_OXIDANT] = 3,
+Rs[RESOURCE_REDUCTANT] = 3, Rs[RESOURCE_PURIFIER] = 3, Rs), _s = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Os), e);
+void 0 === e && (e = {}), this.config = o(o({}, ks), e);
 }
 return e.prototype.run = function() {
 var e, t;
 if (!(Game.cpu.bucket < this.config.minBucket)) {
-var r = Object.values(Game.rooms).filter(function(e) {
-var t;
-return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_STRUCTURES, {
+var r = Or().filter(function(e) {
+return e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_FACTORY;
 }
@@ -17159,7 +17169,7 @@ var s = e.storage;
 if (s && !(s.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.minStorageEnergy)) {
 var c = this.selectProduction(e, n, s);
 if (c) {
-var u = ks[c];
+var u = Ms[c];
 if (u) {
 var l = !0;
 try {
@@ -17197,7 +17207,7 @@ subsystem: "Factory"
 }, e.prototype.selectProduction = function(e, t, r) {
 var o, n, s, c, u, l = [];
 try {
-for (var m = a(Object.entries(ks)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Object.entries(Ms)), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1], v = f, g = !0, h = 0;
 try {
 for (var R = (s = void 0, a(Object.entries(y))), E = R.next(); !E.done; E = R.next()) {
@@ -17222,7 +17232,7 @@ if (s) throw s.error;
 if (g) {
 var b = t.store.getUsedCapacity(v) + r.store.getUsedCapacity(v);
 if (!(b > this.config.outputBufferAmount)) {
-var O = null !== (u = Ms[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
+var O = null !== (u = As[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
 l.push({
 commodity: v,
 priority: O,
@@ -17250,7 +17260,7 @@ var r, o, n = t.storage;
 if (!n) return [];
 var s = this.selectProduction(t, e, n);
 if (!s) return [];
-var c = ks[s];
+var c = Ms[s];
 if (!c) return [];
 var u = [];
 try {
@@ -17276,7 +17286,7 @@ return u;
 }, e.prototype.hasOutputsToRemove = function(e) {
 var t, r;
 try {
-for (var o = a(Object.keys(ks)), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Object.keys(Ms)), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 if (e.store.getUsedCapacity(i) > 0) return !0;
 }
@@ -17308,7 +17318,7 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), _s = new As, Us = {
+}(), Us = new _s, Ns = {
 updateInterval: 500,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -17320,7 +17330,7 @@ opportunityConfidenceThreshold: .7
 !function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.supplyDemandCache = new Map, this.opportunities = [],
-this.config = o(o({}, Us), e);
+this.config = o(o({}, Ns), e);
 }
 e.prototype.run = function() {
 var e, t, r = Game.cpu.getUsed();
@@ -17485,14 +17495,14 @@ cpuBudget: .02
 }) ], e.prototype, "run", null), e = n([ ar() ], e);
 }();
 
-var Ns, Ps = 5e4;
+var Ps, Is = 5e4;
 
-function Is(e) {
+function Gs(e) {
 var t;
 return null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== t ? t : 0;
 }
 
-var Gs = {
+var Ls = {
 updateInterval: 500,
 minGhodium: 5e3,
 minEnergy: 3e5,
@@ -17504,18 +17514,18 @@ donorRoomBuffer: 1e3,
 salvoSyncWindow: 10,
 roiThreshold: 2,
 counterNukeWarThreshold: 60
-}, Ls = 1e7, Ds = 5e6, Fs = ((Ns = {})[STRUCTURE_SPAWN] = 15e3, Ns[STRUCTURE_TOWER] = 5e3,
-Ns[STRUCTURE_STORAGE] = 3e4, Ns[STRUCTURE_TERMINAL] = 1e5, Ns[STRUCTURE_LAB] = 5e4,
-Ns[STRUCTURE_NUKER] = 1e5, Ns[STRUCTURE_POWER_SPAWN] = 1e5, Ns[STRUCTURE_OBSERVER] = 8e3,
-Ns[STRUCTURE_EXTENSION] = 3e3, Ns[STRUCTURE_LINK] = 5e3, Ns);
+}, Ds = 1e7, Fs = 5e6, Bs = ((Ps = {})[STRUCTURE_SPAWN] = 15e3, Ps[STRUCTURE_TOWER] = 5e3,
+Ps[STRUCTURE_STORAGE] = 3e4, Ps[STRUCTURE_TERMINAL] = 1e5, Ps[STRUCTURE_LAB] = 5e4,
+Ps[STRUCTURE_NUKER] = 1e5, Ps[STRUCTURE_POWER_SPAWN] = 1e5, Ps[STRUCTURE_OBSERVER] = 8e3,
+Ps[STRUCTURE_EXTENSION] = 3e3, Ps[STRUCTURE_LINK] = 5e3, Ps);
 
-function Bs(e) {
+function Ws(e) {
 return !!e.threatenedStructures && e.threatenedStructures.some(function(e) {
 return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
 });
 }
 
-function Ws(e, t) {
+function Hs(e, t) {
 var r = {
 empire: t
 };
@@ -17527,18 +17537,18 @@ return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 });
 }
 
-function Hs(e, t) {
+function Ks(e, t) {
 var r, o, n;
 if (!e) return !1;
 var a = null === (r = t.knownRooms) || void 0 === r ? void 0 : r[e], i = Game.rooms[e], s = null == i ? void 0 : i.controller, c = {
 empire: t
 };
 return j(e, c) || j(null == a ? void 0 : a.owner, c) || j(null == a ? void 0 : a.reserver, c) || j(null === (o = null == s ? void 0 : s.owner) || void 0 === o ? void 0 : o.username, c) || j(null === (n = null == s ? void 0 : s.reservation) || void 0 === n ? void 0 : n.username, c) || !!i && function(e, t) {
-return Ws(e.find(FIND_CREEPS), t) || Ws(e.find(FIND_POWER_CREEPS), t) || Ws(e.find(FIND_STRUCTURES), t) || Ws(e.find(FIND_CONSTRUCTION_SITES), t);
+return Hs(e.find(FIND_CREEPS), t) || Hs(e.find(FIND_POWER_CREEPS), t) || Hs(e.find(FIND_STRUCTURES), t) || Hs(e.find(FIND_CONSTRUCTION_SITES), t);
 }(i, t);
 }
 
-function Ks(e, t, r) {
+function Ys(e, t, r) {
 t.timeToLand < 5e3 ? (r.posture = "evacuate", _.warn("EVACUATION TRIGGERED for ".concat(e.name, ": Critical structures threatened by nuke!"), {
 subsystem: "Nuke"
 })) : ("war" !== r.posture && "evacuate" !== r.posture && (r.posture = "defensive"),
@@ -17547,7 +17557,7 @@ subsystem: "Nuke"
 })), r.pheromones.defense = 100;
 }
 
-function Ys() {
+function Vs() {
 var e, t = 0, r = 0;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
@@ -17557,14 +17567,14 @@ n.terminal && (t += n.terminal.store.getUsedCapacity(RESOURCE_ENERGY) || 0, r +=
 return t >= 6e5 && r >= 1e4;
 }
 
-function Vs(e, t, r, o) {
+function qs(e, t, r, o) {
 var n = 0, a = [], c = t.knownRooms[e];
 if (!c) return {
 roomName: e,
 score: 0,
 reasons: [ "No intel" ]
 };
-if (Hs(e, t)) return {
+if (Ks(e, t)) return {
 roomName: e,
 score: 0,
 reasons: [ "Allied room" ]
@@ -17591,7 +17601,7 @@ return Game.map.getRoomLinearDistance(e, t.name);
 n -= 2 * d, a.push("".concat(d, " rooms away"));
 }
 t.warTargets.includes(e) && (n += 15, a.push("War target"));
-var p = new RoomPosition(25, 25, e), f = js(e, p, t);
+var p = new RoomPosition(25, 25, e), f = zs(e, p, t);
 return f >= r.roiThreshold ? (n += Math.min(20, Math.floor(5 * f)), a.push("ROI: ".concat(f.toFixed(1), "x"))) : (n -= 20,
 a.push("Low ROI: ".concat(f.toFixed(1), "x"))), {
 roomName: e,
@@ -17600,7 +17610,7 @@ reasons: a
 };
 }
 
-function qs(e, t, r) {
+function js(e, t, r) {
 var o, n, i = {
 estimatedDamage: 0,
 estimatedValue: 0,
@@ -17610,16 +17620,16 @@ if (!s) {
 var c = r.knownRooms[e];
 if (c) {
 var u = 5 * (c.towerCount || 0) + 10 * (c.spawnCount || 0) + 5;
-i.estimatedDamage = Ls + Ds * u, i.estimatedValue = .01 * i.estimatedDamage;
+i.estimatedDamage = Ds + Fs * u, i.estimatedValue = .01 * i.estimatedDamage;
 }
 return i;
 }
 var l = s.lookForAtArea(LOOK_STRUCTURES, Math.max(0, t.y - 2), Math.max(0, t.x - 2), Math.min(49, t.y + 2), Math.min(49, t.x + 2), !0);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
-var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Ls : Ds;
+var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Ds : Fs;
 p.hits <= v ? (i.estimatedDamage += p.hits, i.threatenedStructures.push("".concat(p.structureType, "-").concat(p.pos.x, ",").concat(p.pos.y)),
-i.estimatedValue += zs(p)) : i.estimatedDamage += v;
+i.estimatedValue += Qs(p)) : i.estimatedDamage += v;
 }
 } catch (e) {
 o = {
@@ -17635,16 +17645,16 @@ if (o) throw o.error;
 return i;
 }
 
-function js(e, t, r) {
-var o = qs(e, t, r);
+function zs(e, t, r) {
+var o = js(e, t, r);
 return 0 === o.estimatedValue ? 0 : o.estimatedValue / 305e3;
 }
 
-function zs(e) {
-return Fs[e.structureType] || 1e3;
+function Qs(e) {
+return Bs[e.structureType] || 1e3;
 }
 
-function Qs(e, t, r) {
+function Xs(e, t, r) {
 var o, n, i, s = null;
 try {
 for (var c = a(Object.values(t)), u = c.next(); !u.done; u = c.next()) {
@@ -17694,9 +17704,9 @@ subsystem: "Nuke"
 }), !0;
 }
 
-var Xs = function() {
+var Zs = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Gs), e),
+void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Ls), e),
 this.getEmpire = t.getEmpire, this.getSwarmState = t.getSwarmState, this.getClusters = t.getClusters;
 }
 return e.prototype.run = function() {
@@ -17742,7 +17752,7 @@ try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value.structure, l = Math.abs(u.pos.x - t.x), m = Math.abs(u.pos.y - t.y), d = Math.max(l, m);
 if (d <= 2) {
-var p = 0 === d ? Ls : Ds;
+var p = 0 === d ? Ds : Fs;
 u.hits <= p && n.push("".concat(u.structureType, "-").concat(u.pos.x, ",").concat(u.pos.y));
 }
 }
@@ -17795,7 +17805,7 @@ for (var c = a(e.incomingNukes), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.sourceRoom && !e.warTargets.includes(l.sourceRoom)) {
 var m = e.knownRooms[l.sourceRoom];
-if (m) if (Hs(l.sourceRoom, e)) _.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
+if (m) if (Ks(l.sourceRoom, e)) _.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
 subsystem: "Nuke"
 }); else if (!(m.controllerLevel < 8)) {
 var d = r(l.roomName);
@@ -17824,7 +17834,7 @@ u && !u.done && (i = c.return) && i.call(c);
 if (n) throw n.error;
 }
 }
-}(t, this.config, this.getSwarmState, Ys), function(e, t, r, o) {
+}(t, this.config, this.getSwarmState, Vs), function(e, t, r, o) {
 var n, a;
 if (e.objectives.warMode) for (var i in Game.rooms) {
 var s = Game.rooms[i];
@@ -17876,10 +17886,10 @@ if (e.nukeCandidates = [], e.objectives.warMode) {
 try {
 for (var i = a(e.warTargets), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (Hs(c, e)) _.warn("Skipping allied nuke target candidate: ".concat(c), {
+if (Ks(c, e)) _.warn("Skipping allied nuke target candidate: ".concat(c), {
 subsystem: "Nuke"
 }); else {
-var u = Vs(c, e, t, r);
+var u = qs(c, e, t, r);
 u.score >= t.minScore && (e.nukeCandidates.push({
 roomName: c,
 score: u.score,
@@ -17923,7 +17933,7 @@ var d = r();
 try {
 for (var p = a(e.nukesInFlight), f = p.next(); !f.done; f = p.next()) {
 var y = f.value, v = y.impactTick - Game.time;
-y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && Qs(y, d, o) && _.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
+y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && Xs(y, d, o) && _.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
 subsystem: "Nuke"
 });
 }
@@ -18059,14 +18069,14 @@ return e.structureType === STRUCTURE_NUKER;
 if (0 !== c.length) try {
 for (var m = a(e.nukeCandidates), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!p.launched) if (Hs(p.roomName, e)) _.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
+if (!p.launched) if (Ks(p.roomName, e)) _.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
 subsystem: "Nuke"
 }); else {
 try {
 for (var f = (n = void 0, a(c)), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (!(Game.map.getRoomLinearDistance(v.room.name, p.roomName) > 10)) {
-var g = new RoomPosition(25, 25, p.roomName), h = qs(p.roomName, g, e), R = js(p.roomName, g, e);
+var g = new RoomPosition(25, 25, p.roomName), h = js(p.roomName, g, e), R = zs(p.roomName, g, e);
 if (R < t.roiThreshold) _.warn("Skipping nuke launch on ".concat(p.roomName, ": ROI ").concat(R.toFixed(2), "x below threshold ").concat(t.roiThreshold, "x"), {
 subsystem: "Nuke"
 }); else {
@@ -18152,11 +18162,11 @@ var t, r;
 if (e.incomingNukes) try {
 for (var o = a(e.incomingNukes), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-if (!i.evacuationTriggered && Bs(i)) {
+if (!i.evacuationTriggered && Ws(i)) {
 var s = Game.rooms[i.roomName];
 if (s) {
 var c = this.getSwarmState(i.roomName);
-c && (Ks(s, i, c), i.evacuationTriggered = !0);
+c && (Ys(s, i, c), i.evacuationTriggered = !0);
 }
 }
 }
@@ -18201,13 +18211,13 @@ subsystem: "Nuke"
 }) : _.debug("No donor room found for ".concat(r, " ").concat(t, " to ").concat(e), {
 subsystem: "Nuke"
 });
-}(e, t, r, this.config, bs);
+}(e, t, r, this.config, Os);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e);
 }, e;
-}(), Zs = [ {
+}(), Js = [ {
 carryParts: 4,
 capacity: 200,
 moveParts: 4,
@@ -18229,7 +18239,7 @@ moveParts: 24,
 cost: 2400
 } ];
 
-function Js(e, t, r, o, n) {
+function $s(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = {});
 var c = n.reserved, u = void 0 !== c && c, l = n.pathLength, m = n.terrainFactor, d = void 0 === m ? 1.2 : m, p = n.safetyBuffer, f = void 0 === p ? 1.2 : p, y = function(e, t) {
@@ -18252,9 +18262,9 @@ var r = 50 * e * t;
 return Math.ceil(2 * r);
 }(y, d), g = function(e, t) {
 return e * (t ? 3e3 : 1500) / 300;
-}(r, u), h = Zs[0];
+}(r, u), h = Js[0];
 try {
-for (var R = a(Zs), E = R.next(); !E.done; E = R.next()) {
+for (var R = a(Js), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.cost <= o)) break;
 h = T;
@@ -18283,7 +18293,7 @@ energyPerTick: g
 };
 }
 
-function $s(e) {
+function ec(e) {
 var t;
 return e ? null !== (t = {
 X: 15,
@@ -18296,12 +18306,12 @@ H: 8
 }[e]) && void 0 !== t ? t : 5 : 0;
 }
 
-function ec(e) {
-var t, r, o = ft.getEmpire(), n = 0, i = ic(e);
+function tc(e) {
+var t, r, o = ft.getEmpire(), n = 0, i = sc(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-l && (l.owner && !sc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
+l && (l.owner && !cc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
 l.towerCount && l.towerCount > 0 && (n += 5 * l.towerCount));
 }
 } catch (e) {
@@ -18318,12 +18328,12 @@ if (t) throw t.error;
 return n;
 }
 
-function tc(e) {
+function rc(e) {
 return "plains" === e ? 15 : "swamp" === e ? -10 : 0;
 }
 
-function rc(e) {
-var t, r, o = ic(e);
+function oc(e) {
+var t, r, o = sc(e);
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (oe(i.value)) return !0;
 } catch (e) {
@@ -18340,7 +18350,7 @@ if (t) throw t.error;
 return !1;
 }
 
-function oc(e) {
+function nc(e) {
 var t = ft.getEmpire(), r = t.knownRooms[e];
 if (null == r ? void 0 : r.hasPortal) return 20;
 var o = function(e, t) {
@@ -18358,34 +18368,34 @@ return null === r || r > 3 ? null : r;
 return null === o ? 0 : o <= 1 ? 10 : o <= 2 ? 6 : o <= 3 ? 3 : 0;
 }
 
-function nc(e, t) {
+function ac(e, t) {
 var r = e < 0 ? "W" : "E", o = t < 0 ? "N" : "S", n = Math.abs(e) - (e < 0 ? 1 : 0), a = Math.abs(t) - (t < 0 ? 1 : 0);
 return "".concat(r).concat(n).concat(o).concat(a);
 }
 
-function ac(e, t, r) {
+function ic(e, t, r) {
 return 0 === t.length ? 0 : r <= 2 ? 25 : r <= 3 ? 15 : r <= 5 ? 5 : 0;
 }
 
-function ic(e) {
+function sc(e) {
 var t = $(e);
 if (!t) return [];
-for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(nc(r + a, o + i));
+for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(ac(r + a, o + i));
 return n;
 }
 
-function sc(e) {
+function cc(e) {
 return j(e, {
 empire: ft.getEmpire()
 });
 }
 
-function cc(e, t, r, o) {
+function uc(e, t, r, o) {
 var n, a = Game.map.getRoomLinearDistance(t, e);
 if (!Number.isFinite(a) || a <= 0) throw new Error("calculateRemoteProfitability: invalid distance ".concat(a, " between ").concat(t, " and ").concat(e));
 if (r.sources <= 0) throw new Error("calculateRemoteProfitability: intel.sources must be positive, got ".concat(r.sources, " for ").concat(e));
 if (void 0 !== r.threatLevel && null !== r.threatLevel && (r.threatLevel < 0 || r.threatLevel > 3)) throw new Error("calculateRemoteProfitability: intel.threatLevel must be in [0, 3], got ".concat(r.threatLevel, " for ").concat(e));
-var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = Js(t, e, r.sources, 800, {
+var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = $s(t, e, r.sources, 800, {
 reserved: m
 }), f = (650 * r.sources + p.haulerConfig.cost * p.recommendedHaulers) / 1500, y = 5e3 * r.sources + 50 * a * 300, v = y / 5e4, g = d * (null !== (n = [ 0, .1, .3, .6 ][r.threatLevel]) && void 0 !== n ? n : 0), h = d - f - v - g, R = f + v, E = R > 0 ? h / R : 0;
 return {
@@ -18409,9 +18419,9 @@ isProfitable: E > 2 && h > 0
 };
 }
 
-var uc = Rt().cpu.bucketThresholds.highMode + 1e3, lc = {
+var lc = Rt().cpu.bucketThresholds.highMode + 1e3, mc = {
 updateInterval: 500,
-minBucket: uc,
+minBucket: lc,
 maxRemoteDistance: 2,
 maxRemotesPerRoom: 5,
 minRemoteSources: 1,
@@ -18420,10 +18430,10 @@ minRclForClaiming: 1,
 minGclProgressForClaim: 0,
 clusterExpansionDistance: 5,
 minStableRoomPercentage: 0
-}, mc = function() {
+}, dc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedUsername = "", this.usernameLastTick = 0,
-this.config = o(o({}, lc), e);
+this.config = o(o({}, mc), e);
 }
 return e.prototype.run = function() {
 var e = ft.getEmpire();
@@ -18505,7 +18515,7 @@ s > o.config.maxRemoteDistance && (_.info("Removing remote ".concat(e, " - too f
 subsystem: "Expansion"
 }), a = "unreachable");
 }
-return !a || (bi.emit("remote.lost", {
+return !a || (Oi.emit("remote.lost", {
 homeRoom: r,
 remoteRoom: e,
 reason: a,
@@ -18518,7 +18528,7 @@ for (var i in t.knownRooms) if (!r.includes(i) && !this.isRemoteAssignedElsewher
 var s = t.knownRooms[i], c = Game.map.getRoomLinearDistance(e, i);
 if ((s.scouted || !(c > 1)) && !s.owner && !(s.reserver && s.reserver !== a || s.isHighway || s.isSK || s.threatLevel >= 2 || c < 1 || c > this.config.maxRemoteDistance)) if (s.scouted) {
 if (!(s.sources < this.config.minRemoteSources)) {
-var u = cc(i, e, s);
+var u = uc(i, e, s);
 if (u.isProfitable) {
 var l = this.scoreRemoteCandidate(s, c);
 n.push({
@@ -18550,10 +18560,10 @@ return r += 50 * e.sources, r -= 20 * t, r -= 30 * e.threatLevel, "plains" === e
 r;
 }, e.prototype.scoreClaimCandidate = function(e, t, r) {
 var o = 0;
-return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += $s(e.mineralType),
-o -= 5 * t, o -= ec(e.name), o -= 15 * e.threatLevel, o += tc(e.terrain), rc(e.name) && (o += 10),
-o += oc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
-o + ac(e.name, r, t);
+return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += ec(e.mineralType),
+o -= 5 * t, o -= tc(e.name), o -= 15 * e.threatLevel, o += rc(e.terrain), oc(e.name) && (o += 10),
+o += nc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
+o + ic(e.name, r, t);
 }, e.prototype.isRemoteAssignedElsewhere = function(e, t) {
 var r, o, n, i = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -18901,13 +18911,13 @@ return this.cachedUsername;
 var r, o, n = [], i = function(e) {
 var t = [], r = $(e);
 if (!r) return [];
-for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(nc(o + a, n + i));
+for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(ac(o + a, n + i));
 return t;
 }(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t.knownRooms[u];
-l && (l.owner && !sc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
+l && (l.owner && !cc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
 l.towerCount && l.towerCount > 0 && n.push("".concat(l.towerCount, " towers in ").concat(u)),
 l.spawnCount && l.spawnCount > 0 && n.push("".concat(l.spawnCount, " spawns in ").concat(u)),
 l.threatLevel >= 2 && n.push("Threat level ".concat(l.threatLevel, " in ").concat(u)));
@@ -18924,11 +18934,11 @@ if (r) throw r.error;
 }
 }
 return function(e) {
-var t, r, o = ft.getEmpire(), n = ic(e), i = new Set;
+var t, r, o = ft.getEmpire(), n = sc(e), i = new Set;
 try {
 for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-(null == l ? void 0 : l.owner) && !sc(l.owner) && i.add(l.owner);
+(null == l ? void 0 : l.owner) && !cc(l.owner) && i.add(l.owner);
 }
 } catch (e) {
 t = {
@@ -19043,10 +19053,10 @@ subsystem: "Expansion"
 }, n([ rr("expansion:manager", "Expansion Manager", {
 priority: Wt.LOW,
 interval: 500,
-minBucket: uc,
+minBucket: lc,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), dc = new mc, pc = function() {
+}(), pc = new dc, fc = function() {
 function e() {}
 return e.prototype.status = function() {
 var e, t, r, o, n, i, s, c, u, l, m = ft.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
@@ -19138,64 +19148,64 @@ return ft.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use ex
 }, e.prototype.resume = function() {
 return ft.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
 }, e.prototype.addRemote = function(e, t) {
-return dc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
+return pc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
 }, e.prototype.removeRemote = function(e, t) {
-return dc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
+return pc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
 }, e.prototype.clearQueue = function() {
 var e = ft.getEmpire(), t = e.claimQueue.length;
 return e.claimQueue = [], "Cleared ".concat(t, " candidates from claim queue. Queue will repopulate on next empire tick.");
-}, n([ jr({
+}, n([ zr({
 name: "expansion.status",
 description: "Show expansion system status, GCL progress, and claim queue",
 usage: "expansion.status()",
 examples: [ "expansion.status()" ],
 category: "Empire"
-}) ], e.prototype, "status", null), n([ jr({
+}) ], e.prototype, "status", null), n([ zr({
 name: "expansion.pause",
 description: "Pause autonomous expansion",
 usage: "expansion.pause()",
 examples: [ "expansion.pause()" ],
 category: "Empire"
-}) ], e.prototype, "pause", null), n([ jr({
+}) ], e.prototype, "pause", null), n([ zr({
 name: "expansion.resume",
 description: "Resume autonomous expansion",
 usage: "expansion.resume()",
 examples: [ "expansion.resume()" ],
 category: "Empire"
-}) ], e.prototype, "resume", null), n([ jr({
+}) ], e.prototype, "resume", null), n([ zr({
 name: "expansion.addRemote",
 description: "Manually add a remote room assignment",
 usage: "expansion.addRemote(homeRoom, remoteRoom)",
 examples: [ "expansion.addRemote('W1N1', 'W2N1')" ],
 category: "Empire"
-}) ], e.prototype, "addRemote", null), n([ jr({
+}) ], e.prototype, "addRemote", null), n([ zr({
 name: "expansion.removeRemote",
 description: "Manually remove a remote room assignment",
 usage: "expansion.removeRemote(homeRoom, remoteRoom)",
 examples: [ "expansion.removeRemote('W1N1', 'W2N1')" ],
 category: "Empire"
-}) ], e.prototype, "removeRemote", null), n([ jr({
+}) ], e.prototype, "removeRemote", null), n([ zr({
 name: "expansion.clearQueue",
 description: "Clear the expansion claim queue",
 usage: "expansion.clearQueue()",
 examples: [ "expansion.clearQueue()" ],
 category: "Empire"
 }) ], e.prototype, "clearQueue", null), e;
-}(), fc = new pc;
+}(), yc = new fc;
 
-function yc(e) {
+function vc(e) {
 return function(e) {
 return "string" == typeof e && e.trimStart().startsWith("{");
 }(e) ? e.trim() : null;
 }
 
-function vc(e) {
+function gc(e) {
 var t;
 if (!e.controller) return null;
 var r = e.controller;
 if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
 var o = function(e) {
-var t = yc(e);
+var t = vc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19213,12 +19223,12 @@ availableQuests: [ o.id ]
 };
 }
 
-function gc() {
+function hc() {
 var e;
 return (null === (e = Memory.tooangel) || void 0 === e ? void 0 : e.npcRooms) || {};
 }
 
-function hc(e) {
+function Rc(e) {
 var t = Memory;
 t.tooangel || (t.tooangel = {}), t.tooangel.npcRooms || (t.tooangel.npcRooms = {});
 var r = t.tooangel.npcRooms[e.roomName];
@@ -19229,7 +19239,7 @@ e.availableQuests = Array.from(o);
 t.tooangel.npcRooms[e.roomName] = e;
 }
 
-function Rc() {
+function Ec() {
 var e = Memory;
 return e.tooangel || (e.tooangel = {
 enabled: !0,
@@ -19251,14 +19261,14 @@ Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionI
 e.tooangel;
 }
 
-var Ec = [ "applied", "active" ];
+var Tc = [ "applied", "active" ];
 
-function Tc(e) {
+function Cc(e) {
 var t, r;
 return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
 }
 
-function Cc(e, t) {
+function Sc(e, t) {
 return !!function(e, t) {
 if (e.sender) return "TooAngel" === e.sender.username;
 var r = function(e) {
@@ -19266,7 +19276,7 @@ var t, r, o = new Set(Object.keys(e.npcRooms || {}));
 try {
 for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Ec.includes(s.status) && s.originRoom && o.add(s.originRoom);
+Tc.includes(s.status) && s.originRoom && o.add(s.originRoom);
 }
 } catch (e) {
 t = {
@@ -19280,25 +19290,25 @@ if (t) throw t.error;
 }
 }
 return o;
-}(Rc());
+}(Ec());
 return !!r.has(e.from) && (void 0 === t || r.has(t));
 }(e, t) && !function(e) {
-return Rc().recentTransactionIds.includes(Tc(e));
+return Ec().recentTransactionIds.includes(Cc(e));
 }(e) && (function(e) {
-var t = Rc(), r = Tc(e);
+var t = Ec(), r = Cc(e);
 t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
 }(e), !0);
 }
 
-var Sc = {
+var wc = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function wc(e) {
-var t = yc(e);
+function xc(e) {
+var t = vc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19309,24 +19319,24 @@ subsystem: "TooAngel"
 return null;
 }
 
-function xc() {
-return Rc().activeQuests || {};
+function bc() {
+return Ec().activeQuests || {};
 }
 
-function bc() {
-var e = xc();
+function Oc() {
+var e = bc();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < Sc.MAX_ACTIVE_QUESTS;
+}).length < wc.MAX_ACTIVE_QUESTS;
 }
 
-function Oc(e) {
-return Sc.SUPPORTED_TYPES.includes(e);
+function kc(e) {
+return wc.SUPPORTED_TYPES.includes(e);
 }
 
-function kc(e, t, r) {
+function Mc(e, t, r) {
 var o, n;
-if (!bc()) return _.debug("Cannot accept more quests (at max capacity)", {
+if (!Oc()) return _.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19343,17 +19353,17 @@ if (!n || !n.terminal || !n.terminal.my) return _.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < Sc.MIN_APPLICATION_ENERGY) return _.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Sc.MIN_APPLICATION_ENERGY), {
+if (l < wc.MIN_APPLICATION_ENERGY) return _.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(wc.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, Sc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, wc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (_.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
-}), Rc().activeQuests[e] = {
+}), Ec().activeQuests[e] = {
 id: e,
 type: "buildcs",
 status: "applied",
@@ -19366,8 +19376,8 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Mc(e) {
-var t = Rc(), r = t.activeQuests[e.id];
+function Ac(e) {
+var t = Ec(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (_.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
 }), r.status = "completed") : (_.warn("Quest ".concat(e.id, " failed"), {
@@ -19377,13 +19387,13 @@ subsystem: "TooAngel"
 });
 }
 
-function Ac() {
+function _c() {
 var e;
-return (null === (e = Rc().reputation) || void 0 === e ? void 0 : e.value) || 0;
+return (null === (e = Ec().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function _c(e) {
-var t = yc(e);
+function Uc(e) {
+var t = vc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19392,8 +19402,8 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function Uc(e) {
-var t, r, o, n = Rc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
+function Nc(e) {
+var t, r, o, n = Ec(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return _.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
 }), !1;
@@ -19408,7 +19418,7 @@ if (!o || !o.terminal || !o.terminal.my) return _.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var c = function(e) {
-var t = gc(), r = null, o = 1 / 0;
+var t = hc(), r = null, o = 1 / 0;
 for (var n in t) {
 var a = Game.map.getRoomLinearDistance(e, n);
 a < o && (o = a, r = t[n]);
@@ -19432,7 +19442,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Nc(e) {
+function Pc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19522,7 +19532,7 @@ l.notifyComplete && (_.info("Quest ".concat(e.id, " (buildcs) completed! All con
 subsystem: "TooAngel"
 }), function(e, t) {
 var r, o, n = function(e) {
-return xc()[e] || null;
+return bc()[e] || null;
 }(e);
 if (!n) return _.warn("Cannot notify completion for unknown quest: ".concat(e), {
 subsystem: "TooAngel"
@@ -19574,7 +19584,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Pc, Ic, Gc = Rt().cpu.bucketThresholds.highMode + 1e3, Lc = Gc, Dc = /^tooangel_error_\d+$/, Fc = function() {
+var Ic, Gc, Lc = Rt().cpu.bucketThresholds.highMode + 1e3, Dc = Lc, Fc = /^tooangel_error_\d+$/, Bc = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19592,19 +19602,19 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, _.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < Lc)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < Dc)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Rc();
+var r = Ec();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = _c(i.description);
-null !== s && Cc(i) && (_.info("Received reputation update from TooAngel: ".concat(s), {
+var s = Uc(i.description);
+null !== s && Sc(i) && (_.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19631,7 +19641,7 @@ if (e) throw e.error;
 }(), function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Rc();
+var r = Ec();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
@@ -19639,12 +19649,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = wc(i.description);
-if (s && Cc(i, s.origin)) {
+var s = xc(i.description);
+if (s && Sc(i, s.origin)) {
 if (_.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-Mc(s);
+Ac(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19658,7 +19668,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Oc(s.quest) || (_.warn("Received unsupported quest type: ".concat(s.quest), {
+}, kc(s.quest) || (_.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19695,15 +19705,15 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (_.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Nc(o) : (_.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Pc(o) : (_.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
 }(), function() {
-var e = Rc().activeQuests || {};
+var e = Ec().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - Sc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (_.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - wc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (_.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19715,9 +19725,9 @@ var e = String(t);
 (function(e) {
 !function() {
 var e = Memory;
-for (var t in e) Dc.test(t) && delete e[t];
+for (var t in e) Fc.test(t) && delete e[t];
 }();
-var t = Rc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
+var t = Ec(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
 return t.errorThrottle = {
 lastErrorTick: i ? Game.time : o,
 count: i ? 1 : n + 1,
@@ -19731,7 +19741,7 @@ subsystem: "TooAngel"
 var e, t, r = function() {
 var e = [];
 for (var t in Game.rooms) {
-var r = vc(Game.rooms[t]);
+var r = gc(Game.rooms[t]);
 r && (_.info("Detected TooAngel NPC room: ".concat(t), {
 subsystem: "TooAngel"
 }), e.push(r));
@@ -19739,7 +19749,7 @@ subsystem: "TooAngel"
 return e;
 }();
 try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) hc(n.value);
+for (var o = a(r), n = o.next(); !n.done; n = o.next()) Rc(n.value);
 } catch (t) {
 e = {
 error: t
@@ -19755,12 +19765,12 @@ r.length > 0 && _.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-Uc();
+Nc();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (bc()) {
-var r = gc(), o = xc();
+if (Oc()) {
+var r = hc(), o = bc();
 for (var n in r) {
 var i = r[n];
 try {
@@ -19768,7 +19778,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return _.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void kc(u, n);
+}), void Mc(u, n);
 }
 } catch (t) {
 e = {
@@ -19785,11 +19795,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return Ac();
+return _c();
 }, e.prototype.getActiveQuests = function() {
-return xc();
+return bc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return kc(e, t, r);
+return Mc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -19806,27 +19816,27 @@ return n.join("\n");
 }, n([ or("empire:tooangel", "TooAngel Manager", {
 priority: Wt.LOW,
 interval: 100,
-minBucket: Gc
+minBucket: Lc
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), Bc = new Fc, Wc = {
+}(), Wc = new Bc, Hc = {
 status: function() {
-return Bc.getStatus();
+return Wc.getStatus();
 },
 enable: function() {
-return Bc.enable(), "TooAngel integration enabled";
+return Wc.enable(), "TooAngel integration enabled";
 },
 disable: function() {
-return Bc.disable(), "TooAngel integration disabled";
+return Wc.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = Ac();
+var e = _c();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return Uc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return Nc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
-var e, t = xc(), r = [ "Active Quests:" ];
+var e, t = bc(), r = [ "Active Quests:" ];
 if (0 === Object.keys(t).length) r.push("  No active quests"); else for (var o in t) {
 var n = t[o], a = n.deadline - Game.time, i = (null === (e = n.assignedCreeps) || void 0 === e ? void 0 : e.length) || 0;
 r.push("  ".concat(o, ":")), r.push("    Type: ".concat(n.type)), r.push("    Target: ".concat(n.targetRoom)),
@@ -19836,7 +19846,7 @@ r.push("    Assigned creeps: ".concat(i));
 return r.join("\n");
 },
 npcs: function() {
-var e = gc(), t = [ "TooAngel NPC Rooms:" ];
+var e = hc(), t = [ "TooAngel NPC Rooms:" ];
 if (0 === Object.keys(e).length) t.push("  No NPC rooms discovered"); else for (var r in e) {
 var o = e[r];
 t.push("  ".concat(r, ":")), t.push("    Has terminal: ".concat(o.hasTerminal)),
@@ -19845,12 +19855,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return kc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return Mc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, Hc = function() {
+}, Kc = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -19969,65 +19979,65 @@ var t = Memory;
 for (var r in t) delete t[r];
 for (var o = 0; o < 100; o++) RawMemory.segments[o] = "";
 return ft.initialize(), "Memory reset complete. All data cleared (main memory + 100 segments).";
-}, n([ jr({
+}, n([ zr({
 name: "memory.status",
 description: "Show current memory usage and status",
 usage: "memory.status()",
 examples: [ "memory.status()" ],
 category: "Memory"
-}) ], e.prototype, "status", null), n([ jr({
+}) ], e.prototype, "status", null), n([ zr({
 name: "memory.analyze",
 description: "Analyze memory usage and show largest consumers",
 usage: "memory.analyze([topN])",
 examples: [ "memory.analyze()", "memory.analyze(20)" ],
 category: "Memory"
-}) ], e.prototype, "analyze", null), n([ jr({
+}) ], e.prototype, "analyze", null), n([ zr({
 name: "memory.prune",
 description: "Manually trigger memory pruning to clean stale data",
 usage: "memory.prune()",
 examples: [ "memory.prune()" ],
 category: "Memory"
-}) ], e.prototype, "prune", null), n([ jr({
+}) ], e.prototype, "prune", null), n([ zr({
 name: "memory.segments",
 description: "Show memory segment allocation and usage",
 usage: "memory.segments()",
 examples: [ "memory.segments()" ],
 category: "Memory"
-}) ], e.prototype, "segments", null), n([ jr({
+}) ], e.prototype, "segments", null), n([ zr({
 name: "memory.compress",
 description: "Test compression on a memory path",
 usage: "memory.compress(path)",
 examples: [ "memory.compress('empire.knownRooms')" ],
 category: "Memory"
-}) ], e.prototype, "compress", null), n([ jr({
+}) ], e.prototype, "compress", null), n([ zr({
 name: "memory.migrations",
 description: "Show migration status and pending migrations",
 usage: "memory.migrations()",
 examples: [ "memory.migrations()" ],
 category: "Memory"
-}) ], e.prototype, "migrations", null), n([ jr({
+}) ], e.prototype, "migrations", null), n([ zr({
 name: "memory.migrate",
 description: "Manually trigger memory migrations",
 usage: "memory.migrate()",
 examples: [ "memory.migrate()" ],
 category: "Memory"
-}) ], e.prototype, "migrate", null), n([ jr({
+}) ], e.prototype, "migrate", null), n([ zr({
 name: "memory.reset",
 description: "Clear all memory (DANGEROUS - requires confirmation)",
 usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), Kc = new Hc, Yc = {
+}(), Yc = new Kc, Vc = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, Vc = function() {
+}, qc = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, Yc), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, Vc), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
@@ -20391,16 +20401,16 @@ interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), qc = new Vc, jc = {
+}(), jc = new qc, zc = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, zc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], Qc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], Xc = function() {
+}, Qc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], Xc = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], Zc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, jc), e);
+this.config = o(o({}, zc), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20554,7 +20564,7 @@ return l.homeRoom = a, l.role = o, _.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? zc : Qc).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? Qc : Xc).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20698,211 +20708,211 @@ interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), Zc = new Xc, Jc = {
+}(), Jc = new Zc, $c = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, $c = ((Pc = {})[RESOURCE_HYDROXIDE] = {
+}, eu = ((Ic = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Pc[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Ic[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Pc[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Ic[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Pc[RESOURCE_GHODIUM] = {
+}, Ic[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Pc[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Ic[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Pc[RESOURCE_UTRIUM_OXIDE] = {
+}, Ic[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Pc[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Ic[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Pc[RESOURCE_KEANIUM_OXIDE] = {
+}, Ic[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Pc[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Ic[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Pc[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Ic[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Pc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Ic[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Pc[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Ic[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Pc[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Ic[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Pc[RESOURCE_GHODIUM_OXIDE] = {
+}, Ic[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Pc[RESOURCE_UTRIUM_ACID] = {
+}, Ic[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Ic[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_KEANIUM_ACID] = {
+}, Ic[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Ic[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_LEMERGIUM_ACID] = {
+}, Ic[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Ic[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_ZYNTHIUM_ACID] = {
+}, Ic[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Ic[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_GHODIUM_ACID] = {
+}, Ic[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Ic[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Pc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Ic[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Ic[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Ic[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Ic[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Ic[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Ic[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Ic[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Ic[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Ic[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Ic[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Pc), eu = ((Ic = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Ic[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Ic[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Ic[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Ic[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Ic[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Ic[RESOURCE_GHODIUM] = 5e3, Ic[RESOURCE_HYDROXIDE] = 5e3, Ic);
+}, Ic), tu = ((Gc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Gc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Gc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Gc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Gc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Gc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Gc[RESOURCE_GHODIUM] = 5e3, Gc[RESOURCE_HYDROXIDE] = 5e3, Gc);
 
-function tu(e, t) {
-var r, o, n, a = null !== (r = eu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function ru(e, t) {
+var r, o, n, a = null !== (r = tu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function ru(e) {
+function ou(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var ou = function() {
+var nu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : Jc;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : $c;
 }
 return e.prototype.getReaction = function(e) {
-return $c[e];
+return eu[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = $c[e];
+var c = eu[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -20924,11 +20934,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = ru(t);
+var d = ou(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if ($c[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < tu(y, t)) {
+if (eu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < ru(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -20987,12 +20997,12 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = ru(t);
+var h = ou(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = $c[T];
+var T = E.value, C = eu[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = tu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = ru(T, t), x = w - S;
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), k = {};
 try {
@@ -21108,7 +21118,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), nu = [ {
+}(), au = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21126,13 +21136,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function au(e) {
-return nu.find(function(t) {
+function iu(e) {
+return au.find(function(t) {
 return t.role === e;
 });
 }
 
-function iu(e, t) {
+function su(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21149,29 +21159,29 @@ return;
 }
 }
 
-function su(e, t) {
+function cu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function cu(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : lu(e, t) && lu(e, r) ? "output" : "boost";
-}
-
-function uu(e, t) {
-return t.filter(function(t) {
-return e.id !== t.id && lu(e, t);
-}).length;
+function uu(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : mu(e, t) && mu(e, r) ? "output" : "boost";
 }
 
 function lu(e, t) {
+return t.filter(function(t) {
+return e.id !== t.id && mu(e, t);
+}).length;
+}
+
+function mu(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var mu, du = function() {
+var du, pu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : Jc;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : $c;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21287,7 +21297,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = iu(s.role, o);
+var s = i.value, c = su(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21309,13 +21319,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, uu(t, e) ];
+return [ t.id, lu(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && lu(e, s) && lu(e, c);
+return t !== a && t !== i && mu(e, s) && mu(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21328,19 +21338,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(su)[0];
+return n.sort(cu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: cu(e, t.input1, t.input2)
+role: uu(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, uu(r, e));
+return Math.max(t, lu(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21484,17 +21494,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), pu = function() {
+}(), fu = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = au(o.role);
+var n = iu(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = au(n.role);
+var r, o, n = e.memory, i = iu(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21572,7 +21582,7 @@ return 0 === c.length && (n.boosted = !0, _.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = au(t);
+var r, o, n = iu(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21603,7 +21613,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = au(t);
+var r, o, n = iu(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21637,7 +21647,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ au("soldier"), au("ranger"), au("healer"), au("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ iu("soldier"), iu("ranger"), iu("healer"), iu("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21694,7 +21704,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = au(e);
+var r = iu(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21704,7 +21714,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = au(e);
+var n = iu(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21738,7 +21748,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), fu = new pu, yu = {
+}(), yu = new fu, vu = {
 info: function(e, t) {
 return _.info(e, t);
 },
@@ -21751,10 +21761,10 @@ return _.error(e, t);
 debug: function(e, t) {
 return _.debug(e, t);
 }
-}, vu = function() {
+}, gu = function() {
 function e() {
-this.manager = new du({
-logger: yu
+this.manager = new pu({
+logger: vu
 });
 }
 return e.prototype.initialize = function(e) {
@@ -21824,14 +21834,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), gu = new vu, hu = function() {
+}(), hu = new gu, Ru = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = gu.getConfig(e);
+var s = hu.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = gu.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = hu.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -21843,7 +21853,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = gu.getBoostLabs(e), f = function(e) {
+var p = hu.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -21874,9 +21884,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = gu.getConfig(e);
+var c = hu.getConfig(e);
 if (!c) return [];
-var u = [], l = gu.getOutputLabs(e);
+var u = [], l = hu.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -21901,7 +21911,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = gu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = hu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -21937,15 +21947,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = gu.getConfig(e);
+var r, o, n, i, s = hu.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = gu.getInputLabs(e), u = c.input1, l = c.input2;
+var c = hu.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = gu.getOutputLabs(e);
+var m = hu.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -21967,23 +21977,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-gu.clearActiveReaction(e), _.info("Cleared active reactions in ".concat(e), {
+hu.clearActiveReaction(e), _.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = gu.setActiveReaction(e, t, r, o);
+var n = hu.setActiveReaction(e, t, r, o);
 return n && _.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return gu.runReactions(e);
+return hu.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return gu.getBoostLabs(e).length > 0;
+return hu.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = gu.getConfig(e);
+var r, o, n, i, s, c = hu.getConfig(e);
 if (!c) return null;
-var u = gu.getBoostLabs(e);
+var u = hu.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -22087,17 +22097,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = gu.getConfig(e);
+var t = hu.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-gu.loadFromMemory(e), gu.initialize(e);
+hu.loadFromMemory(e), hu.initialize(e);
 }, e.prototype.save = function(e) {
-gu.saveToMemory(e);
+hu.saveToMemory(e);
 }, e;
-}(), Ru = new hu, Eu = function() {
+}(), Eu = new Ru, Tu = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = gu.getConfig(e);
+var t, r, o, n, i, s, c, u, l = hu.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22120,7 +22130,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = Ru.getLabResourceNeeds(e);
+var h = Eu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22140,7 +22150,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = Ru.getLabOverflow(e);
+var C = Eu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22162,13 +22172,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return Ru.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return Eu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return Ru.clearReactions(e), "Cleared active reactions in ".concat(e);
+return Eu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = fu.areBoostLabsReady(n, t), s = fu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = yu.areBoostLabsReady(n, t), s = yu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22189,32 +22199,32 @@ if (r) throw r.error;
 }
 } else c += "\nAll boosts ready!";
 return c;
-}, n([ jr({
+}, n([ zr({
 name: "labs.status",
 description: "Get lab status for a room",
 usage: "labs.status(roomName)",
 examples: [ "labs.status('E1S1')" ],
 category: "Labs"
-}) ], e.prototype, "status", null), n([ jr({
+}) ], e.prototype, "status", null), n([ zr({
 name: "labs.setReaction",
 description: "Set active reaction for a room",
 usage: "labs.setReaction(roomName, input1, input2, output)",
 examples: [ "labs.setReaction('E1S1', RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_HYDROXIDE)" ],
 category: "Labs"
-}) ], e.prototype, "setReaction", null), n([ jr({
+}) ], e.prototype, "setReaction", null), n([ zr({
 name: "labs.clear",
 description: "Clear active reaction for a room",
 usage: "labs.clear(roomName)",
 examples: [ "labs.clear('E1S1')" ],
 category: "Labs"
-}) ], e.prototype, "clear", null), n([ jr({
+}) ], e.prototype, "clear", null), n([ zr({
 name: "labs.boost",
 description: "Check boost lab readiness for a role",
 usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), Tu = function() {
+}(), Cu = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22252,29 +22262,29 @@ return s;
 }, e.prototype.profit = function() {
 var e = "=== Market Profit ===\n";
 return (e += "Credits: ".concat(Game.market.credits.toLocaleString(), "\n")) + "\nNote: Detailed profit tracking requires memory access\n";
-}, n([ jr({
+}, n([ zr({
 name: "market.data",
 description: "Get market data for a resource",
 usage: "market.data(resource)",
 examples: [ "market.data(RESOURCE_ENERGY)", "market.data(RESOURCE_GHODIUM)" ],
 category: "Market"
-}) ], e.prototype, "data", null), n([ jr({
+}) ], e.prototype, "data", null), n([ zr({
 name: "market.orders",
 description: "List your active market orders",
 usage: "market.orders()",
 examples: [ "market.orders()" ],
 category: "Market"
-}) ], e.prototype, "orders", null), n([ jr({
+}) ], e.prototype, "orders", null), n([ zr({
 name: "market.profit",
 description: "Show market trading profit statistics",
 usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), Cu = function() {
+}(), Su = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = Zc.getGPLState();
+var e = Jc.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22283,7 +22293,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = Zc.getAssignments();
+var e, t, r = Jc.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22305,7 +22315,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = qc.getActiveOperations();
+var e, t, r = jc.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22330,7 +22340,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return Zc.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return Jc.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22361,74 +22371,74 @@ if (!POWER_INFO[t]) return "Invalid power: ".concat(t);
 if (r.level >= Game.gpl.level) return "Power creep is already at max level (".concat(r.level, "/").concat(Game.gpl.level, ")");
 var o = r.upgrade(t);
 return o === OK ? "Upgraded ".concat(e, " to level ").concat(r.level, " with ").concat(t) : "Failed to upgrade: ".concat(o);
-}, n([ jr({
+}, n([ zr({
 name: "power.gpl",
 description: "Show GPL (Global Power Level) status",
 usage: "power.gpl()",
 examples: [ "power.gpl()" ],
 category: "Power"
-}) ], e.prototype, "gpl", null), n([ jr({
+}) ], e.prototype, "gpl", null), n([ zr({
 name: "power.creeps",
 description: "List power creeps and their assignments",
 usage: "power.creeps()",
 examples: [ "power.creeps()" ],
 category: "Power"
-}) ], e.prototype, "creeps", null), n([ jr({
+}) ], e.prototype, "creeps", null), n([ zr({
 name: "power.operations",
 description: "List active power bank operations",
 usage: "power.operations()",
 examples: [ "power.operations()" ],
 category: "Power"
-}) ], e.prototype, "operations", null), n([ jr({
+}) ], e.prototype, "operations", null), n([ zr({
 name: "power.assign",
 description: "Reassign a power creep to a different room",
 usage: "power.assign(powerCreepName, roomName)",
 examples: [ "power.assign('operator_eco', 'E2S2')" ],
 category: "Power"
-}) ], e.prototype, "assign", null), n([ jr({
+}) ], e.prototype, "assign", null), n([ zr({
 name: "power.create",
 description: "Manually create a new power creep (automatic creation is also enabled)",
 usage: "power.create(name, className)",
 examples: [ "power.create('operator_eco', POWER_CLASS.OPERATOR)", "power.create('my_operator', 'operator')" ],
 category: "Power"
-}) ], e.prototype, "create", null), n([ jr({
+}) ], e.prototype, "create", null), n([ zr({
 name: "power.spawn",
 description: "Manually spawn a power creep at a power spawn",
 usage: "power.spawn(powerCreepName, roomName?)",
 examples: [ "power.spawn('operator_eco')", "power.spawn('operator_eco', 'E2S2')" ],
 category: "Power"
-}) ], e.prototype, "spawn", null), n([ jr({
+}) ], e.prototype, "spawn", null), n([ zr({
 name: "power.upgrade",
 description: "Manually upgrade a power creep with a specific power",
 usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), Su = new Eu, wu = new Tu, xu = new Cu;
+}(), wu = new Tu, xu = new Cu, bu = new Su;
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(mu || (mu = {}));
+}(du || (du = {}));
 
-var bu = {
-level: mu.INFO,
+var Ou = {
+level: du.INFO,
 cpuLogging: !1,
 enableBatching: !0,
 maxBatchSize: 50,
 debugSampleRate: 1,
 maxEntriesPerSubsystemPerTick: 0,
 maxEntriesPerTick: 0
-}, Ou = o({}, bu), ku = [], Mu = {
+}, ku = o({}, Ou), Mu = [], Au = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
 debugSampleCounter: 0
 };
 
-function Au() {
+function _u() {
 var e = "undefined" != typeof Game && "number" == typeof Game.time ? Game.time : 0;
-Mu.tick !== e && (Mu = {
+Au.tick !== e && (Au = {
 tick: e,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22436,47 +22446,47 @@ debugSampleCounter: 0
 });
 }
 
-function _u(e, t) {
+function Uu(e, t) {
 return !!function(e) {
-if (e !== mu.DEBUG) return !0;
-Au();
-var t, r = (t = Ou.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
+if (e !== du.DEBUG) return !0;
+_u();
+var t, r = (t = ku.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
 if (r >= 1) return !0;
 if (r <= 0) return !1;
-Mu.debugSampleCounter += 1;
+Au.debugSampleCounter += 1;
 var o = Math.max(1, Math.ceil(1 / r));
-return Mu.debugSampleCounter % o === 0;
+return Au.debugSampleCounter % o === 0;
 }(e) && function(e) {
-var t, r, o = Uu(Ou.maxEntriesPerTick), n = Uu(Ou.maxEntriesPerSubsystemPerTick);
+var t, r, o = Nu(ku.maxEntriesPerTick), n = Nu(ku.maxEntriesPerSubsystemPerTick);
 if (0 === o && 0 === n) return !0;
-if (Au(), o > 0 && Mu.totalCount >= o) return !1;
+if (_u(), o > 0 && Au.totalCount >= o) return !1;
 if (n > 0) {
 var a = null != e ? e : "global";
-if ((null !== (t = Mu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
+if ((null !== (t = Au.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
 }
-Mu.totalCount += 1;
+Au.totalCount += 1;
 var i = null != e ? e : "global";
-return Mu.perSubsystemCounts.set(i, (null !== (r = Mu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
+return Au.perSubsystemCounts.set(i, (null !== (r = Au.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
 !0;
 }(null == t ? void 0 : t.subsystem);
 }
 
-function Uu(e) {
+function Nu(e) {
 return Number.isFinite(e) && e > 0 ? Math.floor(e) : 0;
 }
 
-function Nu(e) {
-ku.length > 0 && Gu();
-var t = Ou;
-Ou = o(o(o({}, bu), e), {
+function Pu(e) {
+Mu.length > 0 && Lu();
+var t = ku;
+ku = o(o(o({}, Ou), e), {
 level: "level" in e ? e.level : t.level,
 cpuLogging: "cpuLogging" in e ? e.cpuLogging : t.cpuLogging,
 enableBatching: "enableBatching" in e ? e.enableBatching : t.enableBatching,
 maxBatchSize: "maxBatchSize" in e ? e.maxBatchSize : t.maxBatchSize,
 debugSampleRate: "debugSampleRate" in e ? e.debugSampleRate : t.debugSampleRate,
-maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : bu.maxEntriesPerSubsystemPerTick,
-maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : bu.maxEntriesPerTick
-}), ku = [], Mu = {
+maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Ou.maxEntriesPerSubsystemPerTick,
+maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Ou.maxEntriesPerTick
+}), Mu = [], Au = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22484,21 +22494,21 @@ debugSampleCounter: 0
 };
 }
 
-function Pu() {
-return o({}, Ou);
+function Iu() {
+return o({}, ku);
 }
 
-function Iu(e) {
-Ou.enableBatching ? (ku.push(e), ku.length >= Ou.maxBatchSize && Gu()) : console.log(e);
+function Gu(e) {
+ku.enableBatching ? (Mu.push(e), Mu.length >= ku.maxBatchSize && Lu()) : console.log(e);
 }
 
-function Gu() {
-0 !== ku.length && (console.log(ku.join("\n")), ku = []);
+function Lu() {
+0 !== Mu.length && (console.log(Mu.join("\n")), Mu = []);
 }
 
-var Lu = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
+var Du = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
 
-function Du(e) {
+function Fu(e) {
 return JSON.stringify(e, (t = new WeakSet, function(e, r) {
 return "bigint" == typeof r ? r.toString() : "object" != typeof r || null === r ? r : t.has(r) ? "[Circular]" : (t.add(r),
 r);
@@ -22506,7 +22516,7 @@ r);
 var t;
 }
 
-function Fu(e, t, r, o) {
+function Bu(e, t, r, o) {
 void 0 === o && (o = "log");
 var n = {
 type: o,
@@ -22517,35 +22527,35 @@ shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (r.shard && (n.shard = r.shard), r.subsystem && (n.subsystem = r.subsystem),
 r.room && (n.room = r.room), r.creep && (n.creep = r.creep), r.processId && (n.processId = r.processId),
-r.meta)) for (var a in r.meta) Lu.has(a) || (n[a] = r.meta[a]);
-return Du(n);
-}
-
-function Bu(e, t) {
-Ou.level <= mu.DEBUG && _u(mu.DEBUG, t) && Iu(Fu("DEBUG", e, t));
+r.meta)) for (var a in r.meta) Du.has(a) || (n[a] = r.meta[a]);
+return Fu(n);
 }
 
 function Wu(e, t) {
-Ou.level <= mu.INFO && _u(mu.INFO, t) && Iu(Fu("INFO", e, t));
+ku.level <= du.DEBUG && Uu(du.DEBUG, t) && Gu(Bu("DEBUG", e, t));
 }
 
 function Hu(e, t) {
-Ou.level <= mu.WARN && _u(mu.WARN, t) && Iu(Fu("WARN", e, t));
+ku.level <= du.INFO && Uu(du.INFO, t) && Gu(Bu("INFO", e, t));
 }
 
 function Ku(e, t) {
-Ou.level <= mu.ERROR && _u(mu.ERROR, t) && Iu(Fu("ERROR", e, t));
+ku.level <= du.WARN && Uu(du.WARN, t) && Gu(Bu("WARN", e, t));
 }
 
-function Yu(e, t, r) {
-if (!Ou.cpuLogging) return t();
+function Yu(e, t) {
+ku.level <= du.ERROR && Uu(du.ERROR, t) && Gu(Bu("ERROR", e, t));
+}
+
+function Vu(e, t, r) {
+if (!ku.cpuLogging) return t();
 var o = Game.cpu.getUsed(), n = t(), a = Game.cpu.getUsed() - o;
-return Bu("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
+return Wu("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 }
 
-var Vu = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
+var qu = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function qu(e, t, r, o) {
+function ju(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -22554,21 +22564,13 @@ tick: "undefined" != typeof Game ? Game.time : 0,
 shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (n.unit = r), o && (o.shard && (n.shard = o.shard), o.subsystem && (n.subsystem = o.subsystem),
-o.room && (n.room = o.room), o.meta)) for (var a in o.meta) Vu.has(a) || (n[a] = o.meta[a]);
-_u(mu.INFO, o) && Iu(Du(n));
+o.room && (n.room = o.room), o.meta)) for (var a in o.meta) qu.has(a) || (n[a] = o.meta[a]);
+Uu(du.INFO, o) && Gu(Fu(n));
 }
 
-function ju(e) {
+function zu(e) {
 return {
 debug: function(t, r) {
-Bu(t, "string" == typeof r ? {
-subsystem: e,
-room: r
-} : o({
-subsystem: e
-}, r));
-},
-info: function(t, r) {
 Wu(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22576,7 +22578,7 @@ room: r
 subsystem: e
 }, r));
 },
-warn: function(t, r) {
+info: function(t, r) {
 Hu(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22584,7 +22586,7 @@ room: r
 subsystem: e
 }, r));
 },
-error: function(t, r) {
+warn: function(t, r) {
 Ku(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22592,8 +22594,16 @@ room: r
 subsystem: e
 }, r));
 },
+error: function(t, r) {
+Yu(t, "string" == typeof r ? {
+subsystem: e,
+room: r
+} : o({
+subsystem: e
+}, r));
+},
 stat: function(t, r, n, a) {
-qu(t, r, n, "string" == typeof a ? {
+ju(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -22601,7 +22611,7 @@ subsystem: e
 }, a));
 },
 measureCpu: function(t, r, n) {
-return Yu(t, r, "string" == typeof n ? {
+return Vu(t, r, "string" == typeof n ? {
 subsystem: e,
 room: n
 } : o({
@@ -22611,40 +22621,40 @@ subsystem: e
 };
 }
 
-var zu, Qu = {
-debug: Bu,
-info: Wu,
-warn: Hu,
-error: Ku,
-stat: qu,
-measureCpu: Yu,
-configure: Nu,
-getConfig: Pu,
-createLogger: ju,
-flush: Gu
-}, Xu = function() {
+var Qu, Xu = {
+debug: Wu,
+info: Hu,
+warn: Ku,
+error: Yu,
+stat: ju,
+measureCpu: Vu,
+configure: Pu,
+getConfig: Iu,
+createLogger: zu,
+flush: Lu
+}, Zu = function() {
 function e() {}
 return e.prototype.showConfig = function() {
-var e = Rt(), t = Pu();
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(mu[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
-}, n([ jr({
+var e = Rt(), t = Iu();
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(du[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+}, n([ zr({
 name: "showConfig",
 description: "Show current bot configuration",
 usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), Zu = new Map, Ju = ((zu = {})[STRUCTURE_SPAWN] = 100, zu[STRUCTURE_TOWER] = 95,
-zu[STRUCTURE_STORAGE] = 90, zu[STRUCTURE_EXTENSION] = 80, zu[STRUCTURE_TERMINAL] = 75,
-zu[STRUCTURE_LINK] = 70, zu[STRUCTURE_CONTAINER] = 65, zu[STRUCTURE_RAMPART] = 55,
-zu[STRUCTURE_WALL] = 50, zu[STRUCTURE_ROAD] = 30, zu);
+}(), Ju = new Map, $u = ((Qu = {})[STRUCTURE_SPAWN] = 100, Qu[STRUCTURE_TOWER] = 95,
+Qu[STRUCTURE_STORAGE] = 90, Qu[STRUCTURE_EXTENSION] = 80, Qu[STRUCTURE_TERMINAL] = 75,
+Qu[STRUCTURE_LINK] = 70, Qu[STRUCTURE_CONTAINER] = 65, Qu[STRUCTURE_RAMPART] = 55,
+Qu[STRUCTURE_WALL] = 50, Qu[STRUCTURE_ROAD] = 30, Qu);
 
-function $u(e, t) {
+function el(e, t) {
 var r;
 return function(e, t) {
 if (!t || e.structureType !== STRUCTURE_STORAGE) return !1;
 var r = function(e) {
-var t, r, o, n, i = Zu.get(e.name);
+var t, r, o, n, i = Ju.get(e.name);
 if (i && i.tick === Game.time) return i;
 var s = e.find(FIND_MY_STRUCTURES), c = {
 tick: Game.time,
@@ -22668,41 +22678,41 @@ l && !l.done && (r = u.return) && r.call(u);
 if (t) throw t.error;
 }
 }
-return Zu.set(e.name, c), c;
+return Ju.set(e.name, c), c;
 }(t);
 return r.controllerLevel >= 4 && !r.hasStorage && r.builtTowerCount > 0;
-}(e, t) ? 97 : null !== (r = Ju[e.structureType]) && void 0 !== r ? r : 50;
+}(e, t) ? 97 : null !== (r = $u[e.structureType]) && void 0 !== r ? r : 50;
 }
 
-var el = M("CreepContext"), tl = new Map;
+var tl = M("CreepContext"), rl = new Map;
 
-function rl(e) {
+function ol(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function ol(e) {
-return void 0 === e._containers && (rl(e), e._containers = e.allStructures.filter(function(e) {
+function nl(e) {
+return void 0 === e._containers && (ol(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 }
 
-function nl(e) {
+function al(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(t, r) {
 return function(e, t, r) {
-return $u(t, r) - $u(e, r);
+return el(t, r) - el(e, r);
 }(t, r, e.room);
 })), e._prioritizedSites;
 }
 
-function al(e) {
-return void 0 === e._repairTargets && (rl(e), e._repairTargets = e.allStructures.filter(function(e) {
+function il(e) {
+return void 0 === e._repairTargets && (ol(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function il(e) {
+function sl(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = tl.get(e.name);
+var t = rl.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22711,9 +22721,9 @@ hostiles: X(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return tl.set(e.name, r), r;
+return rl.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, el.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, tl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -22778,10 +22788,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return nl(i).length;
+return al(i).length;
 },
 get damagedStructureCount() {
-return al(i).length;
+return il(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -22792,7 +22802,7 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return ol(i);
+return nl(i);
 },
 get sourceContainers() {
 return function(e) {
@@ -22800,7 +22810,7 @@ if (void 0 === e._sourceContainers) {
 var t = function(e) {
 return void 0 === e._sources && (e._sources = e.room.find(FIND_SOURCES)), e._sources;
 }(e);
-0 === t.length ? e._sourceContainers = [] : e._sourceContainers = ol(e).filter(function(e) {
+0 === t.length ? e._sourceContainers = [] : e._sourceContainers = nl(e).filter(function(e) {
 return t.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
@@ -22810,7 +22820,7 @@ return e._sourceContainers;
 }(i);
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (rl(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (ol(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -22839,10 +22849,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return nl(i);
+return al(i);
 },
 get repairTargets() {
-return al(i);
+return il(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -22862,7 +22872,7 @@ e._tombstones;
 var e;
 },
 get mineralContainers() {
-return void 0 === (e = i)._mineralContainers && (rl(e), e._mineralContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._mineralContainers && (ol(e), e._mineralContainers = e.allStructures.filter(function(e) {
 if (e.structureType !== STRUCTURE_CONTAINER) return !1;
 var t = e;
 return Object.keys(t.store).some(function(e) {
@@ -22874,9 +22884,9 @@ var e;
 };
 }
 
-var sl, cl = {}, ul = function() {
-if (sl) return cl;
-sl = 1, Object.defineProperty(cl, "__esModule", {
+var cl, ul = {}, ll = function() {
+if (cl) return ul;
+cl = 1, Object.defineProperty(ul, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== Qe ? Qe : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -24553,14 +24563,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, As = "_rsi";
-return cl.CachingStrategies = vi, cl.CoordListSerializer = fi, cl.CoordSerializer = pi,
-cl.Keys = ji, cl.MoveTargetListSerializer = li, cl.MoveTargetSerializer = ui, cl.NumberSerializer = Oa,
-cl.PositionListSerializer = di, cl.PositionSerializer = mi, cl.adjacentWalkablePositions = xi,
-cl.blockSquare = function(e) {
+return ul.CachingStrategies = vi, ul.CoordListSerializer = fi, ul.CoordSerializer = pi,
+ul.Keys = ji, ul.MoveTargetListSerializer = li, ul.MoveTargetSerializer = ui, ul.NumberSerializer = Oa,
+ul.PositionListSerializer = di, ul.PositionSerializer = mi, ul.adjacentWalkablePositions = xi,
+ul.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, cl.cachePath = ys, cl.cachedPathKey = ps, cl.calculateAdjacencyMatrix = Ti, cl.calculateAdjacentPositions = Ci,
-cl.calculateNearbyPositions = Si, cl.calculatePositionsAtRange = wi, cl.cleanAllCaches = yi,
-cl.clearCachedPath = ks, cl.compressPath = e => {
+}, ul.cachePath = ys, ul.cachedPathKey = ps, ul.calculateAdjacencyMatrix = Ti, ul.calculateAdjacentPositions = Ci,
+ul.calculateNearbyPositions = Si, ul.calculatePositionsAtRange = wi, ul.cleanAllCaches = yi,
+ul.clearCachedPath = ks, ul.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24569,19 +24579,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, cl.config = Ta, cl.decompressPath = e => {
+}, ul.config = Ta, ul.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, cl.fastRoomPosition = Ga, cl.fixEdgePosition = Ei, cl.follow = function(e, t) {
+}, ul.fastRoomPosition = Ga, ul.fixEdgePosition = Ei, ul.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, cl.followPath = hs, cl.fromGlobalPosition = ti, cl.generatePath = ts, cl.getCachedPath = vs,
-cl.getMoveIntents = ns, cl.getRangeTo = ri, cl.globalPosition = ei, cl.isExit = hi,
-cl.isPositionWalkable = bi, cl.move = ds, cl.moveByPath = function(e, t, r) {
+}, ul.followPath = hs, ul.fromGlobalPosition = ti, ul.generatePath = ts, ul.getCachedPath = vs,
+ul.getMoveIntents = ns, ul.getRangeTo = ri, ul.globalPosition = ei, ul.isExit = hi,
+ul.isPositionWalkable = bi, ul.move = ds, ul.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, As));
@@ -24610,9 +24620,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = Mi(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : Ms(e, d, r)) : ERR_NO_PATH;
-}, cl.moveTo = Ms, cl.normalizeTargets = Ri, cl.offsetRoomPosition = Da, cl.packCoord = qa,
-cl.packCoordList = za, cl.packPos = Ya, cl.packPosList = Xa, cl.packRoomName = ii,
-cl.packRoomNames = ni, cl.posAtDirection = oi, cl.preTick = function() {
+}, ul.moveTo = Ms, ul.normalizeTargets = Ri, ul.offsetRoomPosition = Da, ul.packCoord = qa,
+ul.packCoordList = za, ul.packPos = Ya, ul.packPosList = Xa, ul.packRoomName = ii,
+ul.packRoomNames = ni, ul.posAtDirection = oi, ul.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) _i(e), Bi(e);
 !function() {
@@ -24624,34 +24634,34 @@ n.expires && n.expires < Game.time ? (null === (e = Fi.get(n.room1)) || void 0 =
 null === (t = Fi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, cl.reconcileTraffic = function(e) {
+}, ul.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 Ua.with(Oa).set(cs, Game.time);
-}, cl.reconciledRecently = us, cl.resetCachedPath = gs, cl.roomNameFromCoords = $a,
-cl.roomNameToCoords = Ja, cl.sameRoomPosition = La, cl.unpackCoord = ja, cl.unpackCoordList = Qa,
-cl.unpackPos = Va, cl.unpackPosList = Za, cl.unpackRoomName = si, cl.unpackRoomNames = ai,
-cl;
+}, ul.reconciledRecently = us, ul.resetCachedPath = gs, ul.roomNameFromCoords = $a,
+ul.roomNameToCoords = Ja, ul.sameRoomPosition = La, ul.unpackCoord = ja, ul.unpackCoordList = Qa,
+ul.unpackPos = Va, ul.unpackPosList = Za, ul.unpackRoomName = si, ul.unpackRoomNames = ai,
+ul;
 }();
 
-function ll(e) {
+function ml(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var ml, dl = 5e5;
+var dl, pl = 5e5;
 
-function pl(e) {
+function fl(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > dl;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > pl;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - dl), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - pl), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24663,21 +24673,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(ml || (ml = {}));
+}(dl || (dl = {}));
 
-var fl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], yl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], vl = new Set([ "build", "repair", "upgrade" ]), gl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var yl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], vl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], gl = new Set([ "build", "repair", "upgrade" ]), hl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function hl(e, t) {
+function Rl(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function Rl() {
+function El() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function El() {
+function Tl() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24692,8 +24702,8 @@ rooms: {}
 };
 }
 
-function Tl(e) {
-var t = El();
+function Cl(e) {
+var t = Tl();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24712,42 +24722,42 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Cl(e, t, r) {
+function Sl(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Sl(e) {
+function wl(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function wl(e) {
-return yl.includes(e);
-}
-
 function xl(e) {
-return vl.has(e);
+return vl.includes(e);
 }
 
 function bl(e) {
-return e.store.getUsedCapacity(RESOURCE_ENERGY);
+return gl.has(e);
 }
 
 function Ol(e) {
+return e.store.getUsedCapacity(RESOURCE_ENERGY);
+}
+
+function kl(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function kl(e, t, r) {
-if (void 0 === r && (r = {}), "harvest" === t.type) return Ol(e);
-var o = bl(e);
-return r.reserveEmptyEnergyDelivery && wl(t.type) ? Ol(e) : Math.max(1, o);
+function Ml(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return kl(e);
+var o = Ol(e);
+return r.reserveEmptyEnergyDelivery && xl(t.type) ? kl(e) : Math.max(1, o);
 }
 
-function Ml(e, t) {
+function Al(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function Al(e, t, r) {
+function _l(e, t, r) {
 if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -24755,12 +24765,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return bl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && Ol(e.creep) > 0;
+return Ol(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && kl(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return bl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return Ol(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -24779,7 +24789,7 @@ return !1;
 }
 }
 
-function _l(e, t) {
+function Ul(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24796,7 +24806,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Ul(e) {
+function Nl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24804,36 +24814,36 @@ roomName: e.roomName
 };
 }
 
-function Nl(e, t, r, o, n) {
+function Pl(e, t, r, o, n) {
 return {
-id: Cl(e, t, r.id),
+id: Sl(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Ul(r.pos),
+targetPos: Nl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: fl,
+allowedRoles: yl,
 expiresTick: Game.time + 50
 };
 }
 
-function Pl(e, t) {
+function Il(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = Rl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = El()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < p)) {
 t.lastGeneratedTick = Game.time;
-var f = hl("taskBoard.findMyStructures", function() {
+var f = Rl("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && _l(t, Nl(e.name, "refillTower", h, g, ml.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && _l(t, Nl(e.name, "refillExtension", h, g, ml.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && _l(t, Nl(e.name, "refillSpawn", h, g, ml.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Ul(t, Pl(e.name, "refillTower", h, g, dl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Ul(t, Pl(e.name, "refillExtension", h, g, dl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Ul(t, Pl(e.name, "refillSpawn", h, g, dl.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24846,29 +24856,29 @@ v && !v.done && (o = y.return) && o.call(y);
 if (r) throw r.error;
 }
 }
-var R = pl(e);
-R && _l(t, Nl(e.name, "fillTerminalEnergy", R.terminal, R.amount, ml.NORMAL));
+var R = fl(e);
+R && Ul(t, Pl(e.name, "fillTerminalEnergy", R.terminal, R.amount, dl.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
-var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ps ? ml.NORMAL : ml.LOW, S = Math.min(E, 1e3);
-_l(t, Nl(e.name, "storeEnergy", e.storage, S, C));
+var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Is ? dl.NORMAL : dl.LOW, S = Math.min(E, 1e3);
+Ul(t, Pl(e.name, "storeEnergy", e.storage, S, C));
 }
-var w = hl("taskBoard.findHostiles", function() {
+var w = Rl("taskBoard.findHostiles", function() {
 return X(e);
 });
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-_l(t, {
-id: Cl(e.name, "defend", O.id),
+Ul(t, {
+id: Sl(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
-priority: ml.CRITICAL,
+priority: dl.CRITICAL,
 targetId: O.id,
-targetPos: Ul(O.pos),
+targetPos: Nl(O.pos),
 amount: O.hits,
 maxAssignments: 3,
-allowedRoles: gl,
+allowedRoles: hl,
 expiresTick: Game.time + 50
 });
 }
@@ -24883,7 +24893,7 @@ b && !b.done && (i = x.return) && i.call(x);
 if (n) throw n.error;
 }
 }
-var k = hl("taskBoard.findInjuredAllies", function() {
+var k = Rl("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -24893,13 +24903,13 @@ return e.hits < e.hitsMax;
 try {
 for (var M = a(k.slice(0, 5)), A = M.next(); !A.done; A = M.next()) {
 var _ = A.value;
-_l(t, {
-id: Cl(e.name, "heal", _.id),
+Ul(t, {
+id: Sl(e.name, "heal", _.id),
 roomName: e.name,
 type: "heal",
-priority: ml.HIGH,
+priority: dl.HIGH,
 targetId: _.id,
-targetPos: Ul(_.pos),
+targetPos: Nl(_.pos),
 amount: _.hitsMax - _.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -24920,17 +24930,17 @@ if (s) throw s.error;
 }
 }
 
-function Il(e) {
+function Gl(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function Gl(e) {
+function Ll(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && z(e));
 }
 
-function Ll(e) {
+function Dl(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -24942,7 +24952,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? pl(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? fl(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -24955,11 +24965,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !Gl(t);
+return !Ll(t);
 }
 }
 
-function Dl(e, t) {
+function Fl(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -24981,7 +24991,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function Fl(e, t) {
+function Bl(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -24989,7 +24999,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (xl(m.type)) Dl(e, m); else {
+if (bl(m.type)) Fl(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -25006,7 +25016,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-Il(m), Game.time > m.expiresTick || !Ll(m) ? Dl(e, m) : (Sl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !wl(m.type)) && (m.status = "assigned");
+Gl(m), Game.time > m.expiresTick || !Dl(m) ? Fl(e, m) : (wl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !xl(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -25024,7 +25034,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function Bl(e, t, r) {
+function Wl(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -25032,15 +25042,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-Il(t);
+Gl(t);
 }
 }
 
-function Wl(e, t) {
+function Hl(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function Hl(e, t, r) {
+function Kl(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -25054,37 +25064,37 @@ return e.reservations[t];
 }(e, t.creep.name, t.memory.assignedTaskId);
 s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId;
 var c = null;
-if (s && Wl(s, r) && Ll(s) && Al(t, s, r)) {
+if (s && Hl(s, r) && Dl(s) && _l(t, s, r)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= ml.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= dl.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var u = Kl(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : ml.CRITICAL);
+var u = Yl(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : dl.CRITICAL);
 if (!u || l < m || !d) return s;
-c = u, Bl(0, s, t.creep.name), e.stats.preemptions++;
-} else if (s && (c = Kl(e, t, r), Bl(0, s, t.creep.name), e.stats.preemptions++,
+c = u, Wl(0, s, t.creep.name), e.stats.preemptions++;
+} else if (s && (c = Yl(e, t, r), Wl(0, s, t.creep.name), e.stats.preemptions++,
 !c)) return null;
-if (null != c || (c = Kl(e, t, r)), !c) return null;
-var p = kl(t.creep, c, r);
+if (null != c || (c = Yl(e, t, r)), !c) return null;
+var p = Ml(t.creep, c, r);
 if (p <= 0) return null;
-var f = Math.min(Math.max(1, Sl(c)), p);
+var f = Math.min(Math.max(1, wl(c)), p);
 return t.memory.assignedTaskId = c.id, c.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, c.updatedTick = Game.time, Il(c), e.stats.assigned++, c;
+}, c.updatedTick = Game.time, Gl(c), e.stats.assigned++, c;
 }
 
-function Kl(e, t, r) {
+function Yl(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Wl(l, r) && Al(t, l, r) && Ll(l) && !(Sl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || wl(l.type))) {
-var m = Yl(t.creep, l), d = 1e3 * l.priority - m;
+if (Hl(l, r) && _l(t, l, r) && Dl(l) && !(wl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || xl(l.type))) {
+var m = Vl(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -25102,7 +25112,7 @@ if (o) throw o.error;
 return i;
 }
 
-function Yl(e, t) {
+function Vl(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -25110,7 +25120,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function Vl(e, t) {
+function ql(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -25124,7 +25134,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: Ml(e, t.creep.name)
+amount: Al(e, t.creep.name)
 };
 
 case "build":
@@ -25153,7 +25163,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (Gl(t)) return null;
+if (Ll(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -25172,83 +25182,83 @@ return null;
 }
 }
 
-var ql = function() {
+var jl = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== El().enabled;
+return !1 !== Tl().enabled;
 }, e.prototype.setEnabled = function(e) {
-El().enabled = e;
+Tl().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !Rl()) return null;
-var r = Tl(e.room.name);
-hl("taskBoard.cleanup", function() {
-return Fl(r);
-}), hl("taskBoard.generate", function() {
-return Pl(e.room, r);
+if (!this.isEnabled() || !El()) return null;
+var r = Cl(e.room.name);
+Rl("taskBoard.cleanup", function() {
+return Bl(r);
+}), Rl("taskBoard.generate", function() {
+return Il(e.room, r);
 });
-var o = Hl(r, e, {
+var o = Kl(r, e, {
 allowedTypes: t
 });
-return o ? Vl(o, e) : null;
+return o ? ql(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !Rl()) return null;
-var t = Tl(e.room.name);
-hl("taskBoard.cleanup", function() {
-return Fl(t);
-}), hl("taskBoard.generate", function() {
-return Pl(e.room, t);
+if (!this.isEnabled() || !El()) return null;
+var t = Cl(e.room.name);
+Rl("taskBoard.cleanup", function() {
+return Bl(t);
+}), Rl("taskBoard.generate", function() {
+return Il(e.room, t);
 });
-var r = Hl(t, e, {
+var r = Kl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: ml.NORMAL,
+preemptPriority: dl.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = Vl(r, e);
+var o = ql(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.reserveDeliveryWork = function(e) {
-if (!this.isEnabled() || !Rl()) return !1;
-var t = Tl(e.room.name);
-return hl("taskBoard.cleanup", function() {
-return Fl(t);
-}), hl("taskBoard.generate", function() {
-return Pl(e.room, t);
-}), Boolean(Hl(t, e, {
+if (!this.isEnabled() || !El()) return !1;
+var t = Cl(e.room.name);
+return Rl("taskBoard.cleanup", function() {
+return Bl(t);
+}), Rl("taskBoard.generate", function() {
+return Il(e.room, t);
+}), Boolean(Kl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: ml.NORMAL,
+preemptPriority: dl.NORMAL,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.reserveCriticalDeliveryWork = function(e) {
-if (!this.isEnabled() || !Rl()) return !1;
-var t = Tl(e.room.name);
-return hl("taskBoard.cleanup", function() {
-return Fl(t);
-}), hl("taskBoard.generate", function() {
-return Pl(e.room, t);
-}), Boolean(Hl(t, e, {
+if (!this.isEnabled() || !El()) return !1;
+var t = Cl(e.room.name);
+return Rl("taskBoard.cleanup", function() {
+return Bl(t);
+}), Rl("taskBoard.generate", function() {
+return Il(e.room, t);
+}), Boolean(Kl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower" ],
-preemptPriority: ml.HIGH,
+preemptPriority: dl.HIGH,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = Rl();
+var r, o = El();
 if (!this.isEnabled() || !o) return !1;
-var n = Tl(e);
-hl("taskBoard.cleanup", function() {
-return Fl(n);
+var n = Cl(e);
+Rl("taskBoard.cleanup", function() {
+return Bl(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && hl("taskBoard.generate", function() {
-return Pl(a, n);
+return a && Rl("taskBoard.generate", function() {
+return Il(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && Ll(e);
+return t.includes(e.type) && Dl(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && Rl()) {
+if (this.isEnabled() && El()) {
 !function(e) {
-var t, r, o, n, s = El();
+var t, r, o, n, s = Tl();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -25269,20 +25279,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = Tl(e.name);
-hl("taskBoard.cleanup", function() {
-return Fl(t);
-}), hl("taskBoard.generate", function() {
-return Pl(e, t);
+var t = Cl(e.name);
+Rl("taskBoard.cleanup", function() {
+return Bl(t);
+}), Rl("taskBoard.generate", function() {
+return Il(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = El(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = Tl(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) Bl(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) Wl(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -25309,37 +25319,37 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = El(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && wl(c.type) && Ll(c))) return delete e.memory.assignedTaskId,
+var a = Tl(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && xl(c.type) && Dl(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = Ml(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = Al(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-Il(c), u.amount);
+Gl(c), u.amount);
 }, e.prototype.refreshAssignedDeliveryReservation = function(e) {
 var t, r = e.memory.assignedTaskId;
 if (!r) return !1;
-var o = El(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
-if (!(a && i && s && wl(i.type) && Ll(i))) return delete e.memory.assignedTaskId,
+var o = Tl(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && xl(i.type) && Dl(i))) return delete e.memory.assignedTaskId,
 !1;
-var c = kl(e.creep, i, {
+var c = Ml(e.creep, i, {
 reserveEmptyEnergyDelivery: !0
 });
-return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Sl(i) + s.amount), c),
-s.expiresTick = Game.time + 15, i.updatedTick = Game.time, Il(i), !0);
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, wl(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, Gl(i), !0);
 }, e.prototype.clear = function(e) {
-var t = El();
+var t = Tl();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = Rl();
+var t, r = El();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = Tl(e);
-hl("taskBoard.cleanup", function() {
-return Fl(n, !0);
-}), hl("taskBoard.generate", function() {
-return Pl(o, n);
+var n = Cl(e);
+Rl("taskBoard.cleanup", function() {
+return Bl(n, !0);
+}), Rl("taskBoard.generate", function() {
+return Il(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25364,10 +25374,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = Rl(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = El(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = Tl(e);
-Fl(i, !0), Pl(n, i);
+var i = Cl(e);
+Bl(i, !0), Il(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25389,8 +25399,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = Tl(e);
-Fl(s, !0);
+var t, r, o, n, i, s = Cl(e);
+Bl(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25425,15 +25435,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), jl = new ql;
+}(), zl = new jl;
 
-function zl(e) {
+function Ql(e) {
 return e === ERR_NO_PATH;
 }
 
-function Ql(e) {
+function Xl(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && zl(e.moveResult),
+clearState: void 0 !== e.moveResult && Ql(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25444,11 +25454,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var Xl, Zl = M("ActionExecutor");
+var Zl, Jl = M("ActionExecutor");
 
-function Jl(e, t, r) {
+function $l(e, t, r) {
 var o;
-return !!z(r) && (Zl.warn("Refusing harmful action against known ally target", {
+return !!z(r) && (Jl.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25456,37 +25466,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (ul.clearCachedPath(e.creep), xr(e.creep)),
-jl.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (ll.clearCachedPath(e.creep), xr(e.creep)),
+zl.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function $l(e, t, r) {
+function em(e, t, r) {
 var o, n;
-if (!t || !t.type) return Zl.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return Jl.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && Zl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-"idle" === a.type ? Zl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Zl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && Jl.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+"idle" === a.type ? Jl.warn("".concat(e.name, " (").concat(r.memory.role, ") executing IDLE action")) : Jl.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25510,7 +25520,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = tm(e, function() {
+i = rm(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25524,92 +25534,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (Jl(r, a.type, a.target)) {
+if ($l(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = tm(e, function() {
+i = rm(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (Jl(r, a.type, a.target)) {
+if ($l(r, a.type, a.target)) {
 i = !0;
 break;
 }
-tm(e, function() {
+rm(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (Jl(r, a.type, a.target)) {
+if ($l(r, a.type, a.target)) {
 i = !0;
 break;
 }
-tm(e, function() {
+rm(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-tm(e, function() {
+rm(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), zl(ul.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), Ql(ll.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = tm(e, function() {
+i = rm(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (Jl(r, a.type, a.target)) {
+if ($l(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = tm(e, function() {
+i = rm(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-zl(ul.moveTo(e, a.target)) && (i = !0);
+Ql(ll.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-zl(ul.moveTo(e, {
+Ql(ll.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25618,11 +25628,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-zl(em(e, a.target, a.routeType)) && (i = !0);
+Ql(tm(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), zl(em(e, {
+c = new RoomPosition(25, 25, a.roomName), Ql(tm(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25637,38 +25647,38 @@ pos: e,
 range: 10
 };
 });
-zl(ul.moveTo(e, u, {
+Ql(ll.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (ul.isExit(e.pos)) {
+if (ll.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-ul.moveTo(e, l, {
+ll.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || zl(ul.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || Ql(ll.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-zl(ul.moveTo(e, a.target, {
+Ql(ll.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (ul.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), ul.moveTo(e, l, {
+if (ll.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), ll.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = ll(m.name);
+var d = ml(m.name);
 if (d && !e.pos.isEqualTo(d) && function(e) {
 var t = e.currentTick, r = e.lastIdleCollectionMoveTick, o = e.throttleInterval;
 return "scout" !== e.role || void 0 === r || r > t || t - r >= (void 0 === o ? 25 : o);
@@ -25678,7 +25688,7 @@ currentTick: Game.time,
 lastIdleCollectionMoveTick: r.memory.lastIdleCollectionMoveTick
 })) {
 "scout" === r.memory.role && (r.memory.lastIdleCollectionMoveTick = Game.time),
-zl(ul.moveTo(e, d, {
+Ql(ll.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25687,7 +25697,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && ul.moveTo(e, {
+p && ll.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25695,8 +25705,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, ul.clearCachedPath(e), xr(e), jl.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || jl.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, ll.clearCachedPath(e), xr(e), zl.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || zl.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25704,27 +25714,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function em(e, t, r, o) {
-if (!Xl) return ul.moveTo(e, t, o);
+function tm(e, t, r, o) {
+if (!Zl) return ll.moveTo(e, t, o);
 try {
-return Xl(e, t, r, o);
+return Zl(e, t, r, o);
 } catch (n) {
-return Zl.warn("Remote movement handler failed; falling back to default movement", {
+return Jl.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), ul.moveTo(e, t, o);
+}), ll.moveTo(e, t, o);
 }
 }
 
-function tm(e, t, r, o, n, a) {
+function rm(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = ul.moveTo(e, r);
-return s !== OK && Zl.info("Movement attempt returned non-OK result", {
+var s = ll.moveTo(e, r);
+return s !== OK && Jl.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25732,49 +25742,49 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), Ql({
+}), Xl({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = Ql({
+var c = Xl({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
 var n, a, i, s, c, u, l, m = e.memory;
-switch (Xi(m), t) {
+switch (Zi(m), t) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
 var d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length;
-l = 2 * d, Zi(m).energyHarvested += l;
+l = 2 * d, Ji(m).energyHarvested += l;
 break;
 
 case "transfer":
 var p = null !== (n = null == o ? void 0 : o.resourceType) && void 0 !== n ? n : RESOURCE_ENERGY, f = Math.min(null !== (a = null == o ? void 0 : o.amount) && void 0 !== a ? a : e.store.getUsedCapacity(p), e.store.getUsedCapacity(p), null !== (s = null === (i = r.store) || void 0 === i ? void 0 : i.getFreeCapacity(p)) && void 0 !== s ? s : 1 / 0);
 f > 0 && function(e, t) {
-Zi(e).energyTransferred += t;
+Ji(e).energyTransferred += t;
 }(m, f);
 break;
 
 case "build":
 c = m, u = 5 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
-}).length), Zi(c).buildProgress += u;
+}).length), Ji(c).buildProgress += u;
 break;
 
 case "repair":
 !function(e, t) {
-Zi(e).repairProgress += t;
+Ji(e).repairProgress += t;
 }(m, 100 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length));
 break;
 
 case "attack":
-Ji(m, g = 30 * e.body.filter(function(e) {
+$i(m, g = 30 * e.body.filter(function(e) {
 return e.type === ATTACK && e.hits > 0;
 }).length);
 break;
@@ -25783,7 +25793,7 @@ case "rangedAttack":
 var y = e.body.filter(function(e) {
 return e.type === RANGED_ATTACK && e.hits > 0;
 }).length, v = e.pos.getRangeTo(r), g = 0;
-v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), Ji(m, g);
+v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), $i(m, g);
 break;
 
 case "heal":
@@ -25792,18 +25802,18 @@ var h = e.body.filter(function(e) {
 return e.type === HEAL && e.hits > 0;
 }).length;
 !function(e, t) {
-Zi(e).healingDone += t;
+Ji(e).healingDone += t;
 }(m, "heal" === t ? 12 * h : 4 * h);
 break;
 
 case "upgrade":
 !function(e, t) {
-Zi(e).upgradeProgress += t;
+Ji(e).upgradeProgress += t;
 }(m, d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (Zl.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (Jl.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25814,13 +25824,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var rm, om = M("StateMachine");
+var om, nm = M("StateMachine");
 
-function nm(e) {
+function am(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function am(e, t, r) {
+function im(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25842,12 +25852,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== nm(e.amount) ? {
+}, void 0 !== am(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), om.info(r, {
+}(t), nm.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25855,13 +25865,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : om.info("Behavior returned idle action", {
+})) : nm.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (om.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (nm.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25872,11 +25882,11 @@ type: "idle"
 });
 }
 
-function im(e, t, r) {
+function sm(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, am(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, im(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -25956,7 +25966,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) om.info("State completed, evaluating new action", {
+}(a, e)) nm.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26006,7 +26016,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = nm(e.data.amount);
+var c = am(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -26081,12 +26091,12 @@ return null;
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(c) && jl.refreshAssignedDeliveryReservation(e), c;
-var u = e.memory.assignedTaskId, l = jl.refreshCreepReservation(e, c);
+}(c) && zl.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = zl.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-om.info("Task-board delivery reservation missing, re-evaluating behavior", {
+nm.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26096,7 +26106,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-om.info("State reconstruction failed, re-evaluating behavior", {
+nm.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26104,7 +26114,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (om.info("State invalid, re-evaluating behavior", {
+} else a && (nm.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -26113,33 +26123,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return am(e, t(e), "Committed new state action");
+return im(e, t(e), "Committed new state action");
 }
 
-(rm = {})[FIND_SOURCES] = 5e3, rm[FIND_MINERALS] = 5e3, rm[FIND_DEPOSITS] = 100,
-rm[FIND_STRUCTURES] = 50, rm[FIND_MY_STRUCTURES] = 50, rm[FIND_HOSTILE_STRUCTURES] = 20,
-rm[FIND_MY_SPAWNS] = 100, rm[FIND_MY_CONSTRUCTION_SITES] = 20, rm[FIND_CONSTRUCTION_SITES] = 20,
-rm[FIND_CREEPS] = 5, rm[FIND_MY_CREEPS] = 5, rm[FIND_HOSTILE_CREEPS] = 3, rm[FIND_DROPPED_RESOURCES] = 5,
-rm[FIND_TOMBSTONES] = 10, rm[FIND_RUINS] = 10, rm[FIND_FLAGS] = 50, rm[FIND_NUKES] = 20,
-rm[FIND_POWER_CREEPS] = 10, rm[FIND_MY_POWER_CREEPS] = 10;
+(om = {})[FIND_SOURCES] = 5e3, om[FIND_MINERALS] = 5e3, om[FIND_DEPOSITS] = 100,
+om[FIND_STRUCTURES] = 50, om[FIND_MY_STRUCTURES] = 50, om[FIND_HOSTILE_STRUCTURES] = 20,
+om[FIND_MY_SPAWNS] = 100, om[FIND_MY_CONSTRUCTION_SITES] = 20, om[FIND_CONSTRUCTION_SITES] = 20,
+om[FIND_CREEPS] = 5, om[FIND_MY_CREEPS] = 5, om[FIND_HOSTILE_CREEPS] = 3, om[FIND_DROPPED_RESOURCES] = 5,
+om[FIND_TOMBSTONES] = 10, om[FIND_RUINS] = 10, om[FIND_FLAGS] = 50, om[FIND_NUKES] = 20,
+om[FIND_POWER_CREEPS] = 10, om[FIND_MY_POWER_CREEPS] = 10;
 
-var sm, cm, um = {}, lm = {}, mm = {}, dm = {};
-
-function pm() {
-if (sm) return dm;
-sm = 1;
-const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return dm.encode = function(t) {
-if (0 <= t && t < e.length) return e[t];
-throw new TypeError("Must be between 0 and 63: " + t);
-}, dm;
-}
+var cm, um, lm = {}, mm = {}, dm = {}, pm = {};
 
 function fm() {
-if (cm) return mm;
+if (cm) return pm;
 cm = 1;
-const e = pm();
-return mm.encode = function(t) {
+const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
+return pm.encode = function(t) {
+if (0 <= t && t < e.length) return e[t];
+throw new TypeError("Must be between 0 and 63: " + t);
+}, pm;
+}
+
+function ym() {
+if (um) return dm;
+um = 1;
+const e = fm();
+return dm.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -26147,23 +26157,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, mm;
+}, dm;
 }
 
-var ym, vm, gm, hm = {}, Rm = Xe(Object.freeze({
+var vm, gm, hm, Rm = {}, Em = Xe(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Em() {
-return vm ? ym : (vm = 1, ym = "function" == typeof URL ? URL : Rm.URL);
+function Tm() {
+return gm ? vm : (gm = 1, vm = "function" == typeof URL ? URL : Em.URL);
 }
 
-function Tm() {
-if (gm) return hm;
-gm = 1;
-const e = Em();
-hm.getArg = function(e, t, r) {
+function Cm() {
+if (hm) return Rm;
+hm = 1;
+const e = Tm();
+Rm.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -26183,16 +26193,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-hm.toSetString = t ? r : function(e) {
+Rm.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, hm.fromSetString = t ? r : function(e) {
+}, Rm.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, hm.compareByGeneratedPositionsInflated = function(e, t) {
+}, Rm.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, hm.parseSourceMapInput = function(e) {
+}, Rm.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -26246,7 +26256,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return hm.normalize = f, hm.join = y, hm.relative = function(t, r) {
+return Rm.normalize = f, Rm.join = y, Rm.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -26258,18 +26268,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, hm.computeSourceURL = function(e, t, r) {
+}, Rm.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, hm;
+}, Rm;
 }
 
-var Cm, Sm = {};
+var Sm, wm = {};
 
-function wm() {
-if (Cm) return Sm;
-Cm = 1;
+function xm() {
+if (Sm) return wm;
+Sm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -26302,19 +26312,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Sm.ArraySet = e, Sm;
+return wm.ArraySet = e, wm;
 }
 
-var xm, bm, Om = {};
+var bm, Om, km = {};
 
-function km() {
-if (bm) return lm;
+function Mm() {
+if (Om) return mm;
+Om = 1;
+const e = ym(), t = Cm(), r = xm().ArraySet, o = function() {
+if (bm) return km;
 bm = 1;
-const e = fm(), t = Tm(), r = wm().ArraySet, o = function() {
-if (xm) return Om;
-xm = 1;
-const e = Tm();
-return Om.MappingList = class {
+const e = Cm();
+return km.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -26334,7 +26344,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, Om;
+}, km;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26463,13 +26473,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, lm.SourceMapGenerator = n, lm;
+return n.prototype._version = 3, mm.SourceMapGenerator = n, mm;
 }
 
-var Mm, Am = {}, _m = {};
+var Am, _m = {}, Um = {};
 
-function Um() {
-return Mm || (Mm = 1, function(e) {
+function Nm() {
+return Am || (Am = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26481,36 +26491,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(_m)), _m;
+}(Um)), Um;
 }
 
-var Nm, Pm, Im, Gm, Lm = {
+var Pm, Im, Gm, Lm, Dm = {
 exports: {}
 };
 
-function Dm() {
-if (Nm) return Lm.exports;
-Nm = 1;
+function Fm() {
+if (Pm) return Dm.exports;
+Pm = 1;
 let e = null;
-return Lm.exports = function() {
+return Dm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, Lm.exports.initialize = t => {
+}, Dm.exports.initialize = t => {
 e = t;
-}, Lm.exports;
+}, Dm.exports;
 }
 
-function Fm() {
-if (Im) return Pm;
-Im = 1;
-const e = Dm();
+function Bm() {
+if (Gm) return Im;
+Gm = 1;
+const e = Fm();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return Pm = function() {
+return Im = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26577,28 +26587,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, Pm;
+}, Im;
 }
 
-var Bm, Wm, Hm, Km, Ym = {};
+var Wm, Hm, Km, Ym, Vm = {};
 
-function Vm(e, t, r) {
+function qm(e, t, r) {
 return e - t >= r;
 }
 
-function qm(e, t) {
+function jm(e, t) {
 return e.priority - t.priority;
 }
 
-function jm(e, t, r, o) {
+function zm(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function zm(e, t, r, o) {
+function Qm(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function Qm(e) {
+function Xm(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26616,12 +26626,12 @@ if (t) throw t.error;
 return o;
 }
 
-Wm || (Wm = 1, um.SourceMapGenerator = km().SourceMapGenerator, um.SourceMapConsumer = function() {
-if (Gm) return Am;
-Gm = 1;
-const e = Tm(), t = Um(), r = wm().ArraySet;
-fm();
-const o = Dm(), n = Fm(), a = Symbol("smcInternal");
+Hm || (Hm = 1, lm.SourceMapGenerator = Mm().SourceMapGenerator, lm.SourceMapConsumer = function() {
+if (Lm) return _m;
+Lm = 1;
+const e = Cm(), t = Nm(), r = xm().ArraySet;
+ym();
+const o = Fm(), n = Bm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26658,7 +26668,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, Am.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, _m.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26848,7 +26858,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, Am.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, _m.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -26957,11 +26967,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return Am.IndexedSourceMapConsumer = c, Am;
-}().SourceMapConsumer, um.SourceNode = function() {
-if (Bm) return Ym;
-Bm = 1;
-const e = km().SourceMapGenerator, t = Tm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return _m.IndexedSourceMapConsumer = c, _m;
+}().SourceMapConsumer, lm.SourceNode = function() {
+if (Wm) return Vm;
+Wm = 1;
+const e = Mm().SourceMapGenerator, t = Cm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -27100,27 +27110,27 @@ map: o
 };
 }
 }
-return Ym.SourceNode = n, Ym;
+return Vm.SourceNode = n, Vm;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(Km || (Km = {}));
+}(Ym || (Ym = {}));
 
-var Xm, Zm = [ Km.CRITICAL, Km.HIGH, Km.MEDIUM, Km.LOW ], Jm = {
-bucketThresholds: (Hm = {}, Hm[Km.CRITICAL] = 0, Hm[Km.HIGH] = 2e3, Hm[Km.MEDIUM] = 5e3,
-Hm[Km.LOW] = 8e3, Hm),
+var Zm, Jm = [ Ym.CRITICAL, Ym.HIGH, Ym.MEDIUM, Ym.LOW ], $m = {
+bucketThresholds: (Km = {}, Km[Ym.CRITICAL] = 0, Km[Ym.HIGH] = 2e3, Km[Ym.MEDIUM] = 5e3,
+Km[Ym.LOW] = 8e3, Km),
 defaultMaxCpu: 5,
 logExecution: !1
-}, $m = function() {
+}, ed = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: Qm(Zm),
+tasksByPriority: Xm(Jm),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, Jm), e);
+}, this.config = o(o({}, $m), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -27134,13 +27144,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(qm), l = 0;
+var u = Array.from(this.tasks.values()).sort(jm), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (Vm(Game.time, p.lastRun, p.interval)) if (jm(p.priority, s, this.config.bucketThresholds, Km.CRITICAL)) this.stats.skippedThisTick++; else {
+if (qm(Game.time, p.lastRun, p.interval)) if (zm(p.priority, s, this.config.bucketThresholds, Ym.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (zm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (Qm(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -27188,7 +27198,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = Qm(Zm);
+var t, r, o = Xm(Jm);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -27205,22 +27215,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), ed = ((Xm = global)._computationScheduler || (Xm._computationScheduler = new $m),
-Xm._computationScheduler), td = new Map;
+}(), td = ((Zm = global)._computationScheduler || (Zm._computationScheduler = new ed),
+Zm._computationScheduler), rd = new Map;
 
-function rd(e) {
-var t = td.get(e);
+function od(e) {
+var t = rd.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, td.set(e, t)), t;
+}, rd.set(e, t)), t;
 }
 
-function od(e, t, r) {
+function nd(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return nd(e, t[0], r), t[0];
-var i = rd(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return ad(e, t[0], r), t[0];
+var i = od(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -27237,32 +27247,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && nd(e, s, r), s;
+return s && ad(e, s, r), s;
 }
 
-function nd(e, t, r) {
-var o = rd(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function ad(e, t, r) {
+var o = od(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var ad = {
+var id = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function id(e, t, r) {
+function sd(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(ad[t], ";") : "";
+var o = t ? "color: ".concat(id[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function sd(e) {
+function cd(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var cd = {
+var ud = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -27276,7 +27286,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(sd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(cd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -27293,44 +27303,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(sd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(cd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function ud() {
+function ld() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return dd() + pd() + '<div class="module-help">'.concat(e.map(ld).join(""), "</div>");
+return pd() + fd() + '<div class="module-help">'.concat(e.map(md).join(""), "</div>");
 }
 
-var ld = function(e) {
-var t = e.api.map(md).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(id(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(id(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, md = function(e) {
+var md = function(e) {
+var t = e.api.map(dd).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(sd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(sd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, dd = function(e) {
 var t = [];
-e.describe && t.push(id(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(id(e.name, "blue"), ": ").concat(id(e.desc, "green"));
+e.describe && t.push(sd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(sd(e.name, "blue"), ": ").concat(sd(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return id(e.name, "blue");
-}).join(", ") : "", o = id(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return sd(e.name, "blue");
+}).join(", ") : "", o = sd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(id(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, dd = function() {
-return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(sd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
 }, pd = function() {
+return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+}, fd = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, fd = M("EnergyCollection"), yd = [ "refillSpawn", "refillExtension", "refillTower" ], vd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, yd = M("EnergyCollection"), vd = [ "refillSpawn", "refillExtension", "refillTower" ], gd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function gd(e) {
+function hd(e) {
 if (e.droppedResources.length > 0) {
 var t = wr(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return fd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return yd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27340,15 +27350,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = od(e.creep, r, "energy_container");
-if (o) return fd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = nd(e.creep, r, "energy_container");
+if (o) return yd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (fd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return fd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (yd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return yd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27359,8 +27369,8 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ps && vd.has(e.memory.role);
-}(e, n)) return fd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Is && gd.has(e.memory.role);
+}(e, n)) return yd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -27371,41 +27381,41 @@ var a = Er(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = od(e.creep, a, "energy_source");
-if (s) return fd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = nd(e.creep, a, "energy_source");
+if (s) return yd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (fd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return fd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (yd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return yd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return fd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return yd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function hd(e) {
-var t = jl.getAssignedAction(e, yd);
+function Rd(e) {
+var t = zl.getAssignedAction(e, vd);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Rd(e) {
-return jl.hasActiveTask(e.room.name, yd);
-}
-
-function Ed(e, t) {
-return function(e) {
-return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(t) && jl.reserveCriticalDeliveryWork(e), t;
+function Ed(e) {
+return zl.hasActiveTask(e.room.name, vd);
 }
 
 function Td(e, t) {
+return function(e) {
+return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
+}(t) && zl.reserveCriticalDeliveryWork(e), t;
+}
+
+function Cd(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27432,11 +27442,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Cd(e) {
-var t = jl.getAssignedDeliveryAction(e);
+function Sd(e) {
+var t = zl.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Rd(e)) {
-var r = Td(e, "deliver");
+if (!Ed(e)) {
+var r = Cd(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27458,9 +27468,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Sd = /^[WE]\d+[NS]\d+$/;
+var wd = /^[WE]\d+[NS]\d+$/;
 
-function wd(e) {
+function xd(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27470,28 +27480,28 @@ routeType: "hauler"
 } : null;
 }
 
-function xd(e) {
-return Sd.test(e);
-}
-
 function bd(e) {
-var t, r = e.memory, o = r.questAction, n = r.questTarget;
-if ("build" !== o) return null;
-if (!n || !xd(n)) return wd(e);
-var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
-return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
-type: "remoteMoveToRoom",
-roomName: e.homeRoom,
-routeType: "hauler"
-} : null : wd(e) : null;
+return wd.test(e);
 }
 
 function Od(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = bd(e);
+if (!n || !bd(n)) return xd(e);
+var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
+return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
+type: "remoteMoveToRoom",
+roomName: e.homeRoom,
+routeType: "hauler"
+} : null : xd(e) : null;
+}
+
+function kd(e) {
+var t, r = e.memory, o = r.questAction, n = r.questTarget;
+if ("build" !== o) return null;
+var a = Od(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !xd(n)) return null;
+if (!n || !bd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27504,7 +27514,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function kd(e) {
+function Md(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27513,11 +27523,11 @@ var n = e.memory.working;
 return o !== n && br(e.creep), n;
 }
 
-function Md(e) {
+function Ad(e) {
 e.memory.working = !1, br(e.creep);
 }
 
-var Ad = function() {
+var _d = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27612,20 +27622,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), _d = new Ad, Ud = M("LarvaWorkerBehavior");
+}(), Ud = new _d, Nd = M("LarvaWorkerBehavior");
 
-function Nd(e) {
-var t = kd(e), r = bd(e);
+function Pd(e) {
+var t = Md(e), r = Od(e);
 if (r) return r;
 if (t) {
-Ud.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = Od(e);
+Nd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = kd(e);
 if (o) return o;
-var n = Cd(e);
-if (n) return Ud.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = Sd(e);
+if (n) return Nd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = _d.getSwarmState(e.room.name);
+var t, r = Ud.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27642,7 +27652,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Ud.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Nd.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27651,20 +27661,14 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Ud.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Nd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Ud.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-Md(e);
+Nd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+Ad(e);
 }
-return Ed(e, gd(e));
-}
-
-function Pd(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
+return Td(e, hd(e));
 }
 
 function Id(e) {
@@ -27673,38 +27677,44 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-var Gd = new Map;
+function Gd(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
 
-function Ld(e) {
+var Ld = new Map;
+
+function Dd(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var Dd = M("HarvesterBehavior"), Fd = M("HaulerBehavior"), Bd = Ps, Wd = [ "refillSpawn", "refillExtension" ];
+var Fd = M("HarvesterBehavior"), Bd = M("HaulerBehavior"), Wd = Is, Hd = [ "refillSpawn", "refillExtension" ];
 
-function Hd(e, t) {
-return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && jl.reserveDeliveryWork(e),
-"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && jl.reserveDeliveryWork(e),
+function Kd(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && zl.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && zl.reserveDeliveryWork(e),
 t;
 }
 
-function Kd(e, t, r) {
+function Yd(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return nd(e, c, r), c;
+if (c) return ad(e, c, r), c;
 }
-var u = od(e, t, r);
+var u = nd(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function Yd(e) {
+function Vd(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27718,9 +27728,9 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-function Vd(e) {
+function qd(e) {
 if (e.creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
-var t = Cd(e);
+var t = Sd(e);
 if (t) return t;
 }
 var r, o = (r = e.creep, Object.keys(r.store).find(function(e) {
@@ -27738,7 +27748,7 @@ resourceType: o
 } : null;
 }
 
-var qd = {
+var jd = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27748,11 +27758,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, jd = qd, zd = function(e) {
-return jd.getLabResourceNeeds(e);
+}, zd = jd, Qd = function(e) {
+return zd.getLabResourceNeeds(e);
 };
 
-function Qd(e) {
+function Xd(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27774,7 +27784,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = zd(e.room.name);
+var n = Qd(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27802,7 +27812,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, jd.getLabOverflow(r));
+var t, r, o = (r = e.room.name, zd.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27817,7 +27827,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = zd(e.room.name);
+var i = Qd(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27836,8 +27846,8 @@ type: "idle"
 }(e);
 }
 
-var Xd = {
-larvaWorker: Nd,
+var Zd = {
+larvaWorker: Pd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27848,12 +27858,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(Pd).length > 0) return {
+if (e.hostiles.filter(Id).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (kd(e)) {
+if (Md(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27872,7 +27882,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return gd(e);
+return hd(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27906,10 +27916,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(Id)) return {
+if (e.hostiles.some(Gd)) return {
 type: "idle"
 };
-if (kd(e)) {
+if (Md(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27928,10 +27938,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return gd(e);
+return hd(e);
 },
 harvester: function(e) {
-var t, r = (t = Ld(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = Dd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -27980,8 +27990,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), Dd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return Dd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), Fd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return Fd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -28009,7 +28019,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return Dd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return Fd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -28030,20 +28040,20 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (Dd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (Fd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (Dd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (Fd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = kd(e), o = "defenseRefuel" === e.memory.task;
-if (Fd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var t, r = Md(e), o = "defenseRefuel" === e.memory.task;
+if (Bd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -28056,9 +28066,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = jl.getAssignedAction(e, Wd);
+var t = zl.getAssignedAction(e, Hd);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (jl.hasActiveTask(e.room.name, Wd)) return null;
+if (zl.hasActiveTask(e.room.name, Hd)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -28078,17 +28088,17 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = jl.getAssignedDeliveryAction(e);
+var c = zl.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Rd(e)) {
-var u = Td(e, "hauler");
+if (!Ed(e)) {
+var u = Cd(e, "hauler");
 if (u) return u;
 }
 var l = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = pl(e.room);
-return r < 2e4 && o > Bd && n > 0 || Boolean(a) ? {
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = fl(e.room);
+return r < 2e4 && o > Wd && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28114,12 +28124,12 @@ type: "transfer",
 target: m,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return Fd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return Bd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-Fd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-Md(e);
+Bd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+Ad(e);
 }
 if (o) {
 var p = function(e) {
@@ -28127,7 +28137,7 @@ var t = e.sourceContainers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (0 === t.length) return null;
-var r = Kd(e.creep, t, "energy_container");
+var r = Yd(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -28142,7 +28152,7 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (p) return p;
 }
-if (e.droppedResources.length > 0 && (m = wr(e.creep, e.droppedResources, "hauler_drop", 5))) return Hd(e, {
+if (e.droppedResources.length > 0 && (m = wr(e.creep, e.droppedResources, "hauler_drop", 5))) return Kd(e, {
 type: "pickup",
 target: m
 });
@@ -28152,7 +28162,7 @@ return e.store.getUsedCapacity() > 0;
 if (f.length > 0) {
 var y = wr(e.creep, f, "hauler_tomb", 10);
 if (y) {
-if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Hd(e, {
+if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Kd(e, {
 type: "withdraw",
 target: y,
 resourceType: RESOURCE_ENERGY
@@ -28171,24 +28181,24 @@ var g = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (g.length > 0) {
-var h = Kd(e.creep, g, "energy_container");
-if (h) return Fd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-Hd(e, {
+var h = Yd(e.creep, g, "energy_container");
+if (h) return Bd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+Kd(e, {
 type: "withdraw",
 target: h,
 resourceType: RESOURCE_ENERGY
 });
-Fd.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
+Bd.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
 var R = e.creep.pos.findClosestByRange(g);
-if (R) return Fd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
-Hd(e, {
+if (R) return Bd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
+Kd(e, {
 type: "withdraw",
 target: R,
 resourceType: RESOURCE_ENERGY
 });
 }
 if (e.mineralContainers.length > 0) {
-var E = Kd(e.creep, e.mineralContainers, "mineral_container");
+var E = Yd(e.creep, e.mineralContainers, "mineral_container");
 if (E) {
 if (T = Object.keys(E.store).find(function(e) {
 return e !== RESOURCE_ENERGY && E.store.getUsedCapacity(e) > 0;
@@ -28198,11 +28208,11 @@ target: E,
 resourceType: T
 };
 } else {
-Fd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+Bd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var T, C = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (C && (T = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
-}))) return Fd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
+}))) return Bd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
 {
 type: "withdraw",
 target: C,
@@ -28216,7 +28226,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > Bd || pl(e.room)) return {
+if (o < 2e4 && n > Wd || fl(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28247,53 +28257,53 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return S ? Hd(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (Fd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-Hd(e, {
+return S ? Kd(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (Bd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+Kd(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-})) : (Fd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (Bd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 });
 },
 builder: function(e) {
-var t = kd(e), r = bd(e);
+var t = Md(e), r = Od(e);
 if (r) return r;
 if (t) {
-var o = Od(e);
+var o = kd(e);
 if (o) return o;
-var n = hd(e);
+var n = Rd(e);
 if (n) return n;
-if (!Rd(e)) {
-var a = Td(e, "builder");
+if (!Ed(e)) {
+var a = Cd(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = Ld(e), r = function(e) {
-var t = Gd.get(e.name);
+var t = Dd(e), r = function(e) {
+var t = Ld.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(t, r) {
-return Math.max(t, $u(r, e));
+return Math.max(t, el(r, e));
 }, Number.NEGATIVE_INFINITY), n = {
 tick: Game.time,
 sites: r,
 highestPriority: o
 };
-return Gd.set(e.name, n), n;
+return Ld.set(e.name, n), n;
 }(e.room);
 if (0 === r.sites.length) return delete t.targetId, null;
 if (t.targetId) {
 var o = Game.getObjectById(t.targetId);
 if (o && function(e, t) {
 return e.pos.roomName === t.name;
-}(o, e.room) && $u(o, e.room) >= r.highestPriority) return o;
+}(o, e.room) && el(o, e.room) >= r.highestPriority) return o;
 delete t.targetId;
 }
 var n = function(e, t) {
 var r, o, n = t.sites.filter(function(r) {
-return $u(r, e.room) === t.highestPriority;
+return el(r, e.room) === t.highestPriority;
 });
 return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
 }(e, r);
@@ -28312,15 +28322,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Ed(e, gd(e));
+return Td(e, hd(e));
 },
 upgrader: function(e) {
-if (kd(e)) {
-if (Yd(e)) {
-var t = hd(e);
+if (Md(e)) {
+if (Vd(e)) {
+var t = Rd(e);
 if (t) return t;
-if (!Rd(e)) {
-var r = Td(e, "upgrader");
+if (!Ed(e)) {
+var r = Cd(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28331,8 +28341,8 @@ target: e.room.controller
 type: "idle"
 };
 }
-var o = Yd(e), n = function(t) {
-return o ? Ed(e, t) : t;
+var o = Vd(e), n = function(t) {
+return o ? Td(e, t) : t;
 }, a = e.room.controller;
 if (a) {
 var i = a.pos.findInRange(FIND_MY_STRUCTURES, 2, {
@@ -28367,7 +28377,7 @@ type: "withdraw",
 target: m,
 resourceType: RESOURCE_ENERGY
 });
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Ps) return n({
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Is) return n({
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28395,7 +28405,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (kd(e)) {
+if (Md(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28419,7 +28429,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Cd(e) || (e.storage ? {
+} : Sd(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28438,15 +28448,15 @@ return e.pos.getRangeTo(t) <= 2;
 })[0];
 }
 }(e.room);
-return r ? Ed(e, {
+return r ? Td(e, {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
-}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Ed(e, {
+}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Td(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Ed(e, {
+}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Td(e, {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28539,15 +28549,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : Qd(e);
+} : Xd(e);
 },
-labSupply: Qd,
+labSupply: Xd,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (kd(e)) {
+if (Md(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28727,11 +28737,11 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t, r = kd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
+var t, r = Md(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
 if (!o || o === n) return {
 type: "idle"
 };
-if (a && e.room.name === n && (t = Vd(e))) return t;
+if (a && e.room.name === n && (t = qd(e))) return t;
 if (e.nearbyEnemies && e.hostiles.length > 0) {
 var i = e.hostiles.filter(function(t) {
 return e.creep.pos.getRangeTo(t) <= 5 && (t.getActiveBodyparts(ATTACK) > 0 || t.getActiveBodyparts(RANGED_ATTACK) > 0);
@@ -28751,7 +28761,7 @@ if (r || a && e.room.name === n) return e.room.name !== n ? {
 type: "remoteMoveToRoom",
 roomName: n,
 routeType: "hauler"
-} : (t = Vd(e)) || (a && e.room.name === n ? (Md(e), {
+} : (t = qd(e)) || (a && e.room.name === n ? (Ad(e), {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
@@ -28852,16 +28862,16 @@ roomName: o
 }
 };
 
-function Zd(e) {
+function Jd(e) {
 var t;
-return (null !== (t = Xd[e.memory.role]) && void 0 !== t ? t : Nd)(e);
+return (null !== (t = Zd[e.memory.role]) && void 0 !== t ? t : Pd)(e);
 }
 
-var Jd = new Set([ "build", "repair", "upgrade" ]);
+var $d = new Set([ "build", "repair", "upgrade" ]);
 
-function $d(e, t) {
+function ep(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && xd(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && bd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -28870,12 +28880,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Od(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : kd(e);
 }(e, t);
-return r || (Jd.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || Yd(e) ? hd(e) : null : null);
+return r || ($d.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || Vd(e) ? Rd(e) : null : null);
 }
 
-var ep = "patrol", tp = [ {
+var tp = "patrol", rp = [ {
 x: 10,
 y: 5
 }, {
@@ -28911,7 +28921,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], rp = [ {
+} ], op = [ {
 x: 10,
 y: 10
 }, {
@@ -28928,7 +28938,7 @@ x: 25,
 y: 25
 } ];
 
-function op(e) {
+function np(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -28936,7 +28946,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function np(e) {
+function ap(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -28946,9 +28956,9 @@ roomName: e.roomName
 });
 }
 
-function ap(e) {
+function ip(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = bt.get(e.name, {
-namespace: ep
+namespace: tp
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -28968,25 +28978,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(tp), !1), i(rp), !1);
-}(t).map(op).filter(function(e) {
+}(e)), !1), i(rp), !1), i(op), !1);
+}(t).map(np).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return bt.set(e.name, {
-waypoints: np(n),
+waypoints: ap(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: ep,
+namespace: tp,
 ttl: 1e3
 }), n;
 }
 
-function ip(e, t) {
+function sp(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -28996,86 +29006,86 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var sp = M("MilitaryBehaviors");
+var cp = M("MilitaryBehaviors");
 
-function cp(e) {
+function up(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === ci && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === ui && (delete e.task,
 delete e.targetRoom);
 }
 
-function up(e, t) {
+function lp(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function lp(e) {
-return bo(To(e));
-}
-
 function mp(e) {
-return e.creep.room.name === e.homeRoom && X(e.room).length > 0;
+return Oo(Co(e));
 }
 
 function dp(e) {
+return e.creep.room.name === e.homeRoom && X(e.room).length > 0;
+}
+
+function pp(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function pp(e, t) {
+function fp(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function fp(e) {
-return pp(e, "guard") + pp(e, "ranger") + pp(e, "healer");
+function yp(e) {
+return fp(e, "guard") + fp(e, "ranger") + fp(e, "healer");
 }
 
-function yp(e, t, r) {
+function vp(e, t, r) {
 var o = e.memory;
-return mi(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
-}
-
-function vp(e, t) {
-return Object.values(Game.creeps).filter(function(r) {
-return yp(r, e, t);
-});
+return di(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
 function gp(e, t) {
+return Object.values(Game.creeps).filter(function(r) {
+return vp(r, e, t);
+});
+}
+
+function hp(e, t) {
 return "defenseAssist:".concat(e, ":").concat(t, ":active");
 }
 
-function hp(e, t, r) {
-return pp(e, t) > function(e, t) {
+function Rp(e, t, r) {
+return fp(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
-return !r.spawning && o.role === t && mi(o) === e;
+return !r.spawning && o.role === t && di(o) === e;
 }).length;
-}(e.roomName, t) || fp(e) > 0 && lp(e.roomName) && function(e, t) {
-return vp(e, t).length;
+}(e.roomName, t) || yp(e) > 0 && mp(e.roomName) && function(e, t) {
+return gp(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Rp(e, t) {
+function Ep(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== ci) return null;
-if (mp(e)) return null;
+if (t.task && t.task !== ui) return null;
+if (dp(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(dp).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(pp).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== X(l).length && hp(u, t.role, e.homeRoom)) return li(e.creep, {
+if (l && 0 !== X(l).length && Rp(u, t.role, e.homeRoom)) return mi(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
-squadId: gp(e.homeRoom, u.roomName),
-squadSize: lp(u.roomName) ? Math.max(5, fp(u)) : Math.max(1, fp(u))
+squadId: hp(e.homeRoom, u.roomName),
+squadSize: mp(u.roomName) ? Math.max(5, yp(u)) : Math.max(1, yp(u))
 }), u.roomName;
 }
 } catch (e) {
@@ -29092,7 +29102,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Ep(e) {
+function Tp(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -29100,19 +29110,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Tp(e, t) {
+function Cp(e, t) {
 if (!function(e) {
-return Boolean(mi(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(di(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = mi(t);
+var r = di(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = To(r), n = bo(o), a = n ? vp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = mi(e);
+var o = Co(r), n = Oo(o), a = n ? gp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = di(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && yp(e, r, o);
+return e.memory.defenseSquadId === t && vp(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -29126,9 +29136,9 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return vp(e, t).reduce(function(e, t) {
+return gp(e, t).reduce(function(e, t) {
 var r, o;
-return r = e, o = vo(t.body.filter(function(e) {
+return r = e, o = go(t.body.filter(function(e) {
 return e.hits > 0;
 })), {
 partCount: r.partCount + o.partCount,
@@ -29148,16 +29158,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return up(t, "parity-ready"), null;
-if (c >= u) return up(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return lp(t, "parity-ready"), null;
+if (c >= u) return lp(t, "squad-quorum"), null;
 if (l) {
-if (!n) return up(t, "expired-staging"), null;
+if (!n) return lp(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Ep(e) - Ep(t);
+var r = Tp(e) - Tp(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -29165,20 +29175,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return up(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return lp(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return up(t, "squad-quorum"), null;
-if (l) return up(t, "expired-staging"), null;
+if (c >= u) return lp(t, "squad-quorum"), null;
+if (l) return lp(t, "expired-staging"), null;
 }
-var m = ll(e.room.name);
+var m = ml(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function Cp(e) {
+function Sp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -29210,21 +29220,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Sp(e, t) {
+function wp(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function wp(e, t) {
+function xp(e, t) {
 if (!e.swarmState) return null;
-var r = ll(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (sp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = ml(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (cp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function xp(e) {
+function bp(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -29248,7 +29258,7 @@ if (t) throw t.error;
 }
 }
 
-function bp(e) {
+function Op(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -29256,23 +29266,23 @@ return Boolean(e);
 });
 }
 
-function Op(e) {
+function kp(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function kp(e) {
+function Mp(e) {
 var t, r = e.creep.memory;
-if (di(e.creep)) return {
+if (pi(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = xp(e.memory.squadId);
-if (o) return Mp(e, o);
+var o = bp(e.memory.squadId);
+if (o) return Ap(e, o);
 }
-var n = null !== (t = Rp(e, r)) && void 0 !== t ? t : mi(r);
-if (n && !mp(e)) {
-var a = Tp(e, r);
+var n = null !== (t = Ep(e, r)) && void 0 !== t ? t : di(r);
+if (n && !dp(e)) {
+var a = Cp(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -29285,9 +29295,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Cp(e);
+var s = Sp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Sp(e.creep, RANGED_ATTACK), l = Sp(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = wp(e.creep, RANGED_ATTACK), l = wp(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -29299,7 +29309,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Sp(e.creep, RANGED_ATTACK), l = Sp(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = wp(e.creep, RANGED_ATTACK), l = wp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29310,7 +29320,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (cp(r), e.creep.room.name !== e.homeRoom) return {
+} else if (up(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29319,8 +29329,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Cp(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Sp(e.creep, RANGED_ATTACK), l = Sp(e.creep, ATTACK),
+var m = Sp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = wp(e.creep, RANGED_ATTACK), l = wp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -29331,7 +29341,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = ap(e.room), p = ip(e.creep, d);
+var d = ip(e.room), p = sp(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -29345,7 +29355,7 @@ type: "idle"
 };
 }
 
-function Mp(e, t) {
+function Ap(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -29353,7 +29363,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Op(t);
+var n = kp(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -29361,7 +29371,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(bp(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Op(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29384,7 +29394,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = bp(e).filter(function(t) {
+var t, r, o = Op(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29413,7 +29423,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = bp(t).filter(function(t) {
+var r = Op(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29429,7 +29439,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = bp(t).sort(function(e, t) {
+var a = Op(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29466,7 +29476,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = bp(t).filter(function(e) {
+var l = Op(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29483,7 +29493,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = bp(e).find(function(e) {
+return null !== (t = Op(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29494,7 +29504,7 @@ target: m
 type: "idle"
 };
 }
-var d = Cp(e);
+var d = Sp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29506,10 +29516,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Sp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Sp(e.creep, ATTACK) && p <= 1 ? {
+} : wp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29525,10 +29535,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Sp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Sp(e.creep, ATTACK) && p <= 1 ? {
+} : wp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29544,7 +29554,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Op(t)
+target: kp(t)
 };
 
 case "dissolving":
@@ -29562,8 +29572,8 @@ type: "idle"
 }
 }
 
-var Ap = {
-guard: kp,
+var _p = {
+guard: Mp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29572,8 +29582,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = ap(e.room);
-return (o = ip(e.creep, r)) ? {
+var r = ip(e.room);
+return (o = sp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29594,7 +29604,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = ap(e.room), (o = ip(e.creep, r)) ? {
+} : (r = ip(e.room), (o = sp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29608,11 +29618,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Sp(e, HEAL);
+return wp(e, HEAL);
 }), t.filter(function(e) {
-return Sp(e, RANGED_ATTACK);
+return wp(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Sp(e, ATTACK);
+return wp(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29633,7 +29643,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Sp(e.creep, RANGED_ATTACK), u = Sp(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = wp(e.creep, RANGED_ATTACK), u = wp(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29664,19 +29674,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = xp(e.memory.squadId);
-if (o) return Mp(e, o);
+var o = bp(e.memory.squadId);
+if (o) return Ap(e, o);
 }
-var n = null !== (t = Rp(e, r)) && void 0 !== t ? t : mi(r);
-if (n && !mp(e)) {
-var a = Tp(e, r);
+var n = null !== (t = Ep(e, r)) && void 0 !== t ? t : di(r);
+if (n && !dp(e)) {
+var a = Cp(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === X(i).length) return cp(r), {
+if (0 === X(i).length) return up(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29684,7 +29694,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== ci && !r.assistTarget) {
+if (r.targetRoom && r.task !== ui && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -29744,7 +29754,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || mi(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || di(r) === t);
 }(e, t);
 }
 });
@@ -29770,7 +29780,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = ap(e.room), v = ip(e.creep, y);
+var y = ip(e.room), v = sp(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29781,8 +29791,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = xp(e.memory.squadId);
-if (r) return Mp(e, r);
+var r = bp(e.memory.squadId);
+if (r) return Ap(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29804,9 +29814,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Cp(e);
+var a = Sp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Sp(e.creep, RANGED_ATTACK), c = Sp(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = wp(e.creep, RANGED_ATTACK), c = wp(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29825,7 +29835,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = ap(e.room), m = ip(e.creep, l);
+var l = ip(e.room), m = sp(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29847,8 +29857,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = xp(e.memory.squadId);
-if (r) return Mp(e, r);
+var r = bp(e.memory.squadId);
+if (r) return Ap(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29909,9 +29919,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = wp(e, "siegeUnit");
+var p = xp(e, "siegeUnit");
 if (p) return p;
-var f = ap(e.room), y = ip(e.creep, f);
+var f = ip(e.room), y = sp(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -29922,8 +29932,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = xp(e.memory.squadId);
-if (r) return Mp(e, r);
+var r = bp(e.memory.squadId);
+if (r) return Ap(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -29940,7 +29950,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return wp(e, "harasser (no target)") || {
+if (!t) return xp(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -29982,9 +29992,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = wp(e, "harasser (no targets)");
+var c = xp(e, "harasser (no targets)");
 if (c) return c;
-var u = ap(e.room), l = ip(e.creep, u);
+var u = ip(e.room), l = sp(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -29994,12 +30004,12 @@ type: "idle"
 },
 ranger: function(e) {
 var t, r, o = e.creep.memory;
-if (di(e.creep)) return {
+if (pi(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = xp(e.memory.squadId))) return Mp(e, a);
+if (e.memory.squadId && (a = bp(e.memory.squadId))) return Ap(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (mi(o) && cp(o), e.room.name !== e.homeRoom) return {
+if (di(o) && up(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -30013,9 +30023,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Rp(e, o)) && void 0 !== t ? t : mi(o);
-if (i && !mp(e)) {
-var s = Tp(e, o);
+var a, i = null !== (t = Ep(e, o)) && void 0 !== t ? t : di(o);
+if (i && !dp(e)) {
+var s = Cp(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -30025,14 +30035,14 @@ roomName: i
 var u = X(c), l = Z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return cp(o), {
+if (0 === u.length && 0 === l.length) return up(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Cp(e);
+var m = Sp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -30052,8 +30062,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = xp(e.memory.squadId))) return Mp(e, a);
-var p, f = Cp(e);
+if (e.memory.squadId && (a = bp(e.memory.squadId))) return Ap(e, a);
+var p, f = Sp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -30064,7 +30074,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = ap(e.room), v = ip(e.creep, y);
+var y = ip(e.room), v = sp(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -30085,21 +30095,21 @@ type: "idle"
 }
 };
 
-function _p(e) {
+function Up(e) {
 var t;
-return jl.getAssignedAction(e) || (null !== (t = Ap[e.memory.role]) && void 0 !== t ? t : kp)(e);
+return zl.getAssignedAction(e) || (null !== (t = _p[e.memory.role]) && void 0 !== t ? t : Mp)(e);
 }
 
-var Up = M("PowerExecutor");
+var Np = M("PowerExecutor");
 
-function Np(e, t) {
+function Pp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Pp(e) {
+function Ip(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -30141,8 +30151,8 @@ type: "idle"
 };
 }
 
-var Ip = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Gp = {
-powerHarvester: Pp,
+var Gp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Lp = {
+powerHarvester: Ip,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -30214,65 +30224,65 @@ roomName: e.homeRoom
 }
 };
 
-function Lp(e) {
+function Dp(e) {
 var t;
-return (null !== (t = Gp[e.memory.role]) && void 0 !== t ? t : Pp)(e);
+return (null !== (t = Lp[e.memory.role]) && void 0 !== t ? t : Ip)(e);
 }
 
-function Dp(e) {
+function Fp(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var Fp = {
+var Bp = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, Bp = {
+}, Wp = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, Wp = {
+}, Hp = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, Hp = {
+}, Kp = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, Kp = {
+}, Yp = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, Yp = {
+}, Vp = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, Vp = {
+}, qp = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, qp = {
+}, jp = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function jp(e) {
+function zp(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function zp(e) {
+function Qp(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -30280,7 +30290,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function Qp(e) {
+function Xp(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -30288,12 +30298,12 @@ y: parseInt(n, 10)
 };
 }
 
-function Xp(e) {
+function Zp(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = Zp(s);
+o[s.n] = Jp(s);
 }
 } catch (e) {
 t = {
@@ -30309,23 +30319,23 @@ if (t) throw t.error;
 return o;
 }
 
-function Zp(e) {
+function Jp(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = Bp[e.r]) && void 0 !== t ? t : "core",
-health: Jp(e.h),
+role: null !== (t = Wp[e.r]) && void 0 !== t ? t : "core",
+health: $p(e.h),
 activeTasks: e.t,
-portals: e.p.map($p),
+portals: e.p.map(ef),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(ef)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(tf)
 };
 }
 
-function Jp(e) {
+function $p(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = Hp[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = Kp[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -30338,11 +30348,11 @@ lastUpdate: e.u
 };
 }
 
-function $p(e) {
+function ef(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: zp(e.sp),
+sourcePos: Qp(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -30352,7 +30362,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function ef(e) {
+function tf(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -30361,7 +30371,7 @@ bucketLevel: e.b
 };
 }
 
-function tf(e) {
+function rf(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30371,12 +30381,12 @@ isAlly: 1 === e.a
 };
 }
 
-function rf(e) {
+function of(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = of(u);
+i[u.n] = nf(u);
 }
 } catch (e) {
 t = {
@@ -30399,13 +30409,13 @@ updatedAt: e.u
 };
 }
 
-function of(e) {
+function nf(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: Qp(e.pp),
+portalPos: Xp(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30416,46 +30426,46 @@ lastUpdate: e.u
 };
 }
 
-function nf(e) {
+function af(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = Yp[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = Vp[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = qp[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = jp[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function af(e, t) {
+function sf(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
-}
-
-function sf(e) {
-var t;
-return {
-c: null !== (t = Wp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: af(e.cpuUsage, 2),
-b: e.bucketLevel,
-e: Math.round(e.economyIndex),
-w: Math.round(e.warIndex),
-m: Math.round(e.commodityIndex),
-rc: e.roomCount,
-rl: af(e.avgRCL, 1),
-cc: e.creepCount,
-u: e.lastUpdate
-};
 }
 
 function cf(e) {
 var t;
 return {
+c: null !== (t = Hp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: sf(e.cpuUsage, 2),
+b: e.bucketLevel,
+e: Math.round(e.economyIndex),
+w: Math.round(e.warIndex),
+m: Math.round(e.commodityIndex),
+rc: e.roomCount,
+rl: sf(e.avgRCL, 1),
+cc: e.creepCount,
+u: e.lastUpdate
+};
+}
+
+function uf(e) {
+var t;
+return {
 sr: e.sourceRoom,
-sp: jp(e.sourcePos),
+sp: zp(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30464,27 +30474,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function uf(e) {
+function lf(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: af(e.cpuUsed, 2),
+u: sf(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function lf(e) {
+function mf(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(mf)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(df)
 };
 }
 
-function mf(e) {
+function df(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30494,23 +30504,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function df(e) {
+function pf(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = Kp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = Yp[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = Vp[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = qp[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function pf(e) {
+function ff(e) {
 return {
 name: e,
 role: "core",
@@ -30533,7 +30543,7 @@ cpuLimit: 0
 };
 }
 
-function ff(e) {
+function yf(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30543,16 +30553,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = Fp[t.role]) && void 0 !== r ? r : t.role[0],
-h: sf(t.health),
+r: null !== (r = Bp[t.role]) && void 0 !== r ? r : t.role[0],
+h: cf(t.health),
 t: t.activeTasks,
-p: t.portals.map(cf),
+p: t.portals.map(uf),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(uf)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(lf)
 };
 }(t[0], t[1]);
 }),
-g: lf(e.globalTargets),
+g: mf(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30566,7 +30576,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? jp(t.portalPos) : void 0,
+pp: t.portalPos ? zp(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30578,20 +30588,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(df),
+k: e.tasks.map(pf),
 ls: e.lastSync
 };
 var t;
-}(e), r = Dp(JSON.stringify(t));
+}(e), r = Fp(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function yf(e) {
+function vf(e) {
 try {
-var t = JSON.parse(e), r = Dp(JSON.stringify(t.d));
+var t = JSON.parse(e), r = Fp(JSON.stringify(t.d));
 return t.c !== r ? (Ft.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30600,13 +30610,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: Xp(a.s),
+shards: Zp(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(tf)), n),
-footprintOperation: a.o ? rf(a.o) : void 0,
-tasks: a.k.map(nf),
+o.en && (n.enemies = o.en.map(rf)), n),
+footprintOperation: a.o ? of(a.o) : void 0,
+tasks: a.k.map(af),
 lastSync: a.ls,
 checksum: i
 });
@@ -30618,12 +30628,12 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var vf, gf, hf = 102400, Rf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var gf, hf, Rf = 102400, Ef = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function Ef(e, t, r) {
+function Tf(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = wf(t), s = function(e, t, r) {
+var i = xf(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30636,11 +30646,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(Sf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Rf), c = null !== (a = wf(ff(s))) && void 0 !== a ? a : {};
+}(wf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Ef), c = null !== (a = xf(yf(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function Tf(e) {
+function Cf(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30656,69 +30666,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = Sf(r, wf(r))) && void 0 !== t ? t : e;
+return r && null !== (t = wf(r, xf(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function Cf(e, t) {
+function Sf(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(Ef(e, r, t)), !0;
+return InterShardMemory.setLocal(Tf(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function Sf(e, t) {
+function wf(e, t) {
 return t && function(e) {
-return xf(e.d) && "number" == typeof e.c;
-}(t) ? yf(e) : null;
+return bf(e.d) && "number" == typeof e.c;
+}(t) ? vf(e) : null;
 }
 
-function wf(e) {
+function xf(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return xf(t) ? t : null;
+return bf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function xf(e) {
+function bf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(vf || (vf = {})), function(e) {
+}(gf || (gf = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(gf || (gf = {}));
+}(hf || (hf = {}));
 
-var bf = null != Ft ? Ft : {
+var Of = null != Ft ? Ft : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Of = {
+}, kf = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, kf = {
+}, Mf = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Mf = function() {
+}, Af = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Of), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, kf), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30735,19 +30745,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = yf(r);
-o && (this.interShardMemory = o, bf.debug("Loaded InterShardMemory", {
+var o = vf(r);
+o && (this.interShardMemory = o, Of.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-bf.error("Failed to load InterShardMemory: ".concat(n), {
+Of.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = pf(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = ff(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -30908,25 +30918,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-bf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Of.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-bf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Of.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", bf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Of.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-bf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Of.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -30959,7 +30969,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-bf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Of.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -30989,12 +30999,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", bf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Of.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-bf.info("War ended, transitioning to ".concat(i), {
+Of.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, bf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Of.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -31020,7 +31030,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = kf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Mf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -31072,13 +31082,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && bf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Of.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-bf.debug("Could not set shard limits: ".concat(S), {
+Of.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -31086,27 +31096,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (bf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Of.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = Ef(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = Tf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > hf) {
-bf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(hf), {
+if (r.length > Rf) {
+Of.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(Rf), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = Ef(this.interShardMemory, t, {
+var o = Tf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > hf ? (bf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(hf), {
+return o.length > Rf ? (Of.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(Rf), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-bf.error("Failed to sync InterShardMemory: ".concat(n), {
+Of.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -31144,7 +31154,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = pf(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = ff(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -31162,40 +31172,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-bf.info("Repaired InterShardMemory structure", {
+Of.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void bf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Of.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = yf(r);
-if (!o) return void bf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = vf(r);
+if (!o) return void Of.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || bf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Of.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-bf.warn("InterShardMemory verification failed: ".concat(a), {
+Of.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-bf.info("Attempting InterShardMemory recovery", {
+Of.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = yf(r);
-if (o) return this.interShardMemory = o, void bf.info("Recovered InterShardMemory from storage", {
+var o = vf(r);
+if (o) return this.interShardMemory = o, void Of.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -31210,12 +31220,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = pf(n), bf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = ff(n), Of.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-bf.error("InterShardMemory recovery failed: ".concat(a), {
+Of.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31225,7 +31235,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), bf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Of.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -31241,7 +31251,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-bf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Of.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -31257,7 +31267,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), bf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Of.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -31272,7 +31282,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, bf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Of.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -31291,7 +31301,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), bf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Of.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -31337,11 +31347,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, bf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Of.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = ff(this.interShardMemory).length, o = r / hf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = yf(this.interShardMemory).length, o = r / Rf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -31368,11 +31378,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-bf.info("Forcing InterShardMemory sync with validation", {
+Of.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = ff(this.interShardMemory).length, n = ff(o(o({}, this.interShardMemory), {
+var e, t, r = yf(this.interShardMemory).length, n = yf(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31396,8 +31406,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: hf,
-percent: Math.round(r / hf * 1e4) / 100,
+limit: Rf,
+percent: Math.round(r / Rf * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31405,10 +31415,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (vf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (gf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), Af = new Mf, _f = {
+}(), _f = new Af, Uf = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31419,11 +31429,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: gf.LOW,
-NORMAL: gf.NORMAL,
-HIGH: gf.HIGH
+LOW: hf.LOW,
+NORMAL: hf.NORMAL,
+HIGH: hf.HIGH
 }
-}, Uf = function() {
+}, Nf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31433,7 +31443,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = Af.getActiveTransferTasks();
+var n = _f.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31460,7 +31470,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = Af.getOptimalPortalRoute(e.targetShard);
+var t = _f.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31528,7 +31538,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-Af.updateTaskProgress(e.taskId, t);
+_f.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31544,7 +31554,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = _f.optimizeBody({
+i = Uf.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -31555,8 +31565,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = _f.spawnPriorities.LOW;
-e.priority >= 80 ? d = _f.spawnPriorities.HIGH : e.priority >= 50 && (d = _f.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Uf.spawnPriorities.LOW;
+e.priority >= 80 ? d = Uf.spawnPriorities.HIGH : e.priority >= 50 && (d = Uf.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31574,7 +31584,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-_f.spawnQueue.addRequest(y), Ft.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Uf.spawnQueue.addRequest(y), Ft.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31601,7 +31611,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void Af.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void _f.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", Ft.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -31613,8 +31623,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, Af.updateTaskProgress(e.taskId, 100, "complete"),
-Af.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ft.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, _f.updateTaskProgress(e.taskId, 100, "complete"),
+_f.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ft.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31644,12 +31654,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Nf = new Uf;
+}(), Pf = new Nf;
 
-function Pf(e, t, r) {
+function If(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Tf({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Cf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31664,13 +31674,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Cf(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Sf(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function If(e) {
+function Gf(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31698,15 +31708,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Pf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (If("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || X(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Pf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (If("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Pf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (If((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31723,24 +31733,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Pf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, If("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Pf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (If("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Gf(e) {
+function Lf(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Lf(e, t) {
+function Df(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31774,14 +31784,14 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function Df(e, t) {
+function Ff(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function Ff(e) {
-var t = _d.getEmpire();
-if (ul.isExit(e.creep.pos)) return Gf(e.room.name);
+function Bf(e) {
+var t = Ud.getEmpire();
+if (ll.isExit(e.creep.pos)) return Lf(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (!o) {
 if (!(o = function(e, t, r) {
@@ -31796,7 +31806,7 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Df(t.x, t.y - 1), Df(t.x + 1, t.y), Df(t.x, t.y + 1), Df(t.x - 1, t.y) ] : [];
+return t ? [ Ff(t.x, t.y - 1), Ff(t.x + 1, t.y), Ff(t.x, t.y + 1), Ff(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }(e);
@@ -31859,13 +31869,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Lf(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Df(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Lf(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Df(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31875,19 +31885,19 @@ type: "idle"
 };
 }
 
-function Bf(e) {
+function Wf(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function Wf(e) {
-return e.hostiles.some(Bf);
-}
-
 function Hf(e) {
-return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+return e.hostiles.some(Wf);
 }
 
 function Kf(e) {
+return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+}
+
+function Yf(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -31910,8 +31920,8 @@ type: "idle"
 };
 }
 
-var Yf = {
-scout: Ff,
+var Vf = {
+scout: Bf,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -31945,7 +31955,7 @@ return {
 type: "idle"
 };
 }
-if (ul.isExit(e.creep.pos)) return Gf(e.room.name);
+if (ll.isExit(e.creep.pos)) return Lf(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -31967,8 +31977,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: If,
-interShardScout: If,
+interShardClaimer: Gf,
+interShardScout: Gf,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -32044,8 +32054,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return Kf(e);
-if (Wf(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return Yf(e);
+if (Hf(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32086,7 +32096,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return Hf(t) - Hf(e);
+return Kf(t) - Kf(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -32106,7 +32116,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : Kf(e);
+} : Yf(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -32195,9 +32205,9 @@ type: "idle"
 }
 };
 
-function Vf(e, t) {
+function qf(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Wf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Hf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -32205,26 +32215,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function qf(e) {
-var t;
-return (null !== (t = Yf[e.memory.role]) && void 0 !== t ? t : Ff)(e);
-}
-
 function jf(e) {
-var t = il(e);
-$l(e, im(t, Zd, {
-interrupt: $d
-}), t);
+var t;
+return (null !== (t = Vf[e.memory.role]) && void 0 !== t ? t : Bf)(e);
 }
 
 function zf(e) {
-var t = il(e);
-$l(e, im(t, qf, {
-interrupt: Vf
+var t = sl(e);
+em(e, sm(t, Jd, {
+interrupt: ep
 }), t);
 }
 
 function Qf(e) {
+var t = sl(e);
+em(e, sm(t, jf, {
+interrupt: qf
+}), t);
+}
+
+function Xf(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -32265,8 +32275,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Ip.has(i) && z(s))) {
-Up.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && Gp.has(i) && z(s))) {
+Np.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -32277,16 +32287,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && ul.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && ll.moveTo(e, t.target);
 break;
 
 case "moveTo":
-ul.moveTo(e, t.target);
+ll.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-ul.moveTo(e, {
+ll.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -32295,11 +32305,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && ul.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && ll.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && ul.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && ll.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -32331,7 +32341,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Np(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Pp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -32341,7 +32351,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Np(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Pp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -32352,7 +32362,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = Rr(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Np(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Pp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32405,7 +32415,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Np(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Pp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32447,7 +32457,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Np(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Pp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32457,7 +32467,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Np(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Pp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -32465,7 +32475,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && X(e.room).length > 0) {
 var o = Rr(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Np(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Pp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32477,7 +32487,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Np(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Pp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32485,12 +32495,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Np(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Pp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Np(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Pp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32524,18 +32534,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function Xf(e) {
+function Zf(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var Zf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), Jf = -1, $f = Object.create(null);
+var Jf = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), $f = -1, ey = Object.create(null);
 
-function ey(e) {
+function ty(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var ty = {
+var ry = {
 harvester: Wt.CRITICAL,
 queenCarrier: Wt.CRITICAL,
 hauler: Wt.HIGH,
@@ -32570,12 +32580,12 @@ labTech: Wt.IDLE,
 factoryWorker: Wt.IDLE
 };
 
-function ry(e) {
+function oy(e) {
 var t;
-return null !== (t = ty[e]) && void 0 !== t ? t : Wt.MEDIUM;
+return null !== (t = ry[e]) && void 0 !== t ? t : Wt.MEDIUM;
 }
 
-function oy(e) {
+function ny(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32591,30 +32601,30 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && ey(o) === e && t++;
+o && ty(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (Jf !== Game.time && (Jf = Game.time, $f = function() {
+}(e) : null !== (r = ($f !== Game.time && ($f = Game.time, ey = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = ey(o);
+var n = ty(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), $f)[e]) && void 0 !== r ? r : 0;
+}()), ey)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Rt().cpu.disableCreepBootstrapCountCache
 });
-if (o && Game.time % 50 == 0 && Qu.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
+if (o && Game.time % 50 == 0 && Xu.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
 subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!Zf.has(t.role)) return !1;
+if (!Jf.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32624,7 +32634,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Xf(r)) return !1;
+if (!r || !Zf(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32638,7 +32648,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Xf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !Zf(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32646,7 +32656,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Xf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !Zf(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32654,7 +32664,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !Xf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !Zf(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32662,7 +32672,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && Xf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && Zf(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32678,7 +32688,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !Xf(r)) return !1;
+if (!r || !Zf(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32713,41 +32723,41 @@ var t;
 return null !== (t = e.memory.family) && void 0 !== t ? t : "economy";
 }(e), i = t.role;
 try {
-qi.measureSubsystem("role:".concat(i), function() {
+ji.measureSubsystem("role:".concat(i), function() {
 switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = il(e);
-$l(e, im(t, Zd, {
-interrupt: $d
+var t = sl(e);
+em(e, sm(t, Jd, {
+interrupt: ep
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = il(e);
-$l(e, im(t, _p), t);
+var t = sl(e);
+em(e, sm(t, Up), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = il(e);
-$l(e, im(t, qf), t);
+var t = sl(e);
+em(e, sm(t, jf), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = il(e);
-$l(e, im(t, Lp), t);
+var t = sl(e);
+em(e, sm(t, Dp), t);
 }(e);
 }
 });
 } catch (t) {
-Qu.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
+Xu.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
 subsystem: "CreepProcessManager",
 creep: e.name,
 meta: {
@@ -32763,7 +32773,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var ny = function() {
+var ay = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32792,7 +32802,7 @@ if (e) throw e.error;
 }
 }
 var d = s < 5;
-(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && Qu.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
+(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && Xu.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
 subsystem: "CreepProcessManager",
 meta: {
 activeCreeps: r.size,
@@ -32804,8 +32814,8 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = ry(r), n = "creep:".concat(e.name);
-bi.registerProcess({
+var t = e.memory, r = t.role, o = oy(r), n = "creep:".concat(e.name);
+Oi.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
 priority: o,
@@ -32820,14 +32830,14 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && oy(t);
+t && !t.spawning && ny(t);
 }
-}), this.registeredCreeps.add(e.name), Qu.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
+}), this.registeredCreeps.add(e.name), Xu.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.unregisterCreepProcess = function(e) {
 var t = "creep:".concat(e);
-bi.unregisterProcess(t), this.registeredCreeps.delete(e), Qu.info("Unregistered creep process: ".concat(e), {
+Oi.unregisterProcess(t), this.registeredCreeps.delete(e), Xu.info("Unregistered creep process: ".concat(e), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.getMinBucketForRole = function(e, t) {
@@ -32845,7 +32855,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = ry(u.memory.role), m = null !== (r = Wt[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = oy(u.memory.role), m = null !== (r = Wt[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32870,20 +32880,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), ay = new ny;
-
-function iy(e) {
-var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, sy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
-}
+}(), iy = new ay;
 
 function sy(e) {
+var t, r, o;
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, cy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+}
+
+function cy(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function cy(e) {
+function uy(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32896,14 +32906,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function uy(e, t) {
+function ly(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var ly = {
+var my = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -32931,11 +32941,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function my(e, t) {
+function dy(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function dy(e) {
+function py(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -32945,9 +32955,9 @@ tick: Game.time
 }, a;
 }
 
-var py = [ "defense", "war", "expand", "siege" ];
+var fy = [ "defense", "war", "expand", "siege" ];
 
-function fy(e) {
+function yy(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -32960,11 +32970,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function yy(e, t, r) {
-t >= 2 && (e.pheromones.war = my(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = my(e.pheromones.siege + 20, r));
+function vy(e, t, r) {
+t >= 2 && (e.pheromones.war = dy(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = dy(e.pheromones.siege + 20, r));
 }
 
-var vy = function() {
+var gy = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -32979,27 +32989,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), gy = function() {
+}(), hy = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, ly), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, my), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new vy(10),
-energySpawning: new vy(10),
-energyConstruction: new vy(10),
-energyRepair: new vy(10),
-energyTower: new vy(10),
-controllerProgress: new vy(10),
-hostileCount: new vy(5),
-damageReceived: new vy(5),
-idleWorkers: new vy(10),
+energyHarvested: new gy(10),
+energySpawning: new gy(10),
+energyConstruction: new gy(10),
+energyRepair: new gy(10),
+energyTower: new gy(10),
+controllerProgress: new gy(10),
+hostileCount: new gy(5),
+damageReceived: new gy(5),
+idleWorkers: new gy(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = dy(e);
+var o = py(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -33072,7 +33082,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = my(e[s] * c, t);
+e[s] = dy(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -33088,43 +33098,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = dy(t);
+var o = py(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = my(e.harvest + n / 3e3 * 10, r);
+e.harvest = dy(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = my(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = dy(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = my(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = dy(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = my(e.defense + 10 * o, r));
+o > 0 && (e.defense = dy(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = my(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = my(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = dy(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = dy(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = my(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = dy(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = my(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = dy(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = my(e.pheromones.defense + 5 * t, o), yy(e, r, o),
+e.danger = r, e.pheromones.defense = dy(e.pheromones.defense + 5 * t, o), vy(e, r, o),
 _.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -33132,7 +33142,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = my(t / 10, o), yy(e, r, o);
+e.danger = r, e.pheromones.defense = dy(t / 10, o), vy(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -33145,8 +33155,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = my(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = my(f + y, o);
+var p = dy(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = dy(f + y, o);
 }
 }
 }
@@ -33165,18 +33175,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = my(e.pheromones.defense + 5, r), e.pheromones.build = my(e.pheromones.build + 10, r),
+e.pheromones.defense = dy(e.pheromones.defense + 5, r), e.pheromones.build = dy(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = my(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = dy(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = my(e.pheromones.siege + 50, t), e.pheromones.defense = my(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = dy(e.pheromones.siege + 50, t), e.pheromones.defense = dy(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = my(e.pheromones.expand - 10, t), e.pheromones.defense = my(e.pheromones.defense + 5, t);
+e.pheromones.expand = dy(e.pheromones.expand - 10, t), e.pheromones.defense = dy(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -33186,10 +33196,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(fy(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(yy(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(py)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(fy)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -33243,7 +33253,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = my(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = dy(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -33278,7 +33288,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), hy = new gy, Ry = {
+}(), Ry = new hy, Ey = {
 seedNest: {
 rcl: 1
 },
@@ -33319,7 +33329,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, Ey = {
+}, Ty = {
 eco: {
 economy: .75,
 military: .05,
@@ -33362,7 +33372,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Ty = {
+}, Cy = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33419,13 +33429,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Cy = function() {
+}, Sy = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Ry.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Ry.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Ry.fortifiedHive.rcl ? "fortifiedHive" : s >= Ry.matureColony.rcl ? "matureColony" : s >= Ry.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Ey.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Ey.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Ey.fortifiedHive.rcl ? "fortifiedHive" : s >= Ey.matureColony.rcl ? "matureColony" : s >= Ey.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = bt.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -33460,7 +33470,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Ry[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Ey[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33473,7 +33483,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Sy = function() {
+}(), wy = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33486,7 +33496,7 @@ var n = e.posture, a = null != r ? r : e.role;
 return _.info("Posture change: ".concat(n, " -> ").concat(o), {
 room: a,
 subsystem: "Posture"
-}), e.posture = o, bi.emit("posture.change", {
+}), e.posture = o, Oi.emit("posture.change", {
 roomName: a,
 oldPosture: n,
 newPosture: o,
@@ -33495,9 +33505,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return Ey[e];
-}, e.prototype.getResourcePriorities = function(e) {
 return Ty[e];
+}, e.prototype.getResourcePriorities = function(e) {
+return Cy[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33507,15 +33517,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), wy = new Cy, xy = new Sy;
+}(), xy = new Sy, by = new wy;
 
-function by(e) {
+function Oy(e) {
 return !j(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Oy(e, t, r) {
+function ky(e, t, r) {
 if (!e) return null;
 var o = ft.getEmpire();
 if (j(e, {
@@ -33554,11 +33564,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function ky() {
+function My() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var My = new Map, Ay = function() {
+var Ay = new Map, _y = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = X(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33694,7 +33704,7 @@ if (r) throw r.error;
 }(n, c), c;
 var n, c;
 }, e.prototype.getDefensePostureSnapshot = function(e, t, r, o) {
-var n, a = t.clusterId ? ft.getCluster(t.clusterId) : null, i = o.length > 0 ? No(e) : void 0, s = Game.time % 10 == 0 ? e.find(FIND_NUKES) : [];
+var n, a = t.clusterId ? ft.getCluster(t.clusterId) : null, i = o.length > 0 ? Po(e) : void 0, s = Game.time % 10 == 0 ? e.find(FIND_NUKES) : [];
 return {
 roomName: e.name,
 time: Game.time,
@@ -33702,7 +33712,7 @@ currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: My.get(e.name),
+previousStructures: Ay.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33732,7 +33742,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && My.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Ay.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33741,7 +33751,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-by(u) && o.add(u.owner.username);
+Oy(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33755,7 +33765,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Oy(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) ky(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33771,7 +33781,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? hy.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? hy.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && hy.onNukeDetected(t);
+"danger" === y.type ? Ry.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Ry.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Ry.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33821,7 +33831,7 @@ case "hostile.detected":
 case "hostile.cleared":
 case "structure.destroyed":
 case "nuke.detected":
-bi.emit(e.type, e.payload);
+Oi.emit(e.type, e.payload);
 }
 }, e.prototype.runTowerControl = function(e, t, r) {
 var o, n, i, s;
@@ -33831,16 +33841,16 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = ky()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = My()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = ky()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = My()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
 if (!(O.store.getUsedCapacity(RESOURCE_ENERGY) < 10)) {
-var k = Xo({
+var k = Zo({
 tower: O,
 hostiles: f,
 posture: y,
@@ -33877,8 +33887,8 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: xy.isCombatPosture(t.posture),
-wallRepairTarget: Zo(u, t.danger),
+isCombatPosture: by.isCombatPosture(t.posture),
+wallRepairTarget: Jo(u, t.danger),
 bucket: Game.cpu.bucket
 });
 try {
@@ -33901,27 +33911,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), _y = new Ay, Uy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Uy = new _y, Ny = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Ny() {
+function Py() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Py(e, t, r, o) {
+function Iy(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Ny()
+selectedAt: Py()
 });
 }
 
-function Iy(e) {
+function Gy(e) {
 return e >= 2 && e <= 3;
 }
 
-function Gy(e, t, r) {
+function Ly(e, t, r) {
 var o, n = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -33934,7 +33944,7 @@ return e.structureType === t;
 return n.length + a.length + (null !== (o = null == r ? void 0 : r.getPlacedCount(t)) && void 0 !== o ? o : 0);
 }
 
-function Ly(e, t) {
+function Dy(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -33948,23 +33958,23 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var Dy = function() {
+var Fy = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Iy(e) ? 5 : 10;
+return Gy(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
 var p = r, f = null !== (l = null === (u = e.controller) || void 0 === u ? void 0 : u.level) && void 0 !== l ? l : 1, y = function(e, t) {
 void 0 === t && (t = {});
-var r = nn(t.roomSiteCount, e.find(FIND_MY_CONSTRUCTION_SITES).length), o = nn(t.globalSiteCount, function(e) {
+var r = an(t.roomSiteCount, e.find(FIND_MY_CONSTRUCTION_SITES).length), o = an(t.globalSiteCount, function(e) {
 var t;
 return "undefined" == typeof Game ? e : Object.keys(null !== (t = Game.constructionSites) && void 0 !== t ? t : {}).length;
-}(r)), n = nn(t.roomLimit, 10), a = nn(t.globalLimit, an());
-return new sn(r, o, n, a);
+}(r)), n = an(t.roomLimit, 10), a = an(t.globalLimit, sn());
+return new cn(r, o, n, a);
 }(e, {
 roomSiteCount: p.length
-}), v = cn(e, y), g = cn(e, y, {
+}), v = un(e, y), g = un(e, y, {
 bypassRoomLimit: !0
 }), h = n[0], R = null == h || h.pos;
 if (h) {
@@ -33980,17 +33990,17 @@ void 0 === r && (r = {});
 var c = function(e, t, r) {
 var n;
 void 0 === r && (r = {});
-var a = Ln(null != t ? t : e.rcl), c = function(e) {
+var a = Dn(null != t ? t : e.rcl), c = function(e) {
 var t, r, o;
-if (e.anchor) return Wa(e.anchor);
+if (e.anchor) return Ha(e.anchor);
 var n = null === (t = e.existingStructures) || void 0 === t ? void 0 : t.find(function(e) {
-return e.structureType === On;
+return e.structureType === kn;
 });
-if (n) return Wa(n);
+if (n) return Ha(n);
 var a = null === (r = e.existingStructures) || void 0 === r ? void 0 : r.find(function(e) {
-return e.structureType === Tn;
+return e.structureType === Cn;
 });
-if (a) return Wa({
+if (a) return Ha({
 x: a.x + 2,
 y: a.y
 });
@@ -34008,7 +34018,7 @@ y: e.y + t.y
 x: 0,
 y: 0
 });
-return Wa({
+return Ha({
 x: u.x / c.length,
 y: u.y / c.length
 });
@@ -34025,7 +34035,7 @@ ramparts: [],
 unplaced: [],
 errors: [],
 stamps: [],
-version: Fa
+version: Ba
 };
 return {
 facts: o(o({}, e), {
@@ -34033,21 +34043,21 @@ rcl: a
 }),
 plan: u,
 counts: {},
-limits: Dn(a),
-targets: Fn(a),
+limits: Fn(a),
+targets: Bn(a),
 occupied: new Set,
 roadKeys: new Set,
 rampartKeys: new Set
 };
 }(e, t, r);
-ja(c, c.facts.existingStructures, "existing-structure"), ja(c, c.facts.existingConstructionSites, "existing-site");
+za(c, c.facts.existingStructures, "existing-structure"), za(c, c.facts.existingConstructionSites, "existing-site");
 var u = [];
 u.push.apply(u, s([], i(function(e) {
 var t, r, o, n = [];
 try {
 for (var c = a(null !== (o = e.facts.sources) && void 0 !== o ? o : []), u = c.next(); !u.done; u = c.next()) {
-var l = $a(e, u.value, e.plan.anchor);
-l && (Za(e, xa, l), Ja(e, e.plan.anchor, l, "SOURCE_MINING:path", 1));
+var l = ei(e, u.value, e.plan.anchor);
+l && (Ja(e, ba, l), $a(e, e.plan.anchor, l, "SOURCE_MINING:path", 1));
 }
 } catch (e) {
 t = {
@@ -34061,17 +34071,17 @@ if (t) throw t.error;
 }
 }
 if (e.facts.controller) {
-var m = $a(e, e.facts.controller, e.plan.anchor);
+var m = ei(e, e.facts.controller, e.plan.anchor);
 if (m) {
-var d = Za(e, ba, m);
-n.push.apply(n, s([], i(d.missing), !1)), Ja(e, e.plan.anchor, m, "CONTROLLER_STAMP:path", 1);
+var d = Ja(e, Oa, m);
+n.push.apply(n, s([], i(d.missing), !1)), $a(e, e.plan.anchor, m, "CONTROLLER_STAMP:path", 1);
 }
 }
-return e.facts.mineral && e.plan.rcl >= 6 && (d = Za(e, Aa, e.facts.mineral), n.push.apply(n, s([], i(d.missing), !1)),
-Ja(e, e.plan.anchor, e.facts.mineral, "MINERAL_STAMP:path", 6)), n;
+return e.facts.mineral && e.plan.rcl >= 6 && (d = Ja(e, _a, e.facts.mineral), n.push.apply(n, s([], i(d.missing), !1)),
+$a(e, e.plan.anchor, e.facts.mineral, "MINERAL_STAMP:path", 6)), n;
 }(c)), !1)), u.push.apply(u, s([], i(function(e) {
 var t, r, o, n = [];
-n.push.apply(n, s([], i(Za(e, wa, e.plan.anchor).missing), !1));
+n.push.apply(n, s([], i(Ja(e, xa, e.plan.anchor).missing), !1));
 try {
 for (var c = a([ {
 x: (o = e.plan.anchor).x - 6,
@@ -34092,7 +34102,7 @@ y: o.y - 6
 x: o.x + 6,
 y: o.y + 6
 } ]), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = Za(e, Sa, l);
+var l = u.value, m = Ja(e, wa, l);
 n.push.apply(n, s([], i(m.missing), !1));
 }
 } catch (e) {
@@ -34106,13 +34116,13 @@ u && !u.done && (r = c.return) && r.call(c);
 if (t) throw t.error;
 }
 }
-return n.push.apply(n, s([], i(Za(e, Oa, {
+return n.push.apply(n, s([], i(Ja(e, ka, {
 x: e.plan.anchor.x + 4,
 y: e.plan.anchor.y + 1
-}).missing), !1)), n.push.apply(n, s([], i(Za(e, ka, {
+}).missing), !1)), n.push.apply(n, s([], i(Ja(e, Ma, {
 x: e.plan.anchor.x + 4,
 y: e.plan.anchor.y - 3
-}).missing), !1)), n.push.apply(n, s([], i(Za(e, Ma, {
+}).missing), !1)), n.push.apply(n, s([], i(Ja(e, Aa, {
 x: e.plan.anchor.x,
 y: e.plan.anchor.y + 4
 }).missing), !1)), n;
@@ -34121,7 +34131,7 @@ var r, o, n, c, u, l = s([], i(t), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 try {
-for (var m = a(l), d = m.next(); !d.done; d = m.next()) Qa(e, g = d.value) && ei(e, g);
+for (var m = a(l), d = m.next(); !d.done; d = m.next()) Xa(e, g = d.value) && ti(e, g);
 } catch (e) {
 r = {
 error: e
@@ -34134,14 +34144,14 @@ if (r) throw r.error;
 }
 }
 try {
-for (var p = a(Gn), f = p.next(); !f.done; f = p.next()) for (var y = f.value, v = null !== (u = e.targets[y]) && void 0 !== u ? u : 0; Ka(e, y) < v; ) {
+for (var p = a(Ln), f = p.next(); !f.done; f = p.next()) for (var y = f.value, v = null !== (u = e.targets[y]) && void 0 !== u ? u : 0; Ya(e, y) < v; ) {
 var g;
-if (!ei(e, g = {
+if (!ti(e, g = {
 structureType: y,
 priority: 100,
-fallback: ti(y),
+fallback: ri(y),
 reason: "target count not met by preferred stamps",
-localAnchor: y === An ? e.facts.mineral : e.plan.anchor,
+localAnchor: y === _n ? e.facts.mineral : e.plan.anchor,
 minRcl: e.plan.rcl
 })) {
 e.plan.unplaced.push(g), e.plan.errors.push({
@@ -34166,12 +34176,12 @@ if (n) throw n.error;
 }
 }(c, u);
 var l = function(e, t) {
-var r, o, n, i, s, c, u, l, m, d, p, f = Dn(t.rcl), y = Fn(t.rcl), v = {}, g = [], h = new Set;
+var r, o, n, i, s, c, u, l, m, d, p, f = Fn(t.rcl), y = Bn(t.rcl), v = {}, g = [], h = new Set;
 try {
 for (var R = a(t.structures), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 v[T.structureType] = (null !== (u = v[T.structureType]) && void 0 !== u ? u : 0) + 1,
-Ua(e, T.x, T.y) || g.push({
+Na(e, T.x, T.y) || g.push({
 type: "TERRAIN_WALL",
 structureType: T.structureType,
 x: T.x,
@@ -34263,7 +34273,7 @@ var l = e.getTerrain(), m = [], d = [];
 try {
 for (var p = a(e.find(FIND_STRUCTURES)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-ri(y.structureType) && m.push({
+oi(y.structureType) && m.push({
 x: y.pos.x,
 y: y.pos.y,
 structureType: y.structureType
@@ -34332,7 +34342,7 @@ y: E.y
 } : {});
 R = new RoomPosition(T.anchor.x, T.anchor.y, e.name);
 var C, S = (C = T, {
-name: "".concat(Fa, "-rcl-").concat(C.rcl),
+name: "".concat(Ba, "-rcl-").concat(C.rcl),
 rcl: C.rcl,
 anchor: {
 x: C.anchor.x,
@@ -34360,10 +34370,10 @@ y: e.y - C.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Py(t, R, S.name, f);
+Iy(t, R, S.name, f);
 var w = f >= 3 && (t.danger >= 1 || function(e, t, r) {
-var o = Ly(STRUCTURE_TOWER, t);
-return o > 0 && Gy(e, STRUCTURE_TOWER, r) < o;
+var o = Dy(STRUCTURE_TOWER, t);
+return o > 0 && Ly(e, STRUCTURE_TOWER, r) < o;
 }(e, f, y));
 if (w) {
 var x = y.capRequested(t.danger >= 2 ? 3 : 1, {
@@ -34374,7 +34384,7 @@ var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Ly(STRUCTURE_TOWER, g), R = Gy(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Dy(STRUCTURE_TOWER, g), R = Ly(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34407,7 +34417,7 @@ b && !b.done && (s = x.return) && s.call(x);
 if (i) throw i.error;
 }
 }
-var k = ii(t, {
+var k = si(t, {
 existingStructureKeys: E,
 existingSiteKeys: T,
 currentRcl: g
@@ -34468,22 +34478,22 @@ var b = y.capRequested(2);
 b > 0 && function(e, t) {
 var r, o;
 void 0 === t && (t = 1);
-var n = pn(e);
+var n = fn(e);
 if (0 === n.placements.length || t <= 0) return 0;
-var c = e.find(FIND_MY_CONSTRUCTION_SITES), u = dn(e), l = c.filter(function(e) {
+var c = e.find(FIND_MY_CONSTRUCTION_SITES), u = pn(e), l = c.filter(function(e) {
 return e.structureType === STRUCTURE_LINK;
 }), m = u.length + l.length, d = 0, p = function(e, t) {
 return new Set(s(s([], i(e.map(function(e) {
-return ln(e.pos.x, e.pos.y);
+return mn(e.pos.x, e.pos.y);
 })), !1), i(t.map(function(e) {
-return ln(e.pos.x, e.pos.y);
+return mn(e.pos.x, e.pos.y);
 })), !1));
 }(u, l);
 try {
 for (var f = a(n.placements), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (d >= t || m >= n.linkLimit) break;
-var g = ln(v.x, v.y);
+var g = mn(v.x, v.y);
 p.has(g) || e.createConstructionSite(v.x, v.y, STRUCTURE_LINK) === OK && (d += 1,
 m += 1, p.add(g));
 }
@@ -34510,7 +34520,7 @@ if (n.length >= 10) return 0;
 var c = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f = function(e) {
 var t, r, o;
-return null !== (o = un(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
+return null !== (o = ln(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
 }(e);
 if (f < 3) return null;
 var y = e.find(FIND_MY_STRUCTURES, {
@@ -34520,16 +34530,16 @@ return e.structureType === STRUCTURE_LAB;
 }), v = e.find(FIND_MY_CONSTRUCTION_SITES), g = v.filter(function(e) {
 return e.structureType === STRUCTURE_LAB;
 }), h = new Set(y.map(function(e) {
-return yn(e.pos.x, e.pos.y);
+return vn(e.pos.x, e.pos.y);
 })), R = new Set(g.map(function(e) {
-return yn(e.pos.x, e.pos.y);
+return vn(e.pos.x, e.pos.y);
 })), E = new Set(s(s([], i(h), !1), i(R), !1));
 if (E.size > f) return null;
 var T = e.find(FIND_STRUCTURES), C = new Set;
 try {
 for (var S = a(T), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-gn(x, h) && C.add(yn(x.pos.x, x.pos.y));
+hn(x, h) && C.add(vn(x.pos.x, x.pos.y));
 }
 } catch (e) {
 t = {
@@ -34545,7 +34555,7 @@ if (t) throw t.error;
 try {
 for (var b = a(v), O = b.next(); !O.done; O = b.next()) {
 var k = O.value;
-hn(k, R) && C.add(yn(k.pos.x, k.pos.y));
+Rn(k, R) && C.add(vn(k.pos.x, k.pos.y));
 }
 } catch (e) {
 o = {
@@ -34590,7 +34600,7 @@ y: e.find(FIND_MY_SPAWNS)[0].pos.y
 return void 0 !== e;
 });
 try {
-for (var U = a(_), N = U.next(); !N.done; N = U.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) Rn(A, e, P.x + I, P.y + G, M, h, R, C);
+for (var U = a(_), N = U.next(); !N.done; N = U.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) En(A, e, P.x + I, P.y + G, M, h, R, C);
 } catch (e) {
 c = {
 error: e
@@ -34626,7 +34636,7 @@ return void 0 !== e;
 }), o = s([], i(e.values()), !1).filter(function(e) {
 return !t.has(e.key);
 }).sort(function(e, t) {
-var o = En(e, r) - En(t, r);
+var o = Tn(e, r) - Tn(t, r);
 return 0 !== o ? o : e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
 });
 return s(s([], i(r), !1), i(o), !1).slice(0, 80);
@@ -34637,7 +34647,7 @@ var t, r, o = function(t) {
 var r, o, n, c;
 if (e.key === t.key) return "continue";
 var u = B.filter(function(r) {
-return r.key === e.key || r.key === t.key || vn(r, e) <= 2 && vn(r, t) <= 2;
+return r.key === e.key || r.key === t.key || gn(r, e) <= 2 && gn(r, t) <= 2;
 });
 if (u.length < f) return "continue";
 if (s([], i(E), !1).some(function(e) {
@@ -34693,7 +34703,7 @@ return e.existingLab;
 return e.existingSite;
 }).length - e.reduce(function(e, t) {
 return e + t.distanceToHub;
-}, 0) - 5 * vn(t, r);
+}, 0) - 5 * gn(t, r);
 }(T, e, t);
 (!H || C > H.score) && (H = {
 positions: T,
@@ -34773,11 +34783,11 @@ if (r) throw r.error;
 }(v, O);
 }
 var k = function(e, t, r) {
-var o, n, i, s = Fn(t);
+var o, n, i, s = Bn(t);
 try {
 for (var c = a(Object.keys(s)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = null !== (i = s[l]) && void 0 !== i ? i : 0;
-if (!(m <= 0) && Gy(e, l, r) < m) return !0;
+if (!(m <= 0) && Ly(e, l, r) < m) return !0;
 }
 } catch (e) {
 o = {
@@ -34793,8 +34803,8 @@ if (o) throw o.error;
 return !1;
 }(e, f, y);
 if (y.canPlace() || k) {
-if (!xy.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Ny());
+if (!by.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Py());
 }(t, R)) {
 var M = function(e, t, r, o, n) {
 var i, s;
@@ -34802,7 +34812,7 @@ void 0 === n && (n = []);
 var c = function(e, t, r, o) {
 var n, i, s, c, u, l, m, d, p, f;
 void 0 === o && (o = []);
-var y = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 1, v = Zn(r, y), g = e.getTerrain(), h = [], R = new Map;
+var y = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 1, v = Jn(r, y), g = e.getTerrain(), h = [], R = new Map;
 try {
 for (var E = a(v), T = E.next(); !T.done; T = E.next()) {
 var C = T.value, S = t.x + C.x, w = t.y + C.y;
@@ -34822,7 +34832,7 @@ T && !T.done && (i = E.return) && i.call(E);
 if (n) throw n.error;
 }
 }
-var b = Ea(e, t, r.roads, o);
+var b = Ta(e, t, r.roads, o);
 if (R.set(STRUCTURE_ROAD, b), y >= 6) {
 var O = e.find(FIND_MINERALS);
 if (O.length > 0) {
@@ -34832,14 +34842,14 @@ M.add("".concat(k.pos.x, ",").concat(k.pos.y)), R.set(STRUCTURE_EXTRACTOR, M);
 }
 var A = function(e) {
 var t, r, o = function(e) {
-return new Set(pn(e).placements.map(function(e) {
-return ln(e.x, e.y);
+return new Set(fn(e).placements.map(function(e) {
+return mn(e.x, e.y);
 }));
 }(e);
 try {
-for (var n = a(dn(e)), i = n.next(); !i.done; i = n.next()) {
+for (var n = a(pn(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-fn(e, s) && o.add(ln(s.pos.x, s.pos.y));
+yn(e, s) && o.add(mn(s.pos.x, s.pos.y));
 }
 } catch (e) {
 t = {
@@ -34873,7 +34883,7 @@ R.set(STRUCTURE_LINK, _);
 }
 var P = e.find(FIND_STRUCTURES, {
 filter: function(e) {
-return Ca.has(e.structureType) && (!0 === e.my || e.structureType === STRUCTURE_ROAD);
+return Sa.has(e.structureType) && (!0 === e.my || e.structureType === STRUCTURE_ROAD);
 }
 });
 try {
@@ -34951,7 +34961,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Uy.has(e.structureType);
+return Ny.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -34960,7 +34970,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var P = Iy(f) ? 2 : 3, I = y.capRequested(P);
+var P = Gy(f) ? 2 : 3, I = y.capRequested(P);
 I > 0 && (N = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -34970,7 +34980,7 @@ wallsRemoved: 0
 var y = function(e, t, r, o) {
 var n, c, u, l;
 void 0 === o && (o = []);
-var m = Ea(e, t, r, o), d = function(e) {
+var m = Ta(e, t, r, o), d = function(e) {
 var t, r, o, n, c, u, l, m = Game.map.getRoomTerrain(e), d = [], p = [], f = new Set, y = function(e, t, r) {
 if (!(e < 1 || e > 48 || t < 1 || t > 48) && m.get(e, t) !== TERRAIN_MASK_WALL) {
 var o = "".concat(e, ",").concat(t);
@@ -35296,7 +35306,7 @@ wallsRemoved: R
 };
 }(v, R, S.roads, f, I, t.remoteAssignments)), N.wallsRemoved > 0 && ft.addRoomEvent(e.name, "wallRemoved", "".concat(N.wallsRemoved, " wall(s) removed to allow road passage"));
 }
-var G = k ? cn(e, y, {
+var G = k ? un(e, y, {
 bypassRoomLimit: !0
 }) : v, L = y.capRequested(3, {
 bypassRoomLimit: k
@@ -35344,7 +35354,7 @@ return {
 structures: i,
 sites: s
 };
-}(e), p = ii(t, {
+}(e), p = si(t, {
 existingStructureKeys: d.structures,
 existingSiteKeys: d.sites,
 currentRcl: null !== (s = null === (i = e.controller) || void 0 === i ? void 0 : i.level) && void 0 !== s ? s : t.rcl
@@ -35376,19 +35386,19 @@ var o, n;
 void 0 === r && (r = 3);
 var i = e.find(FIND_MY_CONSTRUCTION_SITES);
 if (i.length >= 10) return 0;
-var s = ma(e, t), c = e.getTerrain(), u = function(e) {
+var s = da(e, t), c = e.getTerrain(), u = function(e) {
 var t = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
 }
 });
 return new Set(t.map(function(e) {
-return aa(e.pos);
+return ia(e.pos);
 }));
 }(e), l = new Set(i.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
 }).map(function(e) {
-return aa(e.pos);
+return ia(e.pos);
 })), m = 0;
 try {
 for (var d = a(s.positions), p = d.next(); !p.done; p = d.next()) {
@@ -35396,7 +35406,7 @@ var f = p.value;
 if (m >= r) break;
 if (i.length + m >= 10) break;
 if (!u.has(f) && !l.has(f)) {
-var y = ia(f), v = y.x, g = y.y;
+var y = sa(f), v = y.x, g = y.y;
 c.get(v, g) !== TERRAIN_MASK_WALL && e.createConstructionSite(v, g, STRUCTURE_ROAD) === OK && m++;
 }
 }
@@ -35428,7 +35438,7 @@ protected: 0
 };
 if (t < 2) return u;
 var l = function(e, t) {
-var r = e.find(FIND_MY_STRUCTURES), o = t < 4 ? $o : Jo;
+var r = e.find(FIND_MY_STRUCTURES), o = t < 4 ? en : $o;
 return r.filter(function(e) {
 return o.includes(e.structureType);
 });
@@ -35440,7 +35450,7 @@ var d = Math.min(o, 10 - m.length), p = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_RAMPART;
 }
-}), f = Zo(t, r), y = [], v = function(t) {
+}), f = Jo(t, r), y = [], v = function(t) {
 var o = t.pos, n = o.x, a = o.y;
 if (function(e, t, r) {
 return e.lookForAt(LOOK_STRUCTURES, t, r).some(function(e) {
@@ -35516,38 +35526,38 @@ return e.structureType === STRUCTURE_SPAWN;
 if (!0 === (null === (m = e.controller) || void 0 === m ? void 0 : m.my) && !W) {
 var H = function(e, t) {
 if (t >= 8) {
-var r = Xn(e, jn);
+var r = Zn(e, zn);
 if (r) return {
-blueprint: jn,
+blueprint: zn,
 anchor: r
 };
-if (o = Xn(e, qn)) return {
-blueprint: qn,
+if (o = Zn(e, jn)) return {
+blueprint: jn,
 anchor: o
 };
 }
 var o;
-if (t >= 7 && (o = Xn(e, qn))) return {
-blueprint: qn,
+if (t >= 7 && (o = Zn(e, jn))) return {
+blueprint: jn,
 anchor: o
 };
 if (t >= 5) {
-var n = Xn(e, Vn);
+var n = Zn(e, qn);
 if (n) return {
-blueprint: Vn,
+blueprint: qn,
 anchor: n
 };
 }
 if (t >= 3) {
-var c = Xn(e, Kn);
+var c = Zn(e, Yn);
 if (c) return {
-blueprint: Kn,
+blueprint: Yn,
 anchor: c
 };
 }
-var u = Xn(e, Wn);
+var u = Zn(e, Hn);
 if (u) return {
-blueprint: Wn,
+blueprint: Hn,
 anchor: u
 };
 var l = function(e) {
@@ -35572,7 +35582,7 @@ if (t) throw t.error;
 }
 for (var d = Math.round(s / (n.length + 1)), p = Math.round(c / (n.length + 1)), f = 0; f < 15; f++) for (var y = -f; y <= f; y++) for (var v = -f; v <= f; v++) if (Math.abs(y) === f || Math.abs(v) === f) {
 var g = d + y, h = p + v;
-if (!(g < 3 || g > 46 || h < 3 || h > 46) && zn(e, g, h)) {
+if (!(g < 3 || g > 46 || h < 3 || h > 46) && Qn(e, g, h)) {
 if (Math.max(Math.abs(g - o.pos.x), Math.abs(h - o.pos.y)) > 20) continue;
 if (i.get(g, h) === TERRAIN_MASK_WALL) continue;
 return new RoomPosition(g, h, e.name);
@@ -35583,14 +35593,14 @@ return null;
 if (l) {
 var m = function(e, t, r) {
 var o, n, c = function(e) {
-return e >= 7 ? qn : e >= 5 ? Vn : e >= 3 ? Kn : Wn;
-}(t), u = s([], i(Zn(c, t)), !1).sort(function(e, t) {
-var r = Jn(t.structureType) - Jn(e.structureType);
+return e >= 7 ? jn : e >= 5 ? qn : e >= 3 ? Yn : Hn;
+}(t), u = s([], i(Jn(c, t)), !1).sort(function(e, t) {
+var r = $n(t.structureType) - $n(e.structureType);
 return 0 !== r ? r : t.structureType.localeCompare(e.structureType);
 }), l = new Set, m = [];
 try {
 for (var d = a(u), p = d.next(); !p.done; p = d.next()) {
-var f = p.value, y = r.x + f.x, v = r.y + f.y, g = ea(e, y, v, l);
+var f = p.value, y = r.x + f.x, v = r.y + f.y, g = ta(e, y, v, l);
 if (g) {
 var h = g.x - r.x, R = g.y - r.y;
 m.push({
@@ -35618,7 +35628,7 @@ y: e.y
 };
 }).filter(function(t) {
 var o = r.x + t.x, n = r.y + t.y;
-return $n(e, o, n) && !l.has("".concat(o, ",").concat(n));
+return ea(e, o, n) && !l.has("".concat(o, ",").concat(n));
 });
 return {
 name: "adaptive-".concat(c.name, "-rcl-").concat(Math.max(1, Math.min(8, Math.floor(t)))),
@@ -35640,7 +35650,7 @@ return e.structureType === STRUCTURE_SPAWN;
 blueprint: m,
 anchor: l
 } : {
-blueprint: Wn,
+blueprint: Hn,
 anchor: l
 };
 }
@@ -35649,16 +35659,16 @@ return null;
 if (H && y.canPlace({
 bypassRoomLimit: !0
 })) {
-Py(t, H.anchor, H.blueprint.name, f);
+Iy(t, H.anchor, H.blueprint.name, f);
 var K = e.createConstructionSite(H.anchor.x, H.anchor.y, STRUCTURE_SPAWN);
 y.recordResult(K, STRUCTURE_SPAWN);
 }
 }
 }
 }, e;
-}(), Fy = new Dy;
+}(), By = new Fy;
 
-function By(e) {
+function Wy(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35680,7 +35690,7 @@ siege: e.pheromones.siege
 };
 }
 
-var Wy = {
+var Hy = {
 info: function(e, t) {
 return _.info(e, t);
 },
@@ -35693,10 +35703,10 @@ return _.error(e, t);
 debug: function(e, t) {
 return _.debug(e, t);
 }
-}, Hy = new (function() {
+}, Ky = new (function() {
 function e() {
-this.manager = new ou({
-logger: Wy
+this.manager = new nu({
+logger: Hy
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35706,23 +35716,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = By(t);
+var r = Wy(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = By(t);
+var r = Wy(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), Ky = {
-labManager: Ru,
-boostManager: fu,
-chemistryPlanner: Hy,
-labConfigManager: gu,
-logger: Qu
-}, Yy = function() {
+}()), Yy = {
+labManager: Eu,
+boostManager: yu,
+chemistryPlanner: Ky,
+labConfigManager: hu,
+logger: Xu
+}, Vy = function() {
 function e(e) {
-void 0 === e && (e = Ky), this.deps = e;
+void 0 === e && (e = Yy), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35761,9 +35771,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), Vy = new Yy, qy = function() {
+}(), qy = new Vy, jy = function() {
 function e(e) {
-void 0 === e && (e = Vy), this.labWorkflow = e;
+void 0 === e && (e = qy), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35786,30 +35796,30 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), jy = new qy, zy = {
+}(), zy = new jy, Qy = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, Qy = new Map;
+}, Xy = new Map;
 
-function Xy(e) {
+function Zy(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function Zy(e) {
+function Jy(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var Jy = function() {
+var $y = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, zy), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, Qy), t);
 }
 return e.prototype.run = function(e) {
-var t, r, o, n = qi.startRoom(this.roomName), i = Game.rooms[this.roomName];
+var t, r, o, n = ji.startRoom(this.roomName), i = Game.rooms[this.roomName];
 if (i && (null === (t = i.controller) || void 0 === t ? void 0 : t.my)) {
 var s = Game.cpu.bucket < 6e3;
 s || function(e) {
@@ -35848,7 +35858,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = ft.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = Qy.get(e.name);
+var t = Xy.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35870,38 +35880,38 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return Qy.set(e.name, o), o;
+return Xy.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && hy.updateMetrics(i, c),
-_y.updateThreatAssessment(i, c, {
+if (this.config.enablePheromones && !s && Game.time % 5 == 0 && Ry.updateMetrics(i, c),
+Uy.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), fi.assess(i, c), Ri.checkSafeMode(i, c), this.config.enableEvolution && (wy.updateEvolutionStage(c, i, e),
-s || wy.updateMissingStructures(c, i)), xy.updatePosture(c), this.config.enablePheromones && !s && hy.updatePheromones(c, i),
-this.config.enableTowers && _y.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = Fy.getConstructionInterval(l), d = xy.allowsBuilding(c.posture), p = !d && c.danger >= 2;
+}), yi.assess(i, c), Ei.checkSafeMode(i, c), this.config.enableEvolution && (xy.updateEvolutionStage(c, i, e),
+s || xy.updateMissingStructures(c, i)), by.updatePosture(c), this.config.enablePheromones && !s && Ry.updatePheromones(c, i),
+this.config.enableTowers && Uy.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
+var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = By.getConstructionInterval(l), d = by.allowsBuilding(c.posture), p = !d && c.danger >= 2;
 (d || p) && function(e, t, r) {
-var o = Xy(r), n = Zy(e);
+var o = Zy(r), n = Jy(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (Fy.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, m) && (By.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: p
 }), function(e, t, r) {
-var o = Xy(r), n = Zy(e);
+var o = Zy(r), n = Jy(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, m));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && jy.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && zy.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
 var f = Game.cpu.getUsed() - n;
-qi.recordRoom(i, f), qi.endRoom(this.roomName, n);
-} else qi.endRoom(this.roomName, n);
+ji.recordRoom(i, f), ji.endRoom(this.roomName, n);
+} else ji.endRoom(this.roomName, n);
 }, e;
-}(), $y = function() {
+}(), ev = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -35915,7 +35925,7 @@ var p = u.length;
 try {
 for (var f = a(u), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-this.nodes.has(v.name) || this.nodes.set(v.name, new Jy(v.name));
+this.nodes.has(v.name) || this.nodes.set(v.name, new $y(v.name));
 }
 } catch (t) {
 e = {
@@ -35951,7 +35961,7 @@ try {
 C.run(p);
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e), w = e instanceof Error && e.stack ? e.stack : void 0;
-Qu.error("Error in room ".concat(C.roomName, ": ").concat(S), {
+Xu.error("Error in room ".concat(C.roomName, ": ").concat(S), {
 subsystem: "RoomManager",
 room: C.roomName,
 meta: {
@@ -35978,7 +35988,7 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new Jy(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new $y(e.name));
 var r, o = global, n = o._ownedRooms, a = o._ownedRoomsTick;
 r = n && a === Game.time ? n.length : Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -35989,7 +35999,7 @@ try {
 i.run(r);
 } catch (t) {
 var s = t instanceof Error ? t.message : String(t), c = t instanceof Error && t.stack ? t.stack : void 0;
-Qu.error("Error in room ".concat(e.name, ": ").concat(s), {
+Xu.error("Error in room ".concat(e.name, ": ").concat(s), {
 subsystem: "RoomManager",
 room: e.name,
 meta: {
@@ -35999,9 +36009,9 @@ stack: c
 }
 }
 }, e;
-}(), ev = new $y;
+}(), tv = new ev;
 
-function tv(e) {
+function rv(e) {
 var t, r, o;
 if (X(e).length > 0) return Wt.CRITICAL;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) return Wt.HIGH;
@@ -36012,14 +36022,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return n && (null === (o = null === (r = e.controller) || void 0 === r ? void 0 : r.reservation) || void 0 === o ? void 0 : o.username) === n ? Wt.MEDIUM : Wt.LOW;
 }
 
-function rv(e) {
+function ov(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return .02;
 var r = e.controller.level;
 return X(e).length > 0 ? .12 : r <= 3 ? .04 : r <= 6 ? .06 : .08;
 }
 
-function ov(e, t, r) {
+function nv(e, t, r) {
 var o;
 return t === Wt.CRITICAL ? {
 tickModulo: void 0,
@@ -36039,7 +36049,7 @@ tickOffset: void 0
 };
 }
 
-var nv, av = function() {
+var av, iv = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -36055,7 +36065,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = bi.getProcess(i), c = tv(n), u = rv(n);
+var i = "room:".concat(o), s = Oi.getProcess(i), c = rv(n), u = ov(n);
 this.registeredRooms.has(o) ? s && (s.priority !== c || Math.abs(s.cpuBudget - u) > 1e-4) && this.updateRoomProcess(n, c, u) : this.registerRoomProcess(n);
 }
 try {
@@ -36074,8 +36084,8 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.registerRoomProcess = function(e) {
-var t, r = tv(e), o = rv(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = ov(e, r, a);
-bi.registerProcess({
+var t, r = rv(e), o = ov(e), n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = nv(e, r, a);
+Oi.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (t = e.controller) || void 0 === t ? void 0 : t.my) ? " (owned)" : ""),
 priority: r,
@@ -36091,16 +36101,16 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ev.runRoom(t);
+t && tv.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var s = i.tickModulo ? "(mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset, ")") : "(every tick)";
-Qu.debug("Registered room process: ".concat(e.name, " with priority ").concat(r, " ").concat(s), {
+Xu.debug("Registered room process: ".concat(e.name, " with priority ").concat(r, " ").concat(s), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t, r) {
-var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = ov(e, t, a);
-bi.unregisterProcess(n), bi.registerProcess({
+var o, n = "room:".concat(e.name), a = this.getRoomIndex(e.name), i = nv(e, t, a);
+Oi.unregisterProcess(n), Oi.registerProcess({
 id: n,
 name: "Room ".concat(e.name).concat((null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? " (owned)" : ""),
 priority: t,
@@ -36116,17 +36126,17 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && ev.runRoom(t);
+t && tv.runRoom(t);
 }
 });
 var s = i.tickModulo ? "mod=".concat(i.tickModulo, ", offset=").concat(i.tickOffset) : "every tick";
-Qu.debug("Updated room process: ".concat(e.name, " priority=").concat(t, " budget=").concat(r, " (").concat(s, ")"), {
+Xu.debug("Updated room process: ".concat(e.name, " priority=").concat(t, " budget=").concat(r, " (").concat(s, ")"), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.unregisterRoomProcess = function(e) {
 var t = "room:".concat(e);
-bi.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
-Qu.debug("Unregistered room process: ".concat(e), {
+Oi.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
+Xu.debug("Unregistered room process: ".concat(e), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.getMinBucketForPriority = function(e) {
@@ -36138,7 +36148,7 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = tv(m), p = null !== (r = Wt[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = rv(m), p = null !== (r = Wt[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -36165,10 +36175,10 @@ this.lastSyncTick = -1, this.syncRoomProcesses();
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
 this.lastSyncTick = -1;
 }, e;
-}(), iv = new av, sv = function() {
+}(), sv = new iv, cv = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
-var e = bi.getStatsSummary(), t = bi.getConfig();
+var e = Oi.getStatsSummary(), t = Oi.getConfig();
 return function(e) {
 var t, r, o, n, i = [ "=== Kernel Stats ===", "Bucket Mode: ".concat(e.bucketMode.toUpperCase()), "CPU Bucket: ".concat(e.cpuBucket), "CPU Limit: ".concat(e.cpuLimit.toFixed(2), " (").concat((100 * e.targetCpuUsage).toFixed(0), "% of ").concat(e.gameCpuLimit, ")"), "Remaining CPU: ".concat(e.remainingCpu.toFixed(2)), "", "Processes: ".concat(e.stats.totalProcesses, " total (").concat(e.stats.activeProcesses, " active, ").concat(e.stats.suspendedProcesses, " suspended)"), "Total CPU Used: ".concat(e.stats.totalCpuUsed.toFixed(3)), "Avg CPU/Process: ".concat(e.stats.avgCpuPerProcess.toFixed(4)), "Avg Health Score: ".concat(e.stats.avgHealthScore.toFixed(1), "/100"), "", "Top CPU Consumers:" ];
 try {
@@ -36206,16 +36216,16 @@ if (o) throw o.error;
 }
 return i.join("\n");
 }({
-bucketMode: bi.getBucketMode(),
+bucketMode: Oi.getBucketMode(),
 cpuBucket: Game.cpu.bucket,
-cpuLimit: bi.getCpuLimit(),
+cpuLimit: Oi.getCpuLimit(),
 targetCpuUsage: t.targetCpuUsage,
 gameCpuLimit: Game.cpu.limit,
-remainingCpu: bi.getRemainingCpu(),
+remainingCpu: Oi.getRemainingCpu(),
 stats: e
 });
 }, e.prototype.listProcesses = function() {
-var e = bi.getProcesses();
+var e = Oi.getProcesses();
 return 0 === e.length ? "No processes registered with kernel." : function(e) {
 var t, r;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36242,11 +36252,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(cy(e.summary.byLayer)), "Groups: ".concat(cy(e.summary.byGroup)), "States: ".concat(cy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(uy(e.summary.byLayer)), "Groups: ".concat(uy(e.summary.byGroup)), "States: ".concat(uy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(uy)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(ly)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(iy(m));
+c.push(sy(m));
 }
 } catch (e) {
 t = {
@@ -36283,19 +36293,19 @@ if (o) throw o.error;
 }
 }
 return c.join("\n");
-}(bi.getProcessTopology());
+}(Oi.getProcessTopology());
 }, e.prototype.suspendProcess = function(e) {
-var t = bi.suspendProcess(e);
+var t = Oi.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = bi.resumeProcess(e);
+var t = Oi.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return bi.resetStats(), "Kernel statistics reset.";
+return Oi.resetStats(), "Kernel statistics reset.";
 }, e.prototype.showProcessHealth = function() {
-var e = bi.getProcesses();
+var e = Oi.getProcesses();
 if (0 === e.length) return "No processes registered with kernel.";
-var t = bi.getStatsSummary();
+var t = Oi.getStatsSummary();
 return function(e, t, r) {
 var o, n;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36322,7 +36332,7 @@ return c.push("", "Average Health: ".concat(r.avgHealthScore.toFixed(1), "/100")
 c.join("\n");
 }(e, Game.time, t);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = bi.getProcesses().filter(function(e) {
+var e, t, r = Oi.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -36330,7 +36340,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-bi.resumeProcess(s.id) && o++;
+Oi.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -36345,7 +36355,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = ay.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = iy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36364,7 +36374,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = iv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = sv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36383,7 +36393,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o = bi.getProcesses().filter(function(e) {
+var t, r, o = Oi.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (o = o.filter(function(t) {
@@ -36412,7 +36422,7 @@ if (t) throw t.error;
 }
 return n + "\nTotal: ".concat(o.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r = bi.getProcesses().filter(function(e) {
+var e, t, r = Oi.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === r.length) return "No room processes registered.";
@@ -36438,113 +36448,113 @@ if (e) throw e.error;
 }
 }
 return o + "\nTotal: ".concat(r.length, " room processes");
-}, n([ jr({
+}, n([ zr({
 name: "showKernelStats",
 description: "Show kernel statistics including CPU usage and process info",
 usage: "showKernelStats()",
 examples: [ "showKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showKernelStats", null), n([ jr({
+}) ], e.prototype, "showKernelStats", null), n([ zr({
 name: "listProcesses",
 description: "List all registered kernel processes",
 usage: "listProcesses()",
 examples: [ "listProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "listProcesses", null), n([ jr({
+}) ], e.prototype, "listProcesses", null), n([ zr({
 name: "showProcessTopology",
 description: "Show observable process topology with scheduling and health metadata",
 usage: "showProcessTopology()",
 examples: [ "showProcessTopology()" ],
 category: "Kernel"
-}) ], e.prototype, "showProcessTopology", null), n([ jr({
+}) ], e.prototype, "showProcessTopology", null), n([ zr({
 name: "suspendProcess",
 description: "Suspend a kernel process by ID",
 usage: "suspendProcess(processId)",
 examples: [ "suspendProcess('empire:manager')", "suspendProcess('cluster:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "suspendProcess", null), n([ jr({
+}) ], e.prototype, "suspendProcess", null), n([ zr({
 name: "resumeProcess",
 description: "Resume a suspended kernel process",
 usage: "resumeProcess(processId)",
 examples: [ "resumeProcess('empire:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "resumeProcess", null), n([ jr({
+}) ], e.prototype, "resumeProcess", null), n([ zr({
 name: "resetKernelStats",
 description: "Reset all kernel process statistics",
 usage: "resetKernelStats()",
 examples: [ "resetKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "resetKernelStats", null), n([ jr({
+}) ], e.prototype, "resetKernelStats", null), n([ zr({
 name: "showProcessHealth",
 description: "Show health status of all processes with detailed metrics",
 usage: "showProcessHealth()",
 examples: [ "showProcessHealth()" ],
 category: "Kernel"
-}) ], e.prototype, "showProcessHealth", null), n([ jr({
+}) ], e.prototype, "showProcessHealth", null), n([ zr({
 name: "resumeAllProcesses",
 description: "Resume all suspended processes (use with caution)",
 usage: "resumeAllProcesses()",
 examples: [ "resumeAllProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "resumeAllProcesses", null), n([ jr({
+}) ], e.prototype, "resumeAllProcesses", null), n([ zr({
 name: "showCreepStats",
 description: "Show statistics about creep processes managed by the kernel",
 usage: "showCreepStats()",
 examples: [ "showCreepStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showCreepStats", null), n([ jr({
+}) ], e.prototype, "showCreepStats", null), n([ zr({
 name: "showRoomStats",
 description: "Show statistics about room processes managed by the kernel",
 usage: "showRoomStats()",
 examples: [ "showRoomStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showRoomStats", null), n([ jr({
+}) ], e.prototype, "showRoomStats", null), n([ zr({
 name: "listCreepProcesses",
 description: "List all creep processes with their details",
 usage: "listCreepProcesses(role?)",
 examples: [ "listCreepProcesses()", "listCreepProcesses('harvester')" ],
 category: "Kernel"
-}) ], e.prototype, "listCreepProcesses", null), n([ jr({
+}) ], e.prototype, "listCreepProcesses", null), n([ zr({
 name: "listRoomProcesses",
 description: "List all room processes with their details",
 usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), cv = function() {
+}(), uv = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
-debug: mu.DEBUG,
-info: mu.INFO,
-warn: mu.WARN,
-error: mu.ERROR,
-none: mu.NONE
+debug: du.DEBUG,
+info: du.INFO,
+warn: du.WARN,
+error: du.ERROR,
+none: du.NONE
 }[e.toLowerCase()];
-return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Nu({
+return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Pu({
 level: t
 }), "Log level set to: ".concat(e.toUpperCase()));
 }, e.prototype.toggleDebug = function() {
 var e = !Rt().debug;
 return Et({
 debug: e
-}), Nu({
-level: e ? mu.DEBUG : mu.INFO
+}), Pu({
+level: e ? du.DEBUG : du.INFO
 }), "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
-}, n([ jr({
+}, n([ zr({
 name: "setLogLevel",
 description: "Set the log level for the bot",
 usage: "setLogLevel(level)",
 examples: [ "setLogLevel('debug')", "setLogLevel('info')", "setLogLevel('warn')", "setLogLevel('error')", "setLogLevel('none')" ],
 category: "Logging"
-}) ], e.prototype, "setLogLevel", null), n([ jr({
+}) ], e.prototype, "setLogLevel", null), n([ zr({
 name: "toggleDebug",
 description: "Toggle debug mode on/off (affects log level and debug features)",
 usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), uv = function() {
+}(), lv = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36584,7 +36594,7 @@ hostileCount: null !== (l = null !== (u = null !== (s = this.toNumber(null === (
 var o, n, a, i, s = this.asRecord(null === (o = this.asRecord(e)) || void 0 === o ? void 0 : o.metrics), c = this.asRecord(null == s ? void 0 : s.energy);
 return null !== (i = null !== (a = null !== (n = this.toNumber(null == s ? void 0 : s[t])) && void 0 !== n ? n : this.toNumber(null == c ? void 0 : c[r])) && void 0 !== a ? a : this.toNumber(null == s ? void 0 : s[r])) && void 0 !== i ? i : 0;
 }, e.prototype.showStats = function() {
-var e = Qi.getLatestStats();
+var e = Xi.getLatestStats();
 return e ? "=== SwarmBot Stats (Tick ".concat(e.tick, ") ===\nCPU: ").concat(e.cpuUsed.toFixed(2), "/").concat(e.cpuLimit, " (Bucket: ").concat(e.cpuBucket, ")\nGCL: ").concat(e.gclLevel, " (").concat((100 * e.gclProgress).toFixed(1), "%)\nGPL: ").concat(e.gplLevel, "\nCreeps: ").concat(e.totalCreeps, "\nRooms: ").concat(e.totalRooms, "\n").concat(e.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks.";
@@ -36628,18 +36638,18 @@ return bt.clear(gr), "Room.find() cache cleared and statistics reset";
 var e = !Rt().profiling;
 return Et({
 profiling: e
-}), qi.setEnabled(e), Nu({
+}), ji.setEnabled(e), Pu({
 cpuLogging: e
 }), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.enableCpuDetails = function(e, t, r) {
 var o, n, a;
 void 0 === e && (e = 500), void 0 === t && (t = 1);
-var i = qi.enableCpuDetails(e, t, r);
+var i = ji.enableCpuDetails(e, t, r);
 return "CPU details enabled until tick ".concat(null !== (o = i.expiresTick) && void 0 !== o ? o : "unknown", " (sampleRate=").concat(null !== (n = i.sampleRate) && void 0 !== n ? n : 1, ", labels=").concat((null !== (a = i.labels) && void 0 !== a ? a : []).join(",") || "all", ")");
 }, e.prototype.disableCpuDetails = function() {
-return qi.disableCpuDetails(), "CPU details disabled";
+return ji.disableCpuDetails(), "CPU details disabled";
 }, e.prototype.cpuDetails = function() {
-var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = qi.getCpuDetailsStatus();
+var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = ji.getCpuDetailsStatus();
 if (!u) return "CPU details ".concat(l.enabled ? "enabled" : "disabled", "; no samples published yet");
 var m = Object.entries(null !== (o = u.entries) && void 0 !== o ? o : {}), d = Array.isArray(u.labels) ? u.labels.join(",") : "", p = [ "=== CPU Details ===", "Enabled: ".concat(String(u.enabled), " | Expires: ").concat(null !== (n = u.expires_tick) && void 0 !== n ? n : "n/a", " | Sample rate: ").concat(null !== (s = u.sample_rate) && void 0 !== s ? s : 1, " | Labels: ").concat(d || "all") ];
 try {
@@ -36777,7 +36787,7 @@ I.push("");
 }
 return I.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n = qi.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
+var e, t, r, o, n = ji.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
 if (i += "Rooms Evaluated: ".concat(n.roomsEvaluated, "\n"), i += "Within Budget: ".concat(n.roomsWithinBudget, "\n"),
 i += "Over Budget: ".concat(n.roomsOverBudget, "\n\n"), 0 === n.alerts.length) i += "OK All rooms within budget!\n"; else {
 i += "Alerts: ".concat(n.alerts.length, "\n");
@@ -36824,7 +36834,7 @@ if (r) throw r.error;
 }
 return i;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n = qi.detectAnomalies();
+var e, t, r, o, n = ji.detectAnomalies();
 if (0 === n.length) return "OK No CPU anomalies detected";
 var i = "=== CPU Anomalies Detected: ".concat(n.length, " ===\n\n"), s = n.filter(function(e) {
 return "spike" === e.type;
@@ -36873,7 +36883,7 @@ return i;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n;
 void 0 === e && (e = !1);
-var i = qi.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
+var i = ji.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
 s += "Total: ".concat(i.cpu.used.toFixed(2), " / ").concat(i.cpu.limit, " (").concat(i.cpu.percent.toFixed(1), "%)\n"),
 s += "Bucket: ".concat(i.cpu.bucket, "\n"), s += "Heap: ".concat(i.cpu.heapUsed.toFixed(2), " MB\n\n");
 var c = Object.values(i.rooms).sort(function(e, t) {
@@ -36882,7 +36892,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 s += "Top ".concat(u.length, " Rooms by CPU:\n");
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = qi.postureCodeToName(p);
+var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = ji.postureCodeToName(p);
 s += "  ".concat(d.name, " (RCL").concat(d.rcl, ", ").concat(f, "): avg ").concat(d.profiler.avgCpu.toFixed(3), " | peak ").concat(d.profiler.peakCpu.toFixed(3), " | samples ").concat(d.profiler.samples, "\n");
 }
 } catch (e) {
@@ -36923,7 +36933,7 @@ return s;
 var t, r, o, n;
 if (!e) return "Error: Room name required. Usage: diagnoseRoom('W16S52')";
 if (!Game.rooms[e]) return "Error: Room ".concat(e, " not visible. Make sure you have vision in this room.");
-var s = qi.getCurrentSnapshot(), c = s.rooms[e];
+var s = ji.getCurrentSnapshot(), c = s.rooms[e];
 if (!c) return "Error: No stats available for ".concat(e, ". The room may not have been processed yet.");
 var u = "room:".concat(e), l = s.processes[u], m = ft.getSwarmState(e), d = m && ("war" === m.posture || "siege" === m.posture || m.danger >= 2), p = d ? .25 : .1, f = null !== (o = null == l ? void 0 : l.tickModulo) && void 0 !== o ? o : 1, y = p * f, v = "----------------------------------------------\n";
 v += "  Room Diagnostic: ".concat(e, "\n"), v += "----------------------------------------------\n\n";
@@ -36933,7 +36943,7 @@ energyCapacityTotal: this.getRoomMetricValue(c, "energyCapacityTotal", "capacity
 constructionSites: this.getRoomMetricValue(c, "constructionSites", "construction_sites")
 };
 v += "SUMMARY Basic Info:\n", v += "  RCL: ".concat(c.rcl, "\n"), v += "  Controller Progress: ".concat(c.controller.progressPercent.toFixed(1), "%\n"),
-v += "  Posture: ".concat(qi.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
+v += "  Posture: ".concat(ji.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
 v += "  Hostiles: ".concat(g.hostileCount, "\n\n"), v += "CPU CPU Analysis:\n",
 v += "  Average CPU: ".concat(c.profiler.avgCpu.toFixed(3), "\n"), v += "  Peak CPU: ".concat(c.profiler.peakCpu.toFixed(3), "\n"),
 v += "  Samples: ".concat(c.profiler.samples, "\n"), v += "  Budget: ".concat(y.toFixed(3), " (base ").concat(p, ", modulo ").concat(f, ")\n");
@@ -36984,160 +36994,160 @@ v += "     - Monitor for increases in CPU usage\n") : v += "  OK Room is perform
 g.hostileCount > 0 && (v += "  WARNING  ".concat(g.hostileCount, " hostiles detected - defense active\n"),
 v += "     - War mode increases CPU budget to ".concat(d ? y.toFixed(3) : (.25 * f).toFixed(3), "\n")),
 v += "\n", (v += "Use cpuBreakdown('room') to see all rooms\n") + "Use cpuProfile() for detailed profiling";
-}, n([ jr({
+}, n([ zr({
 name: "showStats",
 description: "Show current bot statistics from memory segment",
 usage: "showStats()",
 examples: [ "showStats()" ],
 category: "Statistics"
-}) ], e.prototype, "showStats", null), n([ jr({
+}) ], e.prototype, "showStats", null), n([ zr({
 name: "cacheStats",
 description: "Show object cache statistics (hits, misses, hit rate, CPU savings)",
 usage: "cacheStats()",
 examples: [ "cacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "cacheStats", null), n([ jr({
+}) ], e.prototype, "cacheStats", null), n([ zr({
 name: "resetCacheStats",
 description: "Reset cache statistics counters (for benchmarking)",
 usage: "resetCacheStats()",
 examples: [ "resetCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "resetCacheStats", null), n([ jr({
+}) ], e.prototype, "resetCacheStats", null), n([ zr({
 name: "roomFindCacheStats",
 description: "Show room.find() cache statistics (hits, misses, hit rate)",
 usage: "roomFindCacheStats()",
 examples: [ "roomFindCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "roomFindCacheStats", null), n([ jr({
+}) ], e.prototype, "roomFindCacheStats", null), n([ zr({
 name: "clearRoomFindCache",
 description: "Clear all room.find() cache entries and reset stats",
 usage: "clearRoomFindCache()",
 examples: [ "clearRoomFindCache()" ],
 category: "Statistics"
-}) ], e.prototype, "clearRoomFindCache", null), n([ jr({
+}) ], e.prototype, "clearRoomFindCache", null), n([ zr({
 name: "toggleProfiling",
 description: "Toggle CPU profiling on/off",
 usage: "toggleProfiling()",
 examples: [ "toggleProfiling()" ],
 category: "Statistics"
-}) ], e.prototype, "toggleProfiling", null), n([ jr({
+}) ], e.prototype, "toggleProfiling", null), n([ zr({
 name: "enableCpuDetails",
 description: "Enable temporary fine-grained CPU detail profiling",
 usage: "enableCpuDetails(ttl?, sampleRate?, labels?)",
 examples: [ "enableCpuDetails(500, 1)", "enableCpuDetails(200, 5, ['remoteInfrastructure', 'taskBoard'])" ],
 category: "Statistics"
-}) ], e.prototype, "enableCpuDetails", null), n([ jr({
+}) ], e.prototype, "enableCpuDetails", null), n([ zr({
 name: "disableCpuDetails",
 description: "Disable temporary fine-grained CPU detail profiling",
 usage: "disableCpuDetails()",
 examples: [ "disableCpuDetails()" ],
 category: "Statistics"
-}) ], e.prototype, "disableCpuDetails", null), n([ jr({
+}) ], e.prototype, "disableCpuDetails", null), n([ zr({
 name: "cpuDetails",
 description: "Show temporary fine-grained CPU detail profiler output",
 usage: "cpuDetails()",
 examples: [ "cpuDetails()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuDetails", null), n([ jr({
+}) ], e.prototype, "cpuDetails", null), n([ zr({
 name: "cpuBreakdown",
 description: "Show detailed CPU breakdown by process, room, creep, and subsystem",
 usage: "cpuBreakdown(type?)",
 examples: [ "cpuBreakdown() // Show all breakdowns", "cpuBreakdown('process') // Show only process breakdown", "cpuBreakdown('room') // Show only room breakdown", "cpuBreakdown('creep') // Show only creep breakdown", "cpuBreakdown('subsystem') // Show only subsystem breakdown" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBreakdown", null), n([ jr({
+}) ], e.prototype, "cpuBreakdown", null), n([ zr({
 name: "cpuBudget",
 description: "Show CPU budget status and violations for all rooms",
 usage: "cpuBudget()",
 examples: [ "cpuBudget()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBudget", null), n([ jr({
+}) ], e.prototype, "cpuBudget", null), n([ zr({
 name: "cpuAnomalies",
 description: "Detect and show CPU usage anomalies (spikes and sustained high usage)",
 usage: "cpuAnomalies()",
 examples: [ "cpuAnomalies()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuAnomalies", null), n([ jr({
+}) ], e.prototype, "cpuAnomalies", null), n([ zr({
 name: "cpuProfile",
 description: "Show comprehensive CPU profiling breakdown by room and subsystem",
 usage: "cpuProfile(showAll?)",
 examples: [ "cpuProfile()", "cpuProfile(true)" ],
 category: "Statistics"
-}) ], e.prototype, "cpuProfile", null), n([ jr({
+}) ], e.prototype, "cpuProfile", null), n([ zr({
 name: "diagnoseRoom",
 description: "Comprehensive diagnostic for a specific room showing CPU usage, budget status, and potential issues",
 usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), lv = function() {
+}(), mv = function() {
 function e() {}
 return e.prototype.listCommands = function() {
-return qr.generateHelp();
+return jr.generateHelp();
 }, e.prototype.commandHelp = function(e) {
-return qr.generateCommandHelp(e);
-}, n([ jr({
+return jr.generateCommandHelp(e);
+}, n([ zr({
 name: "listCommands",
 description: "List all available commands (alias for help)",
 usage: "listCommands()",
 examples: [ "listCommands()" ],
 category: "System"
-}) ], e.prototype, "listCommands", null), n([ jr({
+}) ], e.prototype, "listCommands", null), n([ zr({
 name: "commandHelp",
 description: "Get detailed help for a specific command",
 usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), mv = function() {
+}(), dv = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? jl.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? zl.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? jl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? zl.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return jl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
-}, n([ jr({
+return zl.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+}, n([ zr({
 name: "tasks",
 description: "Show room creep task queue",
 usage: "tasks(roomName?)",
 examples: [ "tasks('W1N1')" ],
 category: "Tasks"
-}) ], e.prototype, "tasks", null), n([ jr({
+}) ], e.prototype, "tasks", null), n([ zr({
 name: "taskAssignments",
 description: "Show creep task reservations for a room",
 usage: "taskAssignments(roomName?)",
 examples: [ "taskAssignments('W1N1')" ],
 category: "Tasks"
-}) ], e.prototype, "taskAssignments", null), n([ jr({
+}) ], e.prototype, "taskAssignments", null), n([ zr({
 name: "clearTasks",
 description: "Clear creep task queue/reservations",
 usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), dv = ((nv = {})[MOVE] = 50, nv[WORK] = 100, nv[CARRY] = 50, nv[ATTACK] = 80,
-nv[RANGED_ATTACK] = 150, nv[HEAL] = 250, nv[CLAIM] = 600, nv[TOUGH] = 10, nv);
+}(), pv = ((av = {})[MOVE] = 50, av[WORK] = 100, av[CARRY] = 50, av[ATTACK] = 80,
+av[RANGED_ATTACK] = 150, av[HEAL] = 250, av[CLAIM] = 600, av[TOUGH] = 10, av);
 
-function pv(e, t) {
+function fv(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, dv), t);
+var r = o(o({}, pv), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : dv[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : pv[t]);
 }, 0);
 }
 
-function fv(e, t) {
+function yv(e, t) {
 void 0 === t && (t = 0);
-var r = pv(e);
+var r = fv(e);
 return {
 parts: e,
 cost: r,
@@ -37145,7 +37155,7 @@ minCapacity: t || r
 };
 }
 
-function yv() {
+function vv() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -37153,11 +37163,11 @@ return Array(o).fill(r);
 });
 }
 
-var vv, gv, hv, Rv = {
+var gv, hv, Rv, Ev = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ fv([ WORK, CARRY ], 150), fv([ WORK, CARRY, MOVE ], 200), fv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), fv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), fv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ yv([ WORK, CARRY ], 150), yv([ WORK, CARRY, MOVE ], 200), yv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), yv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), yv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -37165,7 +37175,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ fv([ WORK, CARRY, MOVE ], 200), fv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), fv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), fv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ yv([ WORK, CARRY, MOVE ], 200), yv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), yv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), yv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37173,7 +37183,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ fv([ WORK, CARRY, MOVE, MOVE ], 250), fv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ yv([ WORK, CARRY, MOVE, MOVE ], 250), yv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37181,7 +37191,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ fv([ WORK, CARRY, MOVE ], 200), fv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), fv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), fv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), fv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ yv([ WORK, CARRY, MOVE ], 200), yv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), yv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), yv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), yv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37189,7 +37199,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ fv([ CARRY, CARRY, MOVE, MOVE ], 200), fv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), fv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ yv([ CARRY, CARRY, MOVE, MOVE ], 200), yv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), yv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37197,7 +37207,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ fv([ WORK, CARRY, MOVE ], 200), fv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), fv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), fv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ yv([ WORK, CARRY, MOVE ], 200), yv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), yv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), yv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -37205,7 +37215,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ fv([ WORK, CARRY, MOVE, MOVE ], 250), fv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), fv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ yv([ WORK, CARRY, MOVE, MOVE ], 250), yv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), yv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37213,7 +37223,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ fv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ yv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37221,7 +37231,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ fv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), fv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ yv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), yv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37229,7 +37239,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ fv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ yv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37237,7 +37247,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ fv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ yv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37245,7 +37255,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ fv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), fv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), fv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), fv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ yv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), yv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), yv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), yv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37253,7 +37263,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ fv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), fv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ yv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), yv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37261,7 +37271,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ fv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), fv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ yv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), yv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37269,16 +37279,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ fv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), fv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), fv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), fv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ yv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), yv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), yv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), yv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Ev = {
+}, Tv = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ fv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), fv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), fv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), fv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ yv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), yv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), yv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), yv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37286,7 +37296,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ fv([ TOUGH, ATTACK, MOVE, MOVE ], 190), fv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), fv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ yv([ TOUGH, ATTACK, MOVE, MOVE ], 190), yv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), yv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37294,7 +37304,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ fv([ HEAL, MOVE, MOVE ], 350), fv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), fv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), fv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ yv([ HEAL, MOVE, MOVE ], 350), yv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), yv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), yv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37302,7 +37312,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ fv([ ATTACK, ATTACK, MOVE, MOVE ], 260), fv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), fv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ yv([ ATTACK, ATTACK, MOVE, MOVE ], 260), yv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), yv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37310,7 +37320,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ fv([ WORK, WORK, MOVE, MOVE ], 300), fv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), fv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ yv([ WORK, WORK, MOVE, MOVE ], 300), yv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), yv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37318,7 +37328,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ fv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), fv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), fv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), fv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ yv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), yv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), yv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), yv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37326,16 +37336,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ fv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), fv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), fv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ yv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), yv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), yv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Tv = {
+}, Cv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ fv(yv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), fv(yv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ yv(vv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), yv(vv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37343,16 +37353,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ fv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), fv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ yv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), yv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Cv = {
+}, Sv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ fv([ MOVE ], 50) ],
+bodies: [ yv([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37360,7 +37370,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ fv([ MOVE ], 50) ],
+bodies: [ yv([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37368,7 +37378,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ fv([ CLAIM, MOVE ], 650) ],
+bodies: [ yv([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37376,7 +37386,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ fv([ CLAIM, MOVE ], 650), fv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ yv([ CLAIM, MOVE ], 650), yv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37384,7 +37394,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ fv([ WORK, CARRY, MOVE, MOVE ], 250), fv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ yv([ WORK, CARRY, MOVE, MOVE ], 250), yv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37392,30 +37402,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ fv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), fv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ yv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), yv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Sv = o(o(o(o({}, Rv), Ev), Cv), Tv);
+}, wv = o(o(o(o({}, Ev), Tv), Sv), Cv);
 
 try {
-for (var wv = a(Object.values(Sv)), xv = wv.next(); !xv.done; xv = wv.next()) xv.value.bodies.sort(function(e, t) {
+for (var xv = a(Object.values(wv)), bv = xv.next(); !bv.done; bv = xv.next()) bv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-vv = {
+gv = {
 error: e
 };
 } finally {
 try {
-xv && !xv.done && (gv = wv.return) && gv.call(wv);
+bv && !bv.done && (hv = xv.return) && hv.call(xv);
 } finally {
-if (vv) throw vv.error;
+if (gv) throw gv.error;
 }
 }
 
-function bv(e) {
+function Ov(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37430,11 +37440,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Ov(o);
+return kv(o);
 }
 
-function Ov(e) {
-var t = pv(e);
+function kv(e) {
+var t = fv(e);
 return {
 parts: e,
 cost: t,
@@ -37442,16 +37452,16 @@ minCapacity: t
 };
 }
 
-function kv(e, t) {
+function Mv(e, t) {
 var r;
-return null !== (r = e.map(Ov).filter(function(e) {
+return null !== (r = e.map(kv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Mv(e) {
+function Av(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37465,7 +37475,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = pv(a);
+var s = fv(a);
 return {
 parts: a,
 cost: s,
@@ -37490,8 +37500,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: pv(p),
-minCapacity: pv(p)
+cost: fv(p),
+minCapacity: fv(p)
 };
 }(e);
 
@@ -37502,7 +37512,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return bv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Ov([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37523,7 +37533,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return bv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Ov([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37532,13 +37542,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Ov).filter(function(e) {
+var u = n.map(kv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = kv(n, t);
+var l = Mv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37548,7 +37558,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = kv(n, t);
+var u = Mv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37557,14 +37567,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = kv(r, t);
+var a = Mv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Av(e) {
+function _v(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37575,9 +37585,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function _v(e, t) {
+function Uv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Av(t)
+memory: _v(t)
 });
 var r;
 }
@@ -37585,9 +37595,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(hv || (hv = {}));
+}(Rv || (Rv = {}));
 
-var Uv = function() {
+var Nv = function() {
 function e() {
 this.queues = new Map, this.revision = 0;
 }
@@ -37685,7 +37695,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = _v(m, d);
+var p = Uv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 _.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37705,7 +37715,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= hv.EMERGENCY;
+return e.priority >= Rv.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37723,7 +37733,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= hv.EMERGENCY ? n.emergency++ : c.priority >= hv.HIGH ? n.high++ : c.priority >= hv.NORMAL ? n.normal++ : n.low++;
+c.priority >= Rv.EMERGENCY ? n.emergency++ : c.priority >= Rv.HIGH ? n.high++ : c.priority >= Rv.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37738,14 +37748,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Nv = new Uv, Pv = {
+}(), Pv = new Nv, Iv = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Iv = {
+}, Gv = {
 predictConsumption: function() {
 return 0;
 },
@@ -37764,7 +37774,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, Gv = {
+}, Lv = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37782,81 +37792,81 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, Lv = {
+}, Dv = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function Dv(e, t, r, o, n) {
-return Js(e, t, r, o, n);
+function Fv(e, t, r, o, n) {
+return $s(e, t, r, o, n);
 }
 
-var Fv = new Map, Bv = -1, Wv = null, Hv = null;
+var Bv = new Map, Wv = -1, Hv = null, Kv = null;
 
-function Kv() {
-Bv === Game.time && Wv === Game.creeps || (Fv.clear(), Hv = null, Bv = Game.time,
-Wv = Game.creeps);
+function Yv() {
+Wv === Game.time && Hv === Game.creeps || (Bv.clear(), Kv = null, Wv = Game.time,
+Hv = Game.creeps);
 }
 
-function Yv(e) {
+function Vv(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function Vv(e, t) {
+function qv(e, t) {
 var r;
-void 0 === t && (t = !1), Kv();
-var o = t ? "".concat(e, "_active") : e, n = Fv.get(o);
+void 0 === t && (t = !1), Yv();
+var o = t ? "".concat(e, "_active") : e, n = Bv.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = Yv(c);
+var u = Vv(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Fv.set(o, a), a;
-}
-
-function qv(e, t, r) {
-return "".concat(e).concat("").concat(t).concat("").concat(r);
+return Bv.set(o, a), a;
 }
 
 function jv(e, t, r) {
+return "".concat(e).concat("").concat(t).concat("").concat(r);
+}
+
+function zv(e, t, r) {
 var o;
 return null !== (o = function() {
 var e;
-if (Kv(), Hv) return Hv;
+if (Yv(), Kv) return Kv;
 var t = new Map;
 for (var r in Game.creeps) {
 var o = Game.creeps[r].memory, n = o.homeRoom, a = o.role, i = o.targetRoom;
 if (n && a && i) {
-var s = qv(n, a, i);
+var s = jv(n, a, i);
 t.set(s, (null !== (e = t.get(s)) && void 0 !== e ? e : 0) + 1);
 }
 }
-return Hv = t, t;
-}().get(qv(e, t, r))) && void 0 !== o ? o : 0;
+return Kv = t, t;
+}().get(jv(e, t, r))) && void 0 !== o ? o : 0;
 }
 
-function zv(e) {
+function Qv(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var Qv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
-
-function Xv(e) {
-return Qv.includes(e);
-}
+var Xv = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
 function Zv(e) {
+return Xv.includes(e);
+}
+
+function Jv(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Jv(e, t, r, o) {
+function $v(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -37869,10 +37879,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return Dv(e, t, Er(r).length, o, {
-reserved: Zv(r)
+if (r) return Fv(e, t, Er(r).length, o, {
+reserved: Jv(r)
 }).recommendedHaulers;
-var n = Dv(e, t, 2, o, {
+var n = Fv(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -37883,7 +37893,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: zv
+filter: Qv
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -37894,7 +37904,7 @@ return 2;
 }
 }
 
-function $v(e, t) {
+function eg(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -37904,13 +37914,13 @@ return null;
 }
 }
 
-function eg() {
+function tg() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function tg(e) {
-var t = eg(), r = function(e) {
+function rg(e) {
+var t = tg(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -37922,14 +37932,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function rg(e) {
+function og(e) {
 var t = ft.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = eg();
+var r = tg();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function og(e) {
+function ng(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -37937,11 +37947,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function ng(e) {
+function ag(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function ag() {
+function ig() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -37951,9 +37961,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var ig = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var sg = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function sg(e, t) {
+function cg(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -37965,8 +37975,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(ag()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Nv.getPendingRequests(c).some(function(r) {
+for (var i = a(ig()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Pv.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -37986,7 +37996,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function cg() {
+function ug() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -38007,7 +38017,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function ug(e, t) {
+function lg(e, t) {
 var r, o, n, c, u = ft.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -38017,15 +38027,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !sg(e.roomName, "claim");
+return !cg(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || og(t));
+return !(!r || r.my || r.owner || r.reservation || ng(t));
 }
-return !rg(e);
+return !og(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -38036,11 +38046,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = cg().filter(function(e) {
-return !sg(e, "claim");
+var r, o, n = ug().filter(function(e) {
+return !cg(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = eg();
+var r, o, n = Game.rooms[e], a = tg();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -38051,7 +38061,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && ig.has(e.type);
+return e.hits > 0 && sg.has(e.type);
 });
 });
 }(n));
@@ -38063,7 +38073,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = $v(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = eg(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -38078,14 +38088,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(cg()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(ug()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !sg(e.roomName, "claim");
+return !e.claimed && !cg(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -38097,20 +38107,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = eg();
+var l = tg();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !sg(p, "claim")) {
+if (!t.has(p) && !cg(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || tg(y)) continue;
-if (og(f)) continue;
+if (y.owner || rg(y)) continue;
+if (ng(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !sg(p, "reserve")) return p;
-} else if (!rg(p) && !sg(p, "reserve")) return p;
+if ((!v || g < 3e3) && !cg(p, "reserve")) return p;
+} else if (!og(p) && !cg(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -38132,34 +38142,34 @@ task: "reserve"
 } : null;
 }
 
-function lg(e) {
+function mg(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function mg(e) {
-return lg(e) ? hv.EMERGENCY : hv.HIGH;
+function dg(e) {
+return mg(e) ? Rv.EMERGENCY : Rv.HIGH;
 }
 
-function dg(e, t, r) {
+function pg(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!ng(e)) return !1;
+if (!ag(e)) return !1;
 var a = e.name === t ? r : ft.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function pg(e, t, r) {
+function fg(e, t, r) {
 var o, n, a = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return dg(e, t, r);
+return pg(e, t, r);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = $v(t.name, e.name)) && void 0 !== r ? r : 999
+distance: null !== (r = eg(t.name, e.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -38167,18 +38177,18 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 return null !== (n = null === (o = a[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function fg(e, t) {
+function yg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !dg(n, e, t)) return null;
+if (!n || !pg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !ng(e);
+return !ag(e);
 }).filter(function(e) {
-return !og(e);
+return !ng(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -38199,9 +38209,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(ag()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(ig()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Nv.getPendingRequests(d).filter(function(t) {
+i += Pv.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -38218,12 +38228,12 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (lg(e) ? 3 : 1);
+}(e.name) < (mg(e) ? 3 : 1);
 }).map(function(t) {
 var r;
 return {
 room: t,
-distance: null !== (r = $v(e, t.name)) && void 0 !== r ? r : 999
+distance: null !== (r = eg(e, t.name)) && void 0 !== r ? r : 999
 };
 }).sort(function(e, t) {
 return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
@@ -38231,10 +38241,10 @@ return e.distance - t.distance || e.room.name.localeCompare(t.room.name);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (pg(u.room, e, t) === e) return {
+if (fg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: mg(u.room)
+priority: dg(u.room)
 };
 }
 } catch (e) {
@@ -38251,10 +38261,10 @@ if (r) throw r.error;
 return null;
 }
 
-function yg(e, t) {
+function vg(e, t) {
 if (t <= 0) return null;
 try {
-var r = Mv({
+var r = Av({
 maxEnergy: t,
 role: e
 });
@@ -38264,26 +38274,26 @@ return null;
 }
 }
 
-function vg(e, t, r) {
-return "healer" === e || "ranger" === e && bo(r) ? null : yg(e, t);
+function gg(e, t, r) {
+return "healer" === e || "ranger" === e && Oo(r) ? null : vg(e, t);
 }
 
-var gg, hg, Rg = new Map;
+var hg, Rg, Eg = new Map;
 
-function Eg(e) {
+function Tg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Tg(e) {
+function Cg(e) {
 var t, r;
-r = Game.time, gg === Game && hg === r || (Rg.clear(), gg = Game, hg = r);
+r = Game.time, hg === Game && Rg === r || (Eg.clear(), hg = Game, Rg = r);
 var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}(), n = Rg.get(e.name);
+}(), n = Eg.get(e.name);
 if (n && n.fallbackEnabled === o) return n.value;
 var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
@@ -38294,7 +38304,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Eg(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Tg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38315,7 +38325,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Eg(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Tg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38329,38 +38339,38 @@ if (o) throw o.error;
 }
 return i;
 }(e)) : i;
-return Rg.set(e.name, {
+return Eg.set(e.name, {
 fallbackEnabled: o,
 value: s
 }), s;
 }
 
-function Cg(e) {
+function Sg(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Sg(e) {
+function wg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? X(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function wg(e) {
+function xg(e) {
 var t = e.defenseRequests;
-return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Cg);
+return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Sg);
 }
 
-var xg = [ "guard", "ranger", "healer" ];
+var bg = [ "guard", "ranger", "healer" ];
 
-function bg(e, t) {
+function Og(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-var Og = null;
+var kg = null;
 
-function kg() {
-var e = Nv.getRevision();
-return Og && Og.game === Game && Og.creeps === Game.creeps && Og.tick === Game.time && Og.queueRevision === e ? Og : Og = {
+function Mg() {
+var e = Pv.getRevision();
+return kg && kg.game === Game && kg.creeps === Game.creeps && kg.tick === Game.time && kg.queueRevision === e ? kg : kg = {
 game: Game,
 creeps: Game.creeps,
 tick: Game.time,
@@ -38373,37 +38383,37 @@ canSpawn: new Map
 };
 }
 
-function Mg(e) {
-var t = kg(), r = Game.rooms[e], o = t.threats.get(e);
+function Ag(e) {
+var t = Mg(), r = Game.rooms[e], o = t.threats.get(e);
 if (o && o.room === r) return o.threatProfile;
-var n = To(e);
+var n = Co(e);
 return t.threats.set(e, {
 room: r,
 threatProfile: n
 }), n;
 }
 
-function Ag(e) {
-return Game.rooms[e.roomName] ? null !== Mg(e.roomName) : Sg(e);
-}
-
 function _g(e) {
+return Game.rooms[e.roomName] ? null !== Ag(e.roomName) : wg(e);
+}
+
+function Ug(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ci ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ui ? e.targetRoom : void 0;
 }
 
-function Ug(e, t) {
+function Ng(e, t) {
 var r, o;
-return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === ci && e.targetRoom === t;
+return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === ui && e.targetRoom === t;
 }
 
-function Ng(e, t, r) {
-var o = vo(r), n = e[t];
-e[t] = n ? ho(n, o) : o;
+function Pg(e, t, r) {
+var o = go(r), n = e[t];
+e[t] = n ? Ro(n, o) : o;
 }
 
-function Pg(e) {
-var t = kg(), r = t.assigned.get(e);
+function Ig(e) {
+var t = Mg(), r = t.assigned.get(e);
 if (r) return r;
 var o = function(e) {
 var t, r, o, n, i, s, c = {
@@ -38414,12 +38424,12 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = d.memory, f = null !== (i = p.role) && void 0 !== i ? i : "";
-if (_o(f) && _g(p) === e) {
+if (Uo(f) && Ug(p) === e) {
 c[f]++;
 var y = (null !== (s = d.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-y.length > 0 && Ng(u, f, y);
+y.length > 0 && Pg(u, f, y);
 }
 }
 } catch (e) {
@@ -38434,9 +38444,9 @@ if (t) throw t.error;
 }
 }
 for (var v in Game.rooms) try {
-for (var g = (o = void 0, a(Nv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
+for (var g = (o = void 0, a(Pv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-_o(R.role) && Ug(R, e) && (c[R.role]++, Ng(u, R.role, R.body.parts));
+Uo(R.role) && Ng(R, e) && (c[R.role]++, Pg(u, R.role, R.body.parts));
 }
 } catch (e) {
 o = {
@@ -38457,8 +38467,8 @@ power: u
 return t.assigned.set(e, o), o;
 }
 
-function Ig(e) {
-var t = kg(), r = t.canSpawn.get(e.name);
+function Gg(e) {
+var t = Mg(), r = t.canSpawn.get(e.name);
 if (r && r.room === e) return r.value;
 var o = function(e) {
 var t;
@@ -38470,20 +38480,20 @@ value: o
 }), o;
 }
 
-function Gg(e, t) {
-var r, o, n = kg(), i = function(e, t) {
+function Lg(e, t) {
+var r, o, n = Mg(), i = function(e, t) {
 var r, o, n, a, i;
 return [ t.name, e.roomName, t.energyCapacityAvailable, Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0), Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0), null !== (a = e.urgency) && void 0 !== a ? a : "", null !== (i = e.createdAt) && void 0 !== i ? i : "" ].join(":");
 }(e, t), s = n.helperPlans.get(i);
 if (s) return s;
-var c = Mg(e.roomName), u = Pg(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Ao(d, c, function(e, t) {
+var c = Ag(e.roomName), u = Ig(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = _o(d, c, function(e, t) {
 return {
-guard: Math.max(0, bg(e, "guard") - t.guard),
-ranger: Math.max(0, bg(e, "ranger") - t.ranger),
-healer: Math.max(0, bg(e, "healer") - t.healer)
+guard: Math.max(0, Og(e, "guard") - t.guard),
+ranger: Math.max(0, Og(e, "ranger") - t.ranger),
+healer: Math.max(0, Og(e, "healer") - t.healer)
 };
 }(e, l), m), f = function(e, t) {
-var r, o, n, i, s = kg(), c = s.capableHelpers.get(e);
+var r, o, n, i, s = Mg(), c = s.capableHelpers.get(e);
 if (c) return c;
 var u = {
 guard: 0,
@@ -38493,10 +38503,10 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.rooms)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d.name !== e && Ig(d)) try {
-for (var p = (n = void 0, a(xg)), f = p.next(); !f.done; f = p.next()) {
+if (d.name !== e && Gg(d)) try {
+for (var p = (n = void 0, a(bg)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Oo(y, d.energyCapacityAvailable, t) && u[y]++;
+ko(y, d.energyCapacityAvailable, t) && u[y]++;
 }
 } catch (e) {
 n = {
@@ -38524,9 +38534,9 @@ if (r) throw r.error;
 return s.capableHelpers.set(e, u), u;
 }(e.roomName, c), y = {};
 try {
-for (var v = a(xg), g = v.next(); !g.done; g = v.next()) {
+for (var v = a(bg), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
-y[h] = Oo(h, d, c);
+y[h] = ko(h, d, c);
 }
 } catch (e) {
 r = {
@@ -38551,43 +38561,43 @@ helperBodies: y
 return n.helperPlans.set(i, R), R;
 }
 
-function Lg(e, t, r) {
-var o = bg(e, t);
-if (!_o(t)) return o;
+function Dg(e, t, r) {
+var o = Og(e, t);
+if (!Uo(t)) return o;
 if (!r.threatProfile) return o;
 var n = r.assignedCounts[t] + r.aggregatePlan.counts[t], a = o > 0 ? function(e, t, r) {
 return function(e, t, r) {
-var o = Oo(e, t, null), n = null == r ? void 0 : r.strongest;
+var o = ko(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
 if (!n) return 1;
-var a = vo(o.parts), i = Math.floor(n.score / Math.max(1, a.score)) + 1, s = Math.ceil(n.partCount / Math.max(1, a.partCount)), c = null == r ? void 0 : r.total, u = c ? Math.floor(c.score / Math.max(1, a.score)) + 1 : 1, l = c ? Math.ceil(c.partCount / Math.max(1, a.partCount)) : 1;
+var a = go(o.parts), i = Math.floor(n.score / Math.max(1, a.score)) + 1, s = Math.ceil(n.partCount / Math.max(1, a.partCount)), c = null == r ? void 0 : r.total, u = c ? Math.floor(c.score / Math.max(1, a.score)) + 1 : 1, l = c ? Math.ceil(c.partCount / Math.max(1, a.partCount)) : 1;
 return Math.min(8, Math.max(1, i, s, u, l));
 }(e, t, r);
 }(t, r.helperEnergyCapacity, r.threatProfile) : 0, i = o > 0 ? r.capableHelpers[t] : 0;
 return Math.max(o, n, a, i);
 }
 
-function Dg(e, t, r) {
-void 0 === r && (r = Gg(e, t));
+function Fg(e, t, r) {
+void 0 === r && (r = Lg(e, t));
 var o = r.aggregatePlan.counts.guard + r.aggregatePlan.counts.ranger + r.aggregatePlan.counts.healer;
 if (o > 0) return o;
-var n = xg.filter(function(t) {
-return !(Lg(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
+var n = bg.filter(function(t) {
+return !(Dg(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
 });
 return Math.max(1, n.length);
 }
 
-function Fg(e, t, r, o) {
+function Bg(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : vg("guard", Tg(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : gg("guard", Cg(r), o) ? 1 : 0;
 }
 
-function Bg(e, t) {
+function Wg(e, t) {
 if (!function(e) {
-return _o(e);
+return Uo(e);
 }(t)) return null;
 var r = Game.rooms[e];
-if (!r || !Ig(r)) return null;
+if (!r || !Gg(r)) return null;
 var o = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38614,15 +38624,15 @@ if (t) throw t.error;
 var n = function(e, t) {
 var r;
 void 0 === t && (t = {});
-var o = wg(e), n = function(e) {
+var o = xg(e), n = function(e) {
 return e.map(function(e) {
 var t, r, o, n, a;
 return [ e.roomName, Math.max(0, null !== (t = e.guardsNeeded) && void 0 !== t ? t : 0), Math.max(0, null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.healersNeeded) && void 0 !== o ? o : 0), null !== (n = e.urgency) && void 0 !== n ? n : "", null !== (a = e.createdAt) && void 0 !== a ? a : "" ].join(":");
 }).join("|");
-}(o), a = kg();
+}(o), a = Mg();
 if ((null === (r = a.activeRequests) || void 0 === r ? void 0 : r.signature) === n) return t.prune && Array.isArray(e.defenseRequests) && a.activeRequests.requests.length !== o.length && (e.defenseRequests = a.activeRequests.requests),
 a.activeRequests.requests;
-var i = o.filter(Ag);
+var i = o.filter(_g);
 return a.activeRequests = {
 signature: n,
 requests: i
@@ -38633,17 +38643,17 @@ prune: !0
 }).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var o = Gg(e, r);
+var o = Lg(e, r);
 return {
 request: e,
 plan: o,
-helperNeed: Math.max(Lg(e, t, o), Fg(e, t, r, o.threatProfile))
+helperNeed: Math.max(Dg(e, t, o), Bg(e, t, r, o.threatProfile))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
 return function(e, t) {
-return _o(t) ? Pg(e).counts[t] : 0;
+return Uo(t) ? Ig(e).counts[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38653,7 +38663,7 @@ return f !== y ? f - y : (null !== (m = t.request.createdAt) && void 0 !== m ? m
 }), s = n[0];
 return s ? function(e, t, r, o) {
 var n;
-void 0 === o && (o = Gg(r, t));
+void 0 === o && (o = Lg(r, t));
 var a = function(e, t) {
 var r = function() {
 var e, t = Memory;
@@ -38670,28 +38680,28 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: ci,
-priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? hv.EMERGENCY : hv.HIGH,
-defenseSquadId: ui(e, r.roomName, a.createdAt),
-defenseSquadSize: Dg(r, t, o),
+task: ui,
+priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Rv.EMERGENCY : Rv.HIGH,
+defenseSquadId: li(e, r.roomName, a.createdAt),
+defenseSquadSize: Fg(r, t, o),
 defenseSquadCreatedAt: a.createdAt
 };
 }(e, r, s.request, s.plan) : null;
 }
 
-var Wg = "defenseRefuel", Hg = {
+var Hg = "defenseRefuel", Kg = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function Kg(e, t) {
+function Yg(e, t) {
 if ("hauler" !== t) return null;
 var r, o, n = Game.rooms[e];
 return n && function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < Hg.cost);
-}(n) ? Tg(n) >= 200 ? null : function(e) {
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < Kg.cost);
+}(n) ? Cg(n) >= 200 ? null : function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38728,9 +38738,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Nv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Pv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === Wg && s++;
+"hauler" === p.role && f === Hg && s++;
 }
 } catch (e) {
 o = {
@@ -38745,24 +38755,24 @@ if (o) throw o.error;
 }
 return s;
 }(e) >= 2 ? null : {
-task: Wg,
-priority: hv.EMERGENCY,
-body: Hg
+task: Hg,
+priority: Rv.EMERGENCY,
+body: Kg
 } : null : null;
-}
-
-function Yg(e) {
-var t = Game.rooms[e];
-return t ? !!t.controller && !tg(t.controller) && !og(t) : !rg(e);
 }
 
 function Vg(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !tg(t.controller) : !rg(e);
+return t ? !!t.controller && !rg(t.controller) && !ng(t) : !og(e);
 }
 
-function qg(e, t, r) {
-var o = Sv[t];
+function qg(e) {
+var t = Game.rooms[e];
+return (null == t ? void 0 : t.controller) ? !rg(t.controller) : !og(e);
+}
+
+function jg(e, t, r) {
+var o = wv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
@@ -38773,7 +38783,7 @@ var i = ft.getCluster(r.clusterId);
 }
 (function(e) {
 return function(e) {
-var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Is(null == e ? void 0 : e.storage), s = Is(null == e ? void 0 : e.terminal), c = a && i < Ps, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
+var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Gs(null == e ? void 0 : e.storage), s = Gs(null == e ? void 0 : e.terminal), c = a && i < Is, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
 return {
 controllerLevel: n,
 isMatureOwnedRoom: a,
@@ -38790,13 +38800,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function jg(e, t, r) {
+function zg(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Yg(l) && jv(e, t, l) < Jv(e, l, t, Game.rooms[l])) return l;
+if (Vg(l) && zv(e, t, l) < $v(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -38812,10 +38822,10 @@ if (o) throw o.error;
 return null;
 }
 
-function zg(e, t, r, o) {
+function Qg(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Sv[t];
+var p = wv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -38829,32 +38839,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Sv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Sv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = wv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = wv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, Vv(e), y)) return !1;
+}(t, qv(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (Xv(t)) return !("remoteWorker" === t && function(e, t) {
-Kv();
-var r = "".concat(e, ":").concat(t), o = Fv.get(r);
+if (Zv(t)) return !("remoteWorker" === t && function(e, t) {
+Yv();
+var r = "".concat(e, ":").concat(t), o = Bv.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Fv.set(r, n), n;
-}(e, t) >= qg(e, t, r)) && null !== jg(e, t, r);
+return Bv.set(r, n), n;
+}(e, t) >= jg(e, t, r)) && null !== zg(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Vg(R)) {
+if (qg(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = X(E).filter(function(e) {
@@ -38862,7 +38872,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && jv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && zv(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -38879,9 +38889,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = Vv(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== fg(e, r);
-if (C >= qg(e, t, r)) return !1;
+var C = null !== (u = qv(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== yg(e, r);
+if (C >= jg(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -38893,14 +38903,14 @@ var r = ft.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = $v(e, o);
+var a = eg(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== ug(e, r);
+if ("claimer" === t) return null !== lg(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -38936,7 +38946,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Pv.getActiveRequests) || void 0 === m ? void 0 : m.call(Pv)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = Iv.getActiveRequests) || void 0 === m ? void 0 : m.call(Iv)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -38964,16 +38974,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Qg(e) {
+function Xg(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Xg(e) {
-return 0 === Qg(Vv(e, !0));
+function Zg(e) {
+return 0 === Xg(qv(e, !0));
 }
 
-function Zg(e) {
+function Jg(e) {
 var t = Er(e);
 return [ {
 role: "harvester",
@@ -38996,14 +39006,14 @@ minCount: 1
 } ];
 }
 
-function Jg(e, t) {
-var r, o, n, i, s = Vv(e, !0);
-if (0 === Qg(s)) return !0;
+function $g(e, t) {
+var r, o, n, i, s = qv(e, !0);
+if (0 === Xg(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = Vv(e, !1), u = Zg(t);
+var c = qv(e, !1), u = Jg(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -39023,36 +39033,36 @@ if (r) throw r.error;
 return !1;
 }
 
-var $g = [ "guard", "ranger", "healer" ];
+var eh = [ "guard", "ranger", "healer" ];
 
-function eh(e, t, r) {
+function th(e, t, r) {
 void 0 === r && (r = 1), e[t] += r, e.total += r;
 }
 
-function th(e, t) {
+function rh(e, t) {
 var r, o;
-return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === ci ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
+return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === ui ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
 }
 
-function rh(e) {
+function oh(e) {
 var t;
-return _o(e.role) && void 0 !== th(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
+return Uo(e.role) && void 0 !== rh(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
 }
 
-function oh(e, t) {
+function nh(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function nh(e, t) {
-return 0 === t.length ? e : ho(e, vo(t));
-}
-
 function ah(e, t) {
-e.assignedPower = nh(e.assignedPower, t);
+return 0 === t.length ? e : Ro(e, go(t));
 }
 
 function ih(e, t) {
+e.assignedPower = ah(e.assignedPower, t);
+}
+
+function sh(e, t) {
 var r, o;
 if (void 0 !== t.defenseAssistReleasedAt) {
 var n = null !== (r = t.defenseAssistReleaseReason) && void 0 !== r ? r : "unknown";
@@ -39062,10 +39072,10 @@ e.released.lastReason = n);
 }
 }
 
-function sh(e, t) {
+function ch(e, t) {
 e.parityPercent = e.targetScore > 0 ? Math.min(100, t.score / e.targetScore * 100) : 0,
 e.blockReason = function(e) {
-var t = $g.filter(function(t) {
+var t = eh.filter(function(t) {
 return e.queued[t] > 0;
 });
 if (t.length > 0 && t.every(function(t) {
@@ -39077,57 +39087,57 @@ return e.requested.total > 0 && 0 === r ? "no-local-assist" : "none";
 }(e);
 }
 
-function ch(e) {
+function uh(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function uh(e, t, r) {
-var n = qg(e.name, r.roleName, t);
+function lh(e, t, r) {
+var n = jg(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function lh(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return hv.EMERGENCY;
+function mh(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Rv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return hv.HIGH;
-if (Lv.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Rv.HIGH;
+if (Dv.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
-var o = ao(e), n = so(e);
+var o = io(e), n = co(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return hv.EMERGENCY;
-if (a > 0) return hv.HIGH;
+if (a >= 100) return Rv.EMERGENCY;
+if (a > 0) return Rv.HIGH;
 }
 return function(e) {
-return e >= 90 ? hv.HIGH : e >= 60 ? hv.NORMAL : hv.LOW;
+return e >= 90 ? Rv.HIGH : e >= 60 ? Rv.NORMAL : Rv.LOW;
 }(o);
 }
 
-function mh(e, t) {
+function dh(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-ch(e);
-var l = Vv(e.name), m = Xg(e.name), d = [];
-if (Jg(e.name, e)) {
+uh(e);
+var l = qv(e.name), m = Zg(e.name), d = [];
+if ($g(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === Qg(Vv(e, !0))) return _.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Xg(qv(e, !0))) return _.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = Vv(e, !1), c = Zg(t);
+var s = qv(e, !1), c = Jg(t);
 _.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -39142,7 +39152,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = zg(e, m.role, r, !0);
+var p = Qg(e, m.role, r, !0);
 if (_.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -39173,17 +39183,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = Sv[p]) && zg(e.name, p, t, !0) ? (d.push(uh(e, t, {
+return p && (g = wv[p]) && Qg(e.name, p, t, !0) ? (d.push(lh(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: lh(e, 0, p, g.priority, m),
+priority: mh(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(Sv)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Kg(e.name, p);
+for (var f = a(Object.entries(wv)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = Yg(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -39194,7 +39204,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = Bg(e.name, p);
+var E = Wg(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -39208,8 +39218,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (zg(e.name, p, t, m)) {
-var T = Xv(p), C = T ? jg(e.name, p, t) : null, S = "claimer" === p ? ug(e.name, t) : null, w = "pioneer" === p ? fg(e.name, t) : null;
+}); else if (Qg(e.name, p, t, m)) {
+var T = Zv(p), C = T ? zg(e.name, p, t) : null, S = "claimer" === p ? lg(e.name, t) : null, w = "pioneer" === p ? yg(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -39219,11 +39229,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(uh(e, t, {
+}) : d.push(lh(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: lh(e, 0, p, g.priority, m),
+priority: mh(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -39245,7 +39255,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = dh(e, l.value);
+var m = ph(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -39266,16 +39276,16 @@ requests: c
 };
 }
 
-function dh(e, t) {
+function ph(e, t) {
 var r, n, i, s = e.energyCapacityAvailable;
 try {
-var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = Iv.getMaxAffordableInTicks(e, c), l = Tg(e), m = t.priority >= hv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && _o(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= hv.EMERGENCY, y = t.assistTarget ? To(t.assistTarget) : null, v = d ? Oo(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = Gv.getMaxAffordableInTicks(e, c), l = Cg(e), m = t.priority >= Rv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Uo(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Rv.EMERGENCY, y = t.assistTarget ? Co(t.assistTarget) : null, v = d ? ko(d, s, y) : null, g = d && f ? function(e, t, r, o) {
 var n;
-return null !== (n = [ Oo(e, t, r), vg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return null !== (n = [ ko(e, t, r), gg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
 return function(e, t, r) {
 if (!t) return !1;
 if ("ranger" !== e) return !0;
-if (r && !bo(r)) return !0;
+if (r && !Oo(r)) return !0;
 var o = t.parts.filter(function(e) {
 return e === RANGED_ATTACK;
 }).length;
@@ -39304,7 +39314,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, m)) && void 0 !== i ? i : Mv({
+}(t.def, m)) && void 0 !== i ? i : Av({
 maxEnergy: m,
 role: t.roleName
 }), E = t.bodyOverride ? s : h ? f ? l : s : m;
@@ -39340,44 +39350,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var ph = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), fh = new Set([ "guard", "ranger", "healer" ]);
+var fh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), yh = new Set([ "guard", "ranger", "healer" ]);
 
-function yh() {
+function vh() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function vh(e) {
+function gh(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function gh(e) {
-var t;
-return e.priority >= hv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
-}
-
 function hh(e) {
 var t;
-return e.priority >= hv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Rv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Rh(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Tg(e), m = Eo(X(e)), d = function(e) {
+function Rh(e) {
+var t;
+return e.priority >= Rv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+}
+
+function Eh(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Cg(e), m = To(X(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? hv.EMERGENCY : hv.HIGH, f = d ? u : p === hv.EMERGENCY ? l : u, y = function(e, t) {
+}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Rv.EMERGENCY : Rv.HIGH, f = d ? u : p === Rv.EMERGENCY ? l : u, y = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Nv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Pv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || Eh(u, e) && ("guard" === u.role && (n.guards++,
-Ch(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Ch(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Ch(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Th(u, e) && ("guard" === u.role && (n.guards++,
+Sh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Sh(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Sh(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -39405,7 +39415,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Ch(n, u, l);
+0 !== l.length && Sh(n, u, l);
 }
 }
 }
@@ -39426,7 +39436,7 @@ var r, n, i = o({}, e);
 try {
 for (var s = a([ "guard", "ranger", "healer" ]), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t[u];
-l && (i[u] = i[u] ? ho(i[u], l) : l);
+l && (i[u] = i[u] ? Ro(i[u], l) : l);
 }
 } catch (e) {
 r = {
@@ -39440,30 +39450,30 @@ if (r) throw r.error;
 }
 }
 return i;
-}(v, y.power), h = Ao(f, m, {
+}(v, y.power), h = _o(f, m, {
 guard: Math.max(0, r.guards - n.guards - y.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - y.counts.healers)
-}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Th("guard", f, m);
-if (R > 0 && E) for (var T = 0; T < R; T++) wh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
-var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Th("ranger", f, m);
-if (C > 0 && S) for (T = 0; T < C; T++) wh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
-var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Th("healer", f, m);
-if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) wh(e, "healer", "military", hv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Ch("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) xh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Ch("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) xh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Ch("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) xh(e, "healer", "military", Rv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
-if (!(t < hv.EMERGENCY || function(e, t) {
+if (!(t < Rv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !fh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !yh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Nv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Pv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < hv.EMERGENCY || fh.has(c.role) && Eh(c, e.name) && c.body.cost <= t && n++;
+c.priority < Rv.EMERGENCY || yh.has(c.role) && Th(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39480,7 +39490,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = yg(t, e);
+var r = vg(t, e);
 return r ? {
 role: t,
 body: r
@@ -39491,49 +39501,49 @@ return Boolean(e);
 if (0 === o.length) return null;
 var n = null == t ? void 0 : t.strongest;
 return null !== (r = o.sort(function(e, t) {
-var r = vo(t.body.parts).score - vo(e.body.parts).score;
+var r = go(t.body.parts).score - go(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && wh(e, n.role, "military", hv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && xh(e, n.role, "military", Rv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, p, l, m), (R > 0 || C > 0 || w > 0) && _.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Eh(e, t) {
+function Th(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Th(e, t, r) {
-return r ? Oo(e, t, r) : null;
-}
-
 function Ch(e, t, r) {
-var o = vo(r);
-e[t] = e[t] ? ho(e[t], o) : o;
+return r ? ko(e, t, r) : null;
 }
 
 function Sh(e, t, r) {
-return Nv.getPendingRequests(e).filter(function(e) {
+var o = go(r);
+e[t] = e[t] ? Ro(e[t], o) : o;
+}
+
+function wh(e, t, r) {
+return Pv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function wh(e, t, r, o, n, a, i, s, c) {
+function xh(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : Mv({
+var u = null != i ? i : Av({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void _.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Nv.addRequest({
+Pv.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -39551,34 +39561,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function xh(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= hv.HIGH) return !1;
+function bh(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Rv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < hv.NORMAL) {
-if (Iv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Rv.NORMAL) {
+if (Gv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === hv.NORMAL && o / e.energyCapacityAvailable < .3 && Iv.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Rv.NORMAL && o / e.energyCapacityAvailable < .3 && Gv.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function bh(e, t) {
+function Oh(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-ch(e);
-var s = Nv.getQueueSize(e.name);
+uh(e);
+var s = Pv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Jg(e.name, e), u = Xg(e.name) && !Nv.hasEmergencySpawns(e.name), l = ao(e), m = so(e);
+var c = $g(e.name, e), u = Zg(e.name) && !Pv.hasEmergencySpawns(e.name), l = io(e), m = co(e);
 if (c) {
-s > 0 && Nv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Rh(e, t, l, m);
+s > 0 && Pv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Eh(e, t, l, m);
 try {
-for (var d = a(mh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(dh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Nv.addRequest(f);
+Pv.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -39591,8 +39601,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Rh(e, t, l, m), function(e) {
-var t, r, o = Gv.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Eh(e, t, l, m), function(e) {
+var t, r, o = Lv.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -39604,17 +39614,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = hv.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = Rv.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Sh(e.name, "powerHarvester", f), g = Sh(e.name, "healer", f), h = Sh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) wh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = wh(e.name, "powerHarvester", f), g = wh(e.name, "healer", f), h = wh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) xh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) wh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) xh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) wh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) xh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -39643,13 +39653,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Nv.getPendingRequests(e.name).map(vh));
+var c = new Set(Pv.getPendingRequests(e.name).map(gh));
 try {
-for (var u = a(mh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= hv.HIGH, p = "claimer" === m.role && yh(), f = gh(m), y = hh(m);
-if (ph.has(m.role) || d || p || f || y) {
-var v = vh(m);
-c.has(v) || (Nv.addRequest(m), c.add(v));
+for (var u = a(dh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Rv.HIGH, p = "claimer" === m.role && vh(), f = hh(m), y = Rh(m);
+if (fh.has(m.role) || d || p || f || y) {
+var v = gh(m);
+c.has(v) || (Pv.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -39666,8 +39676,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(mh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Nv.addRequest(f);
+for (var y = a(dh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Pv.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -39679,32 +39689,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Nv.getQueueStats(e.name);
+var g = Pv.getQueueStats(e.name);
 _.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Nv.clearQueue(e.name);
+} else s > 0 && Pv.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Nv.getAvailableSpawns(e.name);
+var t, r, o = Pv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Tg(e);
+var n = 0, i = Cg(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Nv.getNextRequest(e.name, i);
+var u = c.value, l = Pv.getNextRequest(e.name, i);
 if (!l) break;
-if (xh(e, l, i)) {
+if (bh(e, l, i)) {
 _.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = _v(u, l);
-m === OK ? (n++, i -= l.body.cost, Nv.markInProgress(e.name, l.id, u.id), Nv.removeRequest(e.name, l.id),
+var m = Uv(u, l);
+m === OK ? (n++, i -= l.body.cost, Pv.markInProgress(e.name, l.id, u.id), Pv.removeRequest(e.name, l.id),
 _.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Nv.removeRequest(e.name, l.id), _.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Pv.removeRequest(e.name, l.id), _.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -39720,12 +39730,12 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Nv.getQueueStats(e.name), n = function(e) {
+}(e), o = Pv.getQueueStats(e.name), n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T = Game.rooms[e];
 if (!T) return [];
-var C = Tg(T), S = new Map, w = new Map, x = function(e, t) {
+var C = Cg(T), S = new Map, w = new Map, x = function(e, t) {
 var r;
-w.set(e, nh(null !== (r = w.get(e)) && void 0 !== r ? r : {
+w.set(e, ah(null !== (r = w.get(e)) && void 0 !== r ? r : {
 partCount: 0,
 attack: 0,
 ranged: 0,
@@ -39798,11 +39808,11 @@ blockReason: "none"
 };
 }(e, t, r);
 return function(e, t, r) {
-var o, n, i, s = To(e.targetRoom);
+var o, n, i, s = Co(e.targetRoom);
 e.targetScore = null !== (i = null == s ? void 0 : s.total.score) && void 0 !== i ? i : 0;
 try {
-for (var c = a($g), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = Oo(l, t.energyCapacityAvailable, s);
+for (var c = a(eh), u = c.next(); !u.done; u = c.next()) {
+var l = u.value, m = ko(l, t.energyCapacityAvailable, s);
 m ? (e.bodyCost[l] = m.cost, e.affordable[l] = m.cost <= r) : e.affordable[l] = !1;
 }
 } catch (e) {
@@ -39821,15 +39831,15 @@ if (o) throw o.error;
 try {
 for (var O = a(function(e, t) {
 void 0 === t && (t = {});
-var r = wg(e), o = r.filter(Sg);
+var r = xg(e), o = r.filter(wg);
 return t.prune && Array.isArray(e.defenseRequests) && o.length !== r.length && (e.defenseRequests = o),
 o;
 }(Memory)), k = O.next(); !k.done; k = O.next()) if ((I = k.value).roomName !== e) {
 var M = b(I.roomName, null !== (f = I.urgency) && void 0 !== f ? f : 0);
 try {
-for (var A = (o = void 0, a($g)), _ = A.next(); !_.done; _ = A.next()) {
+for (var A = (o = void 0, a(eh)), _ = A.next(); !_.done; _ = A.next()) {
 var U = _.value;
-eh(M.requested, U, oh(I, U));
+th(M.requested, U, nh(I, U));
 }
 } catch (e) {
 o = {
@@ -39855,11 +39865,11 @@ if (t) throw t.error;
 }
 }
 try {
-for (var N = a(Nv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
+for (var N = a(Pv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
 var I;
-rh(I = P.value) && (D = th(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (eh((M = b(D)).queued, I.role),
+oh(I = P.value) && (D = rh(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (th((M = b(D)).queued, I.role),
 M.bodyCost[I.role] = Math.max(null !== (v = M.bodyCost[I.role]) && void 0 !== v ? v : 0, I.body.cost),
-M.affordable[I.role] = I.body.cost <= C, ah(M, I.body.parts));
+M.affordable[I.role] = I.body.cost <= C, ih(M, I.body.parts));
 }
 } catch (e) {
 c = {
@@ -39875,13 +39885,13 @@ if (c) throw c.error;
 try {
 for (var G = a(Object.values(Game.creeps)), L = G.next(); !L.done; L = G.next()) {
 var D, F = L.value, B = null !== (g = F.memory) && void 0 !== g ? g : {};
-if (B.homeRoom === e && _o(U = null !== (h = B.role) && void 0 !== h ? h : "") && (D = th(B))) {
+if (B.homeRoom === e && Uo(U = null !== (h = B.role) && void 0 !== h ? h : "") && (D = rh(B))) {
 M = b(D);
 var W = (null !== (R = F.body) && void 0 !== R ? R : []).filter(function(e) {
 return e.hits > 0;
 });
-F.spawning ? eh(M.spawning, U) : void 0 === B.defenseAssistReleasedAt && F.room.name === e ? (eh(M.staged, U),
-x(D, W)) : F.room.name === D ? eh(M.arrived, U) : eh(M.moving, U), ih(M, B), ah(M, W);
+F.spawning ? th(M.spawning, U) : void 0 === B.defenseAssistReleasedAt && F.room.name === e ? (th(M.staged, U),
+x(D, W)) : F.room.name === D ? th(M.arrived, U) : th(M.moving, U), sh(M, B), ih(M, W);
 }
 }
 } catch (e) {
@@ -39897,7 +39907,7 @@ if (l) throw l.error;
 }
 var H = s([], i(S.values()), !1);
 try {
-for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) sh(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : go());
+for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) ch(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : ho());
 } catch (e) {
 d = {
 error: e
@@ -39927,7 +39937,7 @@ defenseAssist: n
 }(e, t);
 }
 
-var Oh = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, kh = /^(\d{1,2})\|(.+)$/, Mh = M("SS2TerminalComms"), Ah = function() {
+var kh = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, Mh = /^(\d{1,2})\|(.+)$/, Ah = M("SS2TerminalComms"), _h = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -39987,11 +39997,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(Oh);
+var t = e.match(kh);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(kh);
+var i = a.match(Mh);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -40026,7 +40036,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-Mh.warn("Missing packet in multi-packet message", {
+Ah.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -40042,7 +40052,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), Mh.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), Ah.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -40066,7 +40076,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && Mh.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && Ah.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -40078,7 +40088,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return Mh.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return Ah.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -40086,14 +40096,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), Mh.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), Ah.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (Mh.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (Ah.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -40118,7 +40128,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-Mh.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+Ah.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -40130,7 +40140,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-Mh.info("Completed sending multi-packet message", {
+Ah.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -40138,25 +40148,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? Mh.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? Ah.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (Mh.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (Ah.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else Mh.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else Ah.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else Mh.warn("Terminal not found for queue item, removing from queue", {
+} else Ah.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -40190,7 +40200,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && Mh.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && Ah.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -40200,7 +40210,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-Mh.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+Ah.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -40291,7 +40301,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (Mh.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (Ah.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -40313,7 +40323,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return Mh.error("Error parsing JSON", {
+return Ah.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -40324,7 +40334,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), _h = [ {
+}(), Uh = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -40344,7 +40354,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Uh = function() {
+} ], Nh = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -40391,9 +40401,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), Nh = new Uh;
+}(), Ph = new Nh;
 
-function Ph(e) {
+function Ih(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -40401,19 +40411,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function Ih(e, t) {
+function Gh(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function Gh(e, t) {
+function Lh(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var Lh = {
+var Dh = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -40424,9 +40434,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, Dh = function() {
+}, Fh = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Lh), e);
+void 0 === e && (e = {}), this.config = o(o({}, Dh), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -40447,7 +40457,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = Nh.getSwarmState(r.toRoom);
+var o = Ph.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return _.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -40460,7 +40470,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = Nh.getSwarmState(c);
+var l = Ph.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -40530,9 +40540,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(Ih), u = n.filter(function(e) {
+}).sort(Gh), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(Gh), l = [], m = [], d = function(t) {
+}).sort(Lh), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -40554,11 +40564,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return Ph({
+return Ih({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + Ph({
+}) + Ih({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -40657,7 +40667,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), Fh = new Dh, Bh = {
+}(), Bh = new Fh, Wh = {
 1: {
 guards: 1,
 rangers: 1,
@@ -40678,14 +40688,14 @@ siegeUnits: 1
 }
 };
 
-function Wh(e) {
+function Hh(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function Hh(e) {
+function Kh(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -40708,9 +40718,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function Kh(e) {
+function Yh(e) {
 var t, r, o;
-Hh(e);
+Kh(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -40734,20 +40744,20 @@ if (t) throw t.error;
 return n;
 }
 
-function Yh(e) {
+function Vh(e) {
 var t;
-Hh(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Kh(e);
+Kh(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Yh(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function Vh(e) {
-return !!Yh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function qh(e) {
+return !!Vh(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-Hh(e);
+Kh(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -40758,12 +40768,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = Kh(e);
+var d = Yh(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function qh(e, t) {
+function jh(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -40784,20 +40794,20 @@ if (r) throw r.error;
 return n;
 }
 
-function jh(e, t) {
+function zh(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Bh[r]) && void 0 !== t ? t : Bh[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = Wh[r]) && void 0 !== t ? t : Wh[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = qh(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = jh(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: Wh(r),
+targetComposition: Hh(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -40809,7 +40819,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function zh(e) {
+function Qh(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return _.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -40829,9 +40839,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function Qh(e) {
+function Xh(e) {
 var t = e.members.length;
-Hh(e), e.members.length < t && _.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+Kh(e), e.members.length < t && _.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -40845,7 +40855,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && Vh(e) && (e.state = "moving", _.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && qh(e) && (e.state = "moving", _.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -40874,7 +40884,7 @@ subsystem: "Squad"
 }
 }
 
-var Xh = {
+var Zh = {
 harassment: {
 composition: {
 harassers: 3,
@@ -40961,7 +40971,7 @@ prioritizeDefenses: !0
 }
 };
 
-function Zh(e, t) {
+function Jh(e, t) {
 var r, o, n, a;
 if (!t) return _.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -40976,8 +40986,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function Jh(e, t) {
-var r, o, n, i = Xh[t], s = 0;
+function $h(e, t) {
+var r, o, n, i = Zh[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -41003,7 +41013,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var $h, eR, tR, rR = {
+var eR, tR, rR, oR = {
 move: 50,
 work: 100,
 carry: 50,
@@ -41012,11 +41022,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, oR = new Map;
+}, nR = new Map;
 
-function nR(e, t) {
+function aR(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (oR.has(m)) _.debug("Squad ".concat(m, " already forming"), {
+if (nR.has(m)) _.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -41028,7 +41038,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = Xh[p].composition;
+d = Zh[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -41043,19 +41053,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (oR.set(m, y), function(e, t, r, o) {
+v ? (nR.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = Xh[s].useBoosts;
+i = Zh[s].useBoosts;
 }
-var c = hv.NORMAL;
-"siege" === t.type ? c = hv.HIGH : "defense" === t.type && (c = hv.EMERGENCY);
+var c = Rv.NORMAL;
+"siege" === t.type ? c = Rv.HIGH : "defense" === t.type && (c = Rv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = aR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + rR[t];
-}, 0), m = i ? sR(r) : [], d = {
+var u = iR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + oR[t];
+}, 0), m = i ? cR(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -41084,7 +41094,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Nv.addRequest(d), o.spawnRequests.add(d.id);
+Pv.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -41098,42 +41108,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function aR(e, t, r) {
+function iR(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return iR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return sR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return iR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return sR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return iR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return sR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return iR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return sR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return iR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return sR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return iR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return sR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function iR(e, t, r) {
+function sR(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + rR[t];
+return e + oR[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + rR[t];
+return e + oR[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function sR(e) {
+function cR(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -41164,45 +41174,45 @@ return [];
 }
 }
 
-function cR(e) {
-return oR.has(e);
-}
-
 function uR(e) {
-return Yh(e) || Vh(e);
+return nR.has(e);
 }
 
-($h = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, $h[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-$h[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (eR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-eR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, eR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-eR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (tR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-tR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, tR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-tR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, tR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+function lR(e) {
+return Vh(e) || qh(e);
+}
 
-var lR = {
+(eR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, eR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+eR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (tR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+tR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, tR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+tR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (rR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+rR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, rR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+rR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, rR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+
+var mR = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function mR(e, t) {
-var r = lR[t], o = Nh.getClusters();
+function dR(e, t) {
+var r = mR[t], o = Ph.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function dR(e, t, r) {
+function pR(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = Nh.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = Ph.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: mR(e, i.danger),
+reservedEnergy: dR(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -41292,7 +41302,7 @@ success: !1
 });
 }
 
-var pR = {
+var fR = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -41302,7 +41312,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function fR(e, t, r) {
+function yR(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -41333,7 +41343,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function yR(e, t, r, o) {
+function vR(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -41343,7 +41353,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function vR(e, t) {
+function gR(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -41364,19 +41374,19 @@ if (r) throw r.error;
 return n;
 }
 
-function gR() {
-var e = Nh.getEmpire();
+function hR() {
+var e = Ph.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function hR(e) {
-gR()[e.id] = e;
+function RR(e) {
+hR()[e.id] = e;
 }
 
-function RR(e) {
+function ER(e) {
 e.lastUpdate = Game.time;
-var t = Nh.getCluster(e.clusterId);
-if (!t) return e.state = "failed", hR(e), void _.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = Ph.getCluster(e.clusterId);
+if (!t) return e.state = "failed", RR(e), void _.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -41386,12 +41396,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (uR(r) || cR(e) || nR(0, r), uR(r));
+return !!r && (lR(r) || uR(e) || aR(0, r), lR(r));
 }) && (e.state = "executing", _.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", _.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), hR(e);
+})), RR(e);
 }(e, t);
 break;
 
@@ -41402,7 +41412,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (Qh(o), zh(o)) {
+if (Xh(o), Qh(o)) {
 _.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -41431,7 +41441,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = Nh.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = Ph.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -41458,19 +41468,19 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", _.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), hR(e);
+})), RR(e);
 }(e, t);
 }
 }
 
-function ER(e, t, r) {
+function TR(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
 });
 return "guard" === e ? r.includes(ATTACK) || r.includes(RANGED_ATTACK) : "ranger" === e ? r.includes(RANGED_ATTACK) : r.includes(HEAL);
 }(t, r)) {
-var o = vo(r), n = e.power[t];
+var o = go(r), n = e.power[t];
 e.counts[t]++, e.power[t] = n ? {
 partCount: n.partCount + o.partCount,
 attack: n.attack + o.attack,
@@ -41482,11 +41492,11 @@ score: n.score + o.score
 }
 }
 
-function TR(e, t, r) {
-return Oo(e, t, r);
+function CR(e, t, r) {
+return ko(e, t, r);
 }
 
-function CR(e, t) {
+function SR(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -41499,11 +41509,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function SR(e) {
+function wR(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function wR(e, t, r) {
+function xR(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -41516,25 +41526,25 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function xR(e, t, r) {
-var o = TR(t, e.energyCapacityAvailable, r);
+function bR(e, t, r) {
+var o = CR(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
-var a = vo(o.parts);
+var a = go(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function bR(e, t, r, o) {
+function OR(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = xR(e, t, o);
-if (s !== xR(n, t, o)) return s ? -1 : 1;
+var a, i, s = bR(e, t, o);
+if (s !== bR(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function OR(e, t) {
+function kR(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -41618,39 +41628,39 @@ if (r) throw r.error;
 return u;
 }
 
-function kR(e, t) {
+function MR(e, t) {
 return {
-guard: Math.max(0, CR(e, "guard") - t.counts.guard),
-ranger: Math.max(0, CR(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, CR(e, "healer") - t.counts.healer)
+guard: Math.max(0, SR(e, "guard") - t.counts.guard),
+ranger: Math.max(0, SR(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, SR(e, "healer") - t.counts.healer)
 };
 }
 
-function MR(e) {
+function AR(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function AR(e, t) {
+function _R(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return MR(e.role);
+return AR(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
 role: e.role,
 targetRoom: null !== (o = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.assistTarget) && void 0 !== r ? r : e.targetRoom) && void 0 !== o ? o : "",
-power: vo(e.body.parts)
+power: go(e.body.parts)
 };
 }).filter(function(e) {
 return e.targetRoom.length > 0;
 });
 }
 
-function _R(e) {
+function UR(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ci ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === ui ? e.targetRoom : void 0;
 }
 
-function UR(e) {
+function NR(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -41662,7 +41672,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-MR(m) && _R(l) === e && !u.spawning && ER(i, m, u.body.filter(function(e) {
+AR(m) && UR(l) === e && !u.spawning && TR(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -41680,7 +41690,7 @@ if (t) throw t.error;
 return i;
 }
 
-function NR(e, t, r) {
+function PR(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -41710,16 +41720,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: AR(e, r)
+pendingAssist: _R(e, r)
 };
 }
 }
 
-function PR(e, t) {
+function IR(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = TR(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = CR(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -41740,7 +41750,7 @@ subsystem: "Cluster"
 }
 }
 
-function IR(e, t, r) {
+function GR(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -41782,20 +41792,20 @@ exitAccess: a
 };
 }
 
-function GR(e, t) {
+function LR(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function LR(e, t, r) {
+function DR(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function DR(e) {
+function FR(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function FR(e, t) {
+function BR(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -41806,7 +41816,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function BR(e, t, r) {
+function WR(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -41817,8 +41827,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = DR(g);
-h && (mi(g) || FR(v, h) && (t.assignedCreeps.includes(v.name) || GR(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = FR(g);
+h && (di(g) || BR(v, h) && (t.assignedCreeps.includes(v.name) || LR(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -41855,7 +41865,7 @@ return e.distance - t.distance;
 });
 }
 
-function WR(e, t) {
+function HR(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -41880,21 +41890,21 @@ if (r) throw r.error;
 return i;
 }
 
-function HR(e) {
+function KR(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var KR = {
+var YR = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, YR = function() {
+}, VR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, KR), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, YR), e);
 }
 return e.prototype.run = function() {
-var e = Nh.getClusters();
+var e = Ph.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -41913,7 +41923,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: _h.map(function(t) {
+steps: Uh.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -41932,7 +41942,7 @@ focusRoom: e.focusRoom
 }(e);
 }, e.prototype.runCluster = function(e) {
 var t, r, o = this, n = Game.cpu.getUsed(), i = this.getClusterOperationIntent(e), s = function(t) {
-qi.measureSubsystem(t.statsKey, function() {
+ji.measureSubsystem(t.statsKey, function() {
 o.executeClusterOperation(t.name, e);
 });
 };
@@ -41969,7 +41979,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-Fh.processCluster(t);
+Bh.processCluster(t);
 break;
 
 case "squads":
@@ -42001,7 +42011,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = IR(e, new RoomPosition(s, c, e.name), "defense");
+var u = GR(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -42050,9 +42060,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = Nh.getSwarmState(i);
+var i = n.value, s = Ph.getSwarmState(i);
 if (s) {
-var c = mR(i, s.danger);
+var c = dR(i, s.danger);
 c > 0 && Game.time % 100 == 0 && _.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -42083,7 +42093,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = Nh.getSwarmState(m);
+var m = l.value, d = Ph.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -42115,7 +42125,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += HR(l.controller.level));
+}).length, i += KR(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -42232,7 +42242,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Qh(i), "gathering" !== i.state || uR(i) || cR(i.id) || nR(0, i), zh(i) && (i.state = "dissolving");
+Xh(i), "gathering" !== i.state || lR(i) || uR(i.id) || aR(0, i), Qh(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -42257,7 +42267,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = jh(e, s);
+var s = i.value, c = zh(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -42274,7 +42284,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(gR()).filter(function(e) {
+var t = (a = e.id, Object.values(hR()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -42285,22 +42295,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, pR), n), m = [], d = Nh.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, fR), n), m = [], d = Ph.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = fR(f, y, d);
+var g = yR(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = vR(e, f);
+var h = gR(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = yR(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = vR(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = Zh(f, {
+var C = Jh(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -42335,29 +42345,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-Jh(e, n.doctrine) ? function(e, t, r) {
+$h(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = Nh.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = Ph.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return _.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return _.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = fR(e, o, r);
+var n = yR(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (_.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return _.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (Nh.getEmpire().knownRooms || {})[t], n = null != r ? r : Zh(t, {
+var o = (Ph.getEmpire().knownRooms || {})[t], n = null != r ? r : Jh(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!Jh(e, n)) return _.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!$h(e, n)) return _.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -42370,7 +42380,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-hR(i);
+RR(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -42384,13 +42394,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = qh(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = jh(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: Wh(n),
+targetComposition: Hh(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -42405,8 +42415,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), hR(i), nR(0, c), i.state = "forming", i.lastUpdate = Game.time,
-hR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), RR(i), aR(0, c), i.state = "forming", i.lastUpdate = Game.time,
+RR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 _.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), _.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -42425,11 +42435,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(oR.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(nR.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (_.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), oR.delete(c));
+}), nR.delete(c));
 }
 } catch (t) {
 e = {
@@ -42443,10 +42453,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = gR();
-for (var t in e) RR(e[t]);
+var e = hR();
+for (var t in e) ER(e[t]);
 !function() {
-var e = gR();
+var e = hR();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -42524,14 +42534,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = Nh.getCluster(t, e);
+var t = "cluster_".concat(e), r = Ph.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return _.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = Nh.getCluster(e);
+var o = Ph.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), _.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), _.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -42560,7 +42570,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && dR(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && pR(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -42577,19 +42587,19 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = Nh.getSwarmState(t);
+var n, a, i = Ph.getSwarmState(t);
 if (!i) return "continue";
-if (co(r, i)) {
+if (uo(r, i)) {
 var s = e.defenseRequests.find(function(e) {
 return e.roomName === t;
 });
 if (s) {
-var c = uo(r, i);
+var c = lo(r, i);
 c && (n = s, (a = c).urgency !== n.urgency || a.guardsNeeded !== n.guardsNeeded || a.rangersNeeded !== n.rangersNeeded || a.healersNeeded !== n.healersNeeded || a.threat !== n.threat) && (s.urgency = c.urgency,
 s.guardsNeeded = c.guardsNeeded, s.rangersNeeded = c.rangersNeeded, s.healersNeeded = c.healersNeeded,
 s.createdAt = c.createdAt, s.threat = c.threat);
 } else {
-var l = uo(r, i);
+var l = lo(r, i);
 l && e.defenseRequests.push(o(o({}, l), {
 assignedCreeps: []
 }));
@@ -42618,7 +42628,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = To(g), f[g] = UR(g);
+p[g] = Co(g), f[g] = NR(g);
 }
 } catch (e) {
 r = {
@@ -42634,7 +42644,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = NR(E, m, t);
+d[E] = PR(E, m, t);
 }
 } catch (e) {
 n = {
@@ -42653,13 +42663,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = wR(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = xR(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = OR(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = kR(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Ao(T, R, kR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = _o(T, R, MR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = bR(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = OR(h, b, g.roomName, R), M = 0; M < O; M++) {
 var A = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -42671,13 +42681,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(A.roomName, "_").con
 roomName: A.roomName,
 role: b,
 family: "military",
-priority: SR(g.urgency),
+priority: wR(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: ci,
-defenseSquadId: ui(A.roomName, g.roomName, e.now),
+task: ui,
+defenseSquadId: li(A.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -42717,7 +42727,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) PR(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) IR(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -42732,7 +42742,7 @@ if (u) throw u.error;
 C > 0 && _.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Nv);
+}(e, Pv);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -42744,7 +42754,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = WR(f, BR(e, f, t)), v = y.reduce(function(e, t) {
+var y = HR(f, WR(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -42752,12 +42762,12 @@ e;
 try {
 for (var g = (n = void 0, a(y)), h = g.next(); !h.done; h = g.next()) {
 var R = h.value, E = Math.max(1, Math.min(3, null !== (u = v.get(R.room.name)) && void 0 !== u ? u : 1));
-li(R.creep, {
+mi(R.creep, {
 homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), LR(f, R.role, GR(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), DR(f, R.role, LR(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -42824,24 +42834,24 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), VR = new YR, qR = /^([WE])(\d+)([NS])(\d+)$/;
+}(), qR = new VR, jR = /^([WE])(\d+)([NS])(\d+)$/;
 
-function jR(e) {
-return qR.test(e);
+function zR(e) {
+return jR.test(e);
 }
 
-var zR = {
+var QR = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, QR = function() {
+}, XR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, zR), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, QR), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = Tf();
-this.updateEnemyIntelligence(e), Cf(e, {
+var e = Cf();
+this.updateEnemyIntelligence(e), Sf(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
@@ -42904,7 +42914,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (jR(x)) {
+if (e.isAlly(x)) f.add(x); else if (zR(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -42969,14 +42979,14 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return Tf().globalTargets.enemies || [];
+return Cf().globalTargets.enemies || [];
 }, n([ or("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: Wt.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), XR = new QR, ZR = function() {
+}(), ZR = new XR, JR = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -43053,9 +43063,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), JR = new ZR, $R = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), $R = new JR, eE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function eE(e, t) {
+function tE(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -43078,22 +43088,22 @@ if (r) throw r.error;
 return n;
 }
 
-function tE(e) {
+function rE(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function rE(e, t, r) {
-if (!tE(e)) return 0;
-var o = eE(e.name, t);
+function oE(e, t, r) {
+if (!rE(e)) return 0;
+var o = tE(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
-return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += $s(e.mineralType),
-n -= 5 * o, n -= ec(e.name), n -= 15 * e.threatLevel, n += tc(e.terrain), rc(e.name) && (n += 10),
-n += oc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
-n += ac(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
+return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += ec(e.mineralType),
+n -= 5 * o, n -= tc(e.name), n -= 15 * e.threatLevel, n += rc(e.terrain), oc(e.name) && (n += 10),
+n += nc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
+n += ic(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function oE(e, t) {
+function nE(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -43103,13 +43113,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && $R.has(e.type);
+return e.hits > 0 && eE.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function nE(e, t, r) {
+function aE(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -43119,7 +43129,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function aE(e) {
+function iE(e) {
 return function(e) {
 var t = ee(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -43130,8 +43140,8 @@ isSK: te(t.x) && te(t.y)
 }(e);
 }
 
-function iE(e) {
-var t = aE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function sE(e) {
+var t = iE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -43150,14 +43160,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var sE = {
+var cE = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, cE = function() {
+}, uE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, sE), e);
+void 0 === e && (e = {}), this.config = o(o({}, cE), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -43248,7 +43258,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = aE(e);
+var t = iE(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -43260,14 +43270,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return iE(uE(e));
+return sE(lE(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = iE(uE(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = sE(lE(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function uE(e) {
+function lE(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = X(e), c = Z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -43299,11 +43309,11 @@ swamps: d
 };
 }
 
-var lE = new cE, mE = /^([WE])(\d+)([NS])(\d+)$/, dE = {
+var mE = new uE, dE = /^([WE])(\d+)([NS])(\d+)$/, pE = {
 allies: []
-}, pE = function() {
+}, fE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, dE), e);
+void 0 === e && (e = {}), this.config = o(o({}, pE), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -43323,7 +43333,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!mE.test(e)) return !1;
+if (!dE.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -43431,7 +43441,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return mE.test(e);
+return dE.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -43458,7 +43468,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), fE = new pE, yE = {
+}(), yE = new fE, vE = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -43471,9 +43481,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, vE = function() {
+}, gE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, yE), e);
+void 0 === e && (e = {}), this.config = o(o({}, vE), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = ft.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -43481,27 +43491,27 @@ if (n < this.config.minBucket) Game.time % 100 == 0 && _.warn("Empire manager sk
 subsystem: "Empire"
 }); else {
 var a = this.getBucketMode(n), i = this.shouldRunDegradedModeWork(a), s = this.shouldRunNormalModeWork(a), c = this.shouldRunFullModeWork(a);
-o.lastUpdate = Game.time, s && (qi.measureSubsystem("empire:expansion", function() {
+o.lastUpdate = Game.time, s && (ji.measureSubsystem("empire:expansion", function() {
 t.updateExpansionQueue(o);
-}), qi.measureSubsystem("empire:powerBanks", function() {
+}), ji.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
-})), qi.measureSubsystem("empire:warTargets", function() {
-fE.updateWarTargets(o);
-}), qi.measureSubsystem("empire:objectives", function() {
+})), ji.measureSubsystem("empire:warTargets", function() {
+yE.updateWarTargets(o);
+}), ji.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
-}), qi.measureSubsystem("empire:gclTracking", function() {
+}), ji.measureSubsystem("empire:gclTracking", function() {
 t.trackGCLProgress(o);
-}), s && qi.measureSubsystem("empire:expansionReadiness", function() {
+}), s && ji.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
-}), i && (qi.measureSubsystem("empire:intelRefresh", function() {
-lE.refreshRoomIntel(o);
-}), qi.measureSubsystem("empire:roomDiscovery", function() {
-lE.discoverNearbyRooms(o);
-})), s && qi.measureSubsystem("empire:nukeCandidates", function() {
+}), i && (ji.measureSubsystem("empire:intelRefresh", function() {
+mE.refreshRoomIntel(o);
+}), ji.measureSubsystem("empire:roomDiscovery", function() {
+mE.discoverNearbyRooms(o);
+})), s && ji.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
-}), c && (qi.measureSubsystem("empire:clusterHealth", function() {
-JR.monitorClusterHealth();
-}), qi.measureSubsystem("empire:powerBankProfitability", function() {
+}), c && (ji.measureSubsystem("empire:clusterHealth", function() {
+$R.monitorClusterHealth();
+}), ji.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
 var u = Game.cpu.getUsed() - r, l = Game.cpu.limit * this.config.maxCpuBudget;
@@ -43583,22 +43593,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = oE(f, u);
+var y = Boolean(Game.rooms[f]), v = nE(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = eE(f, t);
+var g = tE(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = nE(h, u, y);
+var h = e.knownRooms[f], R = aE(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? rE(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? oE(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -43642,10 +43652,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && tE(a)) {
-var i = eE(a.name, t);
+if (a && rE(a)) {
+var i = tE(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = rE(a, t, r);
+var s = oE(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -43965,13 +43975,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), gE = new vE;
+}(), hE = new gE;
 
-function hE(e) {
+function RE(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var RE = {
+var EE = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -43979,21 +43989,21 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, EE = function() {
+}, TE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, RE), e);
+this.config = o(o({}, EE), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
 this.lastRun = Game.time, 0 === this.scanQueue.length && this.buildScanQueue(),
-qi.measureSubsystem("intel:scanning", function() {
+ji.measureSubsystem("intel:scanning", function() {
 e.scanRooms();
-}), qi.measureSubsystem("intel:enemyTracking", function() {
+}), ji.measureSubsystem("intel:enemyTracking", function() {
 e.updateEnemyTracking();
-}), qi.measureSubsystem("intel:threatDetection", function() {
+}), ji.measureSubsystem("intel:threatDetection", function() {
 e.detectThreats();
-}), qi.measureSubsystem("intel:threatUpdate", function() {
+}), ji.measureSubsystem("intel:threatUpdate", function() {
 e.updateRoomThreatLevels();
 });
 var r = Game.cpu.getUsed() - t;
@@ -44126,7 +44136,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, hE(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, RE(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -44301,9 +44311,9 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), TE = new EE, CE = function() {
+}(), CE = new TE, SE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Xs(o(o({}, Gs), e), {
+void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new Zs(o(o({}, Ls), e), {
 getEmpire: function() {
 return ft.getEmpire();
 },
@@ -44337,7 +44347,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), SE = new CE, wE = function() {
+}(), wE = new SE, xE = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = ft.getEmpire();
@@ -44355,9 +44365,9 @@ lastScan: 0
 var e = ft.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), xE = new (function(e) {
+}(), bE = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new wE) || this;
+return void 0 === t && (t = {}), e.call(this, t, new xE) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -44367,24 +44377,24 @@ interval: 200,
 minBucket: 9e3,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ar() ], t);
-}(_i));
+}(Ui));
 
-function bE() {
+function OE() {
 return global;
 }
 
-function OE(e) {
+function kE(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function kE(e) {
+function ME(e) {
 return Number(null != e ? e : 0);
 }
 
-var ME = function() {
+var AE = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = bE();
+var e = OE();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -44392,12 +44402,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return bE()._pixelGenerationMemory;
+return OE()._pixelGenerationMemory;
 }, e;
-}(), AE = function(e) {
+}(), _E = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new ME) || this;
+var r = e.call(this, t, new AE) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -44414,7 +44424,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(OE).length : Object.values(null != t ? t : {}).filter(OE).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(kE).length : Object.values(null != t ? t : {}).filter(kE).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -44425,9 +44435,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (kE(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (kE(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = kE(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = kE(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (ME(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (ME(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = ME(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = ME(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -44449,9 +44459,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ ar() ], t);
-}(Ni), _E = new AE;
+}(Pi), UE = new _E;
 
-function UE(e, t) {
+function NE(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !j(e.controller.owner.username)) return {
 lost: !0,
@@ -44473,7 +44483,7 @@ lost: !1
 };
 }
 
-function NE(e, t, r) {
+function PE(e, t, r) {
 var o, n = ft.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -44487,20 +44497,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var PE = Rt().cpu.bucketThresholds.highMode + 1800, IE = {
+var IE = Rt().cpu.bucketThresholds.highMode + 1800, GE = {
 updateInterval: 250,
-minBucket: PE,
+minBucket: IE,
 maxSitesPerRemotePerTick: 2
 };
 
-function GE(e, t) {
+function LE(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var LE = function() {
+var DE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, IE), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, GE), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -44517,8 +44527,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = UE(l);
-m.lost && m.reason && NE(e, u, m.reason);
+var m = NE(l);
+m.lost && m.reason && PE(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -44536,10 +44546,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = GE("remoteInfrastructure.intent", function() {
+var i = LE("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-GE("remoteInfrastructure.execute", function() {
+LE("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -44705,13 +44715,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = GE("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = LE("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = GE("remoteInfrastructure.roomSnapshot", function() {
+u[t] = LE("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -44744,8 +44754,8 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = GE("remoteInfrastructure.calculateRemoteRoads", function() {
-return ha(e, t);
+var n = LE("remoteInfrastructure.calculateRemoteRoads", function() {
+return Ra(e, t);
 });
 return this.remoteRoadCache.set(r, {
 expires: Game.time + 1500,
@@ -44773,14 +44783,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = GE("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = LE("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? GE("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? LE("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -44797,7 +44807,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? GE("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? LE("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -44815,7 +44825,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return GE("remoteInfrastructure.findSources", function() {
+return LE("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -44912,10 +44922,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ rr("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Wt.LOW,
 interval: 1e3,
-minBucket: PE,
+minBucket: IE,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ ar() ], e);
-}(), DE = new LE, FE = new (function(e) {
+}(), FE = new DE, BE = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -44927,7 +44937,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ ar() ], t);
-}(Mf)), BE = function() {
+}(Af)), WE = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -44943,13 +44953,13 @@ e = JSON.stringify(Memory).length;
 e = 0;
 }
 var o = 2097152, n = e / o * 100;
-n > 90 ? Qu.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+n > 90 ? Xu.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
-}) : n > 75 && Qu.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+}) : n > 75 && Xu.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
 });
 }, e.prototype.updateMemorySegmentStats = function() {
-Qi.run();
+Xi.run();
 }, e.prototype.runPheromoneDiffusion = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44971,7 +44981,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-hy.applyDiffusion(o);
+Ry.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -44980,7 +44990,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-gu.initialize(i.name);
+hu.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -45017,7 +45027,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ ar() ], e);
-}(), WE = new BE, HE = new (function() {
+}(), HE = new WE, KE = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -45038,16 +45048,16 @@ this.runProcesses(), this.processQueuedEvents();
 this.processesRegistered = !1;
 }, e;
 }())({
-kernel: bi,
+kernel: Oi,
 eventBus: Yt,
 getCpuConfig: function() {
 return Rt().cpu;
 },
 registerProcesses: function() {
 var e;
-Qu.info("Registering all processes with kernel...", {
+Xu.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), Oi(WE, bs, _s, ns, gE, dc, TE, DE, Ts, xE, _E, SE, qc, Zc, FE, XR, Bc, VR, Ci),
+}), ki(HE, Os, Us, as, hE, pc, CE, FE, Cs, bE, UE, wE, jc, Jc, BE, ZR, Wc, qR, Si),
 function() {
 var e, t, r = Rt().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -45058,7 +45068,7 @@ interval: 20,
 minBucket: 0,
 cpuBudget: .1,
 execute: function() {
-return bs.run();
+return Os.run();
 }
 }, {
 id: "factory:manager",
@@ -45069,7 +45079,7 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return _s.run();
+return Us.run();
 }
 }, {
 id: "link:manager",
@@ -45080,7 +45090,7 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return ns.run();
+return as.run();
 }
 }, {
 id: "empire:market",
@@ -45091,7 +45101,7 @@ interval: 300,
 minBucket: r,
 cpuBudget: .02,
 execute: function() {
-return Ts.run();
+return Cs.run();
 }
 }, {
 id: "cluster:manager",
@@ -45102,7 +45112,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return VR.run();
+return qR.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -45113,13 +45123,13 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .02,
 execute: function() {
-return Ci.run();
+return Si.run();
 }
 } ], n = [];
 try {
 for (var i = a(o), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-bi.getProcess(c.id) || (bi.registerProcess(c), n.push(c.id));
+Oi.getProcess(c.id) || (Oi.registerProcess(c), n.push(c.id));
 }
 } catch (t) {
 e = {
@@ -45132,20 +45142,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-n.length > 0 && Qu.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
+n.length > 0 && Xu.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
 subsystem: "ProcessRegistry",
 meta: {
 processIds: n
 }
 });
-}(), (e = bi.getProcess("empire:market")) && (e.interval = 300, e.minBucket = Rt().cpu.bucketThresholds.lowMode),
-Qu.info("Registered ".concat(bi.getProcesses().length, " processes with kernel"), {
+}(), (e = Oi.getProcess("empire:market")) && (e.interval = 300, e.minBucket = Rt().cpu.bucketThresholds.lowMode),
+Xu.info("Registered ".concat(Oi.getProcesses().length, " processes with kernel"), {
 subsystem: "ProcessRegistry"
 });
 }
-}), KE = "_ownedRooms", YE = "_ownedRoomsTick";
+}), YE = "_ownedRooms", VE = "_ownedRoomsTick";
 
-function VE(e) {
+function qE(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -45155,20 +45165,20 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var qE = ju("NativeCallsTracker");
+var jE = zu("NativeCallsTracker");
 
-function jE(e, t, r) {
+function zE(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) qE.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) jE.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
 }); else try {
 var a = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return qi.recordNativeCall(r), o.apply(this, e);
+return ji.recordNativeCall(r), o.apply(this, e);
 };
 a.__nativeCallsTrackerWrapped = !0, Object.defineProperty(e, t, {
 value: a,
@@ -45177,7 +45187,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-qE.warn("Failed to wrap method", {
+jE.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -45187,30 +45197,30 @@ error: String(e)
 }
 }
 
-var zE, QE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], XE = "shard1", ZE = {
+var QE, XE = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], ZE = "shard1", JE = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, JE = {
+}, $E = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, $E = {
+}, eT = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function eT() {
+function tT() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function tT() {
+function rT() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: QE,
+targetShards: XE,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -45220,12 +45230,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = QE),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = XE),
 Memory.interShardOperation;
 }
 
-function rT() {
-return Tf({
+function oT() {
+return Cf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -45238,32 +45248,32 @@ checksum: 0
 });
 }
 
-function oT(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), Cf(e, {
+function nT(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), Sf(e, {
 updatedSections: t
 });
 }
 
-function nT() {
-var e, t, r, o, n, i, s, c = rT(), u = eT();
+function aT() {
+var e, t, r, o, n, i, s, c = oT(), u = tT();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: QE,
+targetShards: XE,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : QE,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : XE,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && aT() ? "established" : "unreached",
+status: p === u && iT() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -45281,7 +45291,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === XE ? "core" : "frontier",
+role: u === ZE ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -45298,24 +45308,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), oT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), nT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function aT() {
+function iT() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function iT() {
+function sT() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function sT(e, t) {
+function cT(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -45334,9 +45344,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(iT()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(sT()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Nv.getPendingRequests(p.name).filter(function(r) {
+s += Pv.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -45355,7 +45365,7 @@ if (n) throw n.error;
 return s;
 }
 
-function cT(e) {
+function uT(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -45399,7 +45409,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = rT().shards[eT()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = oT().shards[tT()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -45409,8 +45419,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function uT(e, t) {
-if (!(sT("scout", t) >= 1)) {
+function lT(e, t) {
+if (!(cT("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -45448,13 +45458,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Nv.addRequest({
+r && Pv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: $E,
-priority: hv.LOW + 5,
+body: eT,
+priority: Rv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -45465,14 +45475,14 @@ task: "interShardPortalScout"
 }
 }
 
-function lT(e, t, r) {
-sT("interShardClaimer", t) >= 1 || Nv.addRequest({
+function mT(e, t, r) {
+cT("interShardClaimer", t) >= 1 || Pv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: ZE,
-priority: hv.NORMAL + 50,
+body: JE,
+priority: Rv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45485,14 +45495,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function mT(e, t, r) {
-sT("interShardScout", t) >= 1 || Nv.addRequest({
+function dT(e, t, r) {
+cT("interShardScout", t) >= 1 || Pv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: $E,
-priority: hv.NORMAL,
+body: eT,
+priority: Rv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45505,15 +45515,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function dT(e, t, r) {
+function pT(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (sT("interShardPioneer", t.shard) >= 3 || Nv.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (cT("interShardPioneer", t.shard) >= 3 || Pv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: JE,
-priority: hv.NORMAL + 25,
+body: $E,
+priority: Rv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45526,19 +45536,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function pT(e) {
+function fT(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = eT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = tT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : QE), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : XE), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? yf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? vf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -45570,9 +45580,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(iT()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(sT()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Nv.getPendingRequests(l.name).filter(function(e) {
+n += Pv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -45591,22 +45601,22 @@ return n;
 }() < o;
 }
 
-(zE = {
-optimizeBody: Mv,
+(QE = {
+optimizeBody: Av,
 spawnQueue: {
 addRequest: function(e) {
-return Nv.addRequest(e);
+return Pv.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: hv.LOW,
-NORMAL: hv.NORMAL,
-HIGH: hv.HIGH
+LOW: Rv.LOW,
+NORMAL: Rv.NORMAL,
+HIGH: Rv.HIGH
 }
-}).optimizeBody && (_f.optimizeBody = zE.optimizeBody), zE.spawnQueue && (_f.spawnQueue = zE.spawnQueue),
-zE.spawnPriorities && (_f.spawnPriorities = o(o({}, _f.spawnPriorities), zE.spawnPriorities));
+}).optimizeBody && (Uf.optimizeBody = QE.optimizeBody), QE.spawnQueue && (Uf.spawnQueue = QE.spawnQueue),
+QE.spawnPriorities && (Uf.spawnPriorities = o(o({}, Uf.spawnPriorities), QE.spawnPriorities));
 
-var fT, yT = function() {
+var yT, vT = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -45650,7 +45660,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function vT(e) {
+function gT(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -45671,7 +45681,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function gT(e, t, r) {
+function hT(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -45737,16 +45747,16 @@ return u;
 });
 }
 
-function hT(e) {
+function RT(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(fT || (fT = {}));
+}(yT || (yT = {}));
 
-var RT = function() {
+var ET = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -45784,8 +45794,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = gT(h.pos, T.pos, this.logger);
-if (hT(C)) {
+var T = E.value, C = hT(h.pos, T.pos, this.logger);
+if (RT(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -45812,8 +45822,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, M = gT(k, u.pos, this.logger);
-hT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, M = hT(k, u.pos, this.logger);
+RT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -45852,8 +45862,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = gT(e, t, this.logger);
-if (hT(n)) {
+var n = hT(e, t, this.logger);
+if (RT(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -45863,7 +45873,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), ET = function() {
+}(), TT = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -45873,7 +45883,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = vT(s);
+var c = gT(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -45899,7 +45909,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), TT = function() {
+}(), CT = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -45948,7 +45958,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), CT = {
+}(), ST = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -45961,7 +45971,7 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, ST = {
+}, wT = {
 getCachedPath: function(e, t) {
 var r = yr(e, t), o = bt.get(r, {
 namespace: fr
@@ -45988,26 +45998,26 @@ direction: a
 }
 return t;
 }
-}, wT = {
+}, xT = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = Km.MEDIUM), ed.register({
+void 0 === o && (o = Ym.MEDIUM), td.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== Km.CRITICAL
+skippable: o !== Ym.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, xT = new RT(ST, CT), bT = new ET(CT, wT, xT), OT = new TT(CT, ST, xT, ul.moveTo);
+}, bT = new ET(wT, ST), OT = new TT(ST, xT, bT), kT = new CT(ST, wT, bT, ll.moveTo);
 
-function kT(e, t, r, o) {
-return OT.moveToWithRemoteCache(e, t, r, o);
+function MT(e, t, r, o) {
+return kT.moveToWithRemoteCache(e, t, r, o);
 }
 
-var MT, AT = function() {
+var AT, _T = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -46020,12 +46030,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), _T = function() {
+}(), UT = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 Yt.on(e, t);
 }, e;
-}(), UT = function() {
+}(), NT = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -46070,28 +46080,28 @@ m.length > 0 && vr(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), NT = function() {
+}(), PT = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return vT(e);
+return gT(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-xT.precacheRemoteRoutes(e, t);
+bT.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), PT = new yT(new AT, new _T, new UT, new NT), IT = {
+}(), IT = new vT(new _T, new UT, new NT, new PT), GT = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, GT = function() {
+}, LT = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, IT), e);
+this.config = o(o({}, GT), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -46100,10 +46110,10 @@ lastRun: 0
 }, e.prototype.unregisterTask = function(e) {
 this.tasks.delete(e);
 }, e.prototype.getBucketMode = function() {
-return bi.getBucketMode();
+return Oi.getBucketMode();
 }, e.prototype.updateBucketMode = function() {
 var e = this.getBucketMode();
-e !== this.currentMode && (Qu.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
+e !== this.currentMode && (Xu.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
 subsystem: "Scheduler"
 }), this.currentMode = e);
 }, e.prototype.getCpuLimit = function() {
@@ -46151,13 +46161,13 @@ try {
 i.execute(), i.lastRun = Game.time;
 } catch (e) {
 var c = e instanceof Error ? e.message : String(e);
-Qu.error("Task ".concat(i.name, " failed: ").concat(c), {
+Xu.error("Task ".concat(i.name, " failed: ").concat(c), {
 subsystem: "Scheduler"
 });
 }
 var u = Game.cpu.getUsed() - s;
 if (this.tickCpuUsed += u, !this.hasCpuBudget()) {
-Qu.warn("CPU budget exhausted, skipping remaining tasks", {
+Xu.warn("CPU budget exhausted, skipping remaining tasks", {
 subsystem: "Scheduler"
 });
 break;
@@ -46185,123 +46195,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new GT, (MT = {})[FIND_STRUCTURES] = {
+new LT, (AT = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, MT[FIND_MY_STRUCTURES] = {
+}, AT[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, MT[FIND_HOSTILE_STRUCTURES] = {
+}, AT[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, MT[FIND_SOURCES_ACTIVE] = {
+}, AT[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, MT[FIND_SOURCES] = {
+}, AT[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, MT[FIND_MINERALS] = {
+}, AT[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, MT[FIND_DEPOSITS] = {
+}, AT[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, MT[FIND_MY_CONSTRUCTION_SITES] = {
+}, AT[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, MT[FIND_CONSTRUCTION_SITES] = {
+}, AT[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, MT[FIND_CREEPS] = {
+}, AT[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, MT[FIND_MY_CREEPS] = {
+}, AT[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, MT[FIND_HOSTILE_CREEPS] = {
+}, AT[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, MT[FIND_DROPPED_RESOURCES] = {
+}, AT[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, MT[FIND_TOMBSTONES] = {
+}, AT[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, MT[FIND_RUINS] = {
+}, AT[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, MT[FIND_FLAGS] = {
+}, AT[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, MT[FIND_MY_SPAWNS] = {
+}, AT[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, MT[FIND_HOSTILE_SPAWNS] = {
+}, AT[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, MT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, AT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, MT[FIND_NUKES] = {
+}, AT[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, MT[FIND_POWER_CREEPS] = {
+}, AT[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, MT[FIND_MY_POWER_CREEPS] = {
+}, AT[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, MT[FIND_HOSTILE_POWER_CREEPS] = {
+}, AT[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, MT[FIND_EXIT_TOP] = {
+}, AT[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, MT[FIND_EXIT_RIGHT] = {
+}, AT[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, MT[FIND_EXIT_BOTTOM] = {
+}, AT[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, MT[FIND_EXIT_LEFT] = {
+}, AT[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, MT[FIND_EXIT] = {
+}, AT[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var LT = new pe({}, ft), DT = new Se({}, ft);
+var DT = new pe({}, ft), FT = new Se({}, ft);
 
-function FT(e) {
+function BT(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -46309,16 +46319,16 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var BT = !1;
+var WT = !1;
 
-function WT() {
+function HT() {
 var e, t;
-BT || (Nu({
-level: (t = Rt()).debug ? mu.DEBUG : mu.INFO,
+WT || (Pu({
+level: (t = Rt()).debug ? du.DEBUG : du.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
 maxBatchSize: 50
-}), Qu.info("Bot initialized", {
+}), Xu.info("Bot initialized", {
 subsystem: "SwarmBot",
 meta: {
 debug: t.debug,
@@ -46328,11 +46338,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Pv.getPendingTransfers = function(e) {
+r.getPendingTransfers && (Iv.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Pv.needsCarrier = function(e) {
+}), r.needsCarrier && (Iv.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Pv.getActiveRequests = function() {
+}), r.getActiveRequests && (Iv.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -46346,66 +46356,66 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Iv.predictConsumption = function(e) {
+a.predictConsumption && (Gv.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Iv.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (Gv.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Iv.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (Gv.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Iv.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (Gv.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (Gv.getActivePowerBanks = function() {
+i.getActivePowerBanks && (Lv.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (Gv.needsHarvesters = function(e) {
+}), i.needsHarvesters && (Lv.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (Gv.needsCarriers = function(e) {
+}), i.needsCarriers && (Lv.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (Gv.requestSpawns = function(e) {
+}), i.requestSpawns && (Lv.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-Lv.getEmergencyState = function(e) {
+Dv.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
-energyFlowPredictor: Jr,
-powerBankHarvestingManager: qc,
-resourceTransferCoordinator: Nf,
-emergencyResponseManager: fi,
-kernel: bi
+energyFlowPredictor: $r,
+powerBankHarvestingManager: jc,
+resourceTransferCoordinator: Pf,
+emergencyResponseManager: yi,
+kernel: Oi
 }), function(e) {
 var t, r, o, n;
-jd = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : qd.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : qd.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : qd.getLabOverflow
-} : qd;
+zd = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : jd.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : jd.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : jd.getLabOverflow
+} : jd;
 }({
 getLabResourceNeeds: function(e) {
-return Ru.getLabResourceNeeds(e);
+return Eu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return Ru.getLabResourceNeeds(e);
+return Eu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return Ru.getLabOverflow(e);
+return Eu.getLabOverflow(e);
 }
-}), qi.initialize(), t.profiling && (function() {
+}), ji.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) qE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) jE.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
 for (var e = [], r = 0; r < arguments.length; r++) e[r] = arguments[r];
-return qi.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
+return ji.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
 };
 r.__nativeCallsTrackerWrapped = !0, Object.defineProperty(PathFinder, "search", {
 value: r,
@@ -46414,7 +46424,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-qE.warn("Failed to wrap PathFinder.search", {
+jE.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -46422,11 +46432,11 @@ error: String(e)
 }
 }
 }
-}(), jE(e = Creep.prototype, "moveTo", "moveTo"), jE(e, "move", "move"), jE(e, "harvest", "harvest"),
-jE(e, "transfer", "transfer"), jE(e, "withdraw", "withdraw"), jE(e, "build", "build"),
-jE(e, "repair", "repair"), jE(e, "upgradeController", "upgradeController"), jE(e, "attack", "attack"),
-jE(e, "rangedAttack", "rangedAttack"), jE(e, "heal", "heal"), jE(e, "dismantle", "dismantle"),
-jE(e, "say", "say")), function(e) {
+}(), zE(e = Creep.prototype, "moveTo", "moveTo"), zE(e, "move", "move"), zE(e, "harvest", "harvest"),
+zE(e, "transfer", "transfer"), zE(e, "withdraw", "withdraw"), zE(e, "build", "build"),
+zE(e, "repair", "repair"), zE(e, "upgradeController", "upgradeController"), zE(e, "attack", "attack"),
+zE(e, "rangedAttack", "rangedAttack"), zE(e, "heal", "heal"), zE(e, "dismantle", "dismantle"),
+zE(e, "say", "say")), function(e) {
 void 0 === e && (e = Lt);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, kt.L1, {
@@ -46613,15 +46623,15 @@ room: e.homeRoom
 }), _.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(bi, ft, hy), PT.initializePathCacheEvents(), bT.initialize(Km.MEDIUM), Xl = kT,
-He.initialize(), FE.initialize(), BT = !0), ft.initialize();
-var r = HE.configureForCurrentTick();
-"critical" === r && Game.time % 10 == 0 && Qu.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
+}(Oi, ft, Ry), IT.initializePathCacheEvents(), OT.initialize(Ym.MEDIUM), Zl = MT,
+He.initialize(), BE.initialize(), WT = !0), ft.initialize();
+var r = KE.configureForCurrentTick();
+"critical" === r && Game.time % 10 == 0 && Xu.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = tT();
-if (!1 !== r.enabled && (r.lastRun = Game.time, nT(), function() {
-var e, t, r, o, n = rT(), a = n.footprintOperation, i = eT(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = rT();
+if (!1 !== r.enabled && (r.lastRun = Game.time, aT(), function() {
+var e, t, r, o, n = oT(), a = n.footprintOperation, i = tT(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -46634,15 +46644,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, oT(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, nT(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = tT();
+var e, t, r, n, i, s, c = rT();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : QE), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === XE ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : XE), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === ZE ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -46660,10 +46670,10 @@ d && Game.cpu.setShardLimits(m) === OK && _.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !aT())) try {
+}(), !iT())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || zf(s), "interShardPioneer" === c && jf(s);
+"interShardClaimer" !== c && "interShardScout" !== c || Qf(s), "interShardPioneer" === c && zf(s);
 }
 } catch (t) {
 e = {
@@ -46681,23 +46691,23 @@ var n = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
-if (0 === n) return Game.time % 100 == 0 && Qu.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
+if (0 === n) return Game.time % 100 == 0 && Xu.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), qi.publishIdleTick(), void Qu.flush();
-Game.time % 10 == 0 && Qu.info("SwarmBot loop executing at tick ".concat(Game.time), {
+}), ji.publishIdleTick(), void Xu.flush();
+Game.time % 10 == 0 && Xu.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: BT
+systemsInitialized: WT
 }
-}), HE.ensureProcessesRegistered(), qi.startTick(), tl.clear(), HE.startEventTick();
+}), KE.ensureProcessesRegistered(), ji.startTick(), rl.clear(), KE.startEventTick();
 var i = function(e) {
-var t = e.cache[KE], r = e.cache[YE];
+var t = e.cache[YE], r = e.cache[VE];
 if (t && r === e.tick) return t;
 var o = e.rooms().filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
-return e.cache[KE] = o, e.cache[YE] = e.tick, o;
+return e.cache[YE] = o, e.cache[VE] = e.tick, o;
 }({
 tick: Game.time,
 rooms: function() {
@@ -46705,7 +46715,7 @@ return Object.values(Game.rooms);
 },
 cache: global
 });
-qi.measureSubsystem("taskBoard", function() {
+ji.measureSubsystem("taskBoard", function() {
 var e, t, r = Rt(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
 try {
 for (var n = a(function(e) {
@@ -46719,7 +46729,7 @@ rooms: i,
 interval: o
 })), s = n.next(); !s.done; s = n.next()) {
 var c = s.value;
-jl.refreshRoom(c);
+zl.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -46732,20 +46742,20 @@ s && !s.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-}), qi.measureSubsystem("spawns", function() {
+}), ji.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = tT();
+var e, t, r, o = rT();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = nT();
+var n = aT();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : QE), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : XE), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== eT()) try {
+if (d !== tT()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = yf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = vf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -46763,20 +46773,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = iT().sort(function(e, t) {
+var i = sT().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : QE), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : XE), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== eT()) {
+if (u !== tT()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = cT(u);
+var m = uT(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? dT(i, l, m) : pT() ? lT(i, u, m) : (mT(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (uT(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? pT(i, l, m) : fT() ? mT(i, u, m) : (dT(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (lT(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -46793,8 +46803,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = rT();
-d.footprintOperation = n, oT(d);
+var d = oT();
+d.footprintOperation = n, nT(d);
 }
 }
 })(), function() {
@@ -46802,10 +46812,10 @@ var e, t, r, o = Game.cpu.bucket < Rt().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if (null === (r = s.controller) || void 0 === r ? void 0 : r.my) if (!o || FT(s)) {
-var c = bh(s, ft.getOrInitSwarmState(s.name));
-qi.recordSpawnQueue(s.name, c.stats, c.spawned), qi.recordDefenseAssist(s.name, c.defenseAssist);
-} else qi.recordDefenseAssist(s.name, []);
+if (null === (r = s.controller) || void 0 === r ? void 0 : r.my) if (!o || BT(s)) {
+var c = Oh(s, ft.getOrInitSwarmState(s.name));
+ji.recordSpawnQueue(s.name, c.stats, c.spawned), ji.recordDefenseAssist(s.name, c.defenseAssist);
+} else ji.recordDefenseAssist(s.name, []);
 }
 } catch (t) {
 e = {
@@ -46819,21 +46829,21 @@ if (e) throw e.error;
 }
 }
 }();
-}), ul.preTick(), qi.measureSubsystem("processSync", function() {
-ay.syncCreepProcesses(), iv.syncRoomProcesses();
-}), qi.measureSubsystem("kernel", function() {
-HE.runProcesses();
-}), qi.measureSubsystem("eventQueue", function() {
-HE.processQueuedEvents();
-}), qi.measureSubsystem("ss2PacketQueue", function() {
-Ah.processQueue();
-}), bi.hasCpuBudget() && qi.measureSubsystem("powerCreeps", function() {
+}), ll.preTick(), ji.measureSubsystem("processSync", function() {
+iy.syncCreepProcesses(), sv.syncRoomProcesses();
+}), ji.measureSubsystem("kernel", function() {
+KE.runProcesses();
+}), ji.measureSubsystem("eventQueue", function() {
+KE.processQueuedEvents();
+}), ji.measureSubsystem("ss2PacketQueue", function() {
+_h.processQueue();
+}), Oi.hasCpuBudget() && ji.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && Qf(n);
+void 0 !== n.ticksToLive && Xf(n);
 }
 } catch (t) {
 e = {
@@ -46847,18 +46857,18 @@ if (e) throw e.error;
 }
 }
 }();
-}), VE({
-hasCpuBudget: bi.hasCpuBudget(),
+}), qE({
+hasCpuBudget: Oi.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && qi.measureSubsystem("visualizations", function() {
+}) && ji.measureSubsystem("visualizations", function() {
 var e;
 !function(e, t) {
 var r, o;
 if (Rt().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = LT.getConfig(), s = DT.getConfig();
-LT.setConfig(n.roomVisualizerConfig), n.renderMap && DT.setConfig(n.mapVisualizerConfig);
+var i = DT.getConfig(), s = FT.getConfig();
+DT.setConfig(n.roomVisualizerConfig), n.renderMap && FT.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -46869,10 +46879,10 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-LT.draw(m);
+DT.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
-Qu.error("Visualization error in ".concat(m.name, ": ").concat(d), {
+Xu.error("Visualization error in ".concat(m.name, ": ").concat(d), {
 subsystem: "visualizations",
 room: m.name
 });
@@ -46891,19 +46901,19 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-DT.draw();
+FT.draw();
 } catch (e) {
-d = e instanceof Error ? e.message : String(e), Qu.error("Map visualization error: ".concat(d), {
+d = e instanceof Error ? e.message : String(e), Xu.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-LT.setConfig(i), DT.setConfig(s);
+DT.setConfig(i), FT.setConfig(s);
 }
 }
 }
 }(i, (e = {
-hasCpuBudget: bi.hasCpuBudget(),
+hasCpuBudget: Oi.hasCpuBudget(),
 bucketMode: r,
 bucket: Game.cpu.bucket,
 ownedRoomCount: i.length
@@ -46983,19 +46993,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), ul.reconcileTraffic(), VE({
-hasCpuBudget: bi.hasCpuBudget(),
+}), ll.reconcileTraffic(), qE({
+hasCpuBudget: Oi.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && qi.measureSubsystem("scheduledTasks", function() {
+}) && ji.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), ed.run(e);
-}), ft.persistHeapCache(), qi.collectProcessStats(bi.getProcesses().reduce(function(e, t) {
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), td.run(e);
+}), ft.persistHeapCache(), ji.collectProcessStats(Oi.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
-}, new Map)), qi.collectKernelBudgetStats(bi), qi.setSkippedProcesses(bi.getSkippedProcessesThisTick()),
-qi.finalizeTick(), Qu.flush();
+}, new Map)), ji.collectKernelBudgetStats(Oi), ji.setSkippedProcesses(Oi.getSkippedProcessesThisTick()),
+ji.finalizeTick(), Xu.flush();
 }
 
-var HT = function() {
+var KT = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Rt().visualizations;
@@ -47003,15 +47013,6 @@ return Et({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = LT.getConfig(), r = Object.keys(t).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof t[e];
-});
-if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
-var o = e;
-LT.toggle(o);
-var n = LT.getConfig()[o];
-return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t = DT.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
@@ -47019,9 +47020,18 @@ if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.
 var o = e;
 DT.toggle(o);
 var n = DT.getConfig()[o];
+return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t = FT.getConfig(), r = Object.keys(t).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof t[e];
+});
+if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
+var o = e;
+FT.toggle(o);
+var n = FT.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = DT.getConfig();
+var e = FT.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -47089,70 +47099,70 @@ if (t) throw t.error;
 return n;
 }, e.prototype.clearVisCache = function(e) {
 return f.clearCache(e), e ? "Visualization cache cleared for room: ".concat(e) : "All visualization caches cleared";
-}, n([ jr({
+}, n([ zr({
 name: "toggleVisualizations",
 description: "Toggle all visualizations on/off",
 usage: "toggleVisualizations()",
 examples: [ "toggleVisualizations()" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualizations", null), n([ jr({
+}) ], e.prototype, "toggleVisualizations", null), n([ zr({
 name: "toggleVisualization",
 description: "Toggle a specific room visualization feature",
 usage: "toggleVisualization(key)",
 examples: [ "toggleVisualization('showPheromones')", "toggleVisualization('showPaths')", "toggleVisualization('showCombat')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualization", null), n([ jr({
+}) ], e.prototype, "toggleVisualization", null), n([ zr({
 name: "toggleMapVisualization",
 description: "Toggle a specific map visualization feature",
 usage: "toggleMapVisualization(key)",
 examples: [ "toggleMapVisualization('showRoomStatus')", "toggleMapVisualization('showConnections')", "toggleMapVisualization('showThreats')", "toggleMapVisualization('showExpansion')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleMapVisualization", null), n([ jr({
+}) ], e.prototype, "toggleMapVisualization", null), n([ zr({
 name: "showMapConfig",
 description: "Show current map visualization configuration",
 usage: "showMapConfig()",
 examples: [ "showMapConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showMapConfig", null), n([ jr({
+}) ], e.prototype, "showMapConfig", null), n([ zr({
 name: "setVisMode",
 description: "Set visualization mode preset (debug, presentation, minimal, performance)",
 usage: "setVisMode(mode)",
 examples: [ "setVisMode('debug')", "setVisMode('presentation')", "setVisMode('minimal')", "setVisMode('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "setVisMode", null), n([ jr({
+}) ], e.prototype, "setVisMode", null), n([ zr({
 name: "toggleVisLayer",
 description: "Toggle a specific visualization layer",
 usage: "toggleVisLayer(layer)",
 examples: [ "toggleVisLayer('pheromones')", "toggleVisLayer('paths')", "toggleVisLayer('defense')", "toggleVisLayer('economy')", "toggleVisLayer('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisLayer", null), n([ jr({
+}) ], e.prototype, "toggleVisLayer", null), n([ zr({
 name: "showVisPerf",
 description: "Show visualization performance metrics",
 usage: "showVisPerf()",
 examples: [ "showVisPerf()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisPerf", null), n([ jr({
+}) ], e.prototype, "showVisPerf", null), n([ zr({
 name: "showVisConfig",
 description: "Show current visualization configuration",
 usage: "showVisConfig()",
 examples: [ "showVisConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisConfig", null), n([ jr({
+}) ], e.prototype, "showVisConfig", null), n([ zr({
 name: "clearVisCache",
 description: "Clear visualization cache",
 usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), KT = function() {
+}(), YT = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = FE.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = BE.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = FE.getAllShards();
+var e, t, r = BE.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -47174,9 +47184,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (FE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (BE.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = FE.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = BE.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -47201,19 +47211,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = FE.getOptimalPortalRoute(e, t);
+var r, o = BE.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (FE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (BE.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (FE.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (BE.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Nf.getActiveRequests();
+var e, t, r = Pf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -47234,7 +47244,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = FE.getCurrentShardState();
+var e, t, r = BE.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -47255,7 +47265,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = FE.getActiveTransferTasks();
+var e, t, r, o = BE.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -47276,16 +47286,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = FE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(hf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = BE.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Rf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = FE.getMemoryStats();
+var e = BE.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return FE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return BE.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = rT().footprintOperation;
+var e, t, r, o = oT().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -47306,94 +47316,94 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }();
-}, n([ jr({
+}, n([ zr({
 name: "shard.status",
 description: "Display current shard status and metrics",
 usage: "shard.status()",
 examples: [ "shard.status()" ],
 category: "Shard"
-}) ], e.prototype, "status", null), n([ jr({
+}) ], e.prototype, "status", null), n([ zr({
 name: "shard.all",
 description: "List all known shards with summary info",
 usage: "shard.all()",
 examples: [ "shard.all()" ],
 category: "Shard"
-}) ], e.prototype, "all", null), n([ jr({
+}) ], e.prototype, "all", null), n([ zr({
 name: "shard.setRole",
 description: "Manually set the role for the current shard",
 usage: "shard.setRole(role)",
 examples: [ "shard.setRole('core')", "shard.setRole('frontier')", "shard.setRole('resource')", "shard.setRole('backup')", "shard.setRole('war')" ],
 category: "Shard"
-}) ], e.prototype, "setRole", null), n([ jr({
+}) ], e.prototype, "setRole", null), n([ zr({
 name: "shard.portals",
 description: "List all known portals from the current shard",
 usage: "shard.portals(targetShard?)",
 examples: [ "shard.portals()", "shard.portals('shard1')" ],
 category: "Shard"
-}) ], e.prototype, "portals", null), n([ jr({
+}) ], e.prototype, "portals", null), n([ zr({
 name: "shard.bestPortal",
 description: "Find the optimal portal route to a target shard",
 usage: "shard.bestPortal(targetShard, fromRoom?)",
 examples: [ "shard.bestPortal('shard1')", "shard.bestPortal('shard2', 'E1N1')" ],
 category: "Shard"
-}) ], e.prototype, "bestPortal", null), n([ jr({
+}) ], e.prototype, "bestPortal", null), n([ zr({
 name: "shard.createTask",
 description: "Create a cross-shard task",
 usage: "shard.createTask(type, targetShard, targetRoom?, priority?)",
 examples: [ "shard.createTask('colonize', 'shard1', 'E5N5', 80)", "shard.createTask('reinforce', 'shard2', 'W1N1', 90)", "shard.createTask('evacuate', 'shard0', 'E1N1', 100)" ],
 category: "Shard"
-}) ], e.prototype, "createTask", null), n([ jr({
+}) ], e.prototype, "createTask", null), n([ zr({
 name: "shard.transferResource",
 description: "Create a cross-shard resource transfer task",
 usage: "shard.transferResource(targetShard, targetRoom, resourceType, amount, priority?)",
 examples: [ "shard.transferResource('shard1', 'E5N5', 'energy', 50000, 70)", "shard.transferResource('shard2', 'W1N1', 'U', 5000, 80)" ],
 category: "Shard"
-}) ], e.prototype, "transferResource", null), n([ jr({
+}) ], e.prototype, "transferResource", null), n([ zr({
 name: "shard.transfers",
 description: "List active cross-shard resource transfers",
 usage: "shard.transfers()",
 examples: [ "shard.transfers()" ],
 category: "Shard"
-}) ], e.prototype, "transfers", null), n([ jr({
+}) ], e.prototype, "transfers", null), n([ zr({
 name: "shard.cpuHistory",
 description: "Display CPU allocation history for the current shard",
 usage: "shard.cpuHistory()",
 examples: [ "shard.cpuHistory()" ],
 category: "Shard"
-}) ], e.prototype, "cpuHistory", null), n([ jr({
+}) ], e.prototype, "cpuHistory", null), n([ zr({
 name: "shard.tasks",
 description: "List all inter-shard tasks",
 usage: "shard.tasks()",
 examples: [ "shard.tasks()" ],
 category: "Shard"
-}) ], e.prototype, "tasks", null), n([ jr({
+}) ], e.prototype, "tasks", null), n([ zr({
 name: "shard.syncStatus",
 description: "Display InterShardMemory sync status and health",
 usage: "shard.syncStatus()",
 examples: [ "shard.syncStatus()" ],
 category: "Shard"
-}) ], e.prototype, "syncStatus", null), n([ jr({
+}) ], e.prototype, "syncStatus", null), n([ zr({
 name: "shard.memoryStats",
 description: "Display InterShardMemory size breakdown",
 usage: "shard.memoryStats()",
 examples: [ "shard.memoryStats()" ],
 category: "Shard"
-}) ], e.prototype, "memoryStats", null), n([ jr({
+}) ], e.prototype, "memoryStats", null), n([ zr({
 name: "shard.forceSync",
 description: "Force a full InterShardMemory sync with validation",
 usage: "shard.forceSync()",
 examples: [ "shard.forceSync()" ],
 category: "Shard"
-}) ], e.prototype, "forceSync", null), n([ jr({
+}) ], e.prototype, "forceSync", null), n([ zr({
 name: "shard.footprint",
 description: "Display peaceful all-shard footprint/colonization operation status",
 usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), YT = new KT;
+}(), VT = new YT;
 
-function VT(e) {
+function qT(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -47414,7 +47424,7 @@ desc: "Parameter: ".concat(e)
 function e() {}
 e.prototype.uiHelp = function(e) {
 return e ? function(e) {
-var t = qr.getCommandsByCategory(), r = t.get(e);
+var t = jr.getCommandsByCategory(), r = t.get(e);
 if (!r || 0 === r.length) return 'Category "'.concat(e, '" not found. Available categories: ').concat(Array.from(t.keys()).join(", "));
 var o = r.map(function(e) {
 var t, r;
@@ -47423,16 +47433,16 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? VT(e.metadata.usage) : void 0
+params: e.metadata.usage ? qT(e.metadata.usage) : void 0
 };
 });
-return ud({
+return ld({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
 });
 }(e) : function() {
-var e, t, r = qr.getCommandsByCategory(), o = [];
+var e, t, r = jr.getCommandsByCategory(), o = [];
 try {
 for (var n = a(r), c = n.next(); !c.done; c = n.next()) {
 var u = i(c.value, 2), l = u[0], m = u[1].map(function(e) {
@@ -47477,12 +47487,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return ud.apply(void 0, s([], i(o), !1));
+return ld.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return id("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return sd("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return cd.form("spawnCreep", [ {
+return ud.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -47516,20 +47526,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return id("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return sd("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += id("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += id("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += cd.button({
+o += '<div style="margin-bottom: 10px;">', o += sd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += sd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += ud.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += cd.button({
+}), o += " ", (o += ud.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return cd.form("configureLogging", [ {
+return ud.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -47554,7 +47564,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return cd.form("configureVisualization", [ {
+return ud.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -47578,55 +47588,55 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += cd.button({
+e += ud.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += cd.button({
+}), e += " ", (e += ud.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += id("✓ Success message", "green", !0) + "\n", e += id("⚠ Warning message", "yellow", !0) + "\n",
-e += id("✗ Error message", "red", !0) + "\n", e += id("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + id("colored text", "green") + " normal text\n") + "Bold text: " + id("important", null, !0) + "\n";
-}, n([ jr({
+return e += sd("✓ Success message", "green", !0) + "\n", e += sd("⚠ Warning message", "yellow", !0) + "\n",
+e += sd("✗ Error message", "red", !0) + "\n", e += sd("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + sd("colored text", "green") + " normal text\n") + "Bold text: " + sd("important", null, !0) + "\n";
+}, n([ zr({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
 usage: "uiHelp()",
 examples: [ "uiHelp()", 'uiHelp("Logging")', 'uiHelp("Visualization")' ],
 category: "System"
-}) ], e.prototype, "uiHelp", null), n([ jr({
+}) ], e.prototype, "uiHelp", null), n([ zr({
 name: "spawnForm",
 description: "Show interactive form for spawning creeps",
 usage: "spawnForm(roomName)",
 examples: [ 'spawnForm("W1N1")', 'spawnForm("E2S3")' ],
 category: "Spawning"
-}) ], e.prototype, "spawnForm", null), n([ jr({
+}) ], e.prototype, "spawnForm", null), n([ zr({
 name: "roomControl",
 description: "Show interactive room control panel",
 usage: "roomControl(roomName)",
 examples: [ 'roomControl("W1N1")' ],
 category: "Room Management"
-}) ], e.prototype, "roomControl", null), n([ jr({
+}) ], e.prototype, "roomControl", null), n([ zr({
 name: "logForm",
 description: "Show interactive form for configuring logging",
 usage: "logForm()",
 examples: [ "logForm()" ],
 category: "Logging"
-}) ], e.prototype, "logForm", null), n([ jr({
+}) ], e.prototype, "logForm", null), n([ zr({
 name: "visForm",
 description: "Show interactive form for visualization settings",
 usage: "visForm()",
 examples: [ "visForm()" ],
 category: "Visualization"
-}) ], e.prototype, "visForm", null), n([ jr({
+}) ], e.prototype, "visForm", null), n([ zr({
 name: "quickActions",
 description: "Show quick action buttons for common operations",
 usage: "quickActions()",
 examples: [ "quickActions()" ],
 category: "System"
-}) ], e.prototype, "quickActions", null), n([ jr({
+}) ], e.prototype, "quickActions", null), n([ zr({
 name: "colorDemo",
 description: "Show color demonstration for console output",
 usage: "colorDemo()",
@@ -47635,39 +47645,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var qT = new cv, jT = new HT, zT = new uv, QT = new Xu, XT = new sv, ZT = new lv, JT = new mv, $T = "__screepsGlobalRuntimeDiagnostics";
+var jT = new uv, zT = new KT, QT = new lv, XT = new Zu, ZT = new cv, JT = new mv, $T = new dv, eC = "__screepsGlobalRuntimeDiagnostics";
 
-function eC() {
+function tC() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function tC(e, t) {
+function rC(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function rC(e, t) {
+function oC(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function oC(e) {
+function nC(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function nC(e) {
+function aC(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: tC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: tC(n.switchCount, 0),
-lastTick: rC(n.lastTick, Game.time),
-lastResetTick: rC(n.lastResetTick, Game.time),
-lastSwitchTick: oC(n.lastSwitchTick),
-lastSwitchPreviousTick: oC(n.lastSwitchPreviousTick),
-lastWarningTick: oC(n.lastWarningTick)
+resetCount: rC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: rC(n.switchCount, 0),
+lastTick: oC(n.lastTick, Game.time),
+lastResetTick: oC(n.lastResetTick, Game.time),
+lastSwitchTick: nC(n.lastSwitchTick),
+lastSwitchPreviousTick: nC(n.lastSwitchPreviousTick),
+lastWarningTick: nC(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -47681,33 +47691,33 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var aC = ju("Main");
+var iC = zu("Main");
 
 vt.register(), function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-qr.initialize(), zr(qT), zr(jT), zr(zT), zr(QT), zr(XT), zr(ZT), zr(JT), zr(Su),
-zr(wu), zr(xu), zr(YT), zr(eo), zr(fc), zr(Kc), global.tooangel = Wc;
+jr.initialize(), Qr(jT), Qr(zT), Qr(QT), Qr(XT), Qr(ZT), Qr(JT), Qr($T), Qr(wu),
+Qr(xu), Qr(bu), Qr(VT), Qr(to), Qr(yc), Qr(Yc), global.tooangel = Hc;
 var e = global;
 e.botConfig = {
 getConfig: Rt,
 updateConfig: Et
 }, e.botLogger = {
-configureLogger: Nu
-}, e.botVisualizationManager = f, e.botCacheManager = bt, qr.exposeToGlobal();
+configureLogger: Pu
+}, e.botVisualizationManager = f, e.botCacheManager = bt, jr.exposeToGlobal();
 };
-e ? (qr.initialize(), qr.enableLazyLoading(t), qr.exposeToGlobal()) : t();
+e ? (jr.initialize(), jr.enableLazyLoading(t), jr.exposeToGlobal()) : t();
 }(Rt().lazyLoadConsoleCommands), exports.loop = function() {
 try {
 vt.run(), function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : eC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[$T];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : tC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[eC];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[$T] = s, function(e, t) {
-var r, o = nC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[eC] = s, function(e, t) {
+var r, o = aC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -47725,7 +47735,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = nC(e.heapId);
+var n, a = aC(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -47746,14 +47756,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = nC(s.heapId);
+var u = aC(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 }({
-logger: aC
-}), WT();
+logger: iC
+}), HT();
 } catch (e) {
-throw aC.error("Critical error in main loop: ".concat(String(e)), {
+throw iC.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-economy/package.json
+++ b/packages/screeps-economy/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
-    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-memory --if-present",
+    "prebuild": "npm run build -w @ralphschuler/screeps-core -w @ralphschuler/screeps-kernel -w @ralphschuler/screeps-cache -w @ralphschuler/screeps-memory --if-present",
     "build": "tsc",
     "test": "mocha test/**/*.test.ts",
     "test:watch": "mocha --watch test/**/*.test.ts",
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/ralphschuler/screeps/tree/main/packages/screeps-economy#readme",
   "dependencies": {
+    "@ralphschuler/screeps-cache": "*",
     "@ralphschuler/screeps-core": "*",
     "@ralphschuler/screeps-kernel": "*",
     "@ralphschuler/screeps-memory": "*",

--- a/packages/screeps-economy/src/factories/factoryManager.ts
+++ b/packages/screeps-economy/src/factories/factoryManager.ts
@@ -11,6 +11,7 @@
  * Addresses Issue: Factory automation missing
  */
 
+import { getOwnedRooms } from "@ralphschuler/screeps-cache";
 import { logger } from "@ralphschuler/screeps-core";
 import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 
@@ -102,9 +103,8 @@ export class FactoryManager {
     }
 
     // Process all rooms with factories
-    const roomsWithFactories = Object.values(Game.rooms).filter(r => {
-      if (!r.controller?.my) return false;
-      const factories = r.find(FIND_MY_STRUCTURES, {
+    const roomsWithFactories = getOwnedRooms().filter(room => {
+      const factories = room.find(FIND_MY_STRUCTURES, {
         filter: s => s.structureType === STRUCTURE_FACTORY
       });
       return factories.length > 0;

--- a/packages/screeps-economy/src/links/linkManager.ts
+++ b/packages/screeps-economy/src/links/linkManager.ts
@@ -15,6 +15,7 @@
  * - Each link has 800 energy capacity and cooldown after transfer
  */
 
+import { getOwnedRooms } from "@ralphschuler/screeps-cache";
 import { logger } from "@ralphschuler/screeps-core";
 import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 
@@ -92,8 +93,8 @@ export class LinkManager {
     }
 
     // Process links in all owned rooms with RCL >= 5
-    const roomsWithLinks = Object.values(Game.rooms).filter(
-      r => r.controller?.my && r.controller.level >= 5
+    const roomsWithLinks = getOwnedRooms().filter(
+      room => (room.controller?.level ?? 0) >= 5
     );
 
     for (const room of roomsWithLinks) {

--- a/packages/screeps-economy/src/market/marketManager.ts
+++ b/packages/screeps-economy/src/market/marketManager.ts
@@ -27,6 +27,7 @@
  * Verify trading decisions are made correctly based on price data
  */
 
+import { getOwnedRooms as getCachedOwnedRooms } from "@ralphschuler/screeps-cache";
 import { createDefaultMarketMemory, memoryManager } from "@ralphschuler/screeps-memory";
 import type { EmpireMemory, PendingArbitrageTrade, PriceDataPoint, ResourceMarketData } from "@ralphschuler/screeps-memory";
 import { logger } from "@ralphschuler/screeps-core";
@@ -337,7 +338,7 @@ export class MarketManager {
   private getOwnedRooms(): Room[] {
     this.ensureTickCaches();
     if (!this.cachedOwnedRooms) {
-      this.cachedOwnedRooms = Object.values(Game.rooms).filter(room => room.controller?.my);
+      this.cachedOwnedRooms = getCachedOwnedRooms();
     }
     return this.cachedOwnedRooms;
   }

--- a/packages/screeps-economy/src/terminals/terminalManager.ts
+++ b/packages/screeps-economy/src/terminals/terminalManager.ts
@@ -18,6 +18,7 @@
  * - Market integration for surplus/deficit handling
  */
 
+import { getOwnedRooms } from "@ralphschuler/screeps-cache";
 import { logger } from "@ralphschuler/screeps-core";
 import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 import { memoryManager } from "@ralphschuler/screeps-memory";
@@ -171,8 +172,8 @@ export class TerminalManager {
     }
 
     // Process terminals in all owned rooms
-    const roomsWithTerminals = Object.values(Game.rooms).filter(
-      r => r.controller?.my && r.terminal && r.terminal.my && r.terminal.isActive()
+    const roomsWithTerminals = getOwnedRooms().filter(
+      room => room.terminal && room.terminal.my && room.terminal.isActive()
     );
 
     if (roomsWithTerminals.length === 0) {

--- a/packages/screeps-economy/test/FactoryManager.test.ts
+++ b/packages/screeps-economy/test/FactoryManager.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { clearGameObjectCache } from "@ralphschuler/screeps-cache";
 import { FactoryManager } from "../src/factories/factoryManager";
 
 type StoreContents = Partial<Record<ResourceConstant, number>>;
@@ -50,6 +51,7 @@ function createRoomWithFactory(
 }
 
 function runFactory(factoryContents: StoreContents, storageContents: StoreContents): CommodityConstant[] {
+  clearGameObjectCache();
   const produced: CommodityConstant[] = [];
   const room = createRoomWithFactory(
     createStore(factoryContents),
@@ -68,6 +70,7 @@ function runFactory(factoryContents: StoreContents, storageContents: StoreConten
 
 describe("FactoryManager", () => {
   beforeEach(() => {
+    clearGameObjectCache();
     (global as any).Game = {
       ...Game,
       cpu: { ...Game.cpu, bucket: 10000 },

--- a/packages/screeps-economy/test/LinkManager.test.ts
+++ b/packages/screeps-economy/test/LinkManager.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { expect } from 'chai';
+import { clearGameObjectCache } from '@ralphschuler/screeps-cache';
 import { LinkManager } from '../src/links/linkManager';
 
 function store(used: number, capacity = 800) {
@@ -60,8 +61,10 @@ describe('LinkManager', () => {
   let linkManager: LinkManager;
 
   beforeEach(() => {
+    clearGameObjectCache();
     linkManager = new LinkManager();
     (global as any).Game.cpu.bucket = 10000;
+    (global as any).Game.rooms = {};
   });
 
   describe('construction', () => {
@@ -118,6 +121,18 @@ describe('LinkManager', () => {
   });
 
   describe('energy transfer logic', () => {
+    it('should process owned RCL5 rooms from the framework room cache', () => {
+      const sourceLink = link('sourceLink', 500, { source: 1 });
+      const controllerLink = link('controllerLink', 0, { controller: 1 });
+      const storageLink = link('storageLink', 500, { storage: 1 });
+      const room = roomWithLinks({ energyAvailable: 800, links: [sourceLink, controllerLink, storageLink] });
+      (Game.rooms as Record<string, Room>).W1N1 = room;
+
+      linkManager.run();
+
+      expect(sourceLink.calls).to.deep.equal([{ target: 'controllerLink', amount: 500 }]);
+    });
+
     it('should transfer from source link to controller link by default', () => {
       const sourceLink = link('sourceLink', 500, { source: 1 });
       const controllerLink = link('controllerLink', 0, { controller: 1 });

--- a/packages/screeps-economy/test/MarketManager.test.ts
+++ b/packages/screeps-economy/test/MarketManager.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { clearGameObjectCache } from "@ralphschuler/screeps-cache";
 import { MarketManager } from "../src/market/marketManager";
 
 function createStore(contents: Partial<Record<ResourceConstant, number>>, capacity = 100000): StoreDefinition {
@@ -74,7 +75,10 @@ function getEmpireMarket(): any {
 }
 
 describe("MarketManager", () => {
-  beforeEach(() => setupGame());
+  beforeEach(() => {
+    setupGame();
+    clearGameObjectCache();
+  });
 
   it("counts storage plus terminal resources before creating buy orders", () => {
     let createOrderCount = 0;

--- a/packages/screeps-economy/test/TerminalManager.test.ts
+++ b/packages/screeps-economy/test/TerminalManager.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { clearGameObjectCache, getGameObjectCacheStats } from "@ralphschuler/screeps-cache";
 import { TerminalManager } from "../src/terminals/terminalManager";
 import { marketManager } from "../src/market/marketManager";
 
@@ -15,6 +16,13 @@ function createStore(contents: Partial<Record<ResourceConstant, number>>, capaci
     },
     getCapacity: () => capacity
   } as unknown as StoreDefinition;
+}
+
+function createOwnedRoom(name: string): Room {
+  return {
+    name,
+    controller: { my: true, level: 8 }
+  } as unknown as Room;
 }
 
 function createRoom(name: string, terminalStore: StoreDefinition, send?: StructureTerminal["send"]): Room {
@@ -36,6 +44,7 @@ function createRoom(name: string, terminalStore: StoreDefinition, send?: Structu
 
 describe("TerminalManager", () => {
   beforeEach(() => {
+    clearGameObjectCache();
     (global as any).Memory = { rooms: {}, creeps: {}, spawns: {}, flags: {}, powerCreeps: {}, clusters: {}, empire: undefined };
     (global as any).Game = {
       time: 20,
@@ -46,6 +55,25 @@ describe("TerminalManager", () => {
         calcTransactionCost: () => 100
       }
     };
+  });
+
+  it("shares the framework owned-room snapshot within a tick and refreshes next tick", () => {
+    const manager = new TerminalManager({ minBucket: 0 });
+    (Game.rooms as Record<string, Room>).W1N1 = createOwnedRoom("W1N1");
+
+    manager.run();
+
+    expect(getGameObjectCacheStats()).to.include({ hits: 0, misses: 1, size: 1 });
+
+    (Game.rooms as Record<string, Room>).W2N2 = createOwnedRoom("W2N2");
+    manager.run();
+
+    expect(getGameObjectCacheStats()).to.include({ hits: 1, misses: 1, size: 1 });
+
+    Game.time += 1;
+    manager.run();
+
+    expect(getGameObjectCacheStats()).to.include({ hits: 1, misses: 2, size: 1 });
   });
 
   it("runs terminal capacity clearing even with one owned terminal", () => {


### PR DESCRIPTION
## Summary
- Reuses the framework `GameObjectCache` owned-room helper in economy managers instead of direct `Object.values(Game.rooms)` owned-room scans.

## Linked issue
Refs #3176

## Changes
- Added `@ralphschuler/screeps-cache` as an explicit economy package dependency and prebuild input.
- Updated market, terminal, factory, and link managers to enumerate owned rooms through `getOwnedRooms()`.
- Added economy regression coverage for framework owned-room cache same-tick reuse/tick invalidation and LinkManager run-level owned-room processing.
- Refreshed the tracked Screeps bot bundle.

## Validation
- ✅ `npm run test:economy` (73 passing)
- ✅ `npm run lint:economy`
- ✅ `npm run build:economy`
- ✅ `npm run build:bot`
- ✅ `npm run sync:deps:check`
- ✅ `npm run check-versions`
- ✅ `npm run check:no-deep-dist-imports`
- ✅ `npm run check:alliance-safety`
- ✅ `npm run check:bot-bundle-drift` after commit
- ✅ `git diff --check`

## Deployment impact
- Runtime CPU-positive change: economy processes share the framework same-tick owned-room cache.
- Screeps.com deploy path remains `npm run push`; bundle rebuilt in `packages/screeps-bot/dist/main.js`.

## Scope notes
- This is a focused #3176 stage and does not close the broad issue.
- Remaining direct room scans outside economy (bot/visuals/expansion/etc.) are left for later stages under the existing issue.
