### PR TITLE
[codex] Scale defense refuel for hard assists

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -38752,12 +38752,14 @@ minCapacity: 100
 
 function eh(e, t) {
 if ("hauler" !== t) return null;
-var r, o, n = Game.rooms[e];
-return n && function(e) {
+var r = Game.rooms[e];
+if (!r || !function(e) {
 var t;
 return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < $g.cost);
-}(n) ? gg(n) >= 200 ? null : function(e) {
-return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).some(function(t) {
+}(r)) return null;
+if (gg(r) >= 200) return null;
+var o, n, i = function(e) {
+return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
 if ((null !== (r = t.urgency) && void 0 !== r ? r : 1) < 2) return !1;
@@ -38766,15 +38768,56 @@ var n = Game.rooms[t.roomName];
 return Boolean(n && X(n).length > 0);
 });
 var t;
-}(e) && (0 === (o = (r = n).find(FIND_SOURCES)).length ? 0 : r.find(FIND_STRUCTURES, {
+}(e);
+if (0 === i.length) return null;
+if (!((0 === (n = (o = r).find(FIND_SOURCES)).length ? 0 : o.find(FIND_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_CONTAINER && o.some(function(t) {
+return e.structureType === STRUCTURE_CONTAINER && n.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
 }
 }).reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0)) >= 100 ? function(e) {
+}, 0)) >= 100)) return null;
+var s = i.some(function(e) {
+var t, r, o;
+return (null !== (t = e.urgency) && void 0 !== t ? t : 1) >= 3 && ((null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0) > 0 || (null !== (o = e.healersNeeded) && void 0 !== o ? o : 0) > 0);
+}), c = s ? function(e) {
+var t, r, o, n, i, s = 0;
+try {
+for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
+var l = u.value.memory;
+"hauler" === l.role && l.homeRoom === e && l.task === Jg && s++;
+}
+} catch (e) {
+t = {
+error: e
+};
+} finally {
+try {
+u && !u.done && (r = c.return) && r.call(c);
+} finally {
+if (t) throw t.error;
+}
+}
+try {
+for (var m = a(Gv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
+"hauler" === p.role && f === Jg && s++;
+}
+} catch (e) {
+o = {
+error: e
+};
+} finally {
+try {
+d && !d.done && (n = m.return) && n.call(m);
+} finally {
+if (o) throw o.error;
+}
+}
+return s;
+}(e) : function(e) {
 var t, r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -38809,11 +38852,12 @@ if (o) throw o.error;
 }
 }
 return s;
