### PR TITLE
fix(runtime): permit capped critical construction in low bucket

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -35972,24 +35972,26 @@ constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
 return ov.set(e.name, o), o;
 }(i);
-if (this.config.enablePheromones && !s && Game.time % 5 == 0 && by.updateMetrics(i, c),
+this.config.enablePheromones && !s && Game.time % 5 == 0 && by.updateMetrics(i, c),
 Fy.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
 }), gi.assess(i, c), Ci.checkSafeMode(i, c), this.config.enableEvolution && (Uy.updateEvolutionStage(c, i, e),
 s || Uy.updateMissingStructures(c, i)), Ny.updatePosture(c), this.config.enablePheromones && !s && by.updatePheromones(c, i),
-this.config.enableTowers && Fy.runTowerControl(i, c, u.towers), this.config.enableConstruction && !s) {
-var l = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, m = jy.getConstructionInterval(l), d = Ny.allowsBuilding(c.posture), p = !d && c.danger >= 2;
-(d || p) && function(e, t, r) {
+this.config.enableTowers && Fy.runTowerControl(i, c, u.towers);
+var l = 0 === u.spawns.length || c.danger >= 2;
+if (this.config.enableConstruction && (!s || l)) {
+var m = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, d = jy.getConstructionInterval(m), p = Ny.allowsBuilding(c.posture), f = !p && c.danger >= 2 || s && l;
+(p || f) && function(e, t, r) {
 var o = nv(r), n = av(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, m) && (jy.runConstruction(i, c, u.constructionSites, u.spawns, {
-criticalOnly: p
+}(c, Game.time, d) && (jy.runConstruction(i, c, u.constructionSites, u.spawns, {
+criticalOnly: f
 }), function(e, t, r) {
 var o = nv(r), n = av(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
-}(c, Game.time, m));
+}(c, Game.time, d));
 }
 this.config.enableProcessing && !s && Game.time % 5 == 0 && tv.runResourceProcessing(i, c, {
 factory: u.factory,
@@ -35997,8 +35999,8 @@ powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
-var f = Game.cpu.getUsed() - n;
-Xi.recordRoom(i, f), Xi.endRoom(this.roomName, n);
+var y = Game.cpu.getUsed() - n;
+Xi.recordRoom(i, y), Xi.endRoom(this.roomName, n);
 } else Xi.endRoom(this.roomName, n);
 }, e;
 }(), sv = function() {

--- a/packages/screeps-bot/src/core/managers/README.md
+++ b/packages/screeps-bot/src/core/managers/README.md
@@ -110,14 +110,14 @@ roomDefenseManager.updateThreatAssessment(room, swarm, {
 });
 roomDefenseManager.runTowerControl(room, swarm, cache.towers);
 
-// Construction management (every N ticks)
-if (Game.time % roomConstructionManager.getConstructionInterval(rcl) === 0) {
-  roomConstructionManager.runConstruction(
-    room,
-    swarm,
-    cache.constructionSites,
-    cache.spawns
-  );
+// Construction management uses a remembered due tick rather than exact modulo.
+// Under bucket pressure, RoomNode still permits only capped critical-only work
+// for spawnless bootstrap or active danger.
+if (isRoomConstructionDue(swarm, Game.time, roomConstructionManager.getConstructionInterval(rcl))) {
+  roomConstructionManager.runConstruction(room, swarm, cache.constructionSites, cache.spawns, {
+    criticalOnly: lowBucket && (cache.spawns.length === 0 || swarm.danger >= 2)
+  });
+  recordRoomConstructionRun(swarm, Game.time, roomConstructionManager.getConstructionInterval(rcl));
 }
 
 // Economy management (every 5 ticks)

--- a/packages/screeps-bot/src/core/roomNode.ts
+++ b/packages/screeps-bot/src/core/roomNode.ts
@@ -202,19 +202,20 @@ export class RoomNode {
 
     // Run construction
     // Perimeter defense runs more frequently in early game (RCL 2-3) for faster fortification
-    // Regular construction runs at standard interval to balance CPU usage
-    if (this.config.enableConstruction && !lowBucket) {
+    // Regular construction runs at standard interval to balance CPU usage. During bucket
+    // recovery, only spawnless bootstrap or active-danger construction may run, and both
+    // paths are forced through the manager's capped critical-only branch.
+    const allowLowBucketCriticalRecovery = cache.spawns.length === 0 || swarm.danger >= 2;
+    if (this.config.enableConstruction && (!lowBucket || allowLowBucketCriticalRecovery)) {
       const rcl = room.controller?.level ?? 1;
       const constructionInterval = roomConstructionManager.getConstructionInterval(rcl);
       const allowFullConstruction = postureManager.allowsBuilding(swarm.posture);
       const allowCriticalDefenseConstruction = !allowFullConstruction && swarm.danger >= 2;
+      const criticalOnly = allowCriticalDefenseConstruction || (lowBucket && allowLowBucketCriticalRecovery);
 
-      if (
-        (allowFullConstruction || allowCriticalDefenseConstruction) &&
-        isRoomConstructionDue(swarm, Game.time, constructionInterval)
-      ) {
+      if ((allowFullConstruction || criticalOnly) && isRoomConstructionDue(swarm, Game.time, constructionInterval)) {
         roomConstructionManager.runConstruction(room, swarm, cache.constructionSites, cache.spawns, {
-          criticalOnly: allowCriticalDefenseConstruction
+          criticalOnly
         });
         recordRoomConstructionRun(swarm, Game.time, constructionInterval);
       }

--- a/packages/screeps-bot/test/unit/roomConstructionScheduling.test.ts
+++ b/packages/screeps-bot/test/unit/roomConstructionScheduling.test.ts
@@ -69,18 +69,22 @@ describe("RoomNode construction scheduling", () => {
     (globalThis as { Game: typeof Game }).Game = originalGame;
   });
 
-  function createRoom(): Room {
+  function createRoom(hasSpawn = false): Room {
     const controller = {
       id: "controller1" as Id<StructureController>,
       my: true,
       level: 5
     } as StructureController;
+    const spawn = {
+      id: "spawn1" as Id<StructureSpawn>,
+      structureType: STRUCTURE_SPAWN
+    } as StructureSpawn;
 
     return {
       name: "W1N1",
       controller,
       find: (type: FindConstant) => {
-        if (type === FIND_MY_STRUCTURES) return [];
+        if (type === FIND_MY_STRUCTURES) return hasSpawn ? [spawn] : [];
         if (type === FIND_SOURCES) return [];
         if (type === FIND_MY_CONSTRUCTION_SITES) return [];
         return [];
@@ -109,7 +113,7 @@ describe("RoomNode construction scheduling", () => {
   }
 
   it("runs construction when the room process resumes after the remembered due tick", () => {
-    const room = createRoom();
+    const room = createRoom(true);
     const swarm = {
       posture: "eco",
       danger: 0,
@@ -135,5 +139,78 @@ describe("RoomNode construction scheduling", () => {
       nextRunTick: 1013,
       interval: 10
     });
+  });
+
+  it("runs only critical construction for a spawnless recovery room in low bucket", () => {
+    const room = createRoom();
+    const swarm = {
+      posture: "eco",
+      danger: 0
+    };
+    const runConstruction = stubRoomNodeCollaborators(swarm);
+    (globalThis as { Game: typeof Game }).Game = {
+      ...originalGame,
+      time: 2000,
+      rooms: { W1N1: room },
+      cpu: { ...originalGame.cpu, bucket: 5000, getUsed: () => 0 }
+    };
+
+    new RoomNode("W1N1", { enableProcessing: false, enablePheromones: false }).run(1);
+
+    assert.isTrue(
+      runConstruction.calledOnce,
+      "spawnless recovery construction must not be deferred with optional work"
+    );
+    assert.isTrue(
+      runConstruction.calledWithMatch(sinon.match.any, sinon.match.any, sinon.match.any, sinon.match.any, {
+        criticalOnly: true
+      })
+    );
+  });
+
+  it("does not run low-bucket construction for a stable room with spawn capacity", () => {
+    const room = createRoom(true);
+    const swarm = {
+      posture: "eco",
+      danger: 0
+    };
+    const runConstruction = stubRoomNodeCollaborators(swarm);
+    (globalThis as { Game: typeof Game }).Game = {
+      ...originalGame,
+      time: 3000,
+      rooms: { W1N1: room },
+      cpu: { ...originalGame.cpu, bucket: 5000, getUsed: () => 0 }
+    };
+
+    new RoomNode("W1N1", { enableProcessing: false, enablePheromones: false }).run(1);
+
+    assert.isFalse(runConstruction.called, "stable room construction remains optional while the bucket recovers");
+  });
+
+  it("runs capped critical defense construction in low bucket during danger", () => {
+    const room = createRoom(true);
+    const swarm = {
+      posture: "eco",
+      danger: 2
+    };
+    const runConstruction = stubRoomNodeCollaborators(swarm);
+    (globalThis as { Game: typeof Game }).Game = {
+      ...originalGame,
+      time: 4000,
+      rooms: { W1N1: room },
+      cpu: { ...originalGame.cpu, bucket: 5000, getUsed: () => 0 }
+    };
+
+    new RoomNode("W1N1", { enableProcessing: false, enablePheromones: false }).run(1);
+
+    assert.isTrue(
+      runConstruction.calledOnce,
+      "critical defense construction must continue during low-bucket recovery"
+    );
+    assert.isTrue(
+      runConstruction.calledWithMatch(sinon.match.any, sinon.match.any, sinon.match.any, sinon.match.any, {
+        criticalOnly: true
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

Allow survival-critical construction to continue while the CPU bucket recovers, without reopening optional layout work.

## Linked issue

Closes #3357

## Research

- Local Screeps runtime/types and repository construction budget contracts were checked.
- Existing `RoomConstructionManager` `criticalOnly` path already enforces bounded tower/spawn bootstrap behavior and shared construction-site caps.
- SearXNG was attempted for current external mechanics research but the configured backend returned HTTP 403; no external claim was used in the implementation.

## Changes

- `RoomNode` permits low-bucket construction only for spawnless bootstrap or active danger.
- Low-bucket recovery always passes `criticalOnly: true`.
- Stable rooms continue deferring construction under bucket pressure.
- Documentation now describes remembered due-tick scheduling and the low-bucket contract.
- Generated deploy bundle updated.

## Defense impact

- Threat detection: unchanged.
- Defensive response: critical tower/spawn-site placement is no longer starved solely by low bucket.
- Construction adaptation: optional roads, labs, links, cleanup, and normal blueprint work remain deferred.
- Recovery: spawnless rooms can keep the spawn bootstrap path alive during CPU recovery.
- CPU/Memory impact: bounded by the existing critical-only construction budgets; no new persistent Memory fields.

## Tests

- RoomNode scheduling regression tests: spawnless low bucket, stable low bucket, active danger low bucket.
- Related RoomConstructionManager + scheduling tests: 25 passing.
- Bot typecheck: pass.
- Bot lint: pass.
- Bot build and bundle-size check: pass (`1330 KB`, `64.9%` of limit).
- Version/dependency/alliance/deep-import/bundle-drift checks: pass.
- Private-server smoke: running locally; follow-up #3361 tracks the missing deterministic low-bucket scenario.

## Live evidence

Sanitized read-only shard1 sample before deployment found one mid-level owned recovery room with six non-allied hostiles, one friendly creep, no built spawn/tower capacity, and an active spawn construction site. CPU was healthy and no incoming nuke was visible. Exact tactical data remains local.

## Follow-up issues

- #3361 — deterministic private-server low-bucket critical recovery scenario.
- #3210 — current live spawnless hostile-room reinforcement/recovery tracker.
