### PR TITLE
fix(defense): preserve critical danger for incoming nukes

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -33689,8 +33689,8 @@ source: e.roomName
 }));
 }(n, c), function(e, t) {
 var r, o, n, i, s;
-if (e.time % 10 == 0) if (e.nukes.length > 0) {
-if (e.nukeDetected) return;
+if (e.nukes.length > 0) {
+if (t.nextDanger = 3, e.time % 10 != 0 || e.nukeDetected) return;
 t.nextNukeDetected = !0, t.pheromoneEffects.push({
 type: "nukeDetected"
 });

--- a/packages/screeps-bot/src/core/managers/roomDefensePostureModule.ts
+++ b/packages/screeps-bot/src/core/managers/roomDefensePostureModule.ts
@@ -247,10 +247,11 @@ function planHostileEvents(snapshot: DefensePostureSnapshot, intent: DefensePost
 }
 
 function planNukeEvents(snapshot: DefensePostureSnapshot, intent: DefensePostureIntent): void {
-  if (snapshot.time % 10 !== 0) return;
-
   if (snapshot.nukes.length > 0) {
-    if (snapshot.nukeDetected) return;
+    // Incoming nukes remain a critical threat between the periodic event scans.
+    // Preserve danger=3 even when no hostile creeps are visible.
+    intent.nextDanger = 3;
+    if (snapshot.time % 10 !== 0 || snapshot.nukeDetected) return;
 
     intent.nextNukeDetected = true;
     intent.pheromoneEffects.push({ type: "nukeDetected" });

--- a/packages/screeps-bot/test/unit/roomDefensePostureModule.test.ts
+++ b/packages/screeps-bot/test/unit/roomDefensePostureModule.test.ts
@@ -124,6 +124,7 @@ describe("Room defense posture Module", () => {
     );
 
     assert.equal(detected.nextNukeDetected, true);
+    assert.equal(detected.nextDanger, 3);
     assert.deepEqual(detected.pheromoneEffects, [{ type: "nukeDetected" }]);
     assert.deepEqual(detected.kernelEvents, [
       {
@@ -138,8 +139,25 @@ describe("Room defense posture Module", () => {
       }
     ]);
 
+    const retained = planDefensePostureIntent(
+      snapshot({
+        nukeDetected: true,
+        nukes: [
+          {
+            id: "nuke1" as Id<Nuke>,
+            timeToLand: 450,
+            launchRoomName: "W9N9"
+          }
+        ]
+      })
+    );
+    assert.equal(retained.nextDanger, 3);
+    assert.equal(retained.nextNukeDetected, true);
+    assert.deepEqual(retained.kernelEvents, []);
+
     const cleared = planDefensePostureIntent(snapshot({ nukeDetected: true, nukes: [] }));
     assert.equal(cleared.nextNukeDetected, false);
+    assert.equal(cleared.nextDanger, 0);
   });
 
   it("exposes tower action planning as an intent surface", () => {


### PR DESCRIPTION
## Summary

Preserve critical defense danger while incoming nukes remain, including between periodic nuke-event scans.

## Linked issue

Closes #3343

## Research

- Local Screeps API types: `node_modules/@types/screeps/index.d.ts` (`FIND_NUKES`, `Nuke.timeToLand`, `Nuke.launchRoomName`).
- ROADMAP Section 5 requires `danger = 3` on nuke detection.
- SearXNG was attempted but the configured backend was unreachable; local types and existing package tests were sufficient for this API fact-check.

## Changes

- Set posture `nextDanger` to `3` whenever incoming nukes are present.
- Keep periodic event deduplication unchanged.
- Add first-detection, retained-danger, and clear-after-impact unit assertions.
- Regenerated the committed bot bundle.

## Defense impact

- Threat detection: critical nuke danger survives no-hostile ticks.
- Defensive response: safe-mode, evacuation, reinforcement, and recovery consumers retain critical posture input.
- Construction adaptation: unchanged.
- Recovery: unchanged.
- CPU/Memory impact: no additional scans or persistent state.

## Tests

- Focused nuke tests: pass.
- Bot unit tests: 2,401 passing.
- Defense package tests: 82 passing.
- Script tests: 90 passing.
- Node 24 typecheck/lint/build: pass.
- Production audit: 0 vulnerabilities.
- Private-server smoke rerun: in progress; initial attempt was invalidated by concurrent test processes deleting the generated bundle.

## Live evidence

Read-only live structural snapshot was healthy with no non-allied hostiles or nukes visible in the bounded sample. Sensitive room/tactical details are omitted.

## Deployment impact

Safe for normal production deployment after PR checks pass. No Memory migration.

## Follow-up issues

- #3341 stale boost priority after emergency recovery.
- Code-refinement findings for persistent evacuation state and construction-site reconciliation remain tracked for subsequent slices.
