### PR TITLE
fix(defense): detect nukes on distributed room ticks

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -33680,17 +33680,20 @@ if (r) throw r.error;
 }
 }
 }
-} else e.currentDanger > 0 && (t.nextDanger = 0, t.kernelEvents.push({
+} else {
+var m = e.nukeScanPerformed ? e.nukes.length > 0 : e.nukeDetected;
+e.currentDanger > 0 && !m && (t.nextDanger = 0, e.nukeDetected || t.kernelEvents.push({
 type: "hostile.cleared",
 payload: {
 roomName: e.roomName,
 source: e.roomName
 }
 }));
+}
 }(n, c), function(e, t) {
 var r, o, n, i, s;
-if (e.nukes.length > 0) {
-if (t.nextDanger = 3, e.time % 10 != 0 || e.nukeDetected) return;
+if (e.nukeScanPerformed) if (e.nukes.length > 0) {
+if (t.nextDanger = 3, e.nukeDetected) return;
 t.nextNukeDetected = !0, t.pheromoneEffects.push({
 type: "nukeDetected"
 });
@@ -33725,16 +33728,17 @@ l && !l.done && (o = u.return) && o.call(u);
 if (r) throw r.error;
 }
 }
-} else t.nextNukeDetected = !1;
+} else t.nextNukeDetected = !1; else e.nukeDetected && (t.nextDanger = 3);
 }(n, c), c;
 var n, c;
 }, e.prototype.getDefensePostureSnapshot = function(e, t, r, o) {
-var n, a = t.clusterId ? Sr.getCluster(t.clusterId) : null, i = o.length > 0 ? Go(e) : void 0, s = Game.time % 10 == 0 ? e.find(FIND_NUKES) : [];
+var n, a = t.clusterId ? Sr.getCluster(t.clusterId) : null, i = o.length > 0 ? Go(e) : void 0, s = e.find(FIND_NUKES);
 return {
 roomName: e.name,
 time: Game.time,
 currentDanger: t.danger,
 nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
+nukeScanPerformed: !0,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
 previousStructures: Iy.get(e.name),

--- a/packages/screeps-bot/src/core/managers/RoomDefenseManager.ts
+++ b/packages/screeps-bot/src/core/managers/RoomDefenseManager.ts
@@ -69,13 +69,16 @@ export class RoomDefenseManager {
   ): DefensePostureSnapshot {
     const cluster = swarm.clusterId ? memoryManager.getCluster(swarm.clusterId) : null;
     const threat = hostiles.length > 0 ? assessThreat(room) : undefined;
-    const nukes = Game.time % 10 === 0 ? room.find(FIND_NUKES) : [];
+    // Room processes are distributed across offsets; nuke detection must run
+    // whenever this room executes rather than on a global modulo tick.
+    const nukes = room.find(FIND_NUKES);
 
     return {
       roomName: room.name,
       time: Game.time,
       currentDanger: swarm.danger,
       nukeDetected: swarm.nukeDetected ?? false,
+      nukeScanPerformed: true,
       clusterId: swarm.clusterId,
       clusterMemberRooms: cluster?.memberRooms,
       previousStructures: structureCountTracker.get(room.name),

--- a/packages/screeps-bot/src/core/managers/roomDefensePostureModule.ts
+++ b/packages/screeps-bot/src/core/managers/roomDefensePostureModule.ts
@@ -34,6 +34,8 @@ export interface DefensePostureSnapshot {
   time: number;
   currentDanger: DefenseDangerLevel;
   nukeDetected: boolean;
+  /** True only when the current room tick performed an explicit nuke scan. */
+  nukeScanPerformed: boolean;
   clusterId?: string;
   clusterMemberRooms?: string[];
   previousStructures?: DefenseStructureTrackingSnapshot;
@@ -240,18 +242,28 @@ function planHostileEvents(snapshot: DefensePostureSnapshot, intent: DefensePost
     return;
   }
 
-  if (snapshot.currentDanger > 0) {
+  const activeNukeEvidence = snapshot.nukeScanPerformed ? snapshot.nukes.length > 0 : snapshot.nukeDetected;
+  if (snapshot.currentDanger > 0 && !activeNukeEvidence) {
     intent.nextDanger = 0;
-    intent.kernelEvents.push({ type: "hostile.cleared", payload: { roomName: snapshot.roomName, source: snapshot.roomName } });
+    if (!snapshot.nukeDetected) {
+      intent.kernelEvents.push({ type: "hostile.cleared", payload: { roomName: snapshot.roomName, source: snapshot.roomName } });
+    }
   }
 }
 
 function planNukeEvents(snapshot: DefensePostureSnapshot, intent: DefensePostureIntent): void {
+  if (!snapshot.nukeScanPerformed) {
+    // A skipped scan is not evidence that incoming nukes are gone. Preserve the
+    // persisted critical posture until an explicit empty scan is completed.
+    if (snapshot.nukeDetected) intent.nextDanger = 3;
+    return;
+  }
+
   if (snapshot.nukes.length > 0) {
-    // Incoming nukes remain a critical threat between the periodic event scans.
-    // Preserve danger=3 even when no hostile creeps are visible.
+    // Incoming nukes remain a critical threat between room-process executions.
+    // Every explicit room scan may discover the first nuke for this posture.
     intent.nextDanger = 3;
-    if (snapshot.time % 10 !== 0 || snapshot.nukeDetected) return;
+    if (snapshot.nukeDetected) return;
 
     intent.nextNukeDetected = true;
     intent.pheromoneEffects.push({ type: "nukeDetected" });

--- a/packages/screeps-bot/test/unit/roomDefenseManager.test.ts
+++ b/packages/screeps-bot/test/unit/roomDefenseManager.test.ts
@@ -50,8 +50,38 @@ describe("RoomDefenseManager", () => {
       assert.exists(manager);
     });
 
-    it("should detect nukes and update swarm state", () => {
-      assert.exists(manager);
+    it("should detect nukes on a non-modulo room-process tick", () => {
+      const nuke = {
+        id: "nuke1" as Id<Nuke>,
+        timeToLand: 500,
+        launchRoomName: "W9N9"
+      } as Nuke;
+      const room = {
+        name: "W1N1",
+        find: (type: FindConstant) => (type === FIND_NUKES ? [nuke] : [])
+      } as unknown as Room;
+      const swarm = {
+        danger: 0,
+        nukeDetected: false
+      } as SwarmState;
+
+      Game.time = 101;
+      const intent = manager.getDefensePostureIntent(room, swarm, { spawns: [], towers: [] }, []);
+
+      assert.equal(intent.nextDanger, 3);
+      assert.equal(intent.nextNukeDetected, true);
+      assert.deepEqual(intent.kernelEvents, [
+        {
+          type: "nuke.detected",
+          payload: {
+            roomName: "W1N1",
+            nukeId: "nuke1" as Id<Nuke>,
+            landingTick: 601,
+            launchRoomName: "W9N9",
+            source: "W1N1"
+          }
+        }
+      ]);
     });
 
     it("should emit events when hostiles are detected", () => {

--- a/packages/screeps-bot/test/unit/roomDefensePostureModule.test.ts
+++ b/packages/screeps-bot/test/unit/roomDefensePostureModule.test.ts
@@ -11,6 +11,7 @@ function snapshot(overrides: Partial<DefensePostureSnapshot> = {}): DefensePostu
     time: 100,
     currentDanger: 0,
     nukeDetected: false,
+    nukeScanPerformed: true,
     currentStructures: {
       spawns: ["spawn1"],
       towers: ["tower1"]
@@ -109,36 +110,57 @@ describe("Room defense posture Module", () => {
     });
   });
 
-  it("plans first nuke detection once and clears nuke state when gone", () => {
-    const detected = planDefensePostureIntent(
-      snapshot({
-        nukeDetected: false,
-        nukes: [
-          {
-            id: "nuke1" as Id<Nuke>,
-            timeToLand: 500,
-            launchRoomName: "W9N9"
+  it("plans first nuke detection on every room-process offset", () => {
+    for (const time of [100, 101, 102, 103, 104]) {
+      const detected = planDefensePostureIntent(
+        snapshot({
+          time,
+          nukeDetected: false,
+          nukes: [
+            {
+              id: "nuke1" as Id<Nuke>,
+              timeToLand: 500,
+              launchRoomName: "W9N9"
+            }
+          ]
+        })
+      );
+
+      assert.equal(detected.nextNukeDetected, true);
+      assert.equal(detected.nextDanger, 3);
+      assert.deepEqual(detected.pheromoneEffects, [{ type: "nukeDetected" }]);
+      assert.deepEqual(detected.kernelEvents, [
+        {
+          type: "nuke.detected",
+          payload: {
+            roomName: "W1N1",
+            nukeId: "nuke1" as Id<Nuke>,
+            landingTick: time + 500,
+            launchRoomName: "W9N9",
+            source: "W1N1"
           }
-        ]
+        }
+      ]);
+    }
+  });
+
+  it("preserves nuke danger when the scan is skipped", () => {
+    const skipped = planDefensePostureIntent(
+      snapshot({
+        currentDanger: 3,
+        nukeDetected: true,
+        nukeScanPerformed: false,
+        nukes: []
       })
     );
 
-    assert.equal(detected.nextNukeDetected, true);
-    assert.equal(detected.nextDanger, 3);
-    assert.deepEqual(detected.pheromoneEffects, [{ type: "nukeDetected" }]);
-    assert.deepEqual(detected.kernelEvents, [
-      {
-        type: "nuke.detected",
-        payload: {
-          roomName: "W1N1",
-          nukeId: "nuke1" as Id<Nuke>,
-          landingTick: 600,
-          launchRoomName: "W9N9",
-          source: "W1N1"
-        }
-      }
-    ]);
+    assert.equal(skipped.nextNukeDetected, true);
+    assert.equal(skipped.nextDanger, 3);
+    assert.deepEqual(skipped.pheromoneEffects, []);
+    assert.deepEqual(skipped.kernelEvents, []);
+  });
 
+  it("clears nuke state only after an explicit empty scan", () => {
     const retained = planDefensePostureIntent(
       snapshot({
         nukeDetected: true,
@@ -155,9 +177,41 @@ describe("Room defense posture Module", () => {
     assert.equal(retained.nextNukeDetected, true);
     assert.deepEqual(retained.kernelEvents, []);
 
-    const cleared = planDefensePostureIntent(snapshot({ nukeDetected: true, nukes: [] }));
+    const cleared = planDefensePostureIntent(
+      snapshot({ currentDanger: 3, nukeDetected: true, nukes: [] })
+    );
     assert.equal(cleared.nextNukeDetected, false);
     assert.equal(cleared.nextDanger, 0);
+    assert.deepEqual(cleared.kernelEvents, []);
+  });
+
+  it("does not emit hostile-clear when a first nuke supersedes existing danger", () => {
+    const intent = planDefensePostureIntent(
+      snapshot({
+        currentDanger: 2,
+        nukes: [
+          {
+            id: "nuke1" as Id<Nuke>,
+            timeToLand: 500,
+            launchRoomName: "W9N9"
+          }
+        ]
+      })
+    );
+
+    assert.equal(intent.nextDanger, 3);
+    assert.deepEqual(intent.kernelEvents, [
+      {
+        type: "nuke.detected",
+        payload: {
+          roomName: "W1N1",
+          nukeId: "nuke1" as Id<Nuke>,
+          landingTick: 600,
+          launchRoomName: "W9N9",
+          source: "W1N1"
+        }
+      }
+    ]);
   });
 
   it("exposes tower action planning as an intent surface", () => {


### PR DESCRIPTION
## Summary

Fix incoming-nuke detection for owned rooms whose room processes execute on distributed tick offsets.

## Linked issue

Closes #3346

## Research

- Local Screeps types: `node_modules/@types/screeps/index.d.ts` confirms `FIND_NUKES`, `Nuke.timeToLand`, and `Nuke.launchRoomName`.
- Official API reference: https://docs.screeps.com/api/#Nuke
- Repository references: `ROADMAP.md` nuke detection/critical-danger requirements and `docs/NUKE_COORDINATION.md` early-warning behavior.

## Changes

- Scan `FIND_NUKES` whenever the owned room defense manager executes; remove the incompatible global `% 10` gate.
- Add explicit `nukeScanPerformed` posture input so skipped scans cannot clear persisted critical state.
- Clear nuke danger only after an explicit empty scan.
- Avoid emitting hostile-clear when a nuke is the active or superseding danger source.
- Add manager and posture regression tests for non-modulo ticks, all five economic offsets, skipped scans, empty scans, and stale danger.
- Regenerate the tracked bot bundle.

## Defense impact

- Threat detection: first nuke observation is no longer missed by room-process offsets.
- Defensive response: danger remains critical between scans and is cleared only by verified empty observations.
- Construction/recovery: unchanged.
- CPU/Memory: one bounded nuke lookup per room execution; no new persistent memory.
- Alliance safety: unchanged; no targeting or classification paths changed.

## Tests

- `npm run test:unit -w screeps-typescript-starter -- --grep 'Room defense posture Module|RoomDefenseManager'`
- `npm test -w screeps-typescript-starter`
- `npm run test:all`
- `npm run typecheck -w screeps-typescript-starter`
- `npm run lint -w screeps-typescript-starter -- --max-warnings=0`
- `npm run check-versions`
- `npm run sync:deps:check`
- `npm run check:alliance-safety`
- `npm run check:no-deep-dist-imports`
- `npm audit --omit=dev --audit-level=high`
- `npm run quality:duplication`
- `npm run quality:complexity`
- `node packages/screeps-bot/scripts/check-bundle-size.js`

Private-server smoke uploaded and activated the bundle; 43 assertions passed and 0 failed. The standard run failed after the server exited during final polling. An isolated rerun failed closed because 4 player-sandbox checks remained skipped after warmup; backend checks passed. Follow-up issues: #3347 and existing #3205.

## Follow-up issues

- #3347 — preserve diagnostics when the private-server service exits after assertions pass.
- #3205 — diagnose intermittent hard-invader player-sandbox skips.
