### PR TITLE
fix(defense): classify nuke-only rooms as critical

### DIFF
--- a/docs/guides/defense.md
+++ b/docs/guides/defense.md
@@ -68,7 +68,7 @@ The Defense Coordination System provides comprehensive multi-room defense coordi
 
 ## Threat Assessment
 
-File: `packages/screeps-defense/src/threatAssessment.ts`
+File: `packages/screeps-defense/src/threat/threatAssessment.ts`
 
 ### ThreatAnalysis Interface
 
@@ -91,6 +91,8 @@ interface ThreatAnalysis {
   recommendedResponse: "monitor" | "defend" | "assist" | "retreat" | "safemode";
 }
 ```
+
+An incoming nuke is always a critical threat (`dangerLevel = 3`, `recommendedResponse = "safemode"`), even when the room has no visible hostile creeps. The nuke check must therefore run before the empty-room fast path; ally filtering still applies to creep-based threat scoring.
 
 ### DPS Calculation
 
@@ -146,9 +148,10 @@ function detectBoostLevel(creep: Creep): number {
 
 ```typescript
 export function assessThreat(room: Room): ThreatAnalysis {
-  const hostiles = room.find(FIND_HOSTILE_CREEPS);
+  const hostiles = getActualHostileCreeps(room); // excludes permanent allies
+  const nukes = room.find(FIND_NUKES);
   
-  if (hostiles.length === 0) {
+  if (hostiles.length === 0 && nukes.length === 0) {
     return {
       roomName: room.name,
       dangerLevel: 0,
@@ -193,11 +196,10 @@ export function assessThreat(room: Room): ThreatAnalysis {
   if (threatScore > 100 || totalDPS > 150) dangerLevel = 2;
   if (threatScore > 300 || boostedCount > 2) dangerLevel = 3;
   
-  // Check for nukes
-  const nukes = room.find(FIND_NUKES);
+  // Check for nukes; this also handles rooms with no visible hostile creeps.
   if (nukes.length > 0) {
     dangerLevel = 3;
-    threatScore += 1000;
+    threatScore += 500;
   }
   
   // Determine recommended response
@@ -219,8 +221,8 @@ export function assessThreat(room: Room): ThreatAnalysis {
     boostedCount,
     dismantlerCount,
     estimatedDefenderCost: calculateDefenderCost(threatScore),
-    assistanceRequired: dangerLevel >= 2,
-    assistancePriority: Math.min(100, threatScore / 10),
+    assistanceRequired: dangerLevel >= 2 && hostiles.length > 0,
+    assistancePriority: hostiles.length === 0 ? 0 : Math.min(100, threatScore / 10),
     recommendedResponse
   };
 }

--- a/docs/guides/defense.md
+++ b/docs/guides/defense.md
@@ -146,6 +146,8 @@ function detectBoostLevel(creep: Creep): number {
 
 ### Threat Score Calculation
 
+The following is simplified pseudocode. The production implementation additionally accounts for tower support, active body parts, and defender templates; keep its nuke-only contract (`assistanceRequired = false`, `assistancePriority = 0`, and zero defender cost) intact.
+
 ```typescript
 export function assessThreat(room: Room): ThreatAnalysis {
   const hostiles = getActualHostileCreeps(room); // excludes permanent allies
@@ -220,7 +222,7 @@ export function assessThreat(room: Room): ThreatAnalysis {
     meleeCount,
     boostedCount,
     dismantlerCount,
-    estimatedDefenderCost: calculateDefenderCost(threatScore),
+    estimatedDefenderCost: hostiles.length === 0 ? 0 : calculateDefenderCost(totalDPS),
     assistanceRequired: dangerLevel >= 2 && hostiles.length > 0,
     assistancePriority: hostiles.length === 0 ? 0 : Math.min(100, threatScore / 10),
     recommendedResponse
@@ -267,7 +269,7 @@ export class TowerManager {
   }
   
   private findBestHostileTarget(tower: StructureTower): Creep | null {
-    const hostiles = tower.room.find(FIND_HOSTILE_CREEPS);
+    const hostiles = getActualHostileCreeps(tower.room);
     if (hostiles.length === 0) return null;
     
     // Sort by priority:
@@ -722,7 +724,7 @@ if (threat.dangerLevel === 1 && threat.threatScore < 50) {
 **Solution**: Check tower energy and targeting
 ```typescript
 console.log(`Tower energy: ${tower.store.energy}`);
-console.log(`Hostiles: ${room.find(FIND_HOSTILE_CREEPS).length}`);
+console.log(`Hostiles: ${getActualHostileCreeps(room).length}`);
 ```
 
 ### Issue: Defenders Not Responding

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -8034,8 +8034,8 @@ isDismantler: R
 }
 
 function Go(e) {
-var t, r, o = X(e);
-if (0 === o.length) return {
+var t, r, o = X(e), n = e.find(FIND_NUKES);
+if (0 === o.length && 0 === n.length) return {
 roomName: e.name,
 dangerLevel: 0,
 threatScore: 0,
@@ -8052,17 +8052,17 @@ assistanceRequired: !1,
 assistancePriority: 0,
 recommendedResponse: "monitor"
 };
-var n = 0, i = 0, s = 0, c = 0, u = 0, l = 0, m = 0, d = 0, p = function() {
+var i = 0, s = 0, c = 0, u = 0, l = 0, m = 0, d = 0, p = 0, f = function() {
 var e;
 return "undefined" == typeof Memory || !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.workPartThreatScoring);
 }();
 try {
-for (var f = a(o), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = Io(v, {
-scoreWorkPartThreats: p
+for (var y = a(o), v = y.next(); !v.done; v = y.next()) {
+var g = v.value, h = Io(g, {
+scoreWorkPartThreats: f
 });
-i += g.dps, s += v.hits, n += g.scoreContribution, g.isBoosted && c++, g.isHealer && u++,
-g.isRanged && l++, g.isMelee && m++, g.isDismantler && d++;
+s += h.dps, c += g.hits, i += h.scoreContribution, h.isBoosted && u++, h.isHealer && l++,
+h.isRanged && m++, h.isMelee && d++, h.isDismantler && p++;
 }
 } catch (e) {
 t = {
@@ -8070,16 +8070,16 @@ error: e
 };
 } finally {
 try {
-y && !y.done && (r = f.return) && r.call(f);
+v && !v.done && (r = y.return) && r.call(y);
 } finally {
 if (t) throw t.error;
 }
 }
-var h, R = e.find(FIND_MY_STRUCTURES, {
+var R, E = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_TOWER;
 }
-}).reduce(function(e, t) {
+}), T = 0 === o.length ? 0 : E.reduce(function(e, t) {
 var r, n, a = t;
 if (a.structureType !== STRUCTURE_TOWER) return e;
 if ((null !== (n = null === (r = a.store) || void 0 === r ? void 0 : r.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0) < 10) return e;
@@ -8087,7 +8087,7 @@ var i, s = o.reduce(function(e, r) {
 return e + t.pos.getRangeTo(r.pos);
 }, 0);
 return e + ((i = s / o.length) <= 5 ? 600 : i >= 20 ? 150 : 600 - 30 * (i - 5));
-}, 0), E = i > 1.5 * R, T = Math.min(100, Math.max(0, (i - R) / 10)), C = function(e, t, r) {
+}, 0), C = s > 1.5 * T, S = Math.min(100, Math.max(0, (s - T) / 10)), w = function(e, t, r) {
 if (Array.isArray(e)) {
 var o = e.reduce(function(e, t) {
 return e + Bo(t.body.filter(function(e) {
@@ -8103,26 +8103,26 @@ var n = Yo("guard"), a = Yo("ranger"), i = Vo(n), s = Vo(a), c = (i.avgDps + s.a
 t = null != t ? t : c, r = null != r ? r : u;
 }
 return t <= 0 && (t = 300, r = 1300), Math.ceil(e / t) * r;
-}(i), S = Math.max(1, function(e) {
+}(s), x = Math.max(1, function(e) {
 return 0 === e || e < Lo ? 0 : e < Do ? 1 : e < Fo ? 2 : 3;
-}(n));
-return h = n < 100 ? "monitor" : n < 500 && !E ? "defend" : E && n < 1e3 ? "assist" : n > 1e3 || c > 3 ? "safemode" : "defend",
-e.find(FIND_NUKES).length > 0 && (n += 500, h = "safemode", S = 3), {
+}(i));
+return R = i < 100 ? "monitor" : i < 500 && !C ? "defend" : C && i < 1e3 ? "assist" : i > 1e3 || u > 3 ? "safemode" : "defend",
+n.length > 0 && (i += 500, R = "safemode", x = 3), {
 roomName: e.name,
-dangerLevel: S,
-threatScore: n,
+dangerLevel: x,
+threatScore: i,
 hostileCount: o.length,
-totalHostileHitPoints: s,
-totalHostileDPS: i,
-healerCount: u,
-rangedCount: l,
-meleeCount: m,
-boostedCount: c,
-dismantlerCount: d,
-estimatedDefenderCost: C,
-assistanceRequired: E,
-assistancePriority: T,
-recommendedResponse: h
+totalHostileHitPoints: c,
+totalHostileDPS: s,
+healerCount: l,
+rangedCount: m,
+meleeCount: d,
+boostedCount: u,
+dismantlerCount: p,
+estimatedDefenderCost: w,
+assistanceRequired: C,
+assistancePriority: S,
+recommendedResponse: R
 };
 }
 

--- a/packages/screeps-defense/src/threat/threatAssessment.ts
+++ b/packages/screeps-defense/src/threat/threatAssessment.ts
@@ -75,9 +75,11 @@ export interface ThreatAnalysis {
  */
 export function assessThreat(room: Room): ThreatAnalysis {
   const hostiles = getActualHostileCreeps(room);
+  const nukes = room.find(FIND_NUKES);
   
-  // Early exit for no threats
-  if (hostiles.length === 0) {
+  // Incoming nukes are critical even when no hostile creep is visible.
+  // Keep the empty-room fast path only for rooms with no nuke threat.
+  if (hostiles.length === 0 && nukes.length === 0) {
     return {
       roomName: room.name,
       dangerLevel: 0,
@@ -130,7 +132,8 @@ export function assessThreat(room: Room): ThreatAnalysis {
   
   // Calculate actual tower DPS based on distance to hostile creeps
   // See ROADMAP.md Section 12 - Threat-Level & Posture: "Range-Falloff beachten"
-  const towerDPS = towers.reduce((sum, tower) => {
+  // A nuke-only room has no hostile target distance to average.
+  const towerDPS = hostiles.length === 0 ? 0 : towers.reduce((sum, tower) => {
     const structureTower = tower as StructureTower;
 
     if (structureTower.structureType !== STRUCTURE_TOWER) {
@@ -179,7 +182,6 @@ export function assessThreat(room: Room): ThreatAnalysis {
   }
 
   // Check for nuke (overrides everything)
-  const nukes = room.find(FIND_NUKES);
   if (nukes.length > 0) {
     threatScore += 500;
     recommendedResponse = "safemode";

--- a/packages/screeps-defense/test/threatAssessment.test.ts
+++ b/packages/screeps-defense/test/threatAssessment.test.ts
@@ -145,6 +145,35 @@ describe('Threat Assessment', () => {
       expect(analysis.recommendedResponse).to.equal('monitor');
     });
 
+    it('should treat an incoming nuke as critical without visible hostiles', () => {
+      const incomingNuke = {
+        id: 'nuke-only',
+        launchRoomName: 'W2N2',
+        timeToLand: 5000
+      };
+      const tower = {
+        structureType: STRUCTURE_TOWER,
+        store: { getUsedCapacity: () => 100 },
+        pos: { getRangeTo: () => 5 }
+      };
+      mockRoom.find = (type: number) => {
+        if (type === FIND_NUKES) return [incomingNuke];
+        if (type === FIND_MY_STRUCTURES) return [tower];
+        return [];
+      };
+
+      const analysis = assessThreat(mockRoom);
+
+      expect(analysis.dangerLevel).to.equal(3);
+      expect(analysis.threatScore).to.equal(500);
+      expect(analysis.hostileCount).to.equal(0);
+      expect(analysis.totalHostileDPS).to.equal(0);
+      expect(analysis.assistanceRequired).to.equal(false);
+      expect(analysis.assistancePriority).to.equal(0);
+      expect(Number.isFinite(analysis.assistancePriority)).to.equal(true);
+      expect(analysis.recommendedResponse).to.equal('safemode');
+    });
+
     it('should detect hostile creeps', () => {
       const mockHostile = {
         id: 'hostile1',
@@ -157,7 +186,7 @@ describe('Threat Assessment', () => {
         owner: { username: 'Enemy' }
       };
 
-      mockRoom.find = (type: number) => [mockHostile];
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? [mockHostile] : [];
 
       const analysis = assessThreat(mockRoom);
       
@@ -224,7 +253,7 @@ describe('Threat Assessment', () => {
         owner: { username: 'Enemy' }
       };
 
-      mockRoom.find = (type: number) => [mockHostile];
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? [mockHostile] : [];
 
       const analysis = assessThreat(mockRoom);
       
@@ -244,7 +273,7 @@ describe('Threat Assessment', () => {
         owner: { username: 'Enemy' }
       };
 
-      mockRoom.find = (type: number) => [mockHealer];
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? [mockHealer] : [];
 
       const analysis = assessThreat(mockRoom);
       
@@ -263,7 +292,7 @@ describe('Threat Assessment', () => {
         owner: { username: 'Enemy' }
       };
 
-      mockRoom.find = (type: number) => [mockRanged];
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? [mockRanged] : [];
 
       const analysis = assessThreat(mockRoom);
       
@@ -286,7 +315,7 @@ describe('Threat Assessment', () => {
         owner: { username: 'Enemy' }
       };
 
-      mockRoom.find = (type: number) => [mockDismantler];
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? [mockDismantler] : [];
 
       const analysis = assessThreat(mockRoom);
       
@@ -356,7 +385,7 @@ describe('Threat Assessment', () => {
         owner: { username: 'Enemy' }
       };
 
-      mockRoom.find = (type: number) => [mockWeakHostile];
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? [mockWeakHostile] : [];
 
       const analysis = assessThreat(mockRoom);
       
@@ -383,7 +412,7 @@ describe('Threat Assessment', () => {
         }
       ];
 
-      mockRoom.find = (type: number) => mockHostiles;
+      mockRoom.find = (type: number) => type === FIND_HOSTILE_CREEPS ? mockHostiles : [];
 
       const analysis = assessThreat(mockRoom);
       


### PR DESCRIPTION
## Summary

Fixes the nuke-only threat assessment gap: incoming nukes now remain critical even when no hostile creep is visible. The zero-hostile tower path is also finite and safe.

## Linked issue

Closes #3354

## Research

- Official Screeps API: https://docs.screeps.com/api/#Nuke
- Local `@types/screeps` confirms `FIND_NUKES` and `Nuke.timeToLand`; nuke impacts can destroy creeps/sites and cancel safe mode.
- SearXNG was attempted but returned HTTP 403; local types, official docs, existing private-server fixtures, and repository behavior were used instead.

## Changes

- Query `FIND_NUKES` before the empty-room fast path.
- Return danger level 3 and `safemode` for nuke-only rooms.
- Avoid `NaN` tower/assistance metrics when no hostile distance exists.
- Correct threat-test fixtures so nuke and hostile queries are distinct.
- Update defense documentation and regenerate the tracked bot bundle.

## Defense impact

- Threat detection: nuke-only rooms are immediately critical.
- Defensive response: safe-mode posture is preserved without visible hostiles.
- Recovery/construction: unchanged; follow-ups #3356 and #3357 cover critical scheduling and low-bucket recovery construction.
- CPU/Memory: one nuke scan per threat assessment; no new persistent memory.

## Tests

- `npm test -w @ralphschuler/screeps-defense -- --require ./test/setup.cjs` — 88 passing.
- Targeted nuke regression — passing.
- Defense build/lint — passing.
- `npm run build:bot` and `npm run check:bot-bundle-drift` — passing.
- `npm run check-versions` — passing on Node 24.18.0/npm 11.16.0.
- `npm run sync:deps:check`, workspace typecheck, alliance safety, deep-import check, audit — passing.
- `npm run build:docs` — passing.
- Standard private-server smoke — passed, 1,894 ticks, 47/47 runtime assertions.
- `nukerless-nuke` private-server scenario — passed, 36/36 assertions, threat level 3.
- Full `npm run test:all` — package tests passed, but the bundled smoke invocation hit known harness CLI timeout (`#3347`); not a code assertion failure.

## Live evidence

Read-only live snapshot and CPU samples completed on shard1. Sanitized findings were updated in #3210 and #3119. No live nuke was observed in the sampled rooms. CPU/bucket were healthy in the sampled active shard; other shards returned empty samples.

## Follow-ups

- #3356 — schedule nuke-threat rooms in the critical process tier.
- #3357 — permit capped critical recovery construction in low bucket.
- #3347 — preserve diagnostics and resolve private-server CLI timeout noise.
