### PR TITLE
fix(defense): clear stale boost priority after recovery

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -12338,7 +12338,7 @@ this.emergencyStates = new Map;
 }
 return e.prototype.assess = function(e, t) {
 var r, o, n = this.emergencyStates.get(e.name), a = this.calculateEmergencyLevel(e, t);
-if (a === li.NONE && !n) return {
+if (a === li.NONE && this.clearBoostPriority(e.name), a === li.NONE && !n) return {
 level: li.NONE,
 startedAt: Game.time,
 assistanceRequested: !1,
@@ -12358,20 +12358,20 @@ subsystem: "Defense"
 subsystem: "Defense"
 }), o.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, o), o);
 }, e.prototype.calculateEmergencyLevel = function(e, t) {
-var r = X(e);
-if (0 === t.danger && 0 === r.length) return li.NONE;
-var o = co(e), n = lo(e), a = Go(e);
-if (e.find(FIND_MY_STRUCTURES, {
+var r = X(e), o = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
 }
-}).length > 0) return li.CRITICAL;
-var i = r.filter(function(e) {
+}), n = e.find(FIND_NUKES);
+if (0 === t.danger && 0 === r.length && 0 === o.length && 0 === n.length) return li.NONE;
+var a = co(e), i = lo(e), s = Go(e);
+if (o.length > 0 || n.length > 0) return li.CRITICAL;
+var c = r.filter(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && e.boost;
 });
