### PR TITLE
[codex] Return displaced local haulers home

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
@@ -43,6 +43,10 @@ interface HaulerTargetCacheMemory {
  * Uses cached target finding to reduce CPU usage.
  */
 export function hauler(ctx: CreepContext): CreepAction {
+  if (!ctx.isInHomeRoom) {
+    return { type: "remoteMoveToRoom", roomName: ctx.homeRoom, routeType: "hauler" };
+  }
+
   const isWorking = updateWorkingState(ctx);
   const isDefenseRefuel = ctx.memory.task === DEFENSE_REFUEL_TASK;
   logger.debug(`${ctx.creep.name} hauler state: working=${isWorking}, energy=${ctx.creep.store.getUsedCapacity(RESOURCE_ENERGY)}/${ctx.creep.store.getCapacity()}`);

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -389,6 +389,32 @@ describe("Behavior Contracts", () => {
     }
   });
 
+  it("returns a displaced local hauler to its home room before foreign-room logistics", () => {
+    const ctx = createContext("hauler");
+    const foreignRoom = createMockRoom("W1N2");
+    const foreignContainer = {
+      id: "foreign-container" as Id<StructureContainer>,
+      structureType: STRUCTURE_CONTAINER,
+      store: makeEnergyStore(1000, 2000)
+    } as StructureContainer;
+    ctx.room = foreignRoom;
+    ctx.creep.room = foreignRoom;
+    ctx.isInHomeRoom = false;
+    ctx.containers = [foreignContainer];
+
+    const action = evaluateWithStateMachine(ctx, evaluateEconomyBehavior);
+
+    expect(action).to.deep.equal({
+      type: "remoteMoveToRoom",
+      roomName: ctx.homeRoom,
+      routeType: "hauler"
+    });
+    expect(ctx.memory.state).to.include({
+      action: "remoteMoveToRoom",
+      targetRoom: ctx.homeRoom
+    });
+  });
+
   it("keeps hauler critical delivery ordering at spawn, extension, then tower before storage", () => {
     const ctx = createContext("hauler");
     ctx.memory.working = true;

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -28063,7 +28063,13 @@ resourceType: RESOURCE_ENERGY
 });
 },
 hauler: function(e) {
-var t, r = Nd(e), o = "defenseRefuel" === e.memory.task;
+var t;
+if (!e.isInHomeRoom) return {
+type: "remoteMoveToRoom",
+roomName: e.homeRoom,
+routeType: "hauler"
+};
+var r = Nd(e), o = "defenseRefuel" === e.memory.task;
 if (Yd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];


### PR DESCRIPTION
## Summary

- return displaced local haulers to `homeRoom` before foreign-room logistics
- route recovery through the existing Cartographer hauler movement contract
- cover the production state-machine path with a behavior-first regression test
- regenerate the tracked bot bundle

## Live evidence

Fresh read-only shard1 analysis reproduced #3119 in `W18S29`:

- 40 open delivery tasks, 0 assigned, 0 reservations
- 3,809 remaining delivery energy; 2,809 critical
- source containers held 1,052 and 801 energy
- the room's only local hauler was empty and idle in `W18S28` while still counted under `homeRoom=W18S29`
- CPU remained healthy and bucket stayed 10,000

Artifacts: `artifacts/live-analysis-20260710-cycle2/summary.md`, `w18s29-detail.json`, and `w18s29-hauler-location.json` (local sanitized evidence; generated artifacts are intentionally not committed).

## Validation

- [x] New test failed against baseline (`withdraw` from foreign container instead of returning home)
- [x] Targeted regression test passes through `evaluateWithStateMachine`
- [x] `npm run test:roles` — 181 passing
- [x] `npm run test:server:packages` — 82 passing, 10 pending
- [x] `npm run typecheck --workspaces --if-present`
- [x] `npm run lint:all`
- [x] `npm run sync:deps:check`
- [x] `npm run check:alliance-safety`
- [x] `npm run check:no-deep-dist-imports`
- [x] `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- [x] Full post-commit `npm run verify`
- [x] Docker private-server smoke — 3,060 ticks; backend runtime warmed with 24/24 assertions and zero error notifications. The top-level gate also reproduced the known false-green merged/player evidence defect tracked in #3324 (`runtimeWarmed=false`, 14 skipped), so this is reported as degraded rather than overstated.

## Risk / rollback

Risk is low and scoped to the local `hauler` role. `remoteHauler` and inter-room roles are unchanged. A rollback restores prior behavior but can strand local haulers in foreign rooms and suppress replacement demand.

Refs #3119