-}(e) >= 2 ? null : {
+}(e);
+return c >= (s ? 4 : 2) ? null : {
 task: Jg,
 priority: Tv.EMERGENCY,
 body: $g
-} : null : null;
+};
 }
 
 function th(e) {

--- a/packages/screeps-spawn/src/spawn-demand/defenseRefuelDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseRefuelDemand.ts
@@ -9,6 +9,7 @@ const DEFENSE_REFUEL_REQUEST_TTL = 500;
 const DEFENSE_REFUEL_ENERGY_THRESHOLD = 200;
 const DEFENSE_REFUEL_SOURCE_CONTAINER_MIN = 100;
 const DEFENSE_REFUEL_MAX_LOCAL_HAULERS = 2;
+const DEFENSE_REFUEL_MAX_HARD_ASSIST_HAULERS = 4;
 
 const MIN_DEFENSE_REFUEL_BODY: BodyTemplate = {
   parts: [CARRY, MOVE],
@@ -18,6 +19,9 @@ const MIN_DEFENSE_REFUEL_BODY: BodyTemplate = {
 
 interface DefenseAssistRequestMemory {
   roomName: string;
+  guardsNeeded?: number;
+  rangersNeeded?: number;
+  healersNeeded?: number;
   urgency?: number;
   createdAt?: number;
 }
@@ -37,8 +41,8 @@ function getDefenseRequests(): DefenseAssistRequestMemory[] {
   return Array.isArray(requests) ? requests : Object.values(requests ?? {});
 }
 
-function hasVisibleEmergencyDefenseRequest(homeRoom: string): boolean {
-  return getDefenseRequests().some(request => {
+function getVisibleEmergencyDefenseRequests(homeRoom: string): DefenseAssistRequestMemory[] {
+  return getDefenseRequests().filter(request => {
     if (!request || request.roomName === homeRoom) return false;
     if ((request.urgency ?? 1) < 2) return false;
     if (Game.time - (request.createdAt ?? Game.time) > DEFENSE_REFUEL_REQUEST_TTL) return false;
@@ -46,6 +50,12 @@ function hasVisibleEmergencyDefenseRequest(homeRoom: string): boolean {
     const targetRoom = Game.rooms[request.roomName];
     return Boolean(targetRoom && getActualHostileCreeps(targetRoom).length > 0);
   });
+}
+
+function needsScaledDefenseRefuel(requests: DefenseAssistRequestMemory[]): boolean {
+  return requests.some(request =>
+    (request.urgency ?? 1) >= 3 && ((request.rangersNeeded ?? 0) > 0 || (request.healersNeeded ?? 0) > 0)
+  );
 }
 
 function findSourceContainerEnergy(room: Room): number {
@@ -65,6 +75,22 @@ function countLocalHaulersAndQueuedRefuelers(homeRoom: string): number {
   for (const creep of Object.values(Game.creeps)) {
     const memory = creep.memory as unknown as Partial<SwarmCreepMemory>;
     if (memory.role === "hauler" && memory.homeRoom === homeRoom) count++;
+  }
+
+  for (const request of spawnQueue.getPendingRequests(homeRoom)) {
+    const task = (request.additionalMemory as { task?: string } | undefined)?.task;
+    if (request.role === "hauler" && task === DEFENSE_REFUEL_TASK) count++;
+  }
+
+  return count;
+}
+
+function countDedicatedDefenseRefuelers(homeRoom: string): number {
+  let count = 0;
+
+  for (const creep of Object.values(Game.creeps)) {
+    const memory = creep.memory as unknown as Partial<SwarmCreepMemory>;
+    if (memory.role === "hauler" && memory.homeRoom === homeRoom && memory.task === DEFENSE_REFUEL_TASK) count++;
   }
 
   for (const request of spawnQueue.getPendingRequests(homeRoom)) {
@@ -100,9 +126,16 @@ export function getDefenseRefuelSpawnAssignment(homeRoom: string, role: string):
   const home = Game.rooms[homeRoom];
   if (!home || !canSpawnLocalRefueler(home)) return null;
   if (getEffectiveRoomEnergyAvailable(home) >= DEFENSE_REFUEL_ENERGY_THRESHOLD) return null;
-  if (!hasVisibleEmergencyDefenseRequest(homeRoom)) return null;
+  const emergencyRequests = getVisibleEmergencyDefenseRequests(homeRoom);
+  if (emergencyRequests.length === 0) return null;
   if (!canRefuelFromLocalSourceContainers(home)) return null;
-  if (countLocalHaulersAndQueuedRefuelers(homeRoom) >= DEFENSE_REFUEL_MAX_LOCAL_HAULERS) return null;
+
+  const scaleDedicatedRefuel = needsScaledDefenseRefuel(emergencyRequests);
+  const refuelerCount = scaleDedicatedRefuel
+    ? countDedicatedDefenseRefuelers(homeRoom)
+    : countLocalHaulersAndQueuedRefuelers(homeRoom);
+  const maxRefuelers = scaleDedicatedRefuel ? DEFENSE_REFUEL_MAX_HARD_ASSIST_HAULERS : DEFENSE_REFUEL_MAX_LOCAL_HAULERS;
+  if (refuelerCount >= maxRefuelers) return null;
 
   return {
     task: DEFENSE_REFUEL_TASK,

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -1102,6 +1102,95 @@ describe("defense spawn throttling", () => {
     if (firstAssistIndex >= 0) assert.isBelow(refuelIndex, firstAssistIndex);
   });
 
+  it("scales dedicated defense refuelers when ranged/healer assists are still energy-blocked", () => {
+    const helper = createRoom([], "W18S29", 2300, 177, 6);
+    const attacked = createRoom([
+      createHostile([RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, HEAL, MOVE]),
+      createHostile([ATTACK, ATTACK, MOVE, MOVE, MOVE, ATTACK, ATTACK, MOVE]),
+      createHostile([RANGED_ATTACK, MOVE, MOVE, HEAL, HEAL, MOVE]),
+      createHostile([RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, HEAL, MOVE])
+    ], "W18S28", 0, 0, 5, false);
+    const source = createSource();
+    const sourceContainer = createSourceContainer(2000);
+    const originalFind = helper.find.bind(helper);
+    (helper as unknown as { find: Room["find"] }).find = ((type: FindConstant) => {
+      if (type === FIND_SOURCES) return [source];
+      if (type === FIND_STRUCTURES) return [sourceContainer];
+      return originalFind(type as never);
+    }) as Room["find"];
+    Game.rooms.W18S29 = helper;
+    Game.rooms.W18S28 = attacked;
+    Game.creeps = {
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29", task: "defenseRefuel" } },
+      hauler2: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29", task: "defenseRefuel" } },
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W18S29" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W18S29" } }
+    } as unknown as typeof Game.creeps;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W18S28",
+        guardsNeeded: 2,
+        rangersNeeded: 2,
+        healersNeeded: 1,
+        urgency: 3,
+        createdAt: Game.time,
+        threat: "spawnless mixed ranged-heal attack"
+      }
+    ];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const requests = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests;
+
+    const refuel = requests.find(request => request.role === "hauler" && request.additionalMemory?.task === "defenseRefuel");
+    assert.isOk(refuel, "helper should scale refuel throughput before waiting on unaffordable ranger/healer assists");
+    assert.equal(refuel!.priority, SpawnPriority.EMERGENCY);
+    assert.deepEqual(refuel!.body.parts, [CARRY, MOVE]);
+  });
+
+  it("caps scaled defense refuelers after four dedicated emergency haulers", () => {
+    const helper = createRoom([], "W18S29", 2300, 177, 6);
+    const attacked = createRoom([
+      createHostile([RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, HEAL, MOVE]),
+      createHostile([ATTACK, ATTACK, MOVE, MOVE, MOVE, ATTACK, ATTACK, MOVE]),
+      createHostile([RANGED_ATTACK, MOVE, MOVE, HEAL, HEAL, MOVE]),
+      createHostile([RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, HEAL, MOVE])
+    ], "W18S28", 0, 0, 5, false);
+    const source = createSource();
+    const sourceContainer = createSourceContainer(2000);
+    const originalFind = helper.find.bind(helper);
+    (helper as unknown as { find: Room["find"] }).find = ((type: FindConstant) => {
+      if (type === FIND_SOURCES) return [source];
+      if (type === FIND_STRUCTURES) return [sourceContainer];
+      return originalFind(type as never);
+    }) as Room["find"];
+    Game.rooms.W18S29 = helper;
+    Game.rooms.W18S28 = attacked;
+    Game.creeps = {
+      refuel1: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29", task: "defenseRefuel" } },
+      refuel2: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29", task: "defenseRefuel" } },
+      refuel3: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29", task: "defenseRefuel" } },
+      refuel4: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29", task: "defenseRefuel" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29" } },
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W18S29" } }
+    } as unknown as typeof Game.creeps;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W18S28",
+        guardsNeeded: 2,
+        rangersNeeded: 2,
+        healersNeeded: 1,
+        urgency: 3,
+        createdAt: Game.time,
+        threat: "spawnless mixed ranged-heal attack"
+      }
+    ];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const requests = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests;
+
+    assert.isUndefined(requests.find(request => request.role === "hauler" && request.additionalMemory?.task === "defenseRefuel"));
+  });
+
   it("does not add a defense refuel hauler when two local haulers are already available", () => {
     const helper = createRoom([], "W17S29", 2300, 21, 6);
     const attacked = createRoom([createHostile([ATTACK, MOVE])], "W18S28", 0, 0, 5, false);
@@ -1259,6 +1348,41 @@ describe("defense spawn throttling", () => {
     );
     assert.isOk(refuel);
     assert.equal(refuel?.priority, SpawnPriority.EMERGENCY);
+  });
+
+  it("adds an emergency helper-room assist for a spawnless RCL5 room with current mixed hostiles", () => {
+    const liveHostiles = [
+      createHostile([RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, HEAL, MOVE]),
+      createHostile([ATTACK, ATTACK, MOVE, MOVE, MOVE, ATTACK, ATTACK, MOVE]),
+      createHostile([RANGED_ATTACK, MOVE, MOVE, HEAL, HEAL, MOVE]),
+      createHostile([RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, HEAL, MOVE])
+    ];
+    const helper = createRoom([], "W18S29", 800, 800, 6);
+    const attacked = createRoom(liveHostiles, "W18S28", 0, 0, 5, false);
+    Game.rooms.W18S29 = helper;
+    Game.rooms.W18S28 = attacked;
+    Game.creeps = {
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W18S29" } },
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W18S29" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W18S29" } }
+    } as unknown as typeof Game.creeps;
+
+    const request = createDefenseRequest(attacked, { danger: 0, posture: "eco" } as any);
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = request ? [request] : [];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const plan = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any);
+    const assistRequests = plan.requests
+      .filter(spawnRequest => spawnRequest.additionalMemory?.task === "defenseAssist");
+    const emergencyAssist = assistRequests.find(spawnRequest =>
+      spawnRequest.targetRoom === "W18S28" && spawnRequest.priority === SpawnPriority.EMERGENCY
+    );
+
+    assert.isOk(request, "spawnless hostile room should create a defense-assist request");
+    assert.isOk(emergencyAssist, "helper room should answer the live spawnless-hostile pattern");
+    assert.equal(emergencyAssist!.role, "guard");
+    assert.isAtMost(emergencyAssist!.body.cost, helper.energyAvailable);
+    assert.include(emergencyAssist!.additionalMemory, { task: "defenseAssist", assistTarget: "W18S28" });
   });
 
   it("adds an affordable emergency helper-room assist when hard-threat bodies exceed current helper energy", () => {


### PR DESCRIPTION
## Summary

Scales helper-room defense refuel throughput for active spawnless-room hard assist cases.

## Linked issue

Closes #3190

## Changes

### Code changes
- Keeps the existing two-hauler cap for ordinary/simple defense refuel cases.
- Detects visible urgent defense requests that still need ranger/healer assists.
- Allows up to four dedicated `defenseRefuel` haulers for those hard-assist cases, counting dedicated refuel creeps/queued refuel requests instead of all generic haulers.
- Updates the generated bot bundle.

### Test changes
- Adds regression coverage for the current W18S28 pattern: owned RCL5 spawnless room, active mixed ranged/heal/attack hostiles, helper room emits emergency defense assist.
- Adds regression coverage for scaling dedicated defense refuelers when ranger/healer assists are energy-blocked.

### Docs changes
- None; behavior is internal spawn policy.

## Validation

- ✅ `npm test -w @ralphschuler/screeps-spawn -- --grep "scales dedicated defense refuelers|spawnless RCL5 room"` (Node 24)
- ✅ `npm test -w @ralphschuler/screeps-spawn` (Node 24)
- ✅ `npm run lint -w @ralphschuler/screeps-spawn`
- ✅ `npm run build -w @ralphschuler/screeps-spawn`
- ✅ `npm run sync:deps:check`
- ✅ `npm run check-versions` (Node 24)
- ✅ `npm run build:bot` (Node 24)
- ✅ `npm run check:bot-bundle-drift` (Node 24)
- ⚠️ `npm run typecheck -w @ralphschuler/screeps-spawn` unavailable: workspace has no `typecheck` script.
- ⚠️ `npm run build` timed out after 300s in this shell; package build and bot build passed separately.

## Deployment impact

Affects `screeps.com/main` runtime spawn planning through `@ralphschuler/screeps-spawn` and the generated bot bundle. Deploy after merge.

## Live bot evidence

Read-only live analysis on `screeps.com` / `shard1` showed:
- `W18S28` RCL5 spawnless/structureless with `4` Tigga hostiles and `0` friendly creeps.
- `Memory.defenseRequests` for `W18S28`: `guardsNeeded=2`, `rangersNeeded=2`, `healersNeeded=1`, `urgency=3`.
- Helper rooms had dedicated `defenseRefuel` haulers but spawn/extension energy was still too low for ranger/healer assists.

## Follow-up issues

No new issues created per operator constraint. Existing #3242 remains open for W18S28 layout/rebuild tracking.