-}), s = Math.max(0, o.guards - n.guards) + Math.max(0, o.rangers - n.rangers) + Math.max(0, o.healers - n.healers);
-return i.length > 0 && s >= 2 || r.length >= 5 && 0 === n.guards && 0 === n.rangers || a.dangerLevel >= 2 && s >= 2 ? li.HIGH : (t.danger >= 2 || a.dangerLevel >= 2) && s >= 1 ? li.MEDIUM : t.danger >= 1 || r.length > 0 ? li.LOW : li.NONE;
+}), u = Math.max(0, a.guards - i.guards) + Math.max(0, a.rangers - i.rangers) + Math.max(0, a.healers - i.healers);
+return c.length > 0 && u >= 2 || r.length >= 5 && 0 === i.guards && 0 === i.rangers || s.dangerLevel >= 2 && u >= 2 ? li.HIGH : (t.danger >= 2 || s.dangerLevel >= 2) && u >= 1 ? li.MEDIUM : t.danger >= 1 || r.length > 0 ? li.LOW : li.NONE;
 }, e.prototype.executeEmergencyResponse = function(e, t, r) {
 r.level >= li.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
 r.level >= li.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
@@ -12392,6 +12392,12 @@ subsystem: "Defense"
 }), !0);
 }, e.prototype.shouldRefreshDefenseRequest = function(e, t) {
 return t.urgency !== e.urgency || t.guardsNeeded !== e.guardsNeeded || t.rangersNeeded !== e.rangersNeeded || t.healersNeeded !== e.healersNeeded || t.threat !== e.threat;
+}, e.prototype.clearBoostPriority = function(e) {
+var t = Memory, r = t.boostDefensePriority;
+if (r && "object" == typeof r) {
+var o = r;
+delete o[e], 0 === Object.keys(o).length && delete t.boostDefensePriority;
+}
 }, e.prototype.allocateBoostsForDefense = function(e, t) {
 var r, o = Memory, n = null !== (r = o.boostDefensePriority) && void 0 !== r ? r : {};
 n[e.name] = !0, o.boostDefensePriority = n, _.info("Allocated boost priority for defenders in ".concat(e.name), {

--- a/packages/screeps-bot/test/unit/labSystem.test.ts
+++ b/packages/screeps-bot/test/unit/labSystem.test.ts
@@ -173,6 +173,26 @@ describe("Lab System", () => {
       expect(shouldBoost).to.be.true;
     });
 
+    it("should honor active room boost priority at lower danger", () => {
+      const swarm = createDefaultSwarmState();
+      swarm.danger = 2;
+      swarm.missingStructures.labs = false;
+      (global.Memory as Record<string, unknown>).boostDefensePriority = { W1N1: true };
+
+      const mockCreep = {
+        memory: {
+          role: "soldier",
+          boosted: false
+        },
+        room: {
+          name: "W1N1"
+        },
+        body: [{ type: ATTACK, hits: 100 }]
+      } as unknown as Creep;
+
+      expect(boostManager.shouldBoost(mockCreep, swarm)).to.be.true;
+    });
+
     it("should not boost if danger level is too low", () => {
       const swarm = createDefaultSwarmState();
       swarm.danger = 0; // No danger

--- a/packages/screeps-defense/src/emergency/emergencyResponse.ts
+++ b/packages/screeps-defense/src/emergency/emergencyResponse.ts
@@ -71,6 +71,10 @@ export class EmergencyResponseManager {
     const existingState = this.emergencyStates.get(room.name);
     const emergencyLevel = this.calculateEmergencyLevel(room, swarm);
 
+    if (emergencyLevel === EmergencyLevel.NONE) {
+      this.clearBoostPriority(room.name);
+    }
+
     // If no threat and no existing emergency, return default state without creating entry
     // BUGFIX: Don't create emergency state entries for rooms with no threats
     // This prevents spam from repeatedly creating and deleting NONE-level states
@@ -131,16 +135,8 @@ export class EmergencyResponseManager {
   private calculateEmergencyLevel(room: Room, swarm: SwarmState): EmergencyLevel {
     const hostiles = getActualHostileCreeps(room);
 
-    // No emergency if no danger signal and no currently visible hostile.
-    if (swarm.danger === 0 && hostiles.length === 0) {
-      return EmergencyLevel.NONE;
-    }
-
-    const needs = analyzeDefenderNeeds(room);
-    const current = getCurrentDefenders(room);
-    const threat = assessThreat(room);
-
-    // Critical: Critical structures heavily damaged or about to be destroyed
+    // Critical structures and incoming nukes remain emergencies even when the
+    // caller's persisted danger signal has not caught up with the visible room.
     const criticalStructures = room.find(FIND_MY_STRUCTURES, {
       filter: s =>
         (s.structureType === STRUCTURE_SPAWN ||
@@ -148,8 +144,18 @@ export class EmergencyResponseManager {
           s.structureType === STRUCTURE_TERMINAL) &&
         s.hits < s.hitsMax * 0.3
     });
+    const incomingNukes = room.find(FIND_NUKES);
 
-    if (criticalStructures.length > 0) {
+    // No emergency if no danger signal, hostile, critical structure, or nuke.
+    if (swarm.danger === 0 && hostiles.length === 0 && criticalStructures.length === 0 && incomingNukes.length === 0) {
+      return EmergencyLevel.NONE;
+    }
+
+    const needs = analyzeDefenderNeeds(room);
+    const current = getCurrentDefenders(room);
+    const threat = assessThreat(room);
+
+    if (criticalStructures.length > 0 || incomingNukes.length > 0) {
       return EmergencyLevel.CRITICAL;
     }
 
@@ -268,7 +274,22 @@ export class EmergencyResponseManager {
   }
 
   /**
-   * Allocate boosts for defensive creeps
+   * Remove the room's defensive boost override after the threat resolves.
+   */
+  private clearBoostPriority(roomName: string): void {
+    const mem = Memory as unknown as Record<string, unknown>;
+    const boostPriority = mem.boostDefensePriority;
+    if (!boostPriority || typeof boostPriority !== "object") return;
+
+    const priorities = boostPriority as Record<string, boolean>;
+    delete priorities[roomName];
+    if (Object.keys(priorities).length === 0) {
+      delete mem.boostDefensePriority;
+    }
+  }
+
+  /**
+   * Allocate boosts for defensive creeps.
    */
   private allocateBoostsForDefense(room: Room, _swarm: SwarmState): void {
     // Mark swarm state to prioritize boosting defenders

--- a/packages/screeps-defense/test/defenderNeeds.test.ts
+++ b/packages/screeps-defense/test/defenderNeeds.test.ts
@@ -25,7 +25,9 @@ function createRoom(
   controllerLevel = 4,
   spawnCount = 1,
   friendlyRoles: string[] = [],
-  controllerOwned = true
+  controllerOwned = true,
+  criticalStructure = false,
+  incomingNukeCount = 0
 ): Room {
   const spawns = Array.from({ length: spawnCount }, () => ({ spawning: false }));
   const friendlyCreeps = friendlyRoles.map(role => ({ memory: { role } }));
@@ -38,7 +40,12 @@ function createRoom(
       if (type === FIND_HOSTILE_CREEPS) return hostiles;
       if (type === FIND_MY_CREEPS) return friendlyCreeps;
       if (type === FIND_MY_SPAWNS) return spawns;
-      if (type === FIND_MY_STRUCTURES) return [];
+      if (type === FIND_MY_STRUCTURES) {
+        return criticalStructure
+          ? [{ structureType: STRUCTURE_SPAWN, hits: 10, hitsMax: 100 }]
+          : [];
+      }
+      if (type === FIND_NUKES) return Array.from({ length: incomingNukeCount }, () => ({}));
       return [];
     }
   } as unknown as Room;
@@ -203,6 +210,66 @@ describe("defense assistance needs", () => {
     expect(needs.urgency).to.equal(1.0);
     expect(needs.guards).to.equal(1);
     expect(needs.reasons.join("; ")).to.not.include("no local spawn capacity");
+  });
+
+  it("clears boost priority when an active emergency resolves", () => {
+    const manager = new EmergencyResponseManager();
+    const swarm = {
+      danger: 0,
+      posture: "eco",
+      pheromones: { defense: 0, war: 0, siege: 0 }
+    } as any;
+    const room = createRoom([createHostile([ATTACK, MOVE], "XUH2O")], 6, 1);
+
+    manager.assess(room, swarm);
+    expect((Memory as any).boostDefensePriority?.W1N1).to.equal(true);
+
+    (Game as any).time = 1010;
+    manager.assess(createRoom([], 6, 1), { ...swarm, danger: 0 });
+
+    expect((Memory as any).boostDefensePriority?.W1N1).to.equal(undefined);
+  });
+
+  it("clears stale boost priority after a global reset with no active emergency", () => {
+    (Memory as any).boostDefensePriority = { W1N1: true, W2N2: true };
+    const manager = new EmergencyResponseManager();
+    const room = createRoom([], 6, 1);
+
+    manager.assess(room, {
+      danger: 0,
+      posture: "eco",
+      pheromones: { defense: 0, war: 0, siege: 0 }
+    } as any);
+
+    expect((Memory as any).boostDefensePriority).to.deep.equal({ W2N2: true });
+  });
+
+  it("preserves boost priority while critical structures remain damaged", () => {
+    (Memory as any).boostDefensePriority = { W1N1: true };
+    const manager = new EmergencyResponseManager();
+
+    const state = manager.assess(createRoom([], 6, 1, [], true, true), {
+      danger: 0,
+      posture: "eco",
+      pheromones: { defense: 0, war: 0, siege: 0 }
+    } as any);
+
+    expect(state.level).to.equal(EmergencyLevel.CRITICAL);
+    expect((Memory as any).boostDefensePriority?.W1N1).to.equal(true);
+  });
+
+  it("preserves boost priority for an incoming nuke before hostile detection catches up", () => {
+    (Memory as any).boostDefensePriority = { W1N1: true };
+    const manager = new EmergencyResponseManager();
+
+    const state = manager.assess(createRoom([], 6, 1, [], true, false, 1), {
+      danger: 0,
+      posture: "eco",
+      pheromones: { defense: 0, war: 0, siege: 0 }
+    } as any);
+
+    expect(state.level).to.equal(EmergencyLevel.CRITICAL);
+    expect((Memory as any).boostDefensePriority?.W1N1).to.equal(true);
   });
 
   it("records the tick when an existing emergency escalates", () => {


### PR DESCRIPTION
## Summary

Clear per-room defensive boost overrides when emergency recovery returns to `NONE`, including after a global reset with stale Memory. Preserve the override while critical structure damage or incoming nukes still make the room critical.

## Linked issue

Closes #3341

## Research

- Repository evidence: `EmergencyResponseManager` wrote `Memory.boostDefensePriority` but had no recovery cleanup.
- SearXNG was unavailable in this cycle (HTTP 403); no external mechanic assumption was needed for this Memory lifecycle fix.

## Changes

- Added typed runtime cleanup for one room without deleting other active room priorities.
- Ensured critical structure and nuke signals are evaluated before the no-threat fast path.
- Added emergency recovery, global-reset, critical-structure, and incoming-nuke regression tests.
- Added BoostManager consumer coverage for the active room override.
- Regenerated the tracked bot bundle.

## Defense impact

- Threat detection: preserves active critical/nuclear defense state even when persisted danger/hostile signals lag.
- Defensive response: removes stale boost consumption after recovery.
- Recovery: global resets no longer leave old room overrides indefinitely.
- CPU/Memory: removes stale per-room entries; no unbounded data added.

## Tests

- `npm test -w @ralphschuler/screeps-defense` — 92 passing
- `npm run test:unit -w screeps-typescript-starter` — 2419 passing
- `npm run build -w @ralphschuler/screeps-defense` — passed
- `npm run build:bot` — passed; bundle 1.30 MB / 2 MB
- `npm run test:server:smoke` — passed; 6 scenarios, no harness errors
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities
- Alliance safety/deep-import/dependency-sync checks — passed

## Follow-up

- #3210 remains the active live spawnless-hostile recovery risk and is not included in this scoped fix.
