### PR TITLE
fix(defense): use bounded terminal energy for emergency refuel

### DIFF
--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/hauler.ts
@@ -10,6 +10,7 @@
 
 import type { CreepAction, CreepContext } from "../types";
 import { findDistributedTarget, registerAssignment } from "@ralphschuler/screeps-utils";
+import { hasEmergencyDefenseRefuelEnergy } from "@ralphschuler/screeps-defense";
 import { findCachedClosest } from "../../cache";
 import { updateWorkingState, switchToCollectionMode } from "./common/stateManagement";
 import { createLogger } from "@ralphschuler/screeps-core";
@@ -251,18 +252,25 @@ function findDefenseRefuelDelivery(ctx: CreepContext): CreepAction | null {
 }
 
 function findDefenseRefuelCollection(ctx: CreepContext): CreepAction | null {
-  // Spawn demand only creates defenseRefuel haulers when source-adjacent containers
-  // hold useful energy; prefer that same cached source-container set here.
+  // Spawn demand prefers source containers, but emergency helpers may have no
+  // harvestable container energy while a mature terminal still has bounded reserve.
   const sourceContainersWithEnergy = ctx.sourceContainers.filter(
     c => c.store.getUsedCapacity(RESOURCE_ENERGY) > 100
   );
-  if (sourceContainersWithEnergy.length === 0) return null;
 
-  const target = getCachedDistributedTarget(ctx.creep, sourceContainersWithEnergy, "energy_container");
-  if (target) return { type: "withdraw", target, resourceType: RESOURCE_ENERGY };
+  if (sourceContainersWithEnergy.length > 0) {
+    const target = getCachedDistributedTarget(ctx.creep, sourceContainersWithEnergy, "energy_container");
+    if (target) return { type: "withdraw", target, resourceType: RESOURCE_ENERGY };
 
-  const fallback = ctx.creep.pos.findClosestByRange(sourceContainersWithEnergy);
-  if (fallback) return { type: "withdraw", target: fallback, resourceType: RESOURCE_ENERGY };
+    const fallback = ctx.creep.pos.findClosestByRange(sourceContainersWithEnergy);
+    if (fallback) return { type: "withdraw", target: fallback, resourceType: RESOURCE_ENERGY };
+  }
+
+  // The fixed CARRY/MOVE defense-refuel body withdraws at most 100 energy,
+  // while the shared policy keeps the terminal above its emergency floor.
+  if (hasEmergencyDefenseRefuelEnergy(ctx.terminal)) {
+    return { type: "withdraw", target: ctx.terminal!, resourceType: RESOURCE_ENERGY };
+  }
 
   return null;
 }

--- a/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/behaviorContracts.test.ts
@@ -740,6 +740,27 @@ describe("Behavior Contracts", () => {
     expect((action as Extract<CreepAction, { type: "withdraw" }>).resourceType).to.equal(RESOURCE_ENERGY);
   });
 
+  it("withdraws bounded terminal energy for an emergency defenseRefuel hauler when source containers are empty", () => {
+    const terminal = {
+      id: "terminal1",
+      cooldown: 0,
+      store: makeEnergyStore(10_000, 0)
+    } as unknown as StructureTerminal;
+    const ctx = createContext("hauler");
+    ctx.memory.task = "defenseRefuel";
+
+    const action = evaluateEconomyBehavior({
+      ...ctx,
+      sourceContainers: [],
+      containers: [],
+      terminal
+    });
+
+    expect(action.type).to.equal("withdraw");
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).target).to.equal(terminal);
+    expect((action as Extract<CreepAction, { type: "withdraw" }>).resourceType).to.equal(RESOURCE_ENERGY);
+  });
+
   it("keeps spawn delivery ahead of terminal energy buffering", () => {
     const room = createMockRoom("W1N1");
     const spawn = {

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -12327,12 +12327,17 @@ stroke: "#ff0000"
 }(e), !0);
 }
 
+function vi(e) {
+var t;
+return (null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== t ? t : 0) >= 5100;
+}
+
 !function(e) {
 e[e.NONE = 0] = "NONE", e[e.LOW = 1] = "LOW", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL";
 }(li || (li = {}));
 
-var vi = function() {
+var gi = function() {
 function e() {
 this.emergencyStates = new Map;
 }
@@ -12471,27 +12476,27 @@ return r.sort(function(e, t) {
 return t.state.level - e.state.level;
 });
 }, e;
-}(), gi = new vi;
+}(), hi = new gi;
 
-function hi(e) {
+function Ri(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === HEAL || e.type === WORK || e.type === CLAIM);
 });
 }
 
-function Ri(e, t) {
+function Ei(e, t) {
 return e.body.filter(function(e) {
 return e.hits > 0 && e.type === t;
 }).length;
 }
 
-function Ei(e) {
+function Ti(e) {
 return !!e.body.some(function(e) {
 return e.hits > 0 && e.boost;
-}) || Ri(e, WORK) >= 5 || Ri(e, HEAL) >= 3;
+}) || Ei(e, WORK) >= 5 || Ei(e, HEAL) >= 3;
 }
 
-var Ti = function() {
+var Ci = function() {
 function e() {}
 return e.prototype.checkSafeMode = function(e, t) {
 var r, o, n, a, i;
@@ -12509,7 +12514,7 @@ subsystem: "Defense"
 }, e.prototype.shouldTriggerSafeMode = function(e, t) {
 var r, o;
 if (t.danger < 2) return !1;
-var n = X(e), i = n.filter(hi), s = function() {
+var n = X(e), i = n.filter(Ri), s = function() {
 var e;
 return !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.safeModeDangerousHostilesOnly);
 }(), c = s ? i : n;
@@ -12548,21 +12553,21 @@ return "guard" === t || "ranger" === t || "soldier" === t;
 if (c.length > 3 * p.length) return _.warn("Overwhelmed: ".concat(c.length, " safe-mode-relevant hostiles vs ").concat(p.length, " defenders"), {
 subsystem: "Defense"
 }), !0;
-var f = c.filter(Ei);
+var f = c.filter(Ti);
 return f.length > 0 && p.length < 2 * f.length && (_.warn("High-impact siege hostiles detected: ".concat(f.length), {
 subsystem: "Defense"
 }), !0);
 }, e;
-}(), Ci = new Ti, Si = new Set([ "nuke", "siege", "hostile_takeover", "manual" ]), wi = {
+}(), Si = new Ci, wi = new Set([ "nuke", "siege", "hostile_takeover", "manual" ]), xi = {
 triggerDangerLevel: 3,
 nukeEvacuationLeadTime: 5e3,
 minStorageEnergy: 5e4,
 priorityResources: [ RESOURCE_ENERGY, RESOURCE_POWER, RESOURCE_GHODIUM, RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ACID, RESOURCE_CATALYZED_ZYNTHIUM_ACID, RESOURCE_OPS ],
 maxTransfersPerTick: 2
-}, xi = function() {
+}, bi = function() {
 function e(e) {
 void 0 === e && (e = {}), this.evacuations = new Map, this.lastTransferTick = 0,
-this.transfersThisTick = 0, this.config = o(o({}, wi), e);
+this.transfersThisTick = 0, this.config = o(o({}, xi), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o;
@@ -12646,7 +12651,7 @@ delete r.evacuationIntent;
 }, e.prototype.isValidEvacuationIntent = function(e) {
 if (!e || "object" != typeof e) return !1;
 var t = e;
-return Si.has(String(t.reason)) && "number" == typeof t.startedAt && Number.isFinite(t.startedAt) && "string" == typeof t.targetRoom && t.targetRoom.length > 0 && "number" == typeof t.progress && Number.isFinite(t.progress) && "boolean" == typeof t.complete && "number" == typeof t.updatedAt && Number.isFinite(t.updatedAt) && (void 0 === t.deadline || "number" == typeof t.deadline && Number.isFinite(t.deadline));
+return wi.has(String(t.reason)) && "number" == typeof t.startedAt && Number.isFinite(t.startedAt) && "string" == typeof t.targetRoom && t.targetRoom.length > 0 && "number" == typeof t.progress && Number.isFinite(t.progress) && "boolean" == typeof t.complete && "number" == typeof t.updatedAt && Number.isFinite(t.updatedAt) && (void 0 === t.deadline || "number" == typeof t.deadline && Number.isFinite(t.deadline));
 }, e.prototype.persistEvacuation = function(e) {
 var t = Sr.getSwarmState(e.roomName);
 if (t) {
@@ -12892,9 +12897,9 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), bi = new xi;
+}(), Oi = new bi;
 
-function Oi(e) {
+function ki(e) {
 var t = Math.floor(e.bucketThresholds.lowMode / 2), r = {
 high: 1,
 medium: Math.max(1, Math.min(e.taskFrequencies.clusterLogic, e.taskFrequencies.pheromoneUpdate)),
@@ -12929,21 +12934,21 @@ maxPriorityBoost: 50
 };
 }
 
-var ki, Ai = null, Mi = new Proxy({}, {
+var Ai, Mi = null, _i = new Proxy({}, {
 get: function(e, t) {
-return Ai || (Ai = new Ke(Oi(kr().cpu))), Ai[t];
+return Mi || (Mi = new Ke(ki(kr().cpu))), Mi[t];
 },
 set: function(e, t, r) {
-return Ai || (Ai = new Ke(Oi(kr().cpu))), Ai[t] = r, !0;
+return Mi || (Mi = new Ke(ki(kr().cpu))), Mi[t] = r, !0;
 }
 });
 
-function _i() {
+function Ui() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-rt.apply(void 0, s([ Mi ], i(e), !1));
+rt.apply(void 0, s([ _i ], i(e), !1));
 }
 
-var Ui, Ni, Pi = {
+var Ni, Pi, Ii = {
 updateInterval: 200,
 minBucket: 0,
 minCreditsForPixels: 5e5,
@@ -12955,11 +12960,11 @@ targetPixelPrice: 2e3,
 maxPixelsPerTransaction: 10,
 purchaseCooldown: 1e3,
 minBaseMineralReserve: 1e4,
-criticalResourceThresholds: (ki = {}, ki[RESOURCE_GHODIUM] = 5e3, ki),
+criticalResourceThresholds: (Ai = {}, Ai[RESOURCE_GHODIUM] = 5e3, Ai),
 enabled: !0
-}, Ii = function() {
+}, Gi = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Pi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Ii), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13135,15 +13140,15 @@ this.config.enabled = !1, _.info("Pixel buying disabled", {
 subsystem: "PixelBuying"
 });
 }, e;
-}(), Gi = {
+}(), Li = {
 enabled: !0,
 fullBucketTicksRequired: 25,
 bucketMax: 1e4,
 cpuCostPerPixel: 1e4,
 minBucketAfterGeneration: 0
-}, Li = function() {
+}, Di = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, Gi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.config = o(o({}, Li), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13205,7 +13210,7 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), Di = function(e) {
+}(), Fi = function(e) {
 var t = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.map(function(e) {
@@ -13235,18 +13240,18 @@ for (var o = [], n = 1; n < arguments.length; n++) o[n - 1] = arguments[n];
 return console.log.apply(console, s([ "[".concat(e, "] ERROR:"), r ], i(t.apply(void 0, s([], i(o), !1))), !1));
 }
 };
-}("stats"), Fi = function(e) {
+}("stats"), Bi = function(e) {
 var t, r, o;
 return (null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.swarm) || (null === (o = Memory.swarm) || void 0 === o ? void 0 : o[e]) || {};
 };
 
 !function(e) {
 e.ACTIVE = "active", e.DECAY = "decay", e.INACTIVE = "inactive";
-}(Ui || (Ui = {})), function(e) {
+}(Ni || (Ni = {})), function(e) {
 e.PHEROMONES = "pheromones", e.PATHS = "paths", e.TARGETS = "targets", e.DEBUG = "debug";
-}(Ni || (Ni = {}));
+}(Pi || (Pi = {}));
 
-var Bi = new (function() {
+var Wi = new (function() {
 function e() {
 this.metrics = {
 totalCalls: 0,
@@ -13294,7 +13299,7 @@ moveByPath: 0
 }, e;
 }());
 
-function Wi(e, t) {
+function Hi(e, t) {
 var r;
 void 0 === t && (t = {});
 var o = null === (r = t.includeCpuUsage) || void 0 === r || r, n = s([], i(e), !1).sort(function(e, t) {
@@ -13303,15 +13308,15 @@ return t.percentUsed - e.percentUsed;
 var r, n, a = "room:".concat(e.target), i = null === (r = t.processes) || void 0 === r ? void 0 : r[a], s = null !== (n = null == i ? void 0 : i.tickModulo) && void 0 !== n ? n : 1, c = s > 1 ? " [runs every ".concat(s, " ticks]") : "", u = "".concat((100 * e.percentUsed).toFixed(1), "%");
 return o ? "".concat(e.target, ": ").concat(u, " (").concat(e.cpuUsed.toFixed(3), "/").concat(e.budgetLimit.toFixed(3), " CPU)").concat(c) : "".concat(e.target, ": ").concat(u).concat(c);
 });
-return Hi(n, e.length);
+return Ki(n, e.length);
 }
 
-function Hi(e, t) {
+function Ki(e, t) {
 var r = t - e.length;
 return r > 0 && e.push("... ".concat(r, " more omitted")), e.join(", ");
 }
 
-var Ki = {
+var Yi = {
 enabled: !0,
 smoothingFactor: .1,
 trackNativeCalls: !0,
@@ -13333,9 +13338,9 @@ enabled: !0,
 spikeThreshold: 2,
 minSamples: 10
 }
-}, Yi = 1e-9, Vi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
+}, Vi = 1e-9, qi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
 
-function qi() {
+function ji() {
 return {
 tasks: 0,
 openTasks: 0,
@@ -13347,28 +13352,28 @@ remainingAmount: 0
 };
 }
 
-function ji(e) {
+function zi(e) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, e) : 0;
 }
 
-function zi(e) {
+function Qi(e) {
 var t;
 return Object.values(null !== (t = e.reservations) && void 0 !== t ? t : {}).reduce(function(e, t) {
-return e + ji(null == t ? void 0 : t.amount);
+return e + zi(null == t ? void 0 : t.amount);
 }, 0);
 }
 
-var Qi = function() {
+var Xi = function() {
 function e(e) {
 void 0 === e && (e = {}), this.subsystemMeasurements = new Map, this.cpuDetailMeasurements = new Map,
 this.roomMeasurements = new Map, this.lastSegmentUpdate = 0, this.lastBudgetAlertLogTick = -1 / 0,
 this.lastAnomalyLogTick = -1 / 0, this.segmentRequested = !1, this.skippedProcessesThisTick = 0,
-this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Ki), e),
+this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Yi), e),
 this.currentSnapshot = this.createEmptySnapshot(), this.nativeCallsThisTick = this.createEmptyNativeCalls();
 }
 return e.prototype.initialize = function() {
 void 0 === RawMemory.segments[this.config.segmentId] && (RawMemory.setActiveSegments([ this.config.segmentId ]),
-this.segmentRequested = !0), this.installCpuProfilerGlobal(), Di.info("Unified stats system initialized", {
+this.segmentRequested = !0), this.installCpuProfilerGlobal(), Fi.info("Unified stats system initialized", {
 subsystem: "Stats"
 });
 }, e.prototype.preserveRoomStats = function() {
@@ -13405,7 +13410,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-Bi.reset();
+Wi.reset();
 }
 }, e.prototype.publishIdleTick = function() {
 this.startTick(), this.finalizeTick();
@@ -13441,19 +13446,19 @@ return "critical" === e.severity;
 }), C = R.alerts.filter(function(e) {
 return "warning" === e.severity;
 });
-T.length > 0 && Di.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Wi(T, {
+T.length > 0 && Fi.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Hi(T, {
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
-}), C.length > 0 && Di.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Wi(C, {
+}), C.length > 0 && Fi.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Hi(C, {
 includeCpuUsage: !1,
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
 }), this.lastBudgetAlertLogTick = Game.time;
 }
-E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Di.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
-return Hi(s([], i(e), !1).sort(function(e, t) {
+E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Fi.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
+return Ki(s([], i(e), !1).sort(function(e, t) {
 return t.multiplier - e.multiplier;
 }).slice(0, 5).map(function(e) {
 return "".concat(e.target, " (").concat(e.type, "): ").concat(e.current.toFixed(3), " CPU (").concat(e.multiplier.toFixed(1), "x baseline)").concat(e.context ? " - ".concat(e.context) : "");
@@ -13553,7 +13558,7 @@ v.staleReservations = null !== (s = null === (i = y.stats) || void 0 === i ? voi
 v.blockedReservations = null !== (u = null === (c = y.stats) || void 0 === c ? void 0 : c.blockedReservations) && void 0 !== u ? u : 0;
 try {
 for (var g = a(Object.values(null !== (l = y.tasks) && void 0 !== l ? l : {})), h = g.next(); !h.done; h = g.next()) {
-var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : qi(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = ji(R.amount), w = zi(R), x = Math.max(0, S - w), b = Vi.has(E);
+var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : ji(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = zi(R.amount), w = Qi(R), x = Math.max(0, S - w), b = qi.has(E);
 v.tasks++, v.reservations += C, v.amount += S, v.reservedAmount += w, v.remainingAmount += x,
 T.tasks++, T.reservations += C, T.amount += S, T.reservedAmount += w, T.remainingAmount += x,
 "open" === R.status ? (v.openTasks++, T.openTasks++) : "assigned" === R.status && (v.assignedTasks++,
@@ -13777,7 +13782,7 @@ this.defenseAssistTelemetry.set(e, r), (null == o ? void 0 : o.defense) && (o.de
 }, e.prototype.recordRoom = function(e, t) {
 var r, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, k, A;
 if (this.config.enabled) {
-var M = Fi(e.name), _ = Object.values(Game.creeps).filter(function(t) {
+var M = Bi(e.name), _ = Object.values(Game.creeps).filter(function(t) {
 return t.room.name === e.name;
 }).length, U = X(e), N = this.getRoomTaskBoardStats(e.name), P = this.getRemoteStats(e.name, M), I = this.getDefenseStats(e, U, M), G = this.defenseAssistTelemetry.get(e.name), L = this.getControllerDowngradeStats(e), D = this.currentSnapshot.rooms[e.name];
 D || (D = {
@@ -13885,7 +13890,7 @@ storageEnergy: W
 };
 }
 }, e.prototype.isWarRoom = function(e) {
-var t = Fi(e);
+var t = Bi(e);
 return !!t && ("war" === t.posture || "siege" === t.posture || t.danger >= 2);
 }, e.prototype.validateBudgets = function() {
 var e, t, r, o = {
@@ -13900,8 +13905,8 @@ try {
 for (var n = a(Object.entries(this.currentSnapshot.rooms)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
 o.roomsEvaluated++;
-var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Yi ? h : Math.abs(v - g) <= Yi ? g : v;
-v + Yi >= h ? (o.roomsOverBudget++, o.alerts.push({
+var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Vi ? h : Math.abs(v - g) <= Vi ? g : v;
+v + Vi >= h ? (o.roomsOverBudget++, o.alerts.push({
 severity: "critical",
 target: u,
 targetType: "room",
@@ -13909,7 +13914,7 @@ cpuUsed: y,
 budgetLimit: f,
 percentUsed: R,
 tick: Game.time
-})) : v + Yi >= g ? (o.alerts.push({
+})) : v + Vi >= g ? (o.alerts.push({
 severity: "warning",
 target: u,
 targetType: "room",
@@ -13943,7 +13948,7 @@ var v = null !== (n = this.roomMeasurements.get(f)) && void 0 !== n ? n : 0;
 if (!((x = y.profiler.avgCpu) < .01)) {
 var g = v / x;
 if (g >= this.config.anomalyDetection.spikeThreshold) {
-var h = Fi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
+var h = Bi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
 l.push({
 type: "spike",
 target: f,
@@ -14371,7 +14376,7 @@ evictions: 0
 }
 };
 }, e.prototype.finalizePathfindingStats = function() {
-this.currentSnapshot.pathfinding = Bi.getMetrics();
+this.currentSnapshot.pathfinding = Wi.getMetrics();
 }, e.prototype.formatCpuDetailsForMemory = function() {
 var e, t, r, n, s = this.getCpuDetailsConfig(), c = {};
 try {
@@ -14769,24 +14774,24 @@ var o = JSON.parse(r);
 Array.isArray(o) && (t = o);
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Di.error("Failed to parse stats segment: ".concat(n), {
+Fi.error("Failed to parse stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
 t.push(this.currentSnapshot), t.length > this.config.maxHistoryPoints && (t = t.slice(-this.config.maxHistoryPoints));
 var a = JSON.stringify(t);
 if (a.length > e) {
-for (Di.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
+for (Fi.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
 subsystem: "Stats"
 }); a.length > e && t.length > 1; ) t.shift(), a = JSON.stringify(t);
-if (a.length > e) return void Di.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
+if (a.length > e) return void Fi.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
 subsystem: "Stats"
 });
 }
 try {
 RawMemory.segments[this.config.segmentId] = a;
 } catch (e) {
-n = e instanceof Error ? e.message : String(e), Di.error("Failed to save stats segment: ".concat(n), {
+n = e instanceof Error ? e.message : String(e), Fi.error("Failed to save stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
@@ -14803,17 +14808,17 @@ lastUpdate: 0
 }), e.stats.profiler;
 }, e.prototype.logSummary = function() {
 var e, t, r, o, n, i, s, c, u, l, m = this.currentSnapshot;
-Di.info("=== Unified Stats Summary ==="), Di.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
-Di.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
+Fi.info("=== Unified Stats Summary ==="), Fi.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
+Fi.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
 var d = Object.values(m.subsystems).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (d.length > 0) {
-Di.info("Top Subsystems:");
+Fi.info("Top Subsystems:");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Di.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
+Fi.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
 }
 } catch (t) {
 e = {
@@ -14831,11 +14836,11 @@ var v = Object.values(m.roles).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (v.length > 0) {
-Di.info("Top Roles:");
+Fi.info("Top Roles:");
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Di.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
+Fi.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
 }
 } catch (e) {
 r = {
@@ -14853,11 +14858,11 @@ var E = Object.values(m.processes).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (E.length > 0) {
-Di.info("Top Processes:");
+Fi.info("Top Processes:");
 try {
 for (var T = a(E), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-Di.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
+Fi.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
 }
 } catch (e) {
 n = {
@@ -14875,11 +14880,11 @@ var w = Object.values(m.rooms).sort(function(e, t) {
 return t.profiler.avgCpu - e.profiler.avgCpu;
 }).slice(0, 5);
 if (w.length > 0) {
-Di.info("Top Rooms by CPU:");
+Fi.info("Top Rooms by CPU:");
 try {
 for (var x = a(w), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Di.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
+Fi.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
 }
 } catch (e) {
 s = {
@@ -14897,11 +14902,11 @@ var k = Object.values(m.creeps).sort(function(e, t) {
 return t.cpu - e.cpu;
 }).slice(0, 5);
 if (k.length > 0) {
-Di.info("Top Creeps by CPU:");
+Fi.info("Top Creeps by CPU:");
 try {
 for (var A = a(k), M = A.next(); !M.done; M = A.next()) {
 var _ = M.value;
-Di.info("  ".concat(_.name, " (").concat(_.role, "): ").concat(_.cpu.toFixed(3), " CPU in ").concat(_.currentRoom));
+Fi.info("  ".concat(_.name, " (").concat(_.role, "): ").concat(_.cpu.toFixed(3), " CPU in ").concat(_.currentRoom));
 }
 } catch (e) {
 u = {
@@ -14915,7 +14920,7 @@ if (u) throw u.error;
 }
 }
 }
-this.config.trackNativeCalls && Di.info("Native calls: ".concat(m.native.total, " total"));
+this.config.trackNativeCalls && Fi.info("Native calls: ".concat(m.native.total, " total"));
 }, e.prototype.postureToCode = function(e) {
 var t;
 return null !== (t = {
@@ -14961,16 +14966,16 @@ lastUpdate: 0
 return o({}, this.currentSnapshot);
 }, e.POSTURE_NAMES = [ "eco", "expand", "defensive", "war", "siege", "evacuate", "nukePrep" ],
 e;
-}(), Xi = new Qi, Zi = {
+}(), Zi = new Xi, Ji = {
 primarySegment: 90,
 backupSegment: 91,
 retentionPeriod: 1e4,
 updateInterval: 50,
 maxDataPoints: 1e3
-}, Ji = function() {
+}, $i = function() {
 function e(e) {
 void 0 === e && (e = {}), this.statsData = null, this.segmentRequested = !1, this.lastUpdate = 0,
-this.config = o(o({}, Zi), e);
+this.config = o(o({}, Ji), e);
 }
 return e.prototype.initialize = function() {
 RawMemory.setActiveSegments([ this.config.primarySegment ]), this.segmentRequested = !0;
@@ -14981,12 +14986,12 @@ this.lastUpdate = Game.time);
 }, e.prototype.loadFromSegment = function() {
 var e = RawMemory.segments[this.config.primarySegment];
 if (e && 0 !== e.length) try {
-this.statsData = JSON.parse(e), Di.debug("Loaded stats from segment", {
+this.statsData = JSON.parse(e), Fi.debug("Loaded stats from segment", {
 subsystem: "Stats"
 });
 } catch (e) {
 var t = e instanceof Error ? e.message : String(e);
-Di.error("Failed to parse stats segment: ".concat(t), {
+Fi.error("Failed to parse stats segment: ".concat(t), {
 subsystem: "Stats"
 }), this.statsData = this.createDefaultStatsData();
 } else this.statsData = this.createDefaultStatsData();
@@ -15038,7 +15043,7 @@ c["".concat(p, ".energy.capacity")] = d.energyCapacity, c["".concat(p, ".storage
 c["".concat(p, ".terminal.energy")] = d.terminalEnergy, c["".concat(p, ".creeps")] = d.creepCount,
 c["".concat(p, ".controller.progress")] = d.controllerProgress, c["".concat(p, ".controller.progress_total")] = d.controllerProgressTotal,
 c["".concat(p, ".controller.progress_percent")] = d.controllerProgressTotal > 0 ? d.controllerProgress / d.controllerProgressTotal * 100 : 0;
-var f = Fi(d.roomName);
+var f = Bi(d.roomName);
 if (f) {
 if (c["".concat(p, ".brain.danger")] = f.danger, c["".concat(p, ".brain.posture_code")] = this.postureToCode(f.posture),
 c["".concat(p, ".brain.colony_level_code")] = this.colonyLevelToCode(f.colonyLevel),
@@ -15150,7 +15155,7 @@ try {
 this.statsData.lastUpdate = Game.time;
 var i = JSON.stringify(this.statsData);
 if (i.length > n) {
-for (Di.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
+for (Fi.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
 subsystem: "Stats"
 }); i.length > n && this.statsData.history.length > 10; ) this.statsData.history.shift(),
 i = JSON.stringify(this.statsData);
@@ -15169,7 +15174,7 @@ if (e) throw e.error;
 }
 }
 if (i.length > n) {
-Di.warn("Stats data still exceeds limit after trimming, clearing history", {
+Fi.warn("Stats data still exceeds limit after trimming, clearing history", {
 subsystem: "Stats"
 }), this.statsData.history = this.statsData.history.slice(-5);
 try {
@@ -15192,7 +15197,7 @@ i = JSON.stringify(this.statsData);
 RawMemory.segments[this.config.primarySegment] = i;
 } catch (e) {
 var p = e instanceof Error ? e.message : String(e);
-Di.error("Failed to save stats segment: ".concat(p), {
+Fi.error("Failed to save stats segment: ".concat(p), {
 subsystem: "Stats"
 });
 }
@@ -15296,9 +15301,9 @@ fortifiedHive: 4,
 empireDominance: 5
 }[e]) && void 0 !== t ? t : 0;
 }, e;
-}(), $i = new Ji;
+}(), es = new $i;
 
-function es(e) {
+function ts(e) {
 e._metrics || (e._metrics = {
 tasksCompleted: 0,
 energyTransferred: 0,
@@ -15311,15 +15316,15 @@ healingDone: 0
 });
 }
 
-function ts(e) {
-return es(e), e._metrics;
+function rs(e) {
+return ts(e), e._metrics;
 }
 
-function rs(e, t) {
-ts(e).damageDealt += t;
+function os(e, t) {
+rs(e).damageDealt += t;
 }
 
-var os, ns = {
+var ns, as = {
 minBucket: 0,
 minSourceLinkEnergy: 400,
 controllerLinkMaxEnergy: 700,
@@ -15331,11 +15336,11 @@ storageEnergyReserveForSpawnLink: 1e4
 !function(e) {
 e.SOURCE = "source", e.CONTROLLER = "controller", e.STORAGE = "storage", e.SPAWN = "spawn",
 e.UNKNOWN = "unknown";
-}(os || (os = {}));
+}(ns || (ns = {}));
 
-var as, is, ss = function() {
+var is, ss, cs = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, ns), e);
+void 0 === e && (e = {}), this.config = o(o({}, as), e);
 }
 return e.prototype.run = function() {
 var e, t;
@@ -15369,13 +15374,13 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (!(t.length < 2)) {
 var r = this.classifyLinks(e, t), o = r.filter(function(e) {
-return e.role === os.SOURCE;
+return e.role === ns.SOURCE;
 }), n = r.filter(function(e) {
-return e.role === os.CONTROLLER;
+return e.role === ns.CONTROLLER;
 }), a = r.filter(function(e) {
-return e.role === os.STORAGE;
+return e.role === ns.STORAGE;
 }), i = r.filter(function(e) {
-return e.role === os.SPAWN;
+return e.role === ns.SPAWN;
 });
 this.executeTransfers(e, o, n, a, i);
 }
@@ -15412,11 +15417,11 @@ try {
 for (var R = (l = void 0, a(f)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.link.store.getFreeCapacity(RESOURCE_ENERGY) < this.config.transferThreshold)) {
-if (T.role === os.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
+if (T.role === ns.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
 h = T;
 break;
 }
-if (T.role !== os.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
+if (T.role !== ns.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
 h = T;
 break;
 }
@@ -15496,25 +15501,25 @@ i.transferEnergy(m, l));
 var t = e.room, r = t.controller, o = t.storage, n = t.find(FIND_SOURCES), a = t.find(FIND_MY_SPAWNS);
 return this.classifyLinkRole(e, r, o, n, a);
 }, e.prototype.classifyLinkRole = function(e, t, r, o, n) {
-return t && e.pos.getRangeTo(t) <= 2 ? os.CONTROLLER : o.some(function(t) {
+return t && e.pos.getRangeTo(t) <= 2 ? ns.CONTROLLER : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 1;
-}) ? os.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? os.STORAGE : n.some(function(t) {
+}) ? ns.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? ns.STORAGE : n.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? os.SPAWN : o.some(function(t) {
+}) ? ns.SPAWN : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? os.SOURCE : os.UNKNOWN;
+}) ? ns.SOURCE : ns.UNKNOWN;
 }, e.prototype.getRolePriority = function(e) {
 switch (e) {
-case os.CONTROLLER:
+case ns.CONTROLLER:
 return 100;
 
-case os.SPAWN:
+case ns.SPAWN:
 return 75;
 
-case os.STORAGE:
+case ns.STORAGE:
 return 50;
 
-case os.SOURCE:
+case ns.SOURCE:
 return 10;
 
 default:
@@ -15530,9 +15535,9 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (r.length < 2) return !1;
 var o = this.classifyLinks(e, r), n = o.some(function(e) {
-return e.role === os.SOURCE;
+return e.role === ns.SOURCE;
 }), a = o.some(function(e) {
-return e.role === os.CONTROLLER || e.role === os.STORAGE;
+return e.role === ns.CONTROLLER || e.role === ns.STORAGE;
 });
 return n && a;
 }, n([ Qe("link:manager", "Link Manager", {
@@ -15541,23 +15546,23 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), cs = new ss;
+}(), us = new cs;
 
-function us(e) {
+function ls(e) {
 return "string" == typeof e.roomName && e.roomName.length > 0;
 }
 
-function ls(e) {
+function ms(e) {
 var t, r;
 return Math.max(0, null !== (r = null !== (t = e.remainingAmount) && void 0 !== t ? t : e.amount) && void 0 !== r ? r : 0);
 }
 
-function ms(e, t) {
+function ds(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var ds, ps, fs, ys, vs, gs, hs, Rs, Es, Ts, Cs, Ss = {
+var ps, fs, ys, vs, gs, hs, Rs, Es, Ts, Cs, Ss, ws = {
 updateInterval: 100,
 priceUpdateInterval: 500,
 minBucket: 2e3,
@@ -15575,14 +15580,14 @@ highPriceMultiplier: 1.1,
 trendChangeThreshold: .05,
 buyOpportunityAdjustment: 1.02,
 sellOpportunityAdjustment: .98,
-sellThresholds: (as = {}, as[RESOURCE_ENERGY] = 5e5, as[RESOURCE_HYDROGEN] = 2e4,
-as[RESOURCE_OXYGEN] = 2e4, as[RESOURCE_UTRIUM] = 2e4, as[RESOURCE_LEMERGIUM] = 2e4,
-as[RESOURCE_KEANIUM] = 2e4, as[RESOURCE_ZYNTHIUM] = 2e4, as[RESOURCE_CATALYST] = 2e4,
-as),
-buyThresholds: (is = {}, is[RESOURCE_ENERGY] = 1e5, is[RESOURCE_HYDROGEN] = 5e3,
-is[RESOURCE_OXYGEN] = 5e3, is[RESOURCE_UTRIUM] = 5e3, is[RESOURCE_LEMERGIUM] = 5e3,
-is[RESOURCE_KEANIUM] = 5e3, is[RESOURCE_ZYNTHIUM] = 5e3, is[RESOURCE_CATALYST] = 5e3,
+sellThresholds: (is = {}, is[RESOURCE_ENERGY] = 5e5, is[RESOURCE_HYDROGEN] = 2e4,
+is[RESOURCE_OXYGEN] = 2e4, is[RESOURCE_UTRIUM] = 2e4, is[RESOURCE_LEMERGIUM] = 2e4,
+is[RESOURCE_KEANIUM] = 2e4, is[RESOURCE_ZYNTHIUM] = 2e4, is[RESOURCE_CATALYST] = 2e4,
 is),
+buyThresholds: (ss = {}, ss[RESOURCE_ENERGY] = 1e5, ss[RESOURCE_HYDROGEN] = 5e3,
+ss[RESOURCE_OXYGEN] = 5e3, ss[RESOURCE_UTRIUM] = 5e3, ss[RESOURCE_LEMERGIUM] = 5e3,
+ss[RESOURCE_KEANIUM] = 5e3, ss[RESOURCE_ZYNTHIUM] = 5e3, ss[RESOURCE_CATALYST] = 5e3,
+ss),
 trackedResources: [ RESOURCE_ENERGY, RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_UTRIUM, RESOURCE_LEMERGIUM, RESOURCE_KEANIUM, RESOURCE_ZYNTHIUM, RESOURCE_CATALYST, RESOURCE_GHODIUM, RESOURCE_POWER ],
 criticalResources: [ RESOURCE_ENERGY, RESOURCE_GHODIUM ],
 emergencyBuyThreshold: 5e3,
@@ -15600,41 +15605,41 @@ minArbitrageMargin: .05,
 energyOverflowStorageEnter: 8e5,
 energyOverflowStorageExit: 5e5,
 minOverflowEnergySellAmount: 1e3
-}, ws = function() {
+}, xs = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedEmpireTick = -1, this.cachedEmpire = null,
 this.cachedTick = -1, this.cachedMarketOrders = new Map, this.cachedMarketOrderDealAmounts = new Map,
 this.cachedOwnedRooms = null, this.cachedOwnedTerminalRooms = null, this.cachedReadyOwnedTerminalRooms = null,
-this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, Ss), e);
+this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, ws), e);
 }
 return e.prototype.run = function() {
 var e = this;
 this.lastRun = Game.time, this.cachedEmpireTick = -1, this.cachedEmpire = null,
-ms("market.ensureMemory", function() {
+ds("market.ensureMemory", function() {
 return e.ensureMarketMemory();
-}), Game.time % this.config.priceUpdateInterval === 0 && ms("market.updatePriceTracking", function() {
+}), Game.time % this.config.priceUpdateInterval === 0 && ds("market.updatePriceTracking", function() {
 return e.updatePriceTracking();
-}), ms("market.updateOrderStats", function() {
+}), ds("market.updateOrderStats", function() {
 return e.updateOrderStats();
-}), ms("market.reconcilePendingArbitrage", function() {
+}), ds("market.reconcilePendingArbitrage", function() {
 return e.reconcilePendingArbitrage();
-}), ms("market.handleEmergencyBuying", function() {
+}), ds("market.handleEmergencyBuying", function() {
 return e.handleEmergencyBuying();
-}), ms("market.cancelOldOrders", function() {
+}), ds("market.cancelOldOrders", function() {
 return e.cancelOldOrders();
-}), ms("market.manageExistingOrders", function() {
+}), ds("market.manageExistingOrders", function() {
 return e.manageExistingOrders();
-}), this.canRunActiveTrading() && (ms("market.updateBuyOrders", function() {
+}), this.canRunActiveTrading() && (ds("market.updateBuyOrders", function() {
 return e.updateBuyOrders();
-}), ms("market.handleEnergyOverflowSales", function() {
+}), ds("market.handleEnergyOverflowSales", function() {
 return e.handleEnergyOverflowSales();
-}), ms("market.updateSellOrders", function() {
+}), ds("market.updateSellOrders", function() {
 return e.updateSellOrders();
-}), ms("market.checkArbitrageOpportunities", function() {
+}), ds("market.checkArbitrageOpportunities", function() {
 return e.checkArbitrageOpportunities();
-}), ms("market.executeDeal", function() {
+}), ds("market.executeDeal", function() {
 return e.executeDeal();
-}), Game.time % 200 == 0 && ms("market.balanceResourcesAcrossRooms", function() {
+}), Game.time % 200 == 0 && ds("market.balanceResourcesAcrossRooms", function() {
 return e.balanceResourcesAcrossRooms();
 }));
 }, e.prototype.canRunActiveTrading = function() {
@@ -16051,8 +16056,8 @@ energyCreditValue: this.config.energyCreditValue,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}, u.orders.filter(us).map(function(e) {
-var t = Math.min(u.requestedAmount, ls(e), u.maxDealAmount);
+}, u.orders.filter(ls).map(function(e) {
+var t = Math.min(u.requestedAmount, ms(e), u.maxDealAmount);
 if (!(t <= 0)) {
 var r = u.calcTransactionCost(t, u.sourceRoomName, e.roomName), o = e.price * t - r * u.energyCreditValue;
 return {
@@ -16271,8 +16276,8 @@ maxDealAmount: this.config.maxActiveBuyAmount,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}).orders.filter(us).map(function(e) {
-var t = Math.min(ls(e), m.maxDealAmount, m.requestedAmount);
+}).orders.filter(ls).map(function(e) {
+var t = Math.min(ms(e), m.maxDealAmount, m.requestedAmount);
 if (!(t <= 0)) {
 var r = m.calcTransactionCost(t, e.roomName, m.destinationRoomName);
 return {
@@ -16541,7 +16546,7 @@ interval: 100,
 minBucket: 2e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), xs = new ws, bs = function() {
+}(), bs = new xs, Os = function() {
 function e() {
 this.costCache = new Map, this.COST_CACHE_TTL = 100, this.MAX_HOPS = 3;
 }
@@ -16668,7 +16673,7 @@ if (e) throw e.error;
 var r = e.path.indexOf(t);
 return -1 === r || r === e.path.length - 1 ? null : e.path[r + 1] || null;
 }, e;
-}(), Os = new bs, ks = {
+}(), ks = new Os, As = {
 minBucket: 0,
 minStorageEnergy: 5e4,
 terminalEnergyTarget: 2e4,
@@ -16683,9 +16688,9 @@ emergencyDangerThreshold: 2,
 emergencyEnergyAmount: 2e4,
 energySurplusThreshold: 5e4,
 mineralSurplusThreshold: 5e3
-}, As = function() {
+}, Ms = function() {
 function e(e) {
-void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, ks), e);
+void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, As), e);
 }
 return e.prototype.requestTransfer = function(e, t, r, o, n) {
 if (void 0 === n && (n = 3), this.transferQueue.some(function(o) {
@@ -16710,7 +16715,7 @@ if (!(Game.cpu.bucket < this.config.minBucket)) {
 var e = Tt().filter(function(e) {
 return e.terminal && e.terminal.my && e.terminal.isActive();
 });
-0 !== e.length && (Os.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
+0 !== e.length && (ks.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
 e.length < 2 || (this.checkEmergencyTransfers(e), this.balanceEnergy(e), this.balanceMinerals(e),
 this.executeTransfers(e)));
 }
@@ -16738,7 +16743,7 @@ var l = u[0];
 if (!c.transferQueue.some(function(e) {
 return e.toRoom === t.name && e.resourceType === RESOURCE_ENERGY && e.isEmergency;
 })) {
-var m = Os.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
+var m = ks.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
 m && (c.transferQueue.push({
 fromRoom: l.name,
 toRoom: t.name,
@@ -16829,7 +16834,7 @@ var w = C - S;
 if (u && u !== e.name) {
 var x = null === (c = Game.rooms[u]) || void 0 === c ? void 0 : c.terminal;
 if (x && x.store.getFreeCapacity() > w) {
-var b = Os.findOptimalRoute(e.name, u, w);
+var b = ks.findOptimalRoute(e.name, u, w);
 if (b) {
 this.transferQueue.push({
 fromRoom: e.name,
@@ -16845,7 +16850,7 @@ continue;
 }
 }
 }
-Game.time % 10 == 0 && xs.sellSurplusFromTerminal(e.name, T, w) && _.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
+Game.time % 10 == 0 && bs.sellSurplusFromTerminal(e.name, T, w) && _.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
 subsystem: "Terminal"
 });
 }
@@ -16890,7 +16895,7 @@ return r.fromRoom === t.room.name && r.toRoom === e.room.name && r.resourceType 
 })) return "continue";
 var r = Math.min(Math.floor((t.totalEnergy - u.config.energySendThreshold) / 2), u.config.energyRequestThreshold - e.totalEnergy, t.terminal.store.getUsedCapacity(RESOURCE_ENERGY));
 if (r < u.config.minTransferAmount) return "continue";
-var o = Os.findOptimalRoute(t.room.name, e.room.name, r);
+var o = ks.findOptimalRoute(t.room.name, e.room.name, r);
 if (!o) return "continue";
 var n = o.cost / r;
 if (n > u.config.maxTransferCostRatio) return _.debug("Skipping terminal transfer from ".concat(t.room.name, " to ").concat(e.room.name, ": cost ratio ").concat(n.toFixed(2), " too high"), {
@@ -17025,7 +17030,7 @@ var a = r.terminal;
 if (a.cooldown > 0) return "continue";
 var i = t.toRoom;
 if (t.route && !t.route.isDirect) {
-var c = Os.getNextHop(t.route, t.fromRoom);
+var c = ks.getNextHop(t.route, t.fromRoom);
 c && (i = c);
 }
 var u = null === (o = Game.rooms[i]) || void 0 === o ? void 0 : o.terminal;
@@ -17189,25 +17194,25 @@ interval: 20,
 minBucket: 0,
 cpuBudget: .1
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Ms = new As, _s = {
+}(), _s = new Ms, Us = {
 minBucket: 0,
 minStorageEnergy: 8e4,
 inputBufferAmount: 2e3,
 outputBufferAmount: 5e3
-}, Us = ((ds = {})[RESOURCE_UTRIUM_BAR] = ((ps = {})[RESOURCE_UTRIUM] = 500, ps[RESOURCE_ENERGY] = 200,
-ps), ds[RESOURCE_LEMERGIUM_BAR] = ((fs = {})[RESOURCE_LEMERGIUM] = 500, fs[RESOURCE_ENERGY] = 200,
-fs), ds[RESOURCE_ZYNTHIUM_BAR] = ((ys = {})[RESOURCE_ZYNTHIUM] = 500, ys[RESOURCE_ENERGY] = 200,
-ys), ds[RESOURCE_KEANIUM_BAR] = ((vs = {})[RESOURCE_KEANIUM] = 500, vs[RESOURCE_ENERGY] = 200,
-vs), ds[RESOURCE_GHODIUM_MELT] = ((gs = {})[RESOURCE_GHODIUM] = 500, gs[RESOURCE_ENERGY] = 200,
-gs), ds[RESOURCE_OXIDANT] = ((hs = {})[RESOURCE_OXYGEN] = 500, hs[RESOURCE_ENERGY] = 200,
-hs), ds[RESOURCE_REDUCTANT] = ((Rs = {})[RESOURCE_HYDROGEN] = 500, Rs[RESOURCE_ENERGY] = 200,
-Rs), ds[RESOURCE_PURIFIER] = ((Es = {})[RESOURCE_CATALYST] = 500, Es[RESOURCE_ENERGY] = 200,
-Es), ds[RESOURCE_BATTERY] = ((Ts = {})[RESOURCE_ENERGY] = 600, Ts), ds), Ns = ((Cs = {})[RESOURCE_BATTERY] = 10,
-Cs[RESOURCE_UTRIUM_BAR] = 5, Cs[RESOURCE_LEMERGIUM_BAR] = 5, Cs[RESOURCE_ZYNTHIUM_BAR] = 5,
-Cs[RESOURCE_KEANIUM_BAR] = 5, Cs[RESOURCE_GHODIUM_MELT] = 4, Cs[RESOURCE_OXIDANT] = 3,
-Cs[RESOURCE_REDUCTANT] = 3, Cs[RESOURCE_PURIFIER] = 3, Cs), Ps = function() {
+}, Ns = ((ps = {})[RESOURCE_UTRIUM_BAR] = ((fs = {})[RESOURCE_UTRIUM] = 500, fs[RESOURCE_ENERGY] = 200,
+fs), ps[RESOURCE_LEMERGIUM_BAR] = ((ys = {})[RESOURCE_LEMERGIUM] = 500, ys[RESOURCE_ENERGY] = 200,
+ys), ps[RESOURCE_ZYNTHIUM_BAR] = ((vs = {})[RESOURCE_ZYNTHIUM] = 500, vs[RESOURCE_ENERGY] = 200,
+vs), ps[RESOURCE_KEANIUM_BAR] = ((gs = {})[RESOURCE_KEANIUM] = 500, gs[RESOURCE_ENERGY] = 200,
+gs), ps[RESOURCE_GHODIUM_MELT] = ((hs = {})[RESOURCE_GHODIUM] = 500, hs[RESOURCE_ENERGY] = 200,
+hs), ps[RESOURCE_OXIDANT] = ((Rs = {})[RESOURCE_OXYGEN] = 500, Rs[RESOURCE_ENERGY] = 200,
+Rs), ps[RESOURCE_REDUCTANT] = ((Es = {})[RESOURCE_HYDROGEN] = 500, Es[RESOURCE_ENERGY] = 200,
+Es), ps[RESOURCE_PURIFIER] = ((Ts = {})[RESOURCE_CATALYST] = 500, Ts[RESOURCE_ENERGY] = 200,
+Ts), ps[RESOURCE_BATTERY] = ((Cs = {})[RESOURCE_ENERGY] = 600, Cs), ps), Ps = ((Ss = {})[RESOURCE_BATTERY] = 10,
+Ss[RESOURCE_UTRIUM_BAR] = 5, Ss[RESOURCE_LEMERGIUM_BAR] = 5, Ss[RESOURCE_ZYNTHIUM_BAR] = 5,
+Ss[RESOURCE_KEANIUM_BAR] = 5, Ss[RESOURCE_GHODIUM_MELT] = 4, Ss[RESOURCE_OXIDANT] = 3,
+Ss[RESOURCE_REDUCTANT] = 3, Ss[RESOURCE_PURIFIER] = 3, Ss), Is = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, _s), e);
+void 0 === e && (e = {}), this.config = o(o({}, Us), e);
 }
 return e.prototype.run = function() {
 var e, t;
@@ -17249,7 +17254,7 @@ var s = e.storage;
 if (s && !(s.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.minStorageEnergy)) {
 var c = this.selectProduction(e, n, s);
 if (c) {
-var u = Us[c];
+var u = Ns[c];
 if (u) {
 var l = !0;
 try {
@@ -17287,7 +17292,7 @@ subsystem: "Factory"
 }, e.prototype.selectProduction = function(e, t, r) {
 var o, n, s, c, u, l = [];
 try {
-for (var m = a(Object.entries(Us)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Object.entries(Ns)), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1], v = f, g = !0, h = 0;
 try {
 for (var R = (s = void 0, a(Object.entries(y))), E = R.next(); !E.done; E = R.next()) {
@@ -17312,7 +17317,7 @@ if (s) throw s.error;
 if (g) {
 var b = t.store.getUsedCapacity(v) + r.store.getUsedCapacity(v);
 if (!(b > this.config.outputBufferAmount)) {
-var O = null !== (u = Ns[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
+var O = null !== (u = Ps[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
 l.push({
 commodity: v,
 priority: O,
@@ -17340,7 +17345,7 @@ var r, o, n = t.storage;
 if (!n) return [];
 var s = this.selectProduction(t, e, n);
 if (!s) return [];
-var c = Us[s];
+var c = Ns[s];
 if (!c) return [];
 var u = [];
 try {
@@ -17366,7 +17371,7 @@ return u;
 }, e.prototype.hasOutputsToRemove = function(e) {
 var t, r;
 try {
-for (var o = a(Object.keys(Us)), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Object.keys(Ns)), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 if (e.store.getUsedCapacity(i) > 0) return !0;
 }
@@ -17398,7 +17403,7 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Is = new Ps, Gs = {
+}(), Gs = new Is, Ls = {
 updateInterval: 500,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -17410,7 +17415,7 @@ opportunityConfidenceThreshold: .7
 !function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.supplyDemandCache = new Map, this.opportunities = [],
-this.config = o(o({}, Gs), e);
+this.config = o(o({}, Ls), e);
 }
 e.prototype.run = function() {
 var e, t, r = Game.cpu.getUsed();
@@ -17575,14 +17580,14 @@ cpuBudget: .02
 }) ], e.prototype, "run", null), e = n([ Je() ], e);
 }();
 
-var Ls, Ds = 5e4;
+var Ds, Fs = 5e4;
 
-function Fs(e) {
+function Bs(e) {
 var t;
 return null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== t ? t : 0;
 }
 
-var Bs = {
+var Ws = {
 updateInterval: 500,
 minGhodium: 5e3,
 minEnergy: 3e5,
@@ -17594,18 +17599,18 @@ donorRoomBuffer: 1e3,
 salvoSyncWindow: 10,
 roiThreshold: 2,
 counterNukeWarThreshold: 60
-}, Ws = 1e7, Hs = 5e6, Ks = ((Ls = {})[STRUCTURE_SPAWN] = 15e3, Ls[STRUCTURE_TOWER] = 5e3,
-Ls[STRUCTURE_STORAGE] = 3e4, Ls[STRUCTURE_TERMINAL] = 1e5, Ls[STRUCTURE_LAB] = 5e4,
-Ls[STRUCTURE_NUKER] = 1e5, Ls[STRUCTURE_POWER_SPAWN] = 1e5, Ls[STRUCTURE_OBSERVER] = 8e3,
-Ls[STRUCTURE_EXTENSION] = 3e3, Ls[STRUCTURE_LINK] = 5e3, Ls);
+}, Hs = 1e7, Ks = 5e6, Ys = ((Ds = {})[STRUCTURE_SPAWN] = 15e3, Ds[STRUCTURE_TOWER] = 5e3,
+Ds[STRUCTURE_STORAGE] = 3e4, Ds[STRUCTURE_TERMINAL] = 1e5, Ds[STRUCTURE_LAB] = 5e4,
+Ds[STRUCTURE_NUKER] = 1e5, Ds[STRUCTURE_POWER_SPAWN] = 1e5, Ds[STRUCTURE_OBSERVER] = 8e3,
+Ds[STRUCTURE_EXTENSION] = 3e3, Ds[STRUCTURE_LINK] = 5e3, Ds);
 
-function Ys(e) {
+function Vs(e) {
 return !!e.threatenedStructures && e.threatenedStructures.some(function(e) {
 return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
 });
 }
 
-function Vs(e, t) {
+function qs(e, t) {
 var r = {
 empire: t
 };
@@ -17617,18 +17622,18 @@ return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 });
 }
 
-function qs(e, t) {
+function js(e, t) {
 var r, o, n;
 if (!e) return !1;
 var a = null === (r = t.knownRooms) || void 0 === r ? void 0 : r[e], i = Game.rooms[e], s = null == i ? void 0 : i.controller, c = {
 empire: t
 };
 return j(e, c) || j(null == a ? void 0 : a.owner, c) || j(null == a ? void 0 : a.reserver, c) || j(null === (o = null == s ? void 0 : s.owner) || void 0 === o ? void 0 : o.username, c) || j(null === (n = null == s ? void 0 : s.reservation) || void 0 === n ? void 0 : n.username, c) || !!i && function(e, t) {
-return Vs(e.find(FIND_CREEPS), t) || Vs(e.find(FIND_POWER_CREEPS), t) || Vs(e.find(FIND_STRUCTURES), t) || Vs(e.find(FIND_CONSTRUCTION_SITES), t);
+return qs(e.find(FIND_CREEPS), t) || qs(e.find(FIND_POWER_CREEPS), t) || qs(e.find(FIND_STRUCTURES), t) || qs(e.find(FIND_CONSTRUCTION_SITES), t);
 }(i, t);
 }
 
-function js(e, t, r) {
+function zs(e, t, r) {
 t.timeToLand < 5e3 ? (r.posture = "evacuate", _.warn("EVACUATION TRIGGERED for ".concat(e.name, ": Critical structures threatened by nuke!"), {
 subsystem: "Nuke"
 })) : ("war" !== r.posture && "evacuate" !== r.posture && (r.posture = "defensive"),
@@ -17637,7 +17642,7 @@ subsystem: "Nuke"
 })), r.pheromones.defense = 100;
 }
 
-function zs() {
+function Qs() {
 var e, t = 0, r = 0;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
@@ -17647,14 +17652,14 @@ n.terminal && (t += n.terminal.store.getUsedCapacity(RESOURCE_ENERGY) || 0, r +=
 return t >= 6e5 && r >= 1e4;
 }
 
-function Qs(e, t, r, o) {
+function Xs(e, t, r, o) {
 var n = 0, a = [], c = t.knownRooms[e];
 if (!c) return {
 roomName: e,
 score: 0,
 reasons: [ "No intel" ]
 };
-if (qs(e, t)) return {
+if (js(e, t)) return {
 roomName: e,
 score: 0,
 reasons: [ "Allied room" ]
@@ -17681,7 +17686,7 @@ return Game.map.getRoomLinearDistance(e, t.name);
 n -= 2 * d, a.push("".concat(d, " rooms away"));
 }
 t.warTargets.includes(e) && (n += 15, a.push("War target"));
-var p = new RoomPosition(25, 25, e), f = Zs(e, p, t);
+var p = new RoomPosition(25, 25, e), f = Js(e, p, t);
 return f >= r.roiThreshold ? (n += Math.min(20, Math.floor(5 * f)), a.push("ROI: ".concat(f.toFixed(1), "x"))) : (n -= 20,
 a.push("Low ROI: ".concat(f.toFixed(1), "x"))), {
 roomName: e,
@@ -17690,7 +17695,7 @@ reasons: a
 };
 }
 
-function Xs(e, t, r) {
+function Zs(e, t, r) {
 var o, n, i = {
 estimatedDamage: 0,
 estimatedValue: 0,
@@ -17700,16 +17705,16 @@ if (!s) {
 var c = r.knownRooms[e];
 if (c) {
 var u = 5 * (c.towerCount || 0) + 10 * (c.spawnCount || 0) + 5;
-i.estimatedDamage = Ws + Hs * u, i.estimatedValue = .01 * i.estimatedDamage;
+i.estimatedDamage = Hs + Ks * u, i.estimatedValue = .01 * i.estimatedDamage;
 }
 return i;
 }
 var l = s.lookForAtArea(LOOK_STRUCTURES, Math.max(0, t.y - 2), Math.max(0, t.x - 2), Math.min(49, t.y + 2), Math.min(49, t.x + 2), !0);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
-var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Ws : Hs;
+var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Hs : Ks;
 p.hits <= v ? (i.estimatedDamage += p.hits, i.threatenedStructures.push("".concat(p.structureType, "-").concat(p.pos.x, ",").concat(p.pos.y)),
-i.estimatedValue += Js(p)) : i.estimatedDamage += v;
+i.estimatedValue += $s(p)) : i.estimatedDamage += v;
 }
 } catch (e) {
 o = {
@@ -17725,16 +17730,16 @@ if (o) throw o.error;
 return i;
 }
 
-function Zs(e, t, r) {
-var o = Xs(e, t, r);
+function Js(e, t, r) {
+var o = Zs(e, t, r);
 return 0 === o.estimatedValue ? 0 : o.estimatedValue / 305e3;
 }
 
-function Js(e) {
-return Ks[e.structureType] || 1e3;
+function $s(e) {
+return Ys[e.structureType] || 1e3;
 }
 
-function $s(e) {
+function ec(e) {
 if (e.nukesInFlight && (e.nukesInFlight = e.nukesInFlight.filter(function(e) {
 return e.impactTick > Game.time;
 })), e.incomingNukes) {
@@ -17749,7 +17754,7 @@ subsystem: "Nuke"
 }
 }
 
-function ec(e, t, r) {
+function tc(e, t, r) {
 var o, n, i, s = null;
 try {
 for (var c = a(Object.values(t)), u = c.next(); !u.done; u = c.next()) {
@@ -17799,9 +17804,9 @@ subsystem: "Nuke"
 }), !0;
 }
 
-var tc = function() {
+var rc = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Bs), e),
+void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Ws), e),
 this.getEmpire = t.getEmpire, this.getSwarmState = t.getSwarmState, this.getClusters = t.getClusters;
 }
 return e.prototype.run = function(e) {
@@ -17851,7 +17856,7 @@ try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value.structure, l = Math.abs(u.pos.x - t.x), m = Math.abs(u.pos.y - t.y), d = Math.max(l, m);
 if (d <= 2) {
-var p = 0 === d ? Ws : Hs;
+var p = 0 === d ? Hs : Ks;
 u.hits <= p && n.push("".concat(u.structureType, "-").concat(u.pos.x, ",").concat(u.pos.y));
 }
 }
@@ -17889,7 +17894,7 @@ for (var c = a(e.incomingNukes), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.sourceRoom && !e.warTargets.includes(l.sourceRoom)) {
 var m = e.knownRooms[l.sourceRoom];
-if (m) if (qs(l.sourceRoom, e)) _.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
+if (m) if (js(l.sourceRoom, e)) _.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
 subsystem: "Nuke"
 }); else if (!(m.controllerLevel < 8)) {
 var d = r(l.roomName);
@@ -17918,7 +17923,7 @@ u && !u.done && (i = c.return) && i.call(c);
 if (n) throw n.error;
 }
 }
-}(o, this.config, this.getSwarmState, zs), function(e, t, r, o) {
+}(o, this.config, this.getSwarmState, Qs), function(e, t, r, o) {
 var n, a;
 if (e.objectives.warMode) for (var i in Game.rooms) {
 var s = Game.rooms[i];
@@ -17970,10 +17975,10 @@ if (e.nukeCandidates = [], e.objectives.warMode) {
 try {
 for (var i = a(e.warTargets), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (qs(c, e)) _.warn("Skipping allied nuke target candidate: ".concat(c), {
+if (js(c, e)) _.warn("Skipping allied nuke target candidate: ".concat(c), {
 subsystem: "Nuke"
 }); else {
-var u = Qs(c, e, t, r);
+var u = Xs(c, e, t, r);
 u.score >= t.minScore && (e.nukeCandidates.push({
 roomName: c,
 score: u.score,
@@ -18017,7 +18022,7 @@ var d = r();
 try {
 for (var p = a(e.nukesInFlight), f = p.next(); !f.done; f = p.next()) {
 var y = f.value, v = y.impactTick - Game.time;
-y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && ec(y, d, o) && _.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
+y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && tc(y, d, o) && _.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
 subsystem: "Nuke"
 });
 }
@@ -18153,14 +18158,14 @@ return e.structureType === STRUCTURE_NUKER;
 if (0 !== c.length) try {
 for (var m = a(e.nukeCandidates), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!p.launched) if (qs(p.roomName, e)) _.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
+if (!p.launched) if (js(p.roomName, e)) _.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
 subsystem: "Nuke"
 }); else {
 try {
 for (var f = (n = void 0, a(c)), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (!(Game.map.getRoomLinearDistance(v.room.name, p.roomName) > 10)) {
-var g = new RoomPosition(25, 25, p.roomName), h = Xs(p.roomName, g, e), R = Zs(p.roomName, g, e);
+var g = new RoomPosition(25, 25, p.roomName), h = Zs(p.roomName, g, e), R = Js(p.roomName, g, e);
 if (R < t.roiThreshold) _.warn("Skipping nuke launch on ".concat(p.roomName, ": ROI ").concat(R.toFixed(2), "x below threshold ").concat(t.roiThreshold, "x"), {
 subsystem: "Nuke"
 }); else {
@@ -18227,17 +18232,17 @@ if (r) throw r.error;
 }
 }
 }
-}(o, this.config), $s(o)) : $s(o);
+}(o, this.config), ec(o)) : ec(o);
 }, e.prototype.handleEvacuations = function(e) {
 var t, r;
 if (e.incomingNukes) try {
 for (var o = a(e.incomingNukes), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-if (!i.evacuationTriggered && Ys(i)) {
+if (!i.evacuationTriggered && Vs(i)) {
 var s = Game.rooms[i.roomName];
 if (s) {
 var c = this.getSwarmState(i.roomName);
-c && (js(s, i, c), i.evacuationTriggered = !0);
+c && (zs(s, i, c), i.evacuationTriggered = !0);
 }
 }
 }
@@ -18282,13 +18287,13 @@ subsystem: "Nuke"
 }) : _.debug("No donor room found for ".concat(r, " ").concat(t, " to ").concat(e), {
 subsystem: "Nuke"
 });
-}(e, t, r, this.config, Ms);
+}(e, t, r, this.config, _s);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e);
 }, e;
-}(), rc = [ {
+}(), oc = [ {
 carryParts: 4,
 capacity: 200,
 moveParts: 4,
@@ -18310,7 +18315,7 @@ moveParts: 24,
 cost: 2400
 } ];
 
-function oc(e, t, r, o, n) {
+function nc(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = {});
 var c = n.reserved, u = void 0 !== c && c, l = n.pathLength, m = n.terrainFactor, d = void 0 === m ? 1.2 : m, p = n.safetyBuffer, f = void 0 === p ? 1.2 : p, y = function(e, t) {
@@ -18333,9 +18338,9 @@ var r = 50 * e * t;
 return Math.ceil(2 * r);
 }(y, d), g = function(e, t) {
 return e * (t ? 3e3 : 1500) / 300;
-}(r, u), h = rc[0];
+}(r, u), h = oc[0];
 try {
-for (var R = a(rc), E = R.next(); !E.done; E = R.next()) {
+for (var R = a(oc), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.cost <= o)) break;
 h = T;
@@ -18364,7 +18369,7 @@ energyPerTick: g
 };
 }
 
-function nc(e) {
+function ac(e) {
 var t;
 return e ? null !== (t = {
 X: 15,
@@ -18377,12 +18382,12 @@ H: 8
 }[e]) && void 0 !== t ? t : 5 : 0;
 }
 
-function ac(e) {
-var t, r, o = Sr.getEmpire(), n = 0, i = mc(e);
+function ic(e) {
+var t, r, o = Sr.getEmpire(), n = 0, i = dc(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-l && (l.owner && !dc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
+l && (l.owner && !pc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
 l.towerCount && l.towerCount > 0 && (n += 5 * l.towerCount));
 }
 } catch (e) {
@@ -18399,12 +18404,12 @@ if (t) throw t.error;
 return n;
 }
 
-function ic(e) {
+function sc(e) {
 return "plains" === e ? 15 : "swamp" === e ? -10 : 0;
 }
 
-function sc(e) {
-var t, r, o = mc(e);
+function cc(e) {
+var t, r, o = dc(e);
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (oe(i.value)) return !0;
 } catch (e) {
@@ -18421,7 +18426,7 @@ if (t) throw t.error;
 return !1;
 }
 
-function cc(e) {
+function uc(e) {
 var t = Sr.getEmpire(), r = t.knownRooms[e];
 if (null == r ? void 0 : r.hasPortal) return 20;
 var o = function(e, t) {
@@ -18439,34 +18444,34 @@ return null === r || r > 3 ? null : r;
 return null === o ? 0 : o <= 1 ? 10 : o <= 2 ? 6 : o <= 3 ? 3 : 0;
 }
 
-function uc(e, t) {
+function lc(e, t) {
 var r = e < 0 ? "W" : "E", o = t < 0 ? "N" : "S", n = Math.abs(e) - (e < 0 ? 1 : 0), a = Math.abs(t) - (t < 0 ? 1 : 0);
 return "".concat(r).concat(n).concat(o).concat(a);
 }
 
-function lc(e, t, r) {
+function mc(e, t, r) {
 return 0 === t.length ? 0 : r <= 2 ? 25 : r <= 3 ? 15 : r <= 5 ? 5 : 0;
 }
 
-function mc(e) {
+function dc(e) {
 var t = $(e);
 if (!t) return [];
-for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(uc(r + a, o + i));
+for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(lc(r + a, o + i));
 return n;
 }
 
-function dc(e) {
+function pc(e) {
 return j(e, {
 empire: Sr.getEmpire()
 });
 }
 
-function pc(e, t, r, o) {
+function fc(e, t, r, o) {
 var n, a = Game.map.getRoomLinearDistance(t, e);
 if (!Number.isFinite(a) || a <= 0) throw new Error("calculateRemoteProfitability: invalid distance ".concat(a, " between ").concat(t, " and ").concat(e));
 if (r.sources <= 0) throw new Error("calculateRemoteProfitability: intel.sources must be positive, got ".concat(r.sources, " for ").concat(e));
 if (void 0 !== r.threatLevel && null !== r.threatLevel && (r.threatLevel < 0 || r.threatLevel > 3)) throw new Error("calculateRemoteProfitability: intel.threatLevel must be in [0, 3], got ".concat(r.threatLevel, " for ").concat(e));
-var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = oc(t, e, r.sources, 800, {
+var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = nc(t, e, r.sources, 800, {
 reserved: m
 }), f = (650 * r.sources + p.haulerConfig.cost * p.recommendedHaulers) / 1500, y = 5e3 * r.sources + 50 * a * 300, v = y / 5e4, g = d * (null !== (n = [ 0, .1, .3, .6 ][r.threatLevel]) && void 0 !== n ? n : 0), h = d - f - v - g, R = f + v, E = R > 0 ? h / R : 0;
 return {
@@ -18490,9 +18495,9 @@ isProfitable: E > 2 && h > 0
 };
 }
 
-var fc = kr().cpu.bucketThresholds.highMode + 1e3, yc = {
+var yc = kr().cpu.bucketThresholds.highMode + 1e3, vc = {
 updateInterval: 500,
-minBucket: fc,
+minBucket: yc,
 maxRemoteDistance: 2,
 maxRemotesPerRoom: 5,
 minRemoteSources: 1,
@@ -18501,10 +18506,10 @@ minRclForClaiming: 1,
 minGclProgressForClaim: 0,
 clusterExpansionDistance: 5,
 minStableRoomPercentage: 0
-}, vc = function() {
+}, gc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedUsername = "", this.usernameLastTick = 0,
-this.config = o(o({}, yc), e);
+this.config = o(o({}, vc), e);
 }
 return e.prototype.run = function() {
 var e = Sr.getEmpire();
@@ -18586,7 +18591,7 @@ s > o.config.maxRemoteDistance && (_.info("Removing remote ".concat(e, " - too f
 subsystem: "Expansion"
 }), a = "unreachable");
 }
-return !a || (Mi.emit("remote.lost", {
+return !a || (_i.emit("remote.lost", {
 homeRoom: r,
 remoteRoom: e,
 reason: a,
@@ -18599,7 +18604,7 @@ for (var i in t.knownRooms) if (!r.includes(i) && !this.isRemoteAssignedElsewher
 var s = t.knownRooms[i], c = Game.map.getRoomLinearDistance(e, i);
 if ((s.scouted || !(c > 1)) && !s.owner && !(s.reserver && s.reserver !== a || s.isHighway || s.isSK || s.threatLevel >= 2 || c < 1 || c > this.config.maxRemoteDistance)) if (s.scouted) {
 if (!(s.sources < this.config.minRemoteSources)) {
-var u = pc(i, e, s);
+var u = fc(i, e, s);
 if (u.isProfitable) {
 var l = this.scoreRemoteCandidate(s, c);
 n.push({
@@ -18631,10 +18636,10 @@ return r += 50 * e.sources, r -= 20 * t, r -= 30 * e.threatLevel, "plains" === e
 r;
 }, e.prototype.scoreClaimCandidate = function(e, t, r) {
 var o = 0;
-return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += nc(e.mineralType),
-o -= 5 * t, o -= ac(e.name), o -= 15 * e.threatLevel, o += ic(e.terrain), sc(e.name) && (o += 10),
-o += cc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
-o + lc(e.name, r, t);
+return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += ac(e.mineralType),
+o -= 5 * t, o -= ic(e.name), o -= 15 * e.threatLevel, o += sc(e.terrain), cc(e.name) && (o += 10),
+o += uc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
+o + mc(e.name, r, t);
 }, e.prototype.isRemoteAssignedElsewhere = function(e, t) {
 var r, o, n, i = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -18982,13 +18987,13 @@ return this.cachedUsername;
 var r, o, n = [], i = function(e) {
 var t = [], r = $(e);
 if (!r) return [];
-for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(uc(o + a, n + i));
+for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(lc(o + a, n + i));
 return t;
 }(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t.knownRooms[u];
-l && (l.owner && !dc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
+l && (l.owner && !pc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
 l.towerCount && l.towerCount > 0 && n.push("".concat(l.towerCount, " towers in ").concat(u)),
 l.spawnCount && l.spawnCount > 0 && n.push("".concat(l.spawnCount, " spawns in ").concat(u)),
 l.threatLevel >= 2 && n.push("Threat level ".concat(l.threatLevel, " in ").concat(u)));
@@ -19005,11 +19010,11 @@ if (r) throw r.error;
 }
 }
 return function(e) {
-var t, r, o = Sr.getEmpire(), n = mc(e), i = new Set;
+var t, r, o = Sr.getEmpire(), n = dc(e), i = new Set;
 try {
 for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-(null == l ? void 0 : l.owner) && !dc(l.owner) && i.add(l.owner);
+(null == l ? void 0 : l.owner) && !pc(l.owner) && i.add(l.owner);
 }
 } catch (e) {
 t = {
@@ -19124,10 +19129,10 @@ subsystem: "Expansion"
 }, n([ Qe("expansion:manager", "Expansion Manager", {
 priority: Pe.LOW,
 interval: 500,
-minBucket: fc,
+minBucket: yc,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), gc = new vc, hc = function() {
+}(), hc = new gc, Rc = function() {
 function e() {}
 return e.prototype.status = function() {
 var e, t, r, o, n, i, s, c, u, l, m = Sr.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
@@ -19219,9 +19224,9 @@ return Sr.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use ex
 }, e.prototype.resume = function() {
 return Sr.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
 }, e.prototype.addRemote = function(e, t) {
-return gc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
+return hc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
 }, e.prototype.removeRemote = function(e, t) {
-return gc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
+return hc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
 }, e.prototype.clearQueue = function() {
 var e = Sr.getEmpire(), t = e.claimQueue.length;
 return e.claimQueue = [], "Cleared ".concat(t, " candidates from claim queue. Queue will repopulate on next empire tick.");
@@ -19262,21 +19267,21 @@ usage: "expansion.clearQueue()",
 examples: [ "expansion.clearQueue()" ],
 category: "Empire"
 }) ], e.prototype, "clearQueue", null), e;
-}(), Rc = new hc;
+}(), Ec = new Rc;
 
-function Ec(e) {
+function Tc(e) {
 return function(e) {
 return "string" == typeof e && e.trimStart().startsWith("{");
 }(e) ? e.trim() : null;
 }
 
-function Tc(e) {
+function Cc(e) {
 var t;
 if (!e.controller) return null;
 var r = e.controller;
 if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
 var o = function(e) {
-var t = Ec(e);
+var t = Tc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19294,12 +19299,12 @@ availableQuests: [ o.id ]
 };
 }
 
-function Cc() {
+function Sc() {
 var e;
 return (null === (e = Memory.tooangel) || void 0 === e ? void 0 : e.npcRooms) || {};
 }
 
-function Sc(e) {
+function wc(e) {
 var t = Memory;
 t.tooangel || (t.tooangel = {}), t.tooangel.npcRooms || (t.tooangel.npcRooms = {});
 var r = t.tooangel.npcRooms[e.roomName];
@@ -19310,7 +19315,7 @@ e.availableQuests = Array.from(o);
 t.tooangel.npcRooms[e.roomName] = e;
 }
 
-function wc() {
+function xc() {
 var e = Memory;
 return e.tooangel || (e.tooangel = {
 enabled: !0,
@@ -19332,14 +19337,14 @@ Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionI
 e.tooangel;
 }
 
-var xc = [ "applied", "active" ];
+var bc = [ "applied", "active" ];
 
-function bc(e) {
+function Oc(e) {
 var t, r;
 return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
 }
 
-function Oc(e, t) {
+function kc(e, t) {
 return !!function(e, t) {
 if (e.sender) return "TooAngel" === e.sender.username;
 var r = function(e) {
@@ -19347,7 +19352,7 @@ var t, r, o = new Set(Object.keys(e.npcRooms || {}));
 try {
 for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-xc.includes(s.status) && s.originRoom && o.add(s.originRoom);
+bc.includes(s.status) && s.originRoom && o.add(s.originRoom);
 }
 } catch (e) {
 t = {
@@ -19361,25 +19366,25 @@ if (t) throw t.error;
 }
 }
 return o;
-}(wc());
+}(xc());
 return !!r.has(e.from) && (void 0 === t || r.has(t));
 }(e, t) && !function(e) {
-return wc().recentTransactionIds.includes(bc(e));
+return xc().recentTransactionIds.includes(Oc(e));
 }(e) && (function(e) {
-var t = wc(), r = bc(e);
+var t = xc(), r = Oc(e);
 t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
 }(e), !0);
 }
 
-var kc = {
+var Ac = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function Ac(e) {
-var t = Ec(e);
+function Mc(e) {
+var t = Tc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19390,24 +19395,24 @@ subsystem: "TooAngel"
 return null;
 }
 
-function Mc() {
-return wc().activeQuests || {};
+function _c() {
+return xc().activeQuests || {};
 }
 
-function _c() {
-var e = Mc();
+function Uc() {
+var e = _c();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < kc.MAX_ACTIVE_QUESTS;
+}).length < Ac.MAX_ACTIVE_QUESTS;
 }
 
-function Uc(e) {
-return kc.SUPPORTED_TYPES.includes(e);
+function Nc(e) {
+return Ac.SUPPORTED_TYPES.includes(e);
 }
 
-function Nc(e, t, r) {
+function Pc(e, t, r) {
 var o, n;
-if (!_c()) return _.debug("Cannot accept more quests (at max capacity)", {
+if (!Uc()) return _.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19424,17 +19429,17 @@ if (!n || !n.terminal || !n.terminal.my) return _.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < kc.MIN_APPLICATION_ENERGY) return _.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(kc.MIN_APPLICATION_ENERGY), {
+if (l < Ac.MIN_APPLICATION_ENERGY) return _.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Ac.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, kc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, Ac.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (_.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
-}), wc().activeQuests[e] = {
+}), xc().activeQuests[e] = {
 id: e,
 type: "buildcs",
 status: "applied",
@@ -19447,8 +19452,8 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Pc(e) {
-var t = wc(), r = t.activeQuests[e.id];
+function Ic(e) {
+var t = xc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (_.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
 }), r.status = "completed") : (_.warn("Quest ".concat(e.id, " failed"), {
@@ -19458,13 +19463,13 @@ subsystem: "TooAngel"
 });
 }
 
-function Ic() {
+function Gc() {
 var e;
-return (null === (e = wc().reputation) || void 0 === e ? void 0 : e.value) || 0;
+return (null === (e = xc().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function Gc(e) {
-var t = Ec(e);
+function Lc(e) {
+var t = Tc(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19473,8 +19478,8 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function Lc(e) {
-var t, r, o, n = wc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
+function Dc(e) {
+var t, r, o, n = xc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return _.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
 }), !1;
@@ -19489,7 +19494,7 @@ if (!o || !o.terminal || !o.terminal.my) return _.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var c = function(e) {
-var t = Cc(), r = null, o = 1 / 0;
+var t = Sc(), r = null, o = 1 / 0;
 for (var n in t) {
 var a = Game.map.getRoomLinearDistance(e, n);
 a < o && (o = a, r = t[n]);
@@ -19513,7 +19518,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Dc(e) {
+function Fc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19603,7 +19608,7 @@ l.notifyComplete && (_.info("Quest ".concat(e.id, " (buildcs) completed! All con
 subsystem: "TooAngel"
 }), function(e, t) {
 var r, o, n = function(e) {
-return Mc()[e] || null;
+return _c()[e] || null;
 }(e);
 if (!n) return _.warn("Cannot notify completion for unknown quest: ".concat(e), {
 subsystem: "TooAngel"
@@ -19655,7 +19660,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Fc, Bc, Wc = kr().cpu.bucketThresholds.highMode + 1e3, Hc = Wc, Kc = /^tooangel_error_\d+$/, Yc = function() {
+var Bc, Wc, Hc = kr().cpu.bucketThresholds.highMode + 1e3, Kc = Hc, Yc = /^tooangel_error_\d+$/, Vc = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19673,19 +19678,19 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, _.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < Hc)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < Kc)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = wc();
+var r = xc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = Gc(i.description);
-null !== s && Oc(i) && (_.info("Received reputation update from TooAngel: ".concat(s), {
+var s = Lc(i.description);
+null !== s && kc(i) && (_.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19712,7 +19717,7 @@ if (e) throw e.error;
 }(), function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = wc();
+var r = xc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
@@ -19720,12 +19725,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = Ac(i.description);
-if (s && Oc(i, s.origin)) {
+var s = Mc(i.description);
+if (s && kc(i, s.origin)) {
 if (_.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-Pc(s);
+Ic(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19739,7 +19744,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Uc(s.quest) || (_.warn("Received unsupported quest type: ".concat(s.quest), {
+}, Nc(s.quest) || (_.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19776,15 +19781,15 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (_.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Dc(o) : (_.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Fc(o) : (_.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
 }(), function() {
-var e = wc().activeQuests || {};
+var e = xc().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - kc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (_.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - Ac.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (_.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19796,9 +19801,9 @@ var e = String(t);
 (function(e) {
 !function() {
 var e = Memory;
-for (var t in e) Kc.test(t) && delete e[t];
+for (var t in e) Yc.test(t) && delete e[t];
 }();
-var t = wc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
+var t = xc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
 return t.errorThrottle = {
 lastErrorTick: i ? Game.time : o,
 count: i ? 1 : n + 1,
@@ -19812,7 +19817,7 @@ subsystem: "TooAngel"
 var e, t, r = function() {
 var e = [];
 for (var t in Game.rooms) {
-var r = Tc(Game.rooms[t]);
+var r = Cc(Game.rooms[t]);
 r && (_.info("Detected TooAngel NPC room: ".concat(t), {
 subsystem: "TooAngel"
 }), e.push(r));
@@ -19820,7 +19825,7 @@ subsystem: "TooAngel"
 return e;
 }();
 try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) Sc(n.value);
+for (var o = a(r), n = o.next(); !n.done; n = o.next()) wc(n.value);
 } catch (t) {
 e = {
 error: t
@@ -19836,12 +19841,12 @@ r.length > 0 && _.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-Lc();
+Dc();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (_c()) {
-var r = Cc(), o = Mc();
+if (Uc()) {
+var r = Sc(), o = _c();
 for (var n in r) {
 var i = r[n];
 try {
@@ -19849,7 +19854,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return _.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void Nc(u, n);
+}), void Pc(u, n);
 }
 } catch (t) {
 e = {
@@ -19866,11 +19871,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return Ic();
+return Gc();
 }, e.prototype.getActiveQuests = function() {
-return Mc();
+return _c();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return Nc(e, t, r);
+return Pc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -19887,27 +19892,27 @@ return n.join("\n");
 }, n([ Xe("empire:tooangel", "TooAngel Manager", {
 priority: Pe.LOW,
 interval: 100,
-minBucket: Wc
+minBucket: Hc
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Vc = new Yc, qc = {
+}(), qc = new Vc, jc = {
 status: function() {
-return Vc.getStatus();
+return qc.getStatus();
 },
 enable: function() {
-return Vc.enable(), "TooAngel integration enabled";
+return qc.enable(), "TooAngel integration enabled";
 },
 disable: function() {
-return Vc.disable(), "TooAngel integration disabled";
+return qc.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = Ic();
+var e = Gc();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return Lc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return Dc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
-var e, t = Mc(), r = [ "Active Quests:" ];
+var e, t = _c(), r = [ "Active Quests:" ];
 if (0 === Object.keys(t).length) r.push("  No active quests"); else for (var o in t) {
 var n = t[o], a = n.deadline - Game.time, i = (null === (e = n.assignedCreeps) || void 0 === e ? void 0 : e.length) || 0;
 r.push("  ".concat(o, ":")), r.push("    Type: ".concat(n.type)), r.push("    Target: ".concat(n.targetRoom)),
@@ -19917,7 +19922,7 @@ r.push("    Assigned creeps: ".concat(i));
 return r.join("\n");
 },
 npcs: function() {
-var e = Cc(), t = [ "TooAngel NPC Rooms:" ];
+var e = Sc(), t = [ "TooAngel NPC Rooms:" ];
 if (0 === Object.keys(e).length) t.push("  No NPC rooms discovered"); else for (var r in e) {
 var o = e[r];
 t.push("  ".concat(r, ":")), t.push("    Has terminal: ".concat(o.hasTerminal)),
@@ -19926,12 +19931,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return Nc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return Pc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, jc = function() {
+}, zc = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -20099,16 +20104,16 @@ usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), zc = new jc, Qc = {
+}(), Qc = new zc, Xc = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, Xc = function() {
+}, Zc = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, Qc), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, Xc), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
@@ -20472,16 +20477,16 @@ interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Zc = new Xc, Jc = {
+}(), Jc = new Zc, $c = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, $c = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], eu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], tu = function() {
+}, eu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], tu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], ru = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, Jc), e);
+this.config = o(o({}, $c), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20635,7 +20640,7 @@ return l.homeRoom = a, l.role = o, _.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? $c : eu).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? eu : tu).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20779,211 +20784,211 @@ interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), ru = new tu, ou = {
+}(), ou = new ru, nu = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, nu = ((Fc = {})[RESOURCE_HYDROXIDE] = {
+}, au = ((Bc = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Fc[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Bc[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Fc[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Bc[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Fc[RESOURCE_GHODIUM] = {
+}, Bc[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Fc[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Bc[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Fc[RESOURCE_UTRIUM_OXIDE] = {
+}, Bc[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Fc[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Bc[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Fc[RESOURCE_KEANIUM_OXIDE] = {
+}, Bc[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Fc[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Bc[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Fc[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Bc[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Fc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Bc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Fc[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Bc[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Fc[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Bc[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Fc[RESOURCE_GHODIUM_OXIDE] = {
+}, Bc[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Fc[RESOURCE_UTRIUM_ACID] = {
+}, Bc[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Bc[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_KEANIUM_ACID] = {
+}, Bc[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Bc[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_LEMERGIUM_ACID] = {
+}, Bc[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Bc[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_ZYNTHIUM_ACID] = {
+}, Bc[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Bc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_GHODIUM_ACID] = {
+}, Bc[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Bc[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Fc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Bc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Bc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Bc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Bc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Bc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Bc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Bc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Bc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Bc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Bc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Fc), au = ((Bc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Bc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Bc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Bc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Bc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Bc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Bc[RESOURCE_GHODIUM] = 5e3, Bc[RESOURCE_HYDROXIDE] = 5e3, Bc);
+}, Bc), iu = ((Wc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Wc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Wc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Wc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Wc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Wc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Wc[RESOURCE_GHODIUM] = 5e3, Wc[RESOURCE_HYDROXIDE] = 5e3, Wc);
 
-function iu(e, t) {
-var r, o, n, a = null !== (r = au[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function su(e, t) {
+var r, o, n, a = null !== (r = iu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function su(e) {
+function cu(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var cu = function() {
+var uu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : ou;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : nu;
 }
 return e.prototype.getReaction = function(e) {
-return nu[e];
+return au[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = nu[e];
+var c = au[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -21005,11 +21010,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = su(t);
+var d = cu(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (nu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < iu(y, t)) {
+if (au[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < su(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -21068,12 +21073,12 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = su(t);
+var h = cu(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = nu[T];
+var T = E.value, C = au[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = iu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = su(T, t), x = w - S;
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), k = {};
 try {
@@ -21189,7 +21194,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), uu = [ {
+}(), lu = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21207,13 +21212,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function lu(e) {
-return uu.find(function(t) {
+function mu(e) {
+return lu.find(function(t) {
 return t.role === e;
 });
 }
 
-function mu(e, t) {
+function du(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21230,29 +21235,29 @@ return;
 }
 }
 
-function du(e, t) {
+function pu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function pu(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : yu(e, t) && yu(e, r) ? "output" : "boost";
-}
-
-function fu(e, t) {
-return t.filter(function(t) {
-return e.id !== t.id && yu(e, t);
-}).length;
+function fu(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : vu(e, t) && vu(e, r) ? "output" : "boost";
 }
 
 function yu(e, t) {
+return t.filter(function(t) {
+return e.id !== t.id && vu(e, t);
+}).length;
+}
+
+function vu(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var vu, gu = function() {
+var gu, hu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : ou;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : nu;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21368,7 +21373,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = mu(s.role, o);
+var s = i.value, c = du(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21390,13 +21395,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, fu(t, e) ];
+return [ t.id, yu(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && yu(e, s) && yu(e, c);
+return t !== a && t !== i && vu(e, s) && vu(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21409,19 +21414,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(du)[0];
+return n.sort(pu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: pu(e, t.input1, t.input2)
+role: fu(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, fu(r, e));
+return Math.max(t, yu(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21565,17 +21570,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), hu = function() {
+}(), Ru = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = lu(o.role);
+var n = mu(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = lu(n.role);
+var r, o, n = e.memory, i = mu(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21653,7 +21658,7 @@ return 0 === c.length && (n.boosted = !0, _.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = lu(t);
+var r, o, n = mu(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21684,7 +21689,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = lu(t);
+var r, o, n = mu(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21718,7 +21723,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ lu("soldier"), lu("ranger"), lu("healer"), lu("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ mu("soldier"), mu("ranger"), mu("healer"), mu("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21775,7 +21780,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = lu(e);
+var r = mu(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21785,7 +21790,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = lu(e);
+var n = mu(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21819,7 +21824,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), Ru = new hu, Eu = {
+}(), Eu = new Ru, Tu = {
 info: function(e, t) {
 return _.info(e, t);
 },
@@ -21832,10 +21837,10 @@ return _.error(e, t);
 debug: function(e, t) {
 return _.debug(e, t);
 }
-}, Tu = function() {
+}, Cu = function() {
 function e() {
-this.manager = new gu({
-logger: Eu
+this.manager = new hu({
+logger: Tu
 });
 }
 return e.prototype.initialize = function(e) {
@@ -21905,14 +21910,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), Cu = new Tu, Su = function() {
+}(), Su = new Cu, wu = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = Cu.getConfig(e);
+var s = Su.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = Cu.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = Su.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -21924,7 +21929,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = Cu.getBoostLabs(e), f = function(e) {
+var p = Su.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -21955,9 +21960,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = Cu.getConfig(e);
+var c = Su.getConfig(e);
 if (!c) return [];
-var u = [], l = Cu.getOutputLabs(e);
+var u = [], l = Su.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -21982,7 +21987,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = Cu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = Su.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -22018,15 +22023,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = Cu.getConfig(e);
+var r, o, n, i, s = Su.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = Cu.getInputLabs(e), u = c.input1, l = c.input2;
+var c = Su.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = Cu.getOutputLabs(e);
+var m = Su.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -22048,23 +22053,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-Cu.clearActiveReaction(e), _.info("Cleared active reactions in ".concat(e), {
+Su.clearActiveReaction(e), _.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = Cu.setActiveReaction(e, t, r, o);
+var n = Su.setActiveReaction(e, t, r, o);
 return n && _.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return Cu.runReactions(e);
+return Su.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return Cu.getBoostLabs(e).length > 0;
+return Su.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = Cu.getConfig(e);
+var r, o, n, i, s, c = Su.getConfig(e);
 if (!c) return null;
-var u = Cu.getBoostLabs(e);
+var u = Su.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -22168,17 +22173,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = Cu.getConfig(e);
+var t = Su.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-Cu.loadFromMemory(e), Cu.initialize(e);
+Su.loadFromMemory(e), Su.initialize(e);
 }, e.prototype.save = function(e) {
-Cu.saveToMemory(e);
+Su.saveToMemory(e);
 }, e;
-}(), wu = new Su, xu = function() {
+}(), xu = new wu, bu = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = Cu.getConfig(e);
+var t, r, o, n, i, s, c, u, l = Su.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22201,7 +22206,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = wu.getLabResourceNeeds(e);
+var h = xu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22221,7 +22226,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = wu.getLabOverflow(e);
+var C = xu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22243,13 +22248,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return wu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return xu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return wu.clearReactions(e), "Cleared active reactions in ".concat(e);
+return xu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = Ru.areBoostLabsReady(n, t), s = Ru.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = Eu.areBoostLabsReady(n, t), s = Eu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22295,7 +22300,7 @@ usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), bu = function() {
+}(), Ou = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22352,10 +22357,10 @@ usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), Ou = function() {
+}(), ku = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = ru.getGPLState();
+var e = ou.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22364,7 +22369,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = ru.getAssignments();
+var e, t, r = ou.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22386,7 +22391,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = Zc.getActiveOperations();
+var e, t, r = Jc.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22411,7 +22416,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return ru.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return ou.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22485,31 +22490,31 @@ usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), ku = new xu, Au = new bu, Mu = new Ou;
+}(), Au = new bu, Mu = new Ou, _u = new ku;
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(vu || (vu = {}));
+}(gu || (gu = {}));
 
-var _u = {
-level: vu.INFO,
+var Uu = {
+level: gu.INFO,
 cpuLogging: !1,
 enableBatching: !0,
 maxBatchSize: 50,
 debugSampleRate: 1,
 maxEntriesPerSubsystemPerTick: 0,
 maxEntriesPerTick: 0
-}, Uu = o({}, _u), Nu = [], Pu = {
+}, Nu = o({}, Uu), Pu = [], Iu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
 debugSampleCounter: 0
 };
 
-function Iu() {
+function Gu() {
 var e = "undefined" != typeof Game && "number" == typeof Game.time ? Game.time : 0;
-Pu.tick !== e && (Pu = {
+Iu.tick !== e && (Iu = {
 tick: e,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22517,47 +22522,47 @@ debugSampleCounter: 0
 });
 }
 
-function Gu(e, t) {
+function Lu(e, t) {
 return !!function(e) {
-if (e !== vu.DEBUG) return !0;
-Iu();
-var t, r = (t = Uu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
+if (e !== gu.DEBUG) return !0;
+Gu();
+var t, r = (t = Nu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
 if (r >= 1) return !0;
 if (r <= 0) return !1;
-Pu.debugSampleCounter += 1;
+Iu.debugSampleCounter += 1;
 var o = Math.max(1, Math.ceil(1 / r));
-return Pu.debugSampleCounter % o === 0;
+return Iu.debugSampleCounter % o === 0;
 }(e) && function(e) {
-var t, r, o = Lu(Uu.maxEntriesPerTick), n = Lu(Uu.maxEntriesPerSubsystemPerTick);
+var t, r, o = Du(Nu.maxEntriesPerTick), n = Du(Nu.maxEntriesPerSubsystemPerTick);
 if (0 === o && 0 === n) return !0;
-if (Iu(), o > 0 && Pu.totalCount >= o) return !1;
+if (Gu(), o > 0 && Iu.totalCount >= o) return !1;
 if (n > 0) {
 var a = null != e ? e : "global";
-if ((null !== (t = Pu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
+if ((null !== (t = Iu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
 }
-Pu.totalCount += 1;
+Iu.totalCount += 1;
 var i = null != e ? e : "global";
-return Pu.perSubsystemCounts.set(i, (null !== (r = Pu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
+return Iu.perSubsystemCounts.set(i, (null !== (r = Iu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
 !0;
 }(null == t ? void 0 : t.subsystem);
 }
 
-function Lu(e) {
+function Du(e) {
 return Number.isFinite(e) && e > 0 ? Math.floor(e) : 0;
 }
 
-function Du(e) {
-Nu.length > 0 && Wu();
-var t = Uu;
-Uu = o(o(o({}, _u), e), {
+function Fu(e) {
+Pu.length > 0 && Hu();
+var t = Nu;
+Nu = o(o(o({}, Uu), e), {
 level: "level" in e ? e.level : t.level,
 cpuLogging: "cpuLogging" in e ? e.cpuLogging : t.cpuLogging,
 enableBatching: "enableBatching" in e ? e.enableBatching : t.enableBatching,
 maxBatchSize: "maxBatchSize" in e ? e.maxBatchSize : t.maxBatchSize,
 debugSampleRate: "debugSampleRate" in e ? e.debugSampleRate : t.debugSampleRate,
-maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : _u.maxEntriesPerSubsystemPerTick,
-maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : _u.maxEntriesPerTick
-}), Nu = [], Pu = {
+maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Uu.maxEntriesPerSubsystemPerTick,
+maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Uu.maxEntriesPerTick
+}), Pu = [], Iu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22565,21 +22570,21 @@ debugSampleCounter: 0
 };
 }
 
-function Fu() {
-return o({}, Uu);
+function Bu() {
+return o({}, Nu);
 }
 
-function Bu(e) {
-Uu.enableBatching ? (Nu.push(e), Nu.length >= Uu.maxBatchSize && Wu()) : console.log(e);
+function Wu(e) {
+Nu.enableBatching ? (Pu.push(e), Pu.length >= Nu.maxBatchSize && Hu()) : console.log(e);
 }
 
-function Wu() {
-0 !== Nu.length && (console.log(Nu.join("\n")), Nu = []);
+function Hu() {
+0 !== Pu.length && (console.log(Pu.join("\n")), Pu = []);
 }
 
-var Hu = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
+var Ku = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
 
-function Ku(e) {
+function Yu(e) {
 return JSON.stringify(e, (t = new WeakSet, function(e, r) {
 return "bigint" == typeof r ? r.toString() : "object" != typeof r || null === r ? r : t.has(r) ? "[Circular]" : (t.add(r),
 r);
@@ -22587,7 +22592,7 @@ r);
 var t;
 }
 
-function Yu(e, t, r, o) {
+function Vu(e, t, r, o) {
 void 0 === o && (o = "log");
 var n = {
 type: o,
@@ -22598,35 +22603,35 @@ shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (r.shard && (n.shard = r.shard), r.subsystem && (n.subsystem = r.subsystem),
 r.room && (n.room = r.room), r.creep && (n.creep = r.creep), r.processId && (n.processId = r.processId),
-r.meta)) for (var a in r.meta) Hu.has(a) || (n[a] = r.meta[a]);
-return Ku(n);
-}
-
-function Vu(e, t) {
-Uu.level <= vu.DEBUG && Gu(vu.DEBUG, t) && Bu(Yu("DEBUG", e, t));
+r.meta)) for (var a in r.meta) Ku.has(a) || (n[a] = r.meta[a]);
+return Yu(n);
 }
 
 function qu(e, t) {
-Uu.level <= vu.INFO && Gu(vu.INFO, t) && Bu(Yu("INFO", e, t));
+Nu.level <= gu.DEBUG && Lu(gu.DEBUG, t) && Wu(Vu("DEBUG", e, t));
 }
 
 function ju(e, t) {
-Uu.level <= vu.WARN && Gu(vu.WARN, t) && Bu(Yu("WARN", e, t));
+Nu.level <= gu.INFO && Lu(gu.INFO, t) && Wu(Vu("INFO", e, t));
 }
 
 function zu(e, t) {
-Uu.level <= vu.ERROR && Gu(vu.ERROR, t) && Bu(Yu("ERROR", e, t));
+Nu.level <= gu.WARN && Lu(gu.WARN, t) && Wu(Vu("WARN", e, t));
 }
 
-function Qu(e, t, r) {
-if (!Uu.cpuLogging) return t();
+function Qu(e, t) {
+Nu.level <= gu.ERROR && Lu(gu.ERROR, t) && Wu(Vu("ERROR", e, t));
+}
+
+function Xu(e, t, r) {
+if (!Nu.cpuLogging) return t();
 var o = Game.cpu.getUsed(), n = t(), a = Game.cpu.getUsed() - o;
-return Vu("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
+return qu("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 }
 
-var Xu = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
+var Zu = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function Zu(e, t, r, o) {
+function Ju(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -22635,21 +22640,13 @@ tick: "undefined" != typeof Game ? Game.time : 0,
 shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (n.unit = r), o && (o.shard && (n.shard = o.shard), o.subsystem && (n.subsystem = o.subsystem),
-o.room && (n.room = o.room), o.meta)) for (var a in o.meta) Xu.has(a) || (n[a] = o.meta[a]);
-Gu(vu.INFO, o) && Bu(Ku(n));
+o.room && (n.room = o.room), o.meta)) for (var a in o.meta) Zu.has(a) || (n[a] = o.meta[a]);
+Lu(gu.INFO, o) && Wu(Yu(n));
 }
 
-function Ju(e) {
+function $u(e) {
 return {
 debug: function(t, r) {
-Vu(t, "string" == typeof r ? {
-subsystem: e,
-room: r
-} : o({
-subsystem: e
-}, r));
-},
-info: function(t, r) {
 qu(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22657,7 +22654,7 @@ room: r
 subsystem: e
 }, r));
 },
-warn: function(t, r) {
+info: function(t, r) {
 ju(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22665,7 +22662,7 @@ room: r
 subsystem: e
 }, r));
 },
-error: function(t, r) {
+warn: function(t, r) {
 zu(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22673,8 +22670,16 @@ room: r
 subsystem: e
 }, r));
 },
+error: function(t, r) {
+Qu(t, "string" == typeof r ? {
+subsystem: e,
+room: r
+} : o({
+subsystem: e
+}, r));
+},
 stat: function(t, r, n, a) {
-Zu(t, r, n, "string" == typeof a ? {
+Ju(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -22682,7 +22687,7 @@ subsystem: e
 }, a));
 },
 measureCpu: function(t, r, n) {
-return Qu(t, r, "string" == typeof n ? {
+return Xu(t, r, "string" == typeof n ? {
 subsystem: e,
 room: n
 } : o({
@@ -22692,22 +22697,22 @@ subsystem: e
 };
 }
 
-var $u, el = {
-debug: Vu,
-info: qu,
-warn: ju,
-error: zu,
-stat: Zu,
-measureCpu: Qu,
-configure: Du,
-getConfig: Fu,
-createLogger: Ju,
-flush: Wu
-}, tl = function() {
+var el, tl = {
+debug: qu,
+info: ju,
+warn: zu,
+error: Qu,
+stat: Ju,
+measureCpu: Xu,
+configure: Fu,
+getConfig: Bu,
+createLogger: $u,
+flush: Hu
+}, rl = function() {
 function e() {}
 return e.prototype.showConfig = function() {
-var e = kr(), t = Fu();
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(vu[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+var e = kr(), t = Bu();
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(gu[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
 }, n([ Xr({
 name: "showConfig",
 description: "Show current bot configuration",
@@ -22715,13 +22720,13 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), rl = new Map, ol = (($u = {})[STRUCTURE_SPAWN] = 100, $u[STRUCTURE_TOWER] = 95,
-$u[STRUCTURE_STORAGE] = 90, $u[STRUCTURE_EXTENSION] = 80, $u[STRUCTURE_TERMINAL] = 75,
-$u[STRUCTURE_LINK] = 70, $u[STRUCTURE_CONTAINER] = 65, $u[STRUCTURE_RAMPART] = 55,
-$u[STRUCTURE_WALL] = 50, $u[STRUCTURE_ROAD] = 30, $u);
+}(), ol = new Map, nl = ((el = {})[STRUCTURE_SPAWN] = 100, el[STRUCTURE_TOWER] = 95,
+el[STRUCTURE_STORAGE] = 90, el[STRUCTURE_EXTENSION] = 80, el[STRUCTURE_TERMINAL] = 75,
+el[STRUCTURE_LINK] = 70, el[STRUCTURE_CONTAINER] = 65, el[STRUCTURE_RAMPART] = 55,
+el[STRUCTURE_WALL] = 50, el[STRUCTURE_ROAD] = 30, el);
 
-function nl(e) {
-var t, r, o, n, i, s = rl.get(e.name);
+function al(e) {
+var t, r, o, n, i, s = ol.get(e.name);
 if (s && s.tick === Game.time) return s;
 var c = e.find(FIND_MY_STRUCTURES), u = {
 tick: Game.time,
@@ -22746,55 +22751,55 @@ m && !m.done && (r = l.return) && r.call(l);
 if (t) throw t.error;
 }
 }
-return rl.set(e.name, u), u;
+return ol.set(e.name, u), u;
 }
 
-function al(e) {
+function il(e) {
 return !e.hasStorage && e.builtTowerCount > 0;
 }
 
-function il(e, t) {
+function sl(e, t) {
 var r;
 return function(e, t) {
 if (!t || e.structureType !== STRUCTURE_EXTENSION) return !1;
-var r = nl(t);
-return r.controllerLevel >= 4 && al(r) && r.energyCapacityAvailable < 650;
+var r = al(t);
+return r.controllerLevel >= 4 && il(r) && r.energyCapacityAvailable < 650;
 }(e, t) ? 98 : function(e, t) {
 if (!t || e.structureType !== STRUCTURE_STORAGE) return !1;
-var r = nl(t);
-return r.controllerLevel >= 4 && al(r);
-}(e, t) ? 97 : null !== (r = ol[e.structureType]) && void 0 !== r ? r : 50;
+var r = al(t);
+return r.controllerLevel >= 4 && il(r);
+}(e, t) ? 97 : null !== (r = nl[e.structureType]) && void 0 !== r ? r : 50;
 }
 
-var sl = A("CreepContext"), cl = new Map;
+var cl = A("CreepContext"), ul = new Map;
 
-function ul(e) {
+function ll(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function ll(e) {
-return void 0 === e._containers && (ul(e), e._containers = e.allStructures.filter(function(e) {
+function ml(e) {
+return void 0 === e._containers && (ll(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 }
 
-function ml(e) {
+function dl(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(t, r) {
 return function(e, t, r) {
-return il(t, r) - il(e, r);
+return sl(t, r) - sl(e, r);
 }(t, r, e.room);
 })), e._prioritizedSites;
 }
 
-function dl(e) {
-return void 0 === e._repairTargets && (ul(e), e._repairTargets = e.allStructures.filter(function(e) {
+function pl(e) {
+return void 0 === e._repairTargets && (ll(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function pl(e) {
+function fl(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = cl.get(e.name);
+var t = ul.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22803,9 +22808,9 @@ hostiles: X(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return cl.set(e.name, r), r;
+return ul.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, sl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, cl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -22870,10 +22875,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return ml(i).length;
+return dl(i).length;
 },
 get damagedStructureCount() {
-return dl(i).length;
+return pl(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -22884,7 +22889,7 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return ll(i);
+return ml(i);
 },
 get sourceContainers() {
 return function(e) {
@@ -22892,7 +22897,7 @@ if (void 0 === e._sourceContainers) {
 var t = function(e) {
 return void 0 === e._sources && (e._sources = e.room.find(FIND_SOURCES)), e._sources;
 }(e);
-0 === t.length ? e._sourceContainers = [] : e._sourceContainers = ll(e).filter(function(e) {
+0 === t.length ? e._sourceContainers = [] : e._sourceContainers = ml(e).filter(function(e) {
 return t.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
@@ -22902,7 +22907,7 @@ return e._sourceContainers;
 }(i);
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (ul(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (ll(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -22931,10 +22936,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return ml(i);
+return dl(i);
 },
 get repairTargets() {
-return dl(i);
+return pl(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -22954,7 +22959,7 @@ e._tombstones;
 var e;
 },
 get mineralContainers() {
-return void 0 === (e = i)._mineralContainers && (ul(e), e._mineralContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._mineralContainers && (ll(e), e._mineralContainers = e.allStructures.filter(function(e) {
 if (e.structureType !== STRUCTURE_CONTAINER) return !1;
 var t = e;
 return Object.keys(t.store).some(function(e) {
@@ -22966,9 +22971,9 @@ var e;
 };
 }
 
-var fl, yl = {}, vl = function() {
-if (fl) return yl;
-fl = 1, Object.defineProperty(yl, "__esModule", {
+var yl, vl = {}, gl = function() {
+if (yl) return vl;
+yl = 1, Object.defineProperty(vl, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== nr ? nr : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -24645,14 +24650,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, Ms = "_rsi";
-return yl.CachingStrategies = vi, yl.CoordListSerializer = fi, yl.CoordSerializer = pi,
-yl.Keys = ji, yl.MoveTargetListSerializer = li, yl.MoveTargetSerializer = ui, yl.NumberSerializer = Oa,
-yl.PositionListSerializer = di, yl.PositionSerializer = mi, yl.adjacentWalkablePositions = xi,
-yl.blockSquare = function(e) {
+return vl.CachingStrategies = vi, vl.CoordListSerializer = fi, vl.CoordSerializer = pi,
+vl.Keys = ji, vl.MoveTargetListSerializer = li, vl.MoveTargetSerializer = ui, vl.NumberSerializer = Oa,
+vl.PositionListSerializer = di, vl.PositionSerializer = mi, vl.adjacentWalkablePositions = xi,
+vl.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, yl.cachePath = ys, yl.cachedPathKey = ps, yl.calculateAdjacencyMatrix = Ti, yl.calculateAdjacentPositions = Ci,
-yl.calculateNearbyPositions = Si, yl.calculatePositionsAtRange = wi, yl.cleanAllCaches = yi,
-yl.clearCachedPath = ks, yl.compressPath = e => {
+}, vl.cachePath = ys, vl.cachedPathKey = ps, vl.calculateAdjacencyMatrix = Ti, vl.calculateAdjacentPositions = Ci,
+vl.calculateNearbyPositions = Si, vl.calculatePositionsAtRange = wi, vl.cleanAllCaches = yi,
+vl.clearCachedPath = ks, vl.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24661,19 +24666,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, yl.config = Ta, yl.decompressPath = e => {
+}, vl.config = Ta, vl.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, yl.fastRoomPosition = Ga, yl.fixEdgePosition = Ei, yl.follow = function(e, t) {
+}, vl.fastRoomPosition = Ga, vl.fixEdgePosition = Ei, vl.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, yl.followPath = hs, yl.fromGlobalPosition = ti, yl.generatePath = ts, yl.getCachedPath = vs,
-yl.getMoveIntents = ns, yl.getRangeTo = ri, yl.globalPosition = ei, yl.isExit = hi,
-yl.isPositionWalkable = bi, yl.move = ds, yl.moveByPath = function(e, t, r) {
+}, vl.followPath = hs, vl.fromGlobalPosition = ti, vl.generatePath = ts, vl.getCachedPath = vs,
+vl.getMoveIntents = ns, vl.getRangeTo = ri, vl.globalPosition = ei, vl.isExit = hi,
+vl.isPositionWalkable = bi, vl.move = ds, vl.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, Ms));
@@ -24702,9 +24707,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = Ai(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : As(e, d, r)) : ERR_NO_PATH;
-}, yl.moveTo = As, yl.normalizeTargets = Ri, yl.offsetRoomPosition = Da, yl.packCoord = qa,
-yl.packCoordList = za, yl.packPos = Ya, yl.packPosList = Xa, yl.packRoomName = ii,
-yl.packRoomNames = ni, yl.posAtDirection = oi, yl.preTick = function() {
+}, vl.moveTo = As, vl.normalizeTargets = Ri, vl.offsetRoomPosition = Da, vl.packCoord = qa,
+vl.packCoordList = za, vl.packPos = Ya, vl.packPosList = Xa, vl.packRoomName = ii,
+vl.packRoomNames = ni, vl.posAtDirection = oi, vl.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) _i(e), Bi(e);
 !function() {
@@ -24716,34 +24721,34 @@ n.expires && n.expires < Game.time ? (null === (e = Fi.get(n.room1)) || void 0 =
 null === (t = Fi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, yl.reconcileTraffic = function(e) {
+}, vl.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 Ua.with(Oa).set(cs, Game.time);
-}, yl.reconciledRecently = us, yl.resetCachedPath = gs, yl.roomNameFromCoords = $a,
-yl.roomNameToCoords = Ja, yl.sameRoomPosition = La, yl.unpackCoord = ja, yl.unpackCoordList = Qa,
-yl.unpackPos = Va, yl.unpackPosList = Za, yl.unpackRoomName = si, yl.unpackRoomNames = ai,
-yl;
+}, vl.reconciledRecently = us, vl.resetCachedPath = gs, vl.roomNameFromCoords = $a,
+vl.roomNameToCoords = Ja, vl.sameRoomPosition = La, vl.unpackCoord = ja, vl.unpackCoordList = Qa,
+vl.unpackPos = Va, vl.unpackPosList = Za, vl.unpackRoomName = si, vl.unpackRoomNames = ai,
+vl;
 }();
 
-function gl(e) {
+function hl(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var hl, Rl = 5e5;
+var Rl, El = 5e5;
 
-function El(e) {
+function Tl(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Rl;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > El;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Rl), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - El), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24755,21 +24760,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(hl || (hl = {}));
+}(Rl || (Rl = {}));
 
-var Tl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Cl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Sl = new Set([ "build", "repair", "upgrade" ]), wl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Cl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Sl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], wl = new Set([ "build", "repair", "upgrade" ]), xl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function xl(e, t) {
+function bl(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function bl() {
+function Ol() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function Ol() {
+function kl() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24784,8 +24789,8 @@ rooms: {}
 };
 }
 
-function kl(e) {
-var t = Ol();
+function Al(e) {
+var t = kl();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24804,42 +24809,42 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Al(e, t, r) {
+function Ml(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Ml(e) {
+function _l(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function _l(e) {
-return Cl.includes(e);
-}
-
 function Ul(e) {
-return Sl.has(e);
+return Sl.includes(e);
 }
 
 function Nl(e) {
-return e.store.getUsedCapacity(RESOURCE_ENERGY);
+return wl.has(e);
 }
 
 function Pl(e) {
+return e.store.getUsedCapacity(RESOURCE_ENERGY);
+}
+
+function Il(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function Il(e, t, r) {
-if (void 0 === r && (r = {}), "harvest" === t.type) return Pl(e);
-var o = Nl(e);
-return r.reserveEmptyEnergyDelivery && _l(t.type) ? Pl(e) : Math.max(1, o);
+function Gl(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return Il(e);
+var o = Pl(e);
+return r.reserveEmptyEnergyDelivery && Ul(t.type) ? Il(e) : Math.max(1, o);
 }
 
-function Gl(e, t) {
+function Ll(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function Ll(e, t, r) {
+function Dl(e, t, r) {
 if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -24847,12 +24852,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return Nl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && Pl(e.creep) > 0;
+return Pl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && Il(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return Nl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return Pl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -24871,7 +24876,7 @@ return !1;
 }
 }
 
-function Dl(e, t) {
+function Fl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -24888,7 +24893,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Fl(e) {
+function Bl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -24896,36 +24901,36 @@ roomName: e.roomName
 };
 }
 
-function Bl(e, t, r, o, n) {
+function Wl(e, t, r, o, n) {
 return {
-id: Al(e, t, r.id),
+id: Ml(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Fl(r.pos),
+targetPos: Bl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: Tl,
+allowedRoles: Cl,
 expiresTick: Game.time + 50
 };
 }
 
-function Wl(e, t) {
+function Hl(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = bl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = Ol()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < p)) {
 t.lastGeneratedTick = Game.time;
-var f = xl("taskBoard.findMyStructures", function() {
+var f = bl("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Dl(t, Bl(e.name, "refillTower", h, g, hl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Dl(t, Bl(e.name, "refillExtension", h, g, hl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Dl(t, Bl(e.name, "refillSpawn", h, g, hl.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Fl(t, Wl(e.name, "refillTower", h, g, Rl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Fl(t, Wl(e.name, "refillExtension", h, g, Rl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Fl(t, Wl(e.name, "refillSpawn", h, g, Rl.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -24938,29 +24943,29 @@ v && !v.done && (o = y.return) && o.call(y);
 if (r) throw r.error;
 }
 }
-var R = El(e);
-R && Dl(t, Bl(e.name, "fillTerminalEnergy", R.terminal, R.amount, hl.NORMAL));
+var R = Tl(e);
+R && Fl(t, Wl(e.name, "fillTerminalEnergy", R.terminal, R.amount, Rl.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
-var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ds ? hl.NORMAL : hl.LOW, S = Math.min(E, 1e3);
-Dl(t, Bl(e.name, "storeEnergy", e.storage, S, C));
+var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Fs ? Rl.NORMAL : Rl.LOW, S = Math.min(E, 1e3);
+Fl(t, Wl(e.name, "storeEnergy", e.storage, S, C));
 }
-var w = xl("taskBoard.findHostiles", function() {
+var w = bl("taskBoard.findHostiles", function() {
 return X(e);
 });
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Dl(t, {
-id: Al(e.name, "defend", O.id),
+Fl(t, {
+id: Ml(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
-priority: hl.CRITICAL,
+priority: Rl.CRITICAL,
 targetId: O.id,
-targetPos: Fl(O.pos),
+targetPos: Bl(O.pos),
 amount: O.hits,
 maxAssignments: 3,
-allowedRoles: wl,
+allowedRoles: xl,
 expiresTick: Game.time + 50
 });
 }
@@ -24975,7 +24980,7 @@ b && !b.done && (i = x.return) && i.call(x);
 if (n) throw n.error;
 }
 }
-var k = xl("taskBoard.findInjuredAllies", function() {
+var k = bl("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -24985,13 +24990,13 @@ return e.hits < e.hitsMax;
 try {
 for (var A = a(k.slice(0, 5)), M = A.next(); !M.done; M = A.next()) {
 var _ = M.value;
-Dl(t, {
-id: Al(e.name, "heal", _.id),
+Fl(t, {
+id: Ml(e.name, "heal", _.id),
 roomName: e.name,
 type: "heal",
-priority: hl.HIGH,
+priority: Rl.HIGH,
 targetId: _.id,
-targetPos: Fl(_.pos),
+targetPos: Bl(_.pos),
 amount: _.hitsMax - _.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -25012,17 +25017,17 @@ if (s) throw s.error;
 }
 }
 
-function Hl(e) {
+function Kl(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function Kl(e) {
+function Yl(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && z(e));
 }
 
-function Yl(e) {
+function Vl(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -25034,7 +25039,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? El(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? Tl(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -25047,11 +25052,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !Kl(t);
+return !Yl(t);
 }
 }
 
-function Vl(e, t) {
+function ql(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -25073,7 +25078,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function ql(e, t) {
+function jl(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -25081,7 +25086,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (Ul(m.type)) Vl(e, m); else {
+if (Nl(m.type)) ql(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -25098,7 +25103,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-Hl(m), Game.time > m.expiresTick || !Yl(m) ? Vl(e, m) : (Ml(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !_l(m.type)) && (m.status = "assigned");
+Kl(m), Game.time > m.expiresTick || !Vl(m) ? ql(e, m) : (_l(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Ul(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -25116,7 +25121,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function jl(e, t, r) {
+function zl(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -25124,15 +25129,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-Hl(t);
+Kl(t);
 }
 }
 
-function zl(e, t) {
+function Ql(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function Ql(e, t, r) {
+function Xl(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -25146,37 +25151,37 @@ return e.reservations[t];
 }(e, t.creep.name, t.memory.assignedTaskId);
 s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId;
 var c = null;
-if (s && zl(s, r) && Yl(s) && Ll(t, s, r)) {
+if (s && Ql(s, r) && Vl(s) && Dl(t, s, r)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= hl.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Rl.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var u = Xl(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : hl.CRITICAL);
+var u = Zl(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Rl.CRITICAL);
 if (!u || l < m || !d) return s;
-c = u, jl(0, s, t.creep.name), e.stats.preemptions++;
-} else if (s && (c = Xl(e, t, r), jl(0, s, t.creep.name), e.stats.preemptions++,
+c = u, zl(0, s, t.creep.name), e.stats.preemptions++;
+} else if (s && (c = Zl(e, t, r), zl(0, s, t.creep.name), e.stats.preemptions++,
 !c)) return null;
-if (null != c || (c = Xl(e, t, r)), !c) return null;
-var p = Il(t.creep, c, r);
+if (null != c || (c = Zl(e, t, r)), !c) return null;
+var p = Gl(t.creep, c, r);
 if (p <= 0) return null;
-var f = Math.min(Math.max(1, Ml(c)), p);
+var f = Math.min(Math.max(1, _l(c)), p);
 return t.memory.assignedTaskId = c.id, c.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, c.updatedTick = Game.time, Hl(c), e.stats.assigned++, c;
+}, c.updatedTick = Game.time, Kl(c), e.stats.assigned++, c;
 }
 
-function Xl(e, t, r) {
+function Zl(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (zl(l, r) && Ll(t, l, r) && Yl(l) && !(Ml(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || _l(l.type))) {
-var m = Zl(t.creep, l), d = 1e3 * l.priority - m;
+if (Ql(l, r) && Dl(t, l, r) && Vl(l) && !(_l(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Ul(l.type))) {
+var m = Jl(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -25194,7 +25199,7 @@ if (o) throw o.error;
 return i;
 }
 
-function Zl(e, t) {
+function Jl(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -25202,7 +25207,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function Jl(e, t) {
+function $l(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -25216,7 +25221,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: Gl(e, t.creep.name)
+amount: Ll(e, t.creep.name)
 };
 
 case "build":
@@ -25245,7 +25250,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (Kl(t)) return null;
+if (Yl(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -25264,83 +25269,83 @@ return null;
 }
 }
 
-var $l = function() {
+var em = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== Ol().enabled;
+return !1 !== kl().enabled;
 }, e.prototype.setEnabled = function(e) {
-Ol().enabled = e;
+kl().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !bl()) return null;
-var r = kl(e.room.name);
-xl("taskBoard.cleanup", function() {
-return ql(r);
-}), xl("taskBoard.generate", function() {
-return Wl(e.room, r);
+if (!this.isEnabled() || !Ol()) return null;
+var r = Al(e.room.name);
+bl("taskBoard.cleanup", function() {
+return jl(r);
+}), bl("taskBoard.generate", function() {
+return Hl(e.room, r);
 });
-var o = Ql(r, e, {
+var o = Xl(r, e, {
 allowedTypes: t
 });
-return o ? Jl(o, e) : null;
+return o ? $l(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !bl()) return null;
-var t = kl(e.room.name);
-xl("taskBoard.cleanup", function() {
-return ql(t);
-}), xl("taskBoard.generate", function() {
-return Wl(e.room, t);
+if (!this.isEnabled() || !Ol()) return null;
+var t = Al(e.room.name);
+bl("taskBoard.cleanup", function() {
+return jl(t);
+}), bl("taskBoard.generate", function() {
+return Hl(e.room, t);
 });
-var r = Ql(t, e, {
+var r = Xl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: hl.NORMAL,
+preemptPriority: Rl.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = Jl(r, e);
+var o = $l(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.reserveDeliveryWork = function(e) {
-if (!this.isEnabled() || !bl()) return !1;
-var t = kl(e.room.name);
-return xl("taskBoard.cleanup", function() {
-return ql(t);
-}), xl("taskBoard.generate", function() {
-return Wl(e.room, t);
-}), Boolean(Ql(t, e, {
+if (!this.isEnabled() || !Ol()) return !1;
+var t = Al(e.room.name);
+return bl("taskBoard.cleanup", function() {
+return jl(t);
+}), bl("taskBoard.generate", function() {
+return Hl(e.room, t);
+}), Boolean(Xl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: hl.NORMAL,
+preemptPriority: Rl.NORMAL,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.reserveCriticalDeliveryWork = function(e) {
-if (!this.isEnabled() || !bl()) return !1;
-var t = kl(e.room.name);
-return xl("taskBoard.cleanup", function() {
-return ql(t);
-}), xl("taskBoard.generate", function() {
-return Wl(e.room, t);
-}), Boolean(Ql(t, e, {
+if (!this.isEnabled() || !Ol()) return !1;
+var t = Al(e.room.name);
+return bl("taskBoard.cleanup", function() {
+return jl(t);
+}), bl("taskBoard.generate", function() {
+return Hl(e.room, t);
+}), Boolean(Xl(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower" ],
-preemptPriority: hl.HIGH,
+preemptPriority: Rl.HIGH,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = bl();
+var r, o = Ol();
 if (!this.isEnabled() || !o) return !1;
-var n = kl(e);
-xl("taskBoard.cleanup", function() {
-return ql(n);
+var n = Al(e);
+bl("taskBoard.cleanup", function() {
+return jl(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && xl("taskBoard.generate", function() {
-return Wl(a, n);
+return a && bl("taskBoard.generate", function() {
+return Hl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && Yl(e);
+return t.includes(e.type) && Vl(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && bl()) {
+if (this.isEnabled() && Ol()) {
 !function(e) {
-var t, r, o, n, s = Ol();
+var t, r, o, n, s = kl();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -25361,20 +25366,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = kl(e.name);
-xl("taskBoard.cleanup", function() {
-return ql(t);
-}), xl("taskBoard.generate", function() {
-return Wl(e, t);
+var t = Al(e.name);
+bl("taskBoard.cleanup", function() {
+return jl(t);
+}), bl("taskBoard.generate", function() {
+return Hl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = Ol(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = kl(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) jl(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) zl(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -25401,37 +25406,37 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = Ol(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && _l(c.type) && Yl(c))) return delete e.memory.assignedTaskId,
+var a = kl(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && Ul(c.type) && Vl(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = Gl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = Ll(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-Hl(c), u.amount);
+Kl(c), u.amount);
 }, e.prototype.refreshAssignedDeliveryReservation = function(e) {
 var t, r = e.memory.assignedTaskId;
 if (!r) return !1;
-var o = Ol(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
-if (!(a && i && s && _l(i.type) && Yl(i))) return delete e.memory.assignedTaskId,
+var o = kl(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && Ul(i.type) && Vl(i))) return delete e.memory.assignedTaskId,
 !1;
-var c = Il(e.creep, i, {
+var c = Gl(e.creep, i, {
 reserveEmptyEnergyDelivery: !0
 });
-return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Ml(i) + s.amount), c),
-s.expiresTick = Game.time + 15, i.updatedTick = Game.time, Hl(i), !0);
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, _l(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, Kl(i), !0);
 }, e.prototype.clear = function(e) {
-var t = Ol();
+var t = kl();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = bl();
+var t, r = Ol();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = kl(e);
-xl("taskBoard.cleanup", function() {
-return ql(n, !0);
-}), xl("taskBoard.generate", function() {
-return Wl(o, n);
+var n = Al(e);
+bl("taskBoard.cleanup", function() {
+return jl(n, !0);
+}), bl("taskBoard.generate", function() {
+return Hl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25456,10 +25461,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = bl(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = Ol(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = kl(e);
-ql(i, !0), Wl(n, i);
+var i = Al(e);
+jl(i, !0), Hl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25481,8 +25486,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = kl(e);
-ql(s, !0);
+var t, r, o, n, i, s = Al(e);
+jl(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25517,15 +25522,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), em = new $l;
+}(), tm = new em;
 
-function tm(e) {
+function rm(e) {
 return e === ERR_NO_PATH;
 }
 
-function rm(e) {
+function om(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && tm(e.moveResult),
+clearState: void 0 !== e.moveResult && rm(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25536,11 +25541,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var om, nm = A("ActionExecutor");
+var nm, am = A("ActionExecutor");
 
-function am(e, t, r) {
+function im(e, t, r) {
 var o;
-return !!z(r) && (nm.warn("Refusing harmful action against known ally target", {
+return !!z(r) && (am.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25548,37 +25553,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (vl.clearCachedPath(e.creep), ht(e.creep)),
-em.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (gl.clearCachedPath(e.creep), ht(e.creep)),
+tm.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function im(e, t, r) {
+function sm(e, t, r) {
 var o, n;
-if (!t || !t.type) return nm.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return am.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && nm.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-nm.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && am.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+am.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = cm(e, function() {
+i = um(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = cm(e, function() {
+i = um(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = cm(e, function() {
+i = um(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25602,7 +25607,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = cm(e, function() {
+i = um(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25616,92 +25621,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = cm(e, function() {
+i = um(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = cm(e, function() {
+i = um(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = cm(e, function() {
+i = um(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (am(r, a.type, a.target)) {
+if (im(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = cm(e, function() {
+i = um(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (am(r, a.type, a.target)) {
+if (im(r, a.type, a.target)) {
 i = !0;
 break;
 }
-cm(e, function() {
+um(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (am(r, a.type, a.target)) {
+if (im(r, a.type, a.target)) {
 i = !0;
 break;
 }
-cm(e, function() {
+um(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-cm(e, function() {
+um(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), tm(vl.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), rm(gl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = cm(e, function() {
+i = um(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = cm(e, function() {
+i = um(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (am(r, a.type, a.target)) {
+if (im(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = cm(e, function() {
+i = um(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-tm(vl.moveTo(e, a.target)) && (i = !0);
+rm(gl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-tm(vl.moveTo(e, {
+rm(gl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25710,11 +25715,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-tm(sm(e, a.target, a.routeType)) && (i = !0);
+rm(cm(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), tm(sm(e, {
+c = new RoomPosition(25, 25, a.roomName), rm(cm(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25729,44 +25734,44 @@ pos: e,
 range: 10
 };
 });
-tm(vl.moveTo(e, u, {
+rm(gl.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (vl.isExit(e.pos)) {
+if (gl.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-vl.moveTo(e, l, {
+gl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || tm(vl.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || rm(gl.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-tm(vl.moveTo(e, a.target, {
+rm(gl.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (vl.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), vl.moveTo(e, l, {
+if (gl.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), gl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = gl(m.name);
+var d = hl(m.name);
 if (d && !e.pos.isEqualTo(d) && function(e) {
 return "scout" !== e.role;
 }({
 role: r.memory.role
 })) {
-tm(vl.moveTo(e, d, {
+rm(gl.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25775,7 +25780,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && vl.moveTo(e, {
+p && gl.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25783,8 +25788,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, vl.clearCachedPath(e), ht(e), em.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || em.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, gl.clearCachedPath(e), ht(e), tm.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || tm.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25792,27 +25797,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function sm(e, t, r, o) {
-if (!om) return vl.moveTo(e, t, o);
+function cm(e, t, r, o) {
+if (!nm) return gl.moveTo(e, t, o);
 try {
-return om(e, t, r, o);
+return nm(e, t, r, o);
 } catch (n) {
-return nm.warn("Remote movement handler failed; falling back to default movement", {
+return am.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), vl.moveTo(e, t, o);
+}), gl.moveTo(e, t, o);
 }
 }
 
-function cm(e, t, r, o, n, a) {
+function um(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = vl.moveTo(e, r);
-return s !== OK && nm.info("Movement attempt returned non-OK result", {
+var s = gl.moveTo(e, r);
+return s !== OK && am.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25820,49 +25825,49 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), rm({
+}), om({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = rm({
+var c = om({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
 var n, a, i, s, c, u, l, m = e.memory;
-switch (es(m), t) {
+switch (ts(m), t) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
 var d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length;
-l = 2 * d, ts(m).energyHarvested += l;
+l = 2 * d, rs(m).energyHarvested += l;
 break;
 
 case "transfer":
 var p = null !== (n = null == o ? void 0 : o.resourceType) && void 0 !== n ? n : RESOURCE_ENERGY, f = Math.min(null !== (a = null == o ? void 0 : o.amount) && void 0 !== a ? a : e.store.getUsedCapacity(p), e.store.getUsedCapacity(p), null !== (s = null === (i = r.store) || void 0 === i ? void 0 : i.getFreeCapacity(p)) && void 0 !== s ? s : 1 / 0);
 f > 0 && function(e, t) {
-ts(e).energyTransferred += t;
+rs(e).energyTransferred += t;
 }(m, f);
 break;
 
 case "build":
 c = m, u = 5 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
-}).length), ts(c).buildProgress += u;
+}).length), rs(c).buildProgress += u;
 break;
 
 case "repair":
 !function(e, t) {
-ts(e).repairProgress += t;
+rs(e).repairProgress += t;
 }(m, 100 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length));
 break;
 
 case "attack":
-rs(m, g = 30 * e.body.filter(function(e) {
+os(m, g = 30 * e.body.filter(function(e) {
 return e.type === ATTACK && e.hits > 0;
 }).length);
 break;
@@ -25871,7 +25876,7 @@ case "rangedAttack":
 var y = e.body.filter(function(e) {
 return e.type === RANGED_ATTACK && e.hits > 0;
 }).length, v = e.pos.getRangeTo(r), g = 0;
-v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), rs(m, g);
+v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), os(m, g);
 break;
 
 case "heal":
@@ -25880,18 +25885,18 @@ var h = e.body.filter(function(e) {
 return e.type === HEAL && e.hits > 0;
 }).length;
 !function(e, t) {
-ts(e).healingDone += t;
+rs(e).healingDone += t;
 }(m, "heal" === t ? 12 * h : 4 * h);
 break;
 
 case "upgrade":
 !function(e, t) {
-ts(e).upgradeProgress += t;
+rs(e).upgradeProgress += t;
 }(m, d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (nm.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (am.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25902,13 +25907,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var um, lm = A("StateMachine");
+var lm, mm = A("StateMachine");
 
-function mm(e) {
+function dm(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function dm(e, t, r) {
+function pm(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -25930,12 +25935,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== mm(e.amount) ? {
+}, void 0 !== dm(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), lm.info(r, {
+}(t), mm.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25943,13 +25948,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : lm.info("Behavior returned idle action", {
+})) : mm.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (lm.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (mm.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25960,11 +25965,11 @@ type: "idle"
 });
 }
 
-function pm(e, t, r) {
+function fm(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, dm(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, pm(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -26044,7 +26049,7 @@ default:
 return !1;
 }
 var a, i;
-}(a, e)) lm.info("State completed, evaluating new action", {
+}(a, e)) mm.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26094,7 +26099,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = mm(e.data.amount);
+var c = dm(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -26169,12 +26174,12 @@ return null;
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(c) && em.refreshAssignedDeliveryReservation(e), c;
-var u = e.memory.assignedTaskId, l = em.refreshCreepReservation(e, c);
+}(c) && tm.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = tm.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-lm.info("Task-board delivery reservation missing, re-evaluating behavior", {
+mm.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26184,7 +26189,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-lm.info("State reconstruction failed, re-evaluating behavior", {
+mm.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26192,7 +26197,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (lm.info("State invalid, re-evaluating behavior", {
+} else a && (mm.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -26201,33 +26206,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return dm(e, t(e), "Committed new state action");
+return pm(e, t(e), "Committed new state action");
 }
 
-(um = {})[FIND_SOURCES] = 5e3, um[FIND_MINERALS] = 5e3, um[FIND_DEPOSITS] = 100,
-um[FIND_STRUCTURES] = 50, um[FIND_MY_STRUCTURES] = 50, um[FIND_HOSTILE_STRUCTURES] = 20,
-um[FIND_MY_SPAWNS] = 100, um[FIND_MY_CONSTRUCTION_SITES] = 20, um[FIND_CONSTRUCTION_SITES] = 20,
-um[FIND_CREEPS] = 5, um[FIND_MY_CREEPS] = 5, um[FIND_HOSTILE_CREEPS] = 3, um[FIND_DROPPED_RESOURCES] = 5,
-um[FIND_TOMBSTONES] = 10, um[FIND_RUINS] = 10, um[FIND_FLAGS] = 50, um[FIND_NUKES] = 20,
-um[FIND_POWER_CREEPS] = 10, um[FIND_MY_POWER_CREEPS] = 10;
+(lm = {})[FIND_SOURCES] = 5e3, lm[FIND_MINERALS] = 5e3, lm[FIND_DEPOSITS] = 100,
+lm[FIND_STRUCTURES] = 50, lm[FIND_MY_STRUCTURES] = 50, lm[FIND_HOSTILE_STRUCTURES] = 20,
+lm[FIND_MY_SPAWNS] = 100, lm[FIND_MY_CONSTRUCTION_SITES] = 20, lm[FIND_CONSTRUCTION_SITES] = 20,
+lm[FIND_CREEPS] = 5, lm[FIND_MY_CREEPS] = 5, lm[FIND_HOSTILE_CREEPS] = 3, lm[FIND_DROPPED_RESOURCES] = 5,
+lm[FIND_TOMBSTONES] = 10, lm[FIND_RUINS] = 10, lm[FIND_FLAGS] = 50, lm[FIND_NUKES] = 20,
+lm[FIND_POWER_CREEPS] = 10, lm[FIND_MY_POWER_CREEPS] = 10;
 
-var fm, ym, vm = {}, gm = {}, hm = {}, Rm = {};
-
-function Em() {
-if (fm) return Rm;
-fm = 1;
-const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Rm.encode = function(t) {
-if (0 <= t && t < e.length) return e[t];
-throw new TypeError("Must be between 0 and 63: " + t);
-}, Rm;
-}
+var ym, vm, gm = {}, hm = {}, Rm = {}, Em = {};
 
 function Tm() {
-if (ym) return hm;
+if (ym) return Em;
 ym = 1;
-const e = Em();
-return hm.encode = function(t) {
+const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
+return Em.encode = function(t) {
+if (0 <= t && t < e.length) return e[t];
+throw new TypeError("Must be between 0 and 63: " + t);
+}, Em;
+}
+
+function Cm() {
+if (vm) return Rm;
+vm = 1;
+const e = Tm();
+return Rm.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -26235,23 +26240,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, hm;
+}, Rm;
 }
 
-var Cm, Sm, wm, xm = {}, bm = ar(Object.freeze({
+var Sm, wm, xm, bm = {}, Om = ar(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Om() {
-return Sm ? Cm : (Sm = 1, Cm = "function" == typeof URL ? URL : bm.URL);
+function km() {
+return wm ? Sm : (wm = 1, Sm = "function" == typeof URL ? URL : Om.URL);
 }
 
-function km() {
-if (wm) return xm;
-wm = 1;
-const e = Om();
-xm.getArg = function(e, t, r) {
+function Am() {
+if (xm) return bm;
+xm = 1;
+const e = km();
+bm.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -26271,16 +26276,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-xm.toSetString = t ? r : function(e) {
+bm.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, xm.fromSetString = t ? r : function(e) {
+}, bm.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, xm.compareByGeneratedPositionsInflated = function(e, t) {
+}, bm.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, xm.parseSourceMapInput = function(e) {
+}, bm.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -26334,7 +26339,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return xm.normalize = f, xm.join = y, xm.relative = function(t, r) {
+return bm.normalize = f, bm.join = y, bm.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -26346,18 +26351,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, xm.computeSourceURL = function(e, t, r) {
+}, bm.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, xm;
+}, bm;
 }
 
-var Am, Mm = {};
+var Mm, _m = {};
 
-function _m() {
-if (Am) return Mm;
-Am = 1;
+function Um() {
+if (Mm) return _m;
+Mm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -26390,19 +26395,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Mm.ArraySet = e, Mm;
+return _m.ArraySet = e, _m;
 }
 
-var Um, Nm, Pm = {};
+var Nm, Pm, Im = {};
 
-function Im() {
-if (Nm) return gm;
+function Gm() {
+if (Pm) return hm;
+Pm = 1;
+const e = Cm(), t = Am(), r = Um().ArraySet, o = function() {
+if (Nm) return Im;
 Nm = 1;
-const e = Tm(), t = km(), r = _m().ArraySet, o = function() {
-if (Um) return Pm;
-Um = 1;
-const e = km();
-return Pm.MappingList = class {
+const e = Am();
+return Im.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -26422,7 +26427,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, Pm;
+}, Im;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26551,13 +26556,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, gm.SourceMapGenerator = n, gm;
+return n.prototype._version = 3, hm.SourceMapGenerator = n, hm;
 }
 
-var Gm, Lm = {}, Dm = {};
+var Lm, Dm = {}, Fm = {};
 
-function Fm() {
-return Gm || (Gm = 1, function(e) {
+function Bm() {
+return Lm || (Lm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26569,36 +26574,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(Dm)), Dm;
+}(Fm)), Fm;
 }
 
-var Bm, Wm, Hm, Km, Ym = {
+var Wm, Hm, Km, Ym, Vm = {
 exports: {}
 };
 
-function Vm() {
-if (Bm) return Ym.exports;
-Bm = 1;
+function qm() {
+if (Wm) return Vm.exports;
+Wm = 1;
 let e = null;
-return Ym.exports = function() {
+return Vm.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, Ym.exports.initialize = t => {
+}, Vm.exports.initialize = t => {
 e = t;
-}, Ym.exports;
+}, Vm.exports;
 }
 
-function qm() {
-if (Hm) return Wm;
-Hm = 1;
-const e = Vm();
+function jm() {
+if (Km) return Hm;
+Km = 1;
+const e = qm();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return Wm = function() {
+return Hm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26665,28 +26670,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, Wm;
+}, Hm;
 }
 
-var jm, zm, Qm, Xm, Zm = {};
+var zm, Qm, Xm, Zm, Jm = {};
 
-function Jm(e, t, r) {
+function $m(e, t, r) {
 return e - t >= r;
 }
 
-function $m(e, t) {
+function ed(e, t) {
 return e.priority - t.priority;
 }
 
-function ed(e, t, r, o) {
+function td(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function td(e, t, r, o) {
+function rd(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function rd(e) {
+function od(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26704,12 +26709,12 @@ if (t) throw t.error;
 return o;
 }
 
-zm || (zm = 1, vm.SourceMapGenerator = Im().SourceMapGenerator, vm.SourceMapConsumer = function() {
-if (Km) return Lm;
-Km = 1;
-const e = km(), t = Fm(), r = _m().ArraySet;
-Tm();
-const o = Vm(), n = qm(), a = Symbol("smcInternal");
+Qm || (Qm = 1, gm.SourceMapGenerator = Gm().SourceMapGenerator, gm.SourceMapConsumer = function() {
+if (Ym) return Dm;
+Ym = 1;
+const e = Am(), t = Bm(), r = Um().ArraySet;
+Cm();
+const o = qm(), n = jm(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26746,7 +26751,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, Lm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, Dm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -26936,7 +26941,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, Lm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, Dm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -27045,11 +27050,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return Lm.IndexedSourceMapConsumer = c, Lm;
-}().SourceMapConsumer, vm.SourceNode = function() {
-if (jm) return Zm;
-jm = 1;
-const e = Im().SourceMapGenerator, t = km(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return Dm.IndexedSourceMapConsumer = c, Dm;
+}().SourceMapConsumer, gm.SourceNode = function() {
+if (zm) return Jm;
+zm = 1;
+const e = Gm().SourceMapGenerator, t = Am(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -27188,27 +27193,27 @@ map: o
 };
 }
 }
-return Zm.SourceNode = n, Zm;
+return Jm.SourceNode = n, Jm;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(Xm || (Xm = {}));
+}(Zm || (Zm = {}));
 
-var od, nd = [ Xm.CRITICAL, Xm.HIGH, Xm.MEDIUM, Xm.LOW ], ad = {
-bucketThresholds: (Qm = {}, Qm[Xm.CRITICAL] = 0, Qm[Xm.HIGH] = 2e3, Qm[Xm.MEDIUM] = 5e3,
-Qm[Xm.LOW] = 8e3, Qm),
+var nd, ad = [ Zm.CRITICAL, Zm.HIGH, Zm.MEDIUM, Zm.LOW ], id = {
+bucketThresholds: (Xm = {}, Xm[Zm.CRITICAL] = 0, Xm[Zm.HIGH] = 2e3, Xm[Zm.MEDIUM] = 5e3,
+Xm[Zm.LOW] = 8e3, Xm),
 defaultMaxCpu: 5,
 logExecution: !1
-}, id = function() {
+}, sd = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: rd(nd),
+tasksByPriority: od(ad),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, ad), e);
+}, this.config = o(o({}, id), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -27222,13 +27227,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort($m), l = 0;
+var u = Array.from(this.tasks.values()).sort(ed), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (Jm(Game.time, p.lastRun, p.interval)) if (ed(p.priority, s, this.config.bucketThresholds, Xm.CRITICAL)) this.stats.skippedThisTick++; else {
+if ($m(Game.time, p.lastRun, p.interval)) if (td(p.priority, s, this.config.bucketThresholds, Zm.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (td(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (rd(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -27276,7 +27281,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = rd(nd);
+var t, r, o = od(ad);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -27293,22 +27298,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), sd = ((od = global)._computationScheduler || (od._computationScheduler = new id),
-od._computationScheduler), cd = new Map;
+}(), cd = ((nd = global)._computationScheduler || (nd._computationScheduler = new sd),
+nd._computationScheduler), ud = new Map;
 
-function ud(e) {
-var t = cd.get(e);
+function ld(e) {
+var t = ud.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, cd.set(e, t)), t;
+}, ud.set(e, t)), t;
 }
 
-function ld(e, t, r) {
+function md(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return md(e, t[0], r), t[0];
-var i = ud(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return dd(e, t[0], r), t[0];
+var i = ld(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -27325,32 +27330,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && md(e, s, r), s;
+return s && dd(e, s, r), s;
 }
 
-function md(e, t, r) {
-var o = ud(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function dd(e, t, r) {
+var o = ld(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var dd = {
+var pd = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function pd(e, t, r) {
+function fd(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(dd[t], ";") : "";
+var o = t ? "color: ".concat(pd[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function fd(e) {
+function yd(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var yd = {
+var vd = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -27364,7 +27369,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(fd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(yd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -27381,44 +27386,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(fd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(yd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function vd() {
+function gd() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Rd() + Ed() + '<div class="module-help">'.concat(e.map(gd).join(""), "</div>");
+return Ed() + Td() + '<div class="module-help">'.concat(e.map(hd).join(""), "</div>");
 }
 
-var gd = function(e) {
-var t = e.api.map(hd).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(pd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(pd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, hd = function(e) {
+var hd = function(e) {
+var t = e.api.map(Rd).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(fd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(fd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Rd = function(e) {
 var t = [];
-e.describe && t.push(pd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(pd(e.name, "blue"), ": ").concat(pd(e.desc, "green"));
+e.describe && t.push(fd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(fd(e.name, "blue"), ": ").concat(fd(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return pd(e.name, "blue");
-}).join(", ") : "", o = pd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return fd(e.name, "blue");
+}).join(", ") : "", o = fd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(pd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Rd = function() {
-return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(fd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
 }, Ed = function() {
+return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+}, Td = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Td = A("EnergyCollection"), Cd = [ "refillSpawn", "refillExtension", "refillTower" ], Sd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, Cd = A("EnergyCollection"), Sd = [ "refillSpawn", "refillExtension", "refillTower" ], wd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function wd(e) {
+function xd(e) {
 if (e.droppedResources.length > 0) {
 var t = gt(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Cd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27428,15 +27433,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = ld(e.creep, r, "energy_container");
-if (o) return Td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = md(e.creep, r, "energy_container");
+if (o) return Cd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Td.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return Td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (Cd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return Cd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27447,8 +27452,8 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ds && Sd.has(e.memory.role);
-}(e, n)) return Td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Fs && wd.has(e.memory.role);
+}(e, n)) return Cd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -27459,41 +27464,41 @@ var a = pt(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = ld(e.creep, a, "energy_source");
-if (s) return Td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = md(e.creep, a, "energy_source");
+if (s) return Cd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (Td.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return Td.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (Cd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return Cd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return Td.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Cd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function xd(e) {
-var t = em.getAssignedAction(e, Cd);
+function bd(e) {
+var t = tm.getAssignedAction(e, Sd);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function bd(e) {
-return em.hasActiveTask(e.room.name, Cd);
-}
-
-function Od(e, t) {
-return function(e) {
-return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(t) && em.reserveCriticalDeliveryWork(e), t;
+function Od(e) {
+return tm.hasActiveTask(e.room.name, Sd);
 }
 
 function kd(e, t) {
+return function(e) {
+return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
+}(t) && tm.reserveCriticalDeliveryWork(e), t;
+}
+
+function Ad(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27520,11 +27525,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Ad(e) {
-var t = em.getAssignedDeliveryAction(e);
+function Md(e) {
+var t = tm.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!bd(e)) {
-var r = kd(e, "deliver");
+if (!Od(e)) {
+var r = Ad(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27546,9 +27551,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Md = /^[WE]\d+[NS]\d+$/;
+var _d = /^[WE]\d+[NS]\d+$/;
 
-function _d(e) {
+function Ud(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27558,28 +27563,28 @@ routeType: "hauler"
 } : null;
 }
 
-function Ud(e) {
-return Md.test(e);
-}
-
 function Nd(e) {
-var t, r = e.memory, o = r.questAction, n = r.questTarget;
-if ("build" !== o) return null;
-if (!n || !Ud(n)) return _d(e);
-var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
-return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
-type: "remoteMoveToRoom",
-roomName: e.homeRoom,
-routeType: "hauler"
-} : null : _d(e) : null;
+return _d.test(e);
 }
 
 function Pd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = Nd(e);
+if (!n || !Nd(n)) return Ud(e);
+var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
+return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
+type: "remoteMoveToRoom",
+roomName: e.homeRoom,
+routeType: "hauler"
+} : null : Ud(e) : null;
+}
+
+function Id(e) {
+var t, r = e.memory, o = r.questAction, n = r.questTarget;
+if ("build" !== o) return null;
+var a = Pd(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !Ud(n)) return null;
+if (!n || !Nd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27592,7 +27597,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function Id(e) {
+function Gd(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27601,11 +27606,11 @@ var n = e.memory.working;
 return o !== n && Rt(e.creep), n;
 }
 
-function Gd(e) {
+function Ld(e) {
 e.memory.working = !1, Rt(e.creep);
 }
 
-var Ld = function() {
+var Dd = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27700,20 +27705,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), Dd = new Ld, Fd = A("LarvaWorkerBehavior");
+}(), Fd = new Dd, Bd = A("LarvaWorkerBehavior");
 
-function Bd(e) {
-var t = Id(e), r = Nd(e);
+function Wd(e) {
+var t = Gd(e), r = Pd(e);
 if (r) return r;
 if (t) {
-Fd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = Pd(e);
+Bd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = Id(e);
 if (o) return o;
-var n = Ad(e);
-if (n) return Fd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = Md(e);
+if (n) return Bd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = Dd.getSwarmState(e.room.name);
+var t, r = Fd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27730,7 +27735,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Fd.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Bd.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27739,20 +27744,14 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Fd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Bd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Fd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-Gd(e);
+Bd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+Ld(e);
 }
-return Od(e, wd(e));
-}
-
-function Wd(e) {
-return e.body.some(function(e) {
-return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
-});
+return kd(e, xd(e));
 }
 
 function Hd(e) {
@@ -27761,38 +27760,44 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-var Kd = new Map;
+function Kd(e) {
+return e.body.some(function(e) {
+return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
+});
+}
 
-function Yd(e) {
+var Yd = new Map;
+
+function Vd(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var Vd = A("HarvesterBehavior"), qd = A("HaulerBehavior"), jd = Ds, zd = [ "refillSpawn", "refillExtension" ];
+var qd = A("HarvesterBehavior"), jd = A("HaulerBehavior"), zd = Fs, Qd = [ "refillSpawn", "refillExtension" ];
 
-function Qd(e, t) {
-return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && em.reserveDeliveryWork(e),
-"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && em.reserveDeliveryWork(e),
+function Xd(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && tm.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && tm.reserveDeliveryWork(e),
 t;
 }
 
-function Xd(e, t, r) {
+function Zd(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return md(e, c, r), c;
+if (c) return dd(e, c, r), c;
 }
-var u = ld(e, t, r);
+var u = md(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function Zd(e) {
+function Jd(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27806,9 +27811,9 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-function Jd(e) {
+function $d(e) {
 if (e.creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
-var t = Ad(e);
+var t = Md(e);
 if (t) return t;
 }
 var r, o = (r = e.creep, Object.keys(r.store).find(function(e) {
@@ -27826,7 +27831,7 @@ resourceType: o
 } : null;
 }
 
-var $d = {
+var ep = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -27836,11 +27841,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, ep = $d, tp = function(e) {
-return ep.getLabResourceNeeds(e);
+}, tp = ep, rp = function(e) {
+return tp.getLabResourceNeeds(e);
 };
 
-function rp(e) {
+function op(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -27862,7 +27867,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = tp(e.room.name);
+var n = rp(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -27890,7 +27895,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, ep.getLabOverflow(r));
+var t, r, o = (r = e.room.name, tp.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27905,7 +27910,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = tp(e.room.name);
+var i = rp(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -27924,8 +27929,8 @@ type: "idle"
 }(e);
 }
 
-var op = {
-larvaWorker: Bd,
+var np = {
+larvaWorker: Wd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -27936,12 +27941,12 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-if (e.hostiles.filter(Wd).length > 0) return {
+if (e.hostiles.filter(Hd).length > 0) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (Id(e)) {
+if (Gd(e)) {
 var o = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -27960,7 +27965,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return wd(e);
+return xd(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -27994,10 +27999,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(Hd)) return {
+if (e.hostiles.some(Kd)) return {
 type: "idle"
 };
-if (Id(e)) {
+if (Gd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28016,10 +28021,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return wd(e);
+return xd(e);
 },
 harvester: function(e) {
-var t, r = (t = Yd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = Vd(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -28068,8 +28073,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), Vd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return Vd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), qd.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return qd.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -28097,7 +28102,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return Vd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return qd.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -28118,12 +28123,12 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (Vd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (qd.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (Vd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (qd.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
@@ -28136,8 +28141,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-var r = Id(e), o = "defenseRefuel" === e.memory.task;
-if (qd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var r = Gd(e), o = "defenseRefuel" === e.memory.task;
+if (jd.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -28150,9 +28155,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = em.getAssignedAction(e, zd);
+var t = tm.getAssignedAction(e, Qd);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (em.hasActiveTask(e.room.name, zd)) return null;
+if (tm.hasActiveTask(e.room.name, Qd)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -28172,17 +28177,17 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = em.getAssignedDeliveryAction(e);
+var c = tm.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!bd(e)) {
-var u = kd(e, "hauler");
+if (!Od(e)) {
+var u = Ad(e, "hauler");
 if (u) return u;
 }
 var l = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = El(e.room);
-return r < 2e4 && o > jd && n > 0 || Boolean(a) ? {
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Tl(e.room);
+return r < 2e4 && o > zd && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28208,35 +28213,41 @@ type: "transfer",
 target: m,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return qd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return jd.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-qd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-Gd(e);
+jd.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+Ld(e);
 }
 if (o) {
 var p = function(e) {
 var t = e.sourceContainers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
-if (0 === t.length) return null;
-var r = Xd(e.creep, t, "energy_container");
+if (t.length > 0) {
+var r = Zd(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
 };
 var o = e.creep.pos.findClosestByRange(t);
-return o ? {
+if (o) return {
 type: "withdraw",
 target: o,
+resourceType: RESOURCE_ENERGY
+};
+}
+return vi(e.terminal) ? {
+type: "withdraw",
+target: e.terminal,
 resourceType: RESOURCE_ENERGY
 } : null;
 }(e);
 if (p) return p;
 }
-if (e.droppedResources.length > 0 && (m = gt(e.creep, e.droppedResources, "hauler_drop", 5))) return Qd(e, {
+if (e.droppedResources.length > 0 && (m = gt(e.creep, e.droppedResources, "hauler_drop", 5))) return Xd(e, {
 type: "pickup",
 target: m
 });
@@ -28246,7 +28257,7 @@ return e.store.getUsedCapacity() > 0;
 if (f.length > 0) {
 var y = gt(e.creep, f, "hauler_tomb", 10);
 if (y) {
-if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Qd(e, {
+if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return Xd(e, {
 type: "withdraw",
 target: y,
 resourceType: RESOURCE_ENERGY
@@ -28265,24 +28276,24 @@ var g = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (g.length > 0) {
-var h = Xd(e.creep, g, "energy_container");
-if (h) return qd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-Qd(e, {
+var h = Zd(e.creep, g, "energy_container");
+if (h) return jd.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+Xd(e, {
 type: "withdraw",
 target: h,
 resourceType: RESOURCE_ENERGY
 });
-qd.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
+jd.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
 var R = e.creep.pos.findClosestByRange(g);
-if (R) return qd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
-Qd(e, {
+if (R) return jd.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
+Xd(e, {
 type: "withdraw",
 target: R,
 resourceType: RESOURCE_ENERGY
 });
 }
 if (e.mineralContainers.length > 0) {
-var E = Xd(e.creep, e.mineralContainers, "mineral_container");
+var E = Zd(e.creep, e.mineralContainers, "mineral_container");
 if (E) {
 if (T = Object.keys(E.store).find(function(e) {
 return e !== RESOURCE_ENERGY && E.store.getUsedCapacity(e) > 0;
@@ -28292,11 +28303,11 @@ target: E,
 resourceType: T
 };
 } else {
-qd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+jd.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var T, C = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (C && (T = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
-}))) return qd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
+}))) return jd.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
 {
 type: "withdraw",
 target: C,
@@ -28310,7 +28321,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > jd || El(e.room)) return {
+if (o < 2e4 && n > zd || Tl(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28341,53 +28352,53 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return S ? Qd(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (qd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-Qd(e, {
+return S ? Xd(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (jd.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+Xd(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-})) : (qd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (jd.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 });
 },
 builder: function(e) {
-var t = Id(e), r = Nd(e);
+var t = Gd(e), r = Pd(e);
 if (r) return r;
 if (t) {
-var o = Pd(e);
+var o = Id(e);
 if (o) return o;
-var n = xd(e);
+var n = bd(e);
 if (n) return n;
-if (!bd(e)) {
-var a = kd(e, "builder");
+if (!Od(e)) {
+var a = Ad(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = Yd(e), r = function(e) {
-var t = Kd.get(e.name);
+var t = Vd(e), r = function(e) {
+var t = Yd.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(t, r) {
-return Math.max(t, il(r, e));
+return Math.max(t, sl(r, e));
 }, Number.NEGATIVE_INFINITY), n = {
 tick: Game.time,
 sites: r,
 highestPriority: o
 };
-return Kd.set(e.name, n), n;
+return Yd.set(e.name, n), n;
 }(e.room);
 if (0 === r.sites.length) return delete t.targetId, null;
 if (t.targetId) {
 var o = Game.getObjectById(t.targetId);
 if (o && function(e, t) {
 return e.pos.roomName === t.name;
-}(o, e.room) && il(o, e.room) >= r.highestPriority) return o;
+}(o, e.room) && sl(o, e.room) >= r.highestPriority) return o;
 delete t.targetId;
 }
 var n = function(e, t) {
 var r, o, n = t.sites.filter(function(r) {
-return il(r, e.room) === t.highestPriority;
+return sl(r, e.room) === t.highestPriority;
 });
 return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
 }(e, r);
@@ -28406,15 +28417,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Od(e, wd(e));
+return kd(e, xd(e));
 },
 upgrader: function(e) {
-if (Id(e)) {
-if (Zd(e)) {
-var t = xd(e);
+if (Gd(e)) {
+if (Jd(e)) {
+var t = bd(e);
 if (t) return t;
-if (!bd(e)) {
-var r = kd(e, "upgrader");
+if (!Od(e)) {
+var r = Ad(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28425,8 +28436,8 @@ target: e.room.controller
 type: "idle"
 };
 }
-var o = Zd(e), n = function(t) {
-return o ? Od(e, t) : t;
+var o = Jd(e), n = function(t) {
+return o ? kd(e, t) : t;
 }, a = e.room.controller;
 if (a) {
 var i = a.pos.findInRange(FIND_MY_STRUCTURES, 2, {
@@ -28461,7 +28472,7 @@ type: "withdraw",
 target: m,
 resourceType: RESOURCE_ENERGY
 });
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Ds) return n({
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Fs) return n({
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28489,7 +28500,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (Id(e)) {
+if (Gd(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28513,7 +28524,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Ad(e) || (e.storage ? {
+} : Md(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28532,15 +28543,15 @@ return e.pos.getRangeTo(t) <= 2;
 })[0];
 }
 }(e.room);
-return r ? Od(e, {
+return r ? kd(e, {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
-}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Od(e, {
+}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? kd(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Od(e, {
+}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? kd(e, {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28633,15 +28644,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : rp(e);
+} : op(e);
 },
-labSupply: rp,
+labSupply: op,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (Id(e)) {
+if (Gd(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28821,11 +28832,11 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t, r = Id(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
+var t, r = Gd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
 if (!o || o === n) return {
 type: "idle"
 };
-if (a && e.room.name === n && (t = Jd(e))) return t;
+if (a && e.room.name === n && (t = $d(e))) return t;
 if (e.nearbyEnemies && e.hostiles.length > 0) {
 var i = e.hostiles.filter(function(t) {
 return e.creep.pos.getRangeTo(t) <= 5 && (t.getActiveBodyparts(ATTACK) > 0 || t.getActiveBodyparts(RANGED_ATTACK) > 0);
@@ -28845,7 +28856,7 @@ if (r || a && e.room.name === n) return e.room.name !== n ? {
 type: "remoteMoveToRoom",
 roomName: n,
 routeType: "hauler"
-} : (t = Jd(e)) || (a && e.room.name === n ? (Gd(e), {
+} : (t = $d(e)) || (a && e.room.name === n ? (Ld(e), {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
@@ -28946,16 +28957,16 @@ roomName: o
 }
 };
 
-function np(e) {
+function ap(e) {
 var t;
-return (null !== (t = op[e.memory.role]) && void 0 !== t ? t : Bd)(e);
+return (null !== (t = np[e.memory.role]) && void 0 !== t ? t : Wd)(e);
 }
 
-var ap = new Set([ "build", "repair", "upgrade" ]);
+var ip = new Set([ "build", "repair", "upgrade" ]);
 
-function ip(e, t) {
+function sp(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && Ud(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && Nd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -28964,12 +28975,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Pd(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Id(e);
 }(e, t);
-return r || (ap.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || Zd(e) ? xd(e) : null : null);
+return r || (ip.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || Jd(e) ? bd(e) : null : null);
 }
 
-var sp = "patrol", cp = [ {
+var cp = "patrol", up = [ {
 x: 10,
 y: 5
 }, {
@@ -29005,7 +29016,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], up = [ {
+} ], lp = [ {
 x: 10,
 y: 10
 }, {
@@ -29022,7 +29033,7 @@ x: 25,
 y: 25
 } ];
 
-function lp(e) {
+function mp(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -29030,7 +29041,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function mp(e) {
+function dp(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -29040,9 +29051,9 @@ roomName: e.roomName
 });
 }
 
-function dp(e) {
+function pp(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Re.get(e.name, {
-namespace: sp
+namespace: cp
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -29062,25 +29073,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(cp), !1), i(up), !1);
-}(t).map(lp).filter(function(e) {
+}(e)), !1), i(up), !1), i(lp), !1);
+}(t).map(mp).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Re.set(e.name, {
-waypoints: mp(n),
+waypoints: dp(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: sp,
+namespace: cp,
 ttl: 1e3
 }), n;
 }
 
-function pp(e, t) {
+function fp(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -29090,89 +29101,89 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var fp = A("MilitaryBehaviors");
+var yp = A("MilitaryBehaviors");
 
-function yp(e) {
+function vp(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
 delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === mi && (delete e.task,
 delete e.targetRoom);
 }
 
-function vp(e, t) {
+function gp(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function gp(e) {
+function hp(e) {
 return Ao(wo(e));
 }
 
-function hp(e) {
+function Rp(e) {
 return e.creep.room.name === e.homeRoom && X(e.room).length > 0;
 }
 
-function Rp(e) {
+function Ep(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Ep(e, t) {
+function Tp(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Tp(e) {
-return Ep(e, "guard") + Ep(e, "ranger") + Ep(e, "healer");
+function Cp(e) {
+return Tp(e, "guard") + Tp(e, "ranger") + Tp(e, "healer");
 }
 
-function Cp(e, t, r) {
+function Sp(e, t, r) {
 var o = e.memory;
 return fi(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function Sp(e, t) {
+function wp(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return Cp(r, e, t);
+return Sp(r, e, t);
 });
 }
 
-function wp(e) {
+function xp(e) {
 return "number" == typeof e.createdAt && Number.isFinite(e.createdAt) ? e.createdAt : Game.time;
 }
 
-function xp(e, t, r) {
-return Ep(e, t) > function(e, t) {
+function bp(e, t, r) {
+return Tp(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
 return !r.spawning && o.role === t && fi(o) === e;
 }).length;
-}(e.roomName, t) || Tp(e) > 0 && gp(e.roomName) && function(e, t) {
-return Sp(e, t).length;
+}(e.roomName, t) || Cp(e) > 0 && hp(e.roomName) && function(e, t) {
+return wp(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function bp(e, t) {
+function Op(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
 if (t.task && t.task !== mi) return null;
-if (hp(e)) return null;
+if (Rp(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Rp).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ep).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== X(l).length && xp(u, t.role, e.homeRoom)) {
-var m = wp(u);
+if (l && 0 !== X(l).length && bp(u, t.role, e.homeRoom)) {
+var m = xp(u);
 return pi(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
 createdAt: m,
 squadId: di(e.homeRoom, u.roomName, m),
-squadSize: gp(u.roomName) ? Math.max(5, Tp(u)) : Math.max(1, Tp(u))
+squadSize: hp(u.roomName) ? Math.max(5, Cp(u)) : Math.max(1, Cp(u))
 }), u.roomName;
 }
 }
@@ -29190,7 +29201,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Op(e) {
+function kp(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -29198,7 +29209,7 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function kp(e, t) {
+function Ap(e, t) {
 if (!function(e) {
 return Boolean(fi(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
@@ -29206,11 +29217,11 @@ if (e.creep.room.name !== e.homeRoom) return null;
 var r = fi(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = wo(r), n = Ao(o), a = n ? Sp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var o = wo(r), n = Ao(o), a = n ? wp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
 var r = fi(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Cp(e, r, o);
+return e.memory.defenseSquadId === t && Sp(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -29224,7 +29235,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return Sp(e, t).reduce(function(e, t) {
+return wp(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = Ro(t.body.filter(function(e) {
 return e.hits > 0;
@@ -29246,16 +29257,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return vp(t, "parity-ready"), null;
-if (c >= u) return vp(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return gp(t, "parity-ready"), null;
+if (c >= u) return gp(t, "squad-quorum"), null;
 if (l) {
-if (!n) return vp(t, "expired-staging"), null;
+if (!n) return gp(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Op(e) - Op(t);
+var r = kp(e) - kp(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -29263,20 +29274,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return vp(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return gp(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return vp(t, "squad-quorum"), null;
-if (l) return vp(t, "expired-staging"), null;
+if (c >= u) return gp(t, "squad-quorum"), null;
+if (l) return gp(t, "expired-staging"), null;
 }
-var m = gl(e.room.name);
+var m = hl(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function Ap(e) {
+function Mp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -29308,21 +29319,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Mp(e, t) {
+function _p(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function _p(e, t) {
+function Up(e, t) {
 if (!e.swarmState) return null;
-var r = gl(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (fp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = hl(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (yp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Up(e) {
+function Np(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -29346,7 +29357,7 @@ if (t) throw t.error;
 }
 }
 
-function Np(e) {
+function Pp(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -29354,23 +29365,23 @@ return Boolean(e);
 });
 }
 
-function Pp(e) {
+function Ip(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Ip(e) {
+function Gp(e) {
 var t, r = e.creep.memory;
 if (yi(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Up(e.memory.squadId);
-if (o) return Gp(e, o);
+var o = Np(e.memory.squadId);
+if (o) return Lp(e, o);
 }
-var n = null !== (t = bp(e, r)) && void 0 !== t ? t : fi(r);
-if (n && !hp(e)) {
-var a = kp(e, r);
+var n = null !== (t = Op(e, r)) && void 0 !== t ? t : fi(r);
+if (n && !Rp(e)) {
+var a = Ap(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -29383,9 +29394,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Ap(e);
+var s = Mp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Mp(e.creep, RANGED_ATTACK), l = Mp(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = _p(e.creep, RANGED_ATTACK), l = _p(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -29397,7 +29408,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Mp(e.creep, RANGED_ATTACK), l = Mp(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = _p(e.creep, RANGED_ATTACK), l = _p(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29408,7 +29419,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (yp(r), e.creep.room.name !== e.homeRoom) return {
+} else if (vp(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29417,8 +29428,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Ap(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Mp(e.creep, RANGED_ATTACK), l = Mp(e.creep, ATTACK),
+var m = Mp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = _p(e.creep, RANGED_ATTACK), l = _p(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -29429,7 +29440,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = dp(e.room), p = pp(e.creep, d);
+var d = pp(e.room), p = fp(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -29443,7 +29454,7 @@ type: "idle"
 };
 }
 
-function Gp(e, t) {
+function Lp(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -29451,7 +29462,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Pp(t);
+var n = Ip(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -29459,7 +29470,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Np(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Pp(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29482,7 +29493,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Np(e).filter(function(t) {
+var t, r, o = Pp(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29511,7 +29522,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Np(t).filter(function(t) {
+var r = Pp(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29527,7 +29538,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Np(t).sort(function(e, t) {
+var a = Pp(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29564,7 +29575,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Np(t).filter(function(e) {
+var l = Pp(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29581,7 +29592,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Np(e).find(function(e) {
+return null !== (t = Pp(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29592,7 +29603,7 @@ target: m
 type: "idle"
 };
 }
-var d = Ap(e);
+var d = Mp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29604,10 +29615,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Mp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : _p(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Mp(e.creep, ATTACK) && p <= 1 ? {
+} : _p(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29623,10 +29634,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Mp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : _p(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Mp(e.creep, ATTACK) && p <= 1 ? {
+} : _p(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29642,7 +29653,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Pp(t)
+target: Ip(t)
 };
 
 case "dissolving":
@@ -29660,8 +29671,8 @@ type: "idle"
 }
 }
 
-var Lp = {
-guard: Ip,
+var Dp = {
+guard: Gp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29670,8 +29681,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = dp(e.room);
-return (o = pp(e.creep, r)) ? {
+var r = pp(e.room);
+return (o = fp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29692,7 +29703,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = dp(e.room), (o = pp(e.creep, r)) ? {
+} : (r = pp(e.room), (o = fp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29706,11 +29717,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Mp(e, HEAL);
+return _p(e, HEAL);
 }), t.filter(function(e) {
-return Mp(e, RANGED_ATTACK);
+return _p(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Mp(e, ATTACK);
+return _p(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29731,7 +29742,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Mp(e.creep, RANGED_ATTACK), u = Mp(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = _p(e.creep, RANGED_ATTACK), u = _p(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29762,19 +29773,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Up(e.memory.squadId);
-if (o) return Gp(e, o);
+var o = Np(e.memory.squadId);
+if (o) return Lp(e, o);
 }
-var n = null !== (t = bp(e, r)) && void 0 !== t ? t : fi(r);
-if (n && !hp(e)) {
-var a = kp(e, r);
+var n = null !== (t = Op(e, r)) && void 0 !== t ? t : fi(r);
+if (n && !Rp(e)) {
+var a = Ap(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === X(i).length) return yp(r), {
+if (0 === X(i).length) return vp(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29868,7 +29879,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = dp(e.room), v = pp(e.creep, y);
+var y = pp(e.room), v = fp(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -29879,8 +29890,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Up(e.memory.squadId);
-if (r) return Gp(e, r);
+var r = Np(e.memory.squadId);
+if (r) return Lp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -29902,9 +29913,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Ap(e);
+var a = Mp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Mp(e.creep, RANGED_ATTACK), c = Mp(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = _p(e.creep, RANGED_ATTACK), c = _p(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -29923,7 +29934,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = dp(e.room), m = pp(e.creep, l);
+var l = pp(e.room), m = fp(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -29945,8 +29956,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Up(e.memory.squadId);
-if (r) return Gp(e, r);
+var r = Np(e.memory.squadId);
+if (r) return Lp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30007,9 +30018,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = _p(e, "siegeUnit");
+var p = Up(e, "siegeUnit");
 if (p) return p;
-var f = dp(e.room), y = pp(e.creep, f);
+var f = pp(e.room), y = fp(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -30020,8 +30031,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Up(e.memory.squadId);
-if (r) return Gp(e, r);
+var r = Np(e.memory.squadId);
+if (r) return Lp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -30038,7 +30049,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return _p(e, "harasser (no target)") || {
+if (!t) return Up(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -30080,9 +30091,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = _p(e, "harasser (no targets)");
+var c = Up(e, "harasser (no targets)");
 if (c) return c;
-var u = dp(e.room), l = pp(e.creep, u);
+var u = pp(e.room), l = fp(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -30095,9 +30106,9 @@ var t, r, o = e.creep.memory;
 if (yi(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Up(e.memory.squadId))) return Gp(e, a);
+if (e.memory.squadId && (a = Np(e.memory.squadId))) return Lp(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (fi(o) && yp(o), e.room.name !== e.homeRoom) return {
+if (fi(o) && vp(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -30111,9 +30122,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = bp(e, o)) && void 0 !== t ? t : fi(o);
-if (i && !hp(e)) {
-var s = kp(e, o);
+var a, i = null !== (t = Op(e, o)) && void 0 !== t ? t : fi(o);
+if (i && !Rp(e)) {
+var s = Ap(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -30123,14 +30134,14 @@ roomName: i
 var u = X(c), l = Z(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return yp(o), {
+if (0 === u.length && 0 === l.length) return vp(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Ap(e);
+var m = Mp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -30150,8 +30161,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Up(e.memory.squadId))) return Gp(e, a);
-var p, f = Ap(e);
+if (e.memory.squadId && (a = Np(e.memory.squadId))) return Lp(e, a);
+var p, f = Mp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -30162,7 +30173,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = dp(e.room), v = pp(e.creep, y);
+var y = pp(e.room), v = fp(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -30183,21 +30194,21 @@ type: "idle"
 }
 };
 
-function Dp(e) {
+function Fp(e) {
 var t;
-return em.getAssignedAction(e) || (null !== (t = Lp[e.memory.role]) && void 0 !== t ? t : Ip)(e);
+return tm.getAssignedAction(e) || (null !== (t = Dp[e.memory.role]) && void 0 !== t ? t : Gp)(e);
 }
 
-var Fp = A("PowerExecutor");
+var Bp = A("PowerExecutor");
 
-function Bp(e, t) {
+function Wp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Wp(e) {
+function Hp(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -30239,8 +30250,8 @@ type: "idle"
 };
 }
 
-var Hp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Kp = {
-powerHarvester: Wp,
+var Kp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Yp = {
+powerHarvester: Hp,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -30312,65 +30323,65 @@ roomName: e.homeRoom
 }
 };
 
-function Yp(e) {
+function Vp(e) {
 var t;
-return (null !== (t = Kp[e.memory.role]) && void 0 !== t ? t : Wp)(e);
+return (null !== (t = Yp[e.memory.role]) && void 0 !== t ? t : Hp)(e);
 }
 
-function Vp(e) {
+function qp(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var qp = {
+var jp = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, jp = {
+}, zp = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, zp = {
+}, Qp = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, Qp = {
+}, Xp = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, Xp = {
+}, Zp = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, Zp = {
+}, Jp = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, Jp = {
+}, $p = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, $p = {
+}, ef = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function ef(e) {
+function tf(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function tf(e) {
+function rf(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -30378,7 +30389,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function rf(e) {
+function of(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -30386,12 +30397,12 @@ y: parseInt(n, 10)
 };
 }
 
-function of(e) {
+function nf(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = nf(s);
+o[s.n] = af(s);
 }
 } catch (e) {
 t = {
@@ -30407,23 +30418,23 @@ if (t) throw t.error;
 return o;
 }
 
-function nf(e) {
+function af(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = jp[e.r]) && void 0 !== t ? t : "core",
-health: af(e.h),
+role: null !== (t = zp[e.r]) && void 0 !== t ? t : "core",
+health: sf(e.h),
 activeTasks: e.t,
-portals: e.p.map(sf),
+portals: e.p.map(cf),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(cf)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(uf)
 };
 }
 
-function af(e) {
+function sf(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = Qp[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = Xp[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -30436,11 +30447,11 @@ lastUpdate: e.u
 };
 }
 
-function sf(e) {
+function cf(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: tf(e.sp),
+sourcePos: rf(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -30450,7 +30461,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function cf(e) {
+function uf(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -30459,7 +30470,7 @@ bucketLevel: e.b
 };
 }
 
-function uf(e) {
+function lf(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30469,12 +30480,12 @@ isAlly: 1 === e.a
 };
 }
 
-function lf(e) {
+function mf(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = mf(u);
+i[u.n] = df(u);
 }
 } catch (e) {
 t = {
@@ -30497,13 +30508,13 @@ updatedAt: e.u
 };
 }
 
-function mf(e) {
+function df(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: rf(e.pp),
+portalPos: of(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30514,46 +30525,46 @@ lastUpdate: e.u
 };
 }
 
-function df(e) {
+function pf(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = Zp[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = Jp[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = $p[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = ef[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function pf(e, t) {
+function ff(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
-}
-
-function ff(e) {
-var t;
-return {
-c: null !== (t = zp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: pf(e.cpuUsage, 2),
-b: e.bucketLevel,
-e: Math.round(e.economyIndex),
-w: Math.round(e.warIndex),
-m: Math.round(e.commodityIndex),
-rc: e.roomCount,
-rl: pf(e.avgRCL, 1),
-cc: e.creepCount,
-u: e.lastUpdate
-};
 }
 
 function yf(e) {
 var t;
 return {
+c: null !== (t = Qp[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: ff(e.cpuUsage, 2),
+b: e.bucketLevel,
+e: Math.round(e.economyIndex),
+w: Math.round(e.warIndex),
+m: Math.round(e.commodityIndex),
+rc: e.roomCount,
+rl: ff(e.avgRCL, 1),
+cc: e.creepCount,
+u: e.lastUpdate
+};
+}
+
+function vf(e) {
+var t;
+return {
 sr: e.sourceRoom,
-sp: ef(e.sourcePos),
+sp: tf(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30562,27 +30573,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function vf(e) {
+function gf(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: pf(e.cpuUsed, 2),
+u: ff(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function gf(e) {
+function hf(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(hf)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Rf)
 };
 }
 
-function hf(e) {
+function Rf(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30592,23 +30603,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Rf(e) {
+function Ef(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = Xp[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = Zp[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = Jp[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = $p[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Ef(e) {
+function Tf(e) {
 return {
 name: e,
 role: "core",
@@ -30631,7 +30642,7 @@ cpuLimit: 0
 };
 }
 
-function Tf(e) {
+function Cf(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30641,16 +30652,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = qp[t.role]) && void 0 !== r ? r : t.role[0],
-h: ff(t.health),
+r: null !== (r = jp[t.role]) && void 0 !== r ? r : t.role[0],
+h: yf(t.health),
 t: t.activeTasks,
-p: t.portals.map(yf),
+p: t.portals.map(vf),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(vf)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(gf)
 };
 }(t[0], t[1]);
 }),
-g: gf(e.globalTargets),
+g: hf(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30664,7 +30675,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? ef(t.portalPos) : void 0,
+pp: t.portalPos ? tf(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30676,20 +30687,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Rf),
+k: e.tasks.map(Ef),
 ls: e.lastSync
 };
 var t;
-}(e), r = Vp(JSON.stringify(t));
+}(e), r = qp(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Cf(e) {
+function Sf(e) {
 try {
-var t = JSON.parse(e), r = Vp(JSON.stringify(t.d));
+var t = JSON.parse(e), r = qp(JSON.stringify(t.d));
 return t.c !== r ? (Ue.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30698,13 +30709,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: of(a.s),
+shards: nf(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(uf)), n),
-footprintOperation: a.o ? lf(a.o) : void 0,
-tasks: a.k.map(df),
+o.en && (n.enemies = o.en.map(lf)), n),
+footprintOperation: a.o ? mf(a.o) : void 0,
+tasks: a.k.map(pf),
 lastSync: a.ls,
 checksum: i
 });
@@ -30716,12 +30727,12 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Sf, wf, xf = 102400, bf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var wf, xf, bf = 102400, Of = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function Of(e, t, r) {
+function kf(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = _f(t), s = function(e, t, r) {
+var i = Uf(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30734,11 +30745,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(Mf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : bf), c = null !== (a = _f(Tf(s))) && void 0 !== a ? a : {};
+}(_f(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Of), c = null !== (a = Uf(Cf(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function kf(e) {
+function Af(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30754,69 +30765,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = Mf(r, _f(r))) && void 0 !== t ? t : e;
+return r && null !== (t = _f(r, Uf(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function Af(e, t) {
+function Mf(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(Of(e, r, t)), !0;
+return InterShardMemory.setLocal(kf(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function Mf(e, t) {
+function _f(e, t) {
 return t && function(e) {
-return Uf(e.d) && "number" == typeof e.c;
-}(t) ? Cf(e) : null;
+return Nf(e.d) && "number" == typeof e.c;
+}(t) ? Sf(e) : null;
 }
 
-function _f(e) {
+function Uf(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return Uf(t) ? t : null;
+return Nf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function Uf(e) {
+function Nf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Sf || (Sf = {})), function(e) {
+}(wf || (wf = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(wf || (wf = {}));
+}(xf || (xf = {}));
 
-var Nf = null != Ue ? Ue : {
+var Pf = null != Ue ? Ue : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Pf = {
+}, If = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, If = {
+}, Gf = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Gf = function() {
+}, Lf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Pf), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, If), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -30833,19 +30844,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Cf(r);
-o && (this.interShardMemory = o, Nf.debug("Loaded InterShardMemory", {
+var o = Sf(r);
+o && (this.interShardMemory = o, Pf.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Nf.error("Failed to load InterShardMemory: ".concat(n), {
+Pf.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Ef(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Tf(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -31006,25 +31017,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Nf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Pf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Nf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Pf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Nf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Pf.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Nf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Pf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -31057,7 +31068,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Nf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Pf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31087,12 +31098,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Nf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Pf.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Nf.info("War ended, transitioning to ".concat(i), {
+Pf.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Nf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Pf.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -31118,7 +31129,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = If[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Gf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -31170,13 +31181,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Nf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Pf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Nf.debug("Could not set shard limits: ".concat(S), {
+Pf.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -31184,27 +31195,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Nf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Pf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = Of(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = kf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > xf) {
-Nf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(xf), {
+if (r.length > bf) {
+Pf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(bf), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = Of(this.interShardMemory, t, {
+var o = kf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > xf ? (Nf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(xf), {
+return o.length > bf ? (Pf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(bf), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Nf.error("Failed to sync InterShardMemory: ".concat(n), {
+Pf.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -31242,7 +31253,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Ef(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Tf(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -31260,40 +31271,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Nf.info("Repaired InterShardMemory structure", {
+Pf.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Nf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Pf.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Cf(r);
-if (!o) return void Nf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Sf(r);
+if (!o) return void Pf.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Nf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Pf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Nf.warn("InterShardMemory verification failed: ".concat(a), {
+Pf.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Nf.info("Attempting InterShardMemory recovery", {
+Pf.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Cf(r);
-if (o) return this.interShardMemory = o, void Nf.info("Recovered InterShardMemory from storage", {
+var o = Sf(r);
+if (o) return this.interShardMemory = o, void Pf.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -31308,12 +31319,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Ef(n), Nf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Tf(n), Pf.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Nf.error("InterShardMemory recovery failed: ".concat(a), {
+Pf.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31323,7 +31334,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Nf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Pf.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -31339,7 +31350,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Nf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Pf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -31355,7 +31366,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Nf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Pf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -31370,7 +31381,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Nf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Pf.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -31389,7 +31400,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Nf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Pf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -31435,11 +31446,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Nf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Pf.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = Tf(this.interShardMemory).length, o = r / xf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = Cf(this.interShardMemory).length, o = r / bf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -31466,11 +31477,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Nf.info("Forcing InterShardMemory sync with validation", {
+Pf.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = Tf(this.interShardMemory).length, n = Tf(o(o({}, this.interShardMemory), {
+var e, t, r = Cf(this.interShardMemory).length, n = Cf(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31494,8 +31505,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: xf,
-percent: Math.round(r / xf * 1e4) / 100,
+limit: bf,
+percent: Math.round(r / bf * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31503,10 +31514,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Sf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (wf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), Lf = new Gf, Df = {
+}(), Df = new Lf, Ff = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31517,11 +31528,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: wf.LOW,
-NORMAL: wf.NORMAL,
-HIGH: wf.HIGH
+LOW: xf.LOW,
+NORMAL: xf.NORMAL,
+HIGH: xf.HIGH
 }
-}, Ff = function() {
+}, Bf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31531,7 +31542,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = Lf.getActiveTransferTasks();
+var n = Df.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31558,7 +31569,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = Lf.getOptimalPortalRoute(e.targetShard);
+var t = Df.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31626,7 +31637,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-Lf.updateTaskProgress(e.taskId, t);
+Df.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31642,7 +31653,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = Df.optimizeBody({
+i = Ff.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -31653,8 +31664,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Df.spawnPriorities.LOW;
-e.priority >= 80 ? d = Df.spawnPriorities.HIGH : e.priority >= 50 && (d = Df.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Ff.spawnPriorities.LOW;
+e.priority >= 80 ? d = Ff.spawnPriorities.HIGH : e.priority >= 50 && (d = Ff.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31672,7 +31683,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-Df.spawnQueue.addRequest(y), Ue.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Ff.spawnQueue.addRequest(y), Ue.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31699,7 +31710,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void Lf.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void Df.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", Ue.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -31711,8 +31722,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, Lf.updateTaskProgress(e.taskId, 100, "complete"),
-Lf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ue.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, Df.updateTaskProgress(e.taskId, 100, "complete"),
+Df.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ue.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31742,12 +31753,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Bf = new Ff;
+}(), Wf = new Bf;
 
-function Wf(e, t, r) {
+function Hf(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = kf({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Af({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31762,13 +31773,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Af(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Mf(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function Hf(e) {
+function Kf(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31796,15 +31807,15 @@ target: n.pos
 type: "idle"
 };
 }(e, i);
-if (Wf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Hf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || X(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Wf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Hf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Wf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Hf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31821,24 +31832,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Wf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Hf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Wf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Hf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Kf(e) {
+function Yf(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function Yf(e, t) {
+function Vf(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -31872,12 +31883,12 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function Vf(e, t) {
+function qf(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function qf(e) {
+function jf(e) {
 var t = Game.map.describeExits(e), r = t ? Object.values(t) : [], o = function(e) {
 var t = function(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
@@ -31888,20 +31899,20 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ Vf(t.x, t.y - 1), Vf(t.x + 1, t.y), Vf(t.x, t.y + 1), Vf(t.x - 1, t.y) ] : [];
+return t ? [ qf(t.x, t.y - 1), qf(t.x + 1, t.y), qf(t.x, t.y + 1), qf(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }
 
-function jf(e) {
-var t = Dd.getEmpire();
-if (vl.isExit(e.creep.pos)) return Kf(e.room.name);
+function zf(e) {
+var t = Fd.getEmpire();
+if (gl.isExit(e.creep.pos)) return Yf(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (o && !function(e, t) {
-return t === e || qf(e).includes(t);
+return t === e || jf(e).includes(t);
 }(e.room.name, o) && (delete e.memory.targetRoom, o = void 0), !o) {
 if (o = function(e, t, r) {
-var o, n, i, s, c = t.knownRooms, u = qf(e);
+var o, n, i, s, c = t.knownRooms, u = jf(e);
 if (0 !== u.length) {
 var l = [];
 try {
@@ -31961,13 +31972,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Yf(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (Vf(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (Yf(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (Vf(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -31977,19 +31988,19 @@ type: "idle"
 };
 }
 
-function zf(e) {
+function Qf(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function Qf(e) {
-return e.hostiles.some(zf);
-}
-
 function Xf(e) {
-return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+return e.hostiles.some(Qf);
 }
 
 function Zf(e) {
+return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+}
+
+function Jf(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32012,8 +32023,8 @@ type: "idle"
 };
 }
 
-var Jf = {
-scout: jf,
+var $f = {
+scout: zf,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -32047,7 +32058,7 @@ return {
 type: "idle"
 };
 }
-if (vl.isExit(e.creep.pos)) return Kf(e.room.name);
+if (gl.isExit(e.creep.pos)) return Yf(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -32069,8 +32080,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Hf,
-interShardScout: Hf,
+interShardClaimer: Kf,
+interShardScout: Kf,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -32146,8 +32157,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return Zf(e);
-if (Qf(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return Jf(e);
+if (Xf(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32188,7 +32199,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return Xf(t) - Xf(e);
+return Zf(t) - Zf(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -32208,7 +32219,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : Zf(e);
+} : Jf(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -32297,9 +32308,9 @@ type: "idle"
 }
 };
 
-function $f(e, t) {
+function ey(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Qf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : Xf(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -32307,26 +32318,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function ey(e) {
-var t;
-return (null !== (t = Jf[e.memory.role]) && void 0 !== t ? t : jf)(e);
-}
-
 function ty(e) {
-var t = pl(e);
-im(e, pm(t, np, {
-interrupt: ip
-}), t);
+var t;
+return (null !== (t = $f[e.memory.role]) && void 0 !== t ? t : zf)(e);
 }
 
 function ry(e) {
-var t = pl(e);
-im(e, pm(t, ey, {
-interrupt: $f
+var t = fl(e);
+sm(e, fm(t, ap, {
+interrupt: sp
 }), t);
 }
 
 function oy(e) {
+var t = fl(e);
+sm(e, fm(t, ty, {
+interrupt: ey
+}), t);
+}
+
+function ny(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -32367,8 +32378,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Hp.has(i) && z(s))) {
-Fp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && Kp.has(i) && z(s))) {
+Bp.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -32379,16 +32390,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && vl.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && gl.moveTo(e, t.target);
 break;
 
 case "moveTo":
-vl.moveTo(e, t.target);
+gl.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-vl.moveTo(e, {
+gl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -32397,11 +32408,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && vl.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && gl.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && vl.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && gl.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -32433,7 +32444,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Bp(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Wp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -32443,7 +32454,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Bp(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Wp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -32454,7 +32465,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = dt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Bp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Wp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32507,7 +32518,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Bp(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Wp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32549,7 +32560,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Bp(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Wp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32559,7 +32570,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Bp(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Wp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -32567,7 +32578,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && X(e.room).length > 0) {
 var o = dt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Bp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Wp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32579,7 +32590,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Bp(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Wp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32587,12 +32598,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Bp(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Wp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Bp(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Wp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32626,18 +32637,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function ny(e) {
+function ay(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var ay = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), iy = -1, sy = Object.create(null);
+var iy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), sy = -1, cy = Object.create(null);
 
-function cy(e) {
+function uy(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var uy = {
+var ly = {
 harvester: Pe.CRITICAL,
 queenCarrier: Pe.CRITICAL,
 hauler: Pe.HIGH,
@@ -32672,12 +32683,12 @@ labTech: Pe.IDLE,
 factoryWorker: Pe.IDLE
 };
 
-function ly(e) {
+function my(e) {
 var t;
-return null !== (t = uy[e]) && void 0 !== t ? t : Pe.MEDIUM;
+return null !== (t = ly[e]) && void 0 !== t ? t : Pe.MEDIUM;
 }
 
-function my(e) {
+function dy(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32693,30 +32704,30 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && cy(o) === e && t++;
+o && uy(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (iy !== Game.time && (iy = Game.time, sy = function() {
+}(e) : null !== (r = (sy !== Game.time && (sy = Game.time, cy = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = cy(o);
+var n = uy(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), sy)[e]) && void 0 !== r ? r : 0;
+}()), cy)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== kr().cpu.disableCreepBootstrapCountCache
 });
-if (o && Game.time % 50 == 0 && el.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
+if (o && Game.time % 50 == 0 && tl.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
 subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!ay.has(t.role)) return !1;
+if (!iy.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32726,7 +32737,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !ny(r)) return !1;
+if (!r || !ay(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32740,7 +32751,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !ny(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !ay(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32748,7 +32759,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !ny(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !ay(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32756,7 +32767,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !ny(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !ay(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32764,7 +32775,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && ny(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && ay(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32780,7 +32791,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !ny(r)) return !1;
+if (!r || !ay(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32815,41 +32826,41 @@ var t;
 return null !== (t = e.memory.family) && void 0 !== t ? t : "economy";
 }(e), i = t.role;
 try {
-Xi.measureSubsystem("role:".concat(i), function() {
+Zi.measureSubsystem("role:".concat(i), function() {
 switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = pl(e);
-im(e, pm(t, np, {
-interrupt: ip
+var t = fl(e);
+sm(e, fm(t, ap, {
+interrupt: sp
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = pl(e);
-im(e, pm(t, Dp), t);
+var t = fl(e);
+sm(e, fm(t, Fp), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = pl(e);
-im(e, pm(t, ey), t);
+var t = fl(e);
+sm(e, fm(t, ty), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = pl(e);
-im(e, pm(t, Yp), t);
+var t = fl(e);
+sm(e, fm(t, Vp), t);
 }(e);
 }
 });
 } catch (t) {
-el.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
+tl.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
 subsystem: "CreepProcessManager",
 creep: e.name,
 meta: {
@@ -32865,7 +32876,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var dy = function() {
+var py = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -32894,7 +32905,7 @@ if (e) throw e.error;
 }
 }
 var d = s < 5;
-(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && el.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
+(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && tl.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
 subsystem: "CreepProcessManager",
 meta: {
 activeCreeps: r.size,
@@ -32906,8 +32917,8 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = ly(r), n = "creep:".concat(e.name);
-Mi.registerProcess({
+var t = e.memory, r = t.role, o = my(r), n = "creep:".concat(e.name);
+_i.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
 priority: o,
@@ -32922,14 +32933,14 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && my(t);
+t && !t.spawning && dy(t);
 }
-}), this.registeredCreeps.add(e.name), el.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
+}), this.registeredCreeps.add(e.name), tl.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.unregisterCreepProcess = function(e) {
 var t = "creep:".concat(e);
-Mi.unregisterProcess(t), this.registeredCreeps.delete(e), el.info("Unregistered creep process: ".concat(e), {
+_i.unregisterProcess(t), this.registeredCreeps.delete(e), tl.info("Unregistered creep process: ".concat(e), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.getMinBucketForRole = function(e, t) {
@@ -32947,7 +32958,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = ly(u.memory.role), m = null !== (r = Pe[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = my(u.memory.role), m = null !== (r = Pe[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -32972,20 +32983,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), py = new dy;
-
-function fy(e) {
-var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, yy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
-}
+}(), fy = new py;
 
 function yy(e) {
+var t, r, o;
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, vy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+}
+
+function vy(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function vy(e) {
+function gy(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -32998,14 +33009,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function gy(e, t) {
+function hy(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var hy = {
+var Ry = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -33033,11 +33044,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function Ry(e, t) {
+function Ey(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function Ey(e) {
+function Ty(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -33047,9 +33058,9 @@ tick: Game.time
 }, a;
 }
 
-var Ty = [ "defense", "war", "expand", "siege" ];
+var Cy = [ "defense", "war", "expand", "siege" ];
 
-function Cy(e) {
+function Sy(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -33062,11 +33073,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function Sy(e, t, r) {
-t >= 2 && (e.pheromones.war = Ry(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ry(e.pheromones.siege + 20, r));
+function wy(e, t, r) {
+t >= 2 && (e.pheromones.war = Ey(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ey(e.pheromones.siege + 20, r));
 }
 
-var wy = function() {
+var xy = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -33081,27 +33092,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), xy = function() {
+}(), by = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, hy), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Ry), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new wy(10),
-energySpawning: new wy(10),
-energyConstruction: new wy(10),
-energyRepair: new wy(10),
-energyTower: new wy(10),
-controllerProgress: new wy(10),
-hostileCount: new wy(5),
-damageReceived: new wy(5),
-idleWorkers: new wy(10),
+energyHarvested: new xy(10),
+energySpawning: new xy(10),
+energyConstruction: new xy(10),
+energyRepair: new xy(10),
+energyTower: new xy(10),
+controllerProgress: new xy(10),
+hostileCount: new xy(5),
+damageReceived: new xy(5),
+idleWorkers: new xy(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = Ey(e);
+var o = Ty(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -33174,7 +33185,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = Ry(e[s] * c, t);
+e[s] = Ey(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -33190,43 +33201,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = Ey(t);
+var o = Ty(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = Ry(e.harvest + n / 3e3 * 10, r);
+e.harvest = Ey(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = Ry(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = Ey(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = Ry(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = Ey(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = Ry(e.defense + 10 * o, r));
+o > 0 && (e.defense = Ey(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = Ry(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ry(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = Ey(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ey(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = Ry(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = Ey(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = Ry(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = Ey(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Ry(e.pheromones.defense + 5 * t, o), Sy(e, r, o),
+e.danger = r, e.pheromones.defense = Ey(e.pheromones.defense + 5 * t, o), wy(e, r, o),
 _.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -33234,7 +33245,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Ry(t / 10, o), Sy(e, r, o);
+e.danger = r, e.pheromones.defense = Ey(t / 10, o), wy(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -33247,8 +33258,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = Ry(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = Ry(f + y, o);
+var p = Ey(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = Ey(f + y, o);
 }
 }
 }
@@ -33267,18 +33278,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = Ry(e.pheromones.defense + 5, r), e.pheromones.build = Ry(e.pheromones.build + 10, r),
+e.pheromones.defense = Ey(e.pheromones.defense + 5, r), e.pheromones.build = Ey(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ry(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ey(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = Ry(e.pheromones.siege + 50, t), e.pheromones.defense = Ry(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = Ey(e.pheromones.siege + 50, t), e.pheromones.defense = Ey(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = Ry(e.pheromones.expand - 10, t), e.pheromones.defense = Ry(e.pheromones.defense + 5, t);
+e.pheromones.expand = Ey(e.pheromones.expand - 10, t), e.pheromones.defense = Ey(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -33288,10 +33299,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Cy(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(Sy(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Ty)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(Cy)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -33345,7 +33356,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = Ry(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = Ey(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -33380,7 +33391,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), by = new xy, Oy = {
+}(), Oy = new by, ky = {
 seedNest: {
 rcl: 1
 },
@@ -33421,7 +33432,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, ky = {
+}, Ay = {
 eco: {
 economy: .75,
 military: .05,
@@ -33464,7 +33475,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Ay = {
+}, My = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33521,13 +33532,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, My = function() {
+}, _y = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Oy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Oy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Oy.fortifiedHive.rcl ? "fortifiedHive" : s >= Oy.matureColony.rcl ? "matureColony" : s >= Oy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = ky.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = ky.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= ky.fortifiedHive.rcl ? "fortifiedHive" : s >= ky.matureColony.rcl ? "matureColony" : s >= ky.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Re.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -33562,7 +33573,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Oy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = ky[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33575,7 +33586,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), _y = function() {
+}(), Uy = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33588,7 +33599,7 @@ var n = e.posture, a = null != r ? r : e.role;
 return _.info("Posture change: ".concat(n, " -> ").concat(o), {
 room: a,
 subsystem: "Posture"
-}), e.posture = o, Mi.emit("posture.change", {
+}), e.posture = o, _i.emit("posture.change", {
 roomName: a,
 oldPosture: n,
 newPosture: o,
@@ -33597,9 +33608,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return ky[e];
-}, e.prototype.getResourcePriorities = function(e) {
 return Ay[e];
+}, e.prototype.getResourcePriorities = function(e) {
+return My[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33609,15 +33620,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Uy = new My, Ny = new _y;
+}(), Ny = new _y, Py = new Uy;
 
-function Py(e) {
+function Iy(e) {
 return !j(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Iy(e, t, r) {
+function Gy(e, t, r) {
 if (!e) return null;
 var o = Sr.getEmpire();
 if (j(e, {
@@ -33656,11 +33667,11 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Gy() {
+function Ly() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var Ly = new Map, Dy = function() {
+var Dy = new Map, Fy = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = X(e), n = this.getDefensePostureIntent(e, t, r, o);
@@ -33808,7 +33819,7 @@ nukeDetected: null !== (n = t.nukeDetected) && void 0 !== n && n,
 nukeScanPerformed: !0,
 clusterId: t.clusterId,
 clusterMemberRooms: null == a ? void 0 : a.memberRooms,
-previousStructures: Ly.get(e.name),
+previousStructures: Dy.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -33838,7 +33849,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && Ly.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && Dy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -33847,7 +33858,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Py(u) && o.add(u.owner.username);
+Iy(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -33861,7 +33872,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Iy(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Gy(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -33877,7 +33888,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? by.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? by.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && by.onNukeDetected(t);
+"danger" === y.type ? Oy.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Oy.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Oy.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -33927,7 +33938,7 @@ case "hostile.detected":
 case "hostile.cleared":
 case "structure.destroyed":
 case "nuke.detected":
-Mi.emit(e.type, e.payload);
+_i.emit(e.type, e.payload);
 }
 }, e.prototype.runTowerControl = function(e, t, r) {
 var o, n, i, s;
@@ -33937,10 +33948,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Gy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = Ly()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Gy()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = Ly()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -33983,7 +33994,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Ny.isCombatPosture(t.posture),
+isCombatPosture: Py.isCombatPosture(t.posture),
 wallRepairTarget: en(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -34007,27 +34018,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Fy = new Dy, By = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), By = new Fy, Wy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Wy() {
+function Hy() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Hy(e, t, r, o) {
+function Ky(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Wy()
+selectedAt: Hy()
 });
 }
 
-function Ky(e) {
+function Yy(e) {
 return e >= 2 && e <= 3;
 }
 
-function Yy(e, t, r) {
+function Vy(e, t, r) {
 var o, n = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -34040,7 +34051,7 @@ return e.structureType === t;
 return n.length + a.length + (null !== (o = null == r ? void 0 : r.getPlacedCount(t)) && void 0 !== o ? o : 0);
 }
 
-function Vy(e, t) {
+function qy(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -34054,10 +34065,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var qy = function() {
+var jy = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Ky(e) ? 5 : 10;
+return Yy(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -34466,10 +34477,10 @@ y: e.y - C.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Hy(t, R, S.name, f);
+Ky(t, R, S.name, f);
 var w = f >= 3 && (t.danger >= 1 || function(e, t, r) {
-var o = Vy(STRUCTURE_TOWER, t);
-return o > 0 && Yy(e, STRUCTURE_TOWER, r) < o;
+var o = qy(STRUCTURE_TOWER, t);
+return o > 0 && Vy(e, STRUCTURE_TOWER, r) < o;
 }(e, f, y));
 if (w) {
 var x = y.capRequested(t.danger >= 2 ? 3 : 1, {
@@ -34480,7 +34491,7 @@ var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = Vy(STRUCTURE_TOWER, g), R = Yy(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = qy(STRUCTURE_TOWER, g), R = Vy(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34883,7 +34894,7 @@ var o, n, i, s = Hn(t);
 try {
 for (var c = a(Object.keys(s)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = null !== (i = s[l]) && void 0 !== i ? i : 0;
-if (!(m <= 0) && Yy(e, l, r) < m) return !0;
+if (!(m <= 0) && Vy(e, l, r) < m) return !0;
 }
 } catch (e) {
 o = {
@@ -34899,8 +34910,8 @@ if (o) throw o.error;
 return !1;
 }(e, f, y);
 if (y.canPlace() || k) {
-if (!Ny.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Wy());
+if (!Py.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Hy());
 }(t, R)) {
 var A = function(e, t, r, o, n) {
 var i, s;
@@ -35057,7 +35068,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return By.has(e.structureType);
+return Wy.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -35066,7 +35077,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var P = Ky(f) ? 2 : 3, I = y.capRequested(P);
+var P = Yy(f) ? 2 : 3, I = y.capRequested(P);
 I > 0 && (N = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -35755,16 +35766,16 @@ return null;
 if (H && y.canPlace({
 bypassRoomLimit: !0
 })) {
-Hy(t, H.anchor, H.blueprint.name, f);
+Ky(t, H.anchor, H.blueprint.name, f);
 var K = e.createConstructionSite(H.anchor.x, H.anchor.y, STRUCTURE_SPAWN);
 y.recordResult(K, STRUCTURE_SPAWN);
 }
 }
 }
 }, e;
-}(), jy = new qy;
+}(), zy = new jy;
 
-function zy(e) {
+function Qy(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35786,7 +35797,7 @@ siege: e.pheromones.siege
 };
 }
 
-var Qy = {
+var Xy = {
 info: function(e, t) {
 return _.info(e, t);
 },
@@ -35799,10 +35810,10 @@ return _.error(e, t);
 debug: function(e, t) {
 return _.debug(e, t);
 }
-}, Xy = new (function() {
+}, Zy = new (function() {
 function e() {
-this.manager = new cu({
-logger: Qy
+this.manager = new uu({
+logger: Xy
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35812,23 +35823,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = zy(t);
+var r = Qy(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = zy(t);
+var r = Qy(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), Zy = {
-labManager: wu,
-boostManager: Ru,
-chemistryPlanner: Xy,
-labConfigManager: Cu,
-logger: el
-}, Jy = function() {
+}()), Jy = {
+labManager: xu,
+boostManager: Eu,
+chemistryPlanner: Zy,
+labConfigManager: Su,
+logger: tl
+}, $y = function() {
 function e(e) {
-void 0 === e && (e = Zy), this.deps = e;
+void 0 === e && (e = Jy), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -35867,9 +35878,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), $y = new Jy, ev = function() {
+}(), ev = new $y, tv = function() {
 function e(e) {
-void 0 === e && (e = $y), this.labWorkflow = e;
+void 0 === e && (e = ev), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -35892,30 +35903,30 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), tv = new ev, rv = {
+}(), rv = new tv, ov = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, ov = new Map;
+}, nv = new Map;
 
-function nv(e) {
+function av(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function av(e) {
+function iv(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var iv = function() {
+var sv = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, rv), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, ov), t);
 }
 return e.prototype.run = function(e) {
-var t, r, o, n = Xi.startRoom(this.roomName), i = Game.rooms[this.roomName];
+var t, r, o, n = Zi.startRoom(this.roomName), i = Game.rooms[this.roomName];
 if (i && (null === (t = i.controller) || void 0 === t ? void 0 : t.my)) {
 var s = Game.cpu.bucket < 6e3;
 s || function(e) {
@@ -35954,7 +35965,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = Sr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = ov.get(e.name);
+var t = nv.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -35976,40 +35987,40 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return ov.set(e.name, o), o;
+return nv.set(e.name, o), o;
 }(i);
-this.config.enablePheromones && !s && Game.time % 5 == 0 && by.updateMetrics(i, c),
-Fy.updateThreatAssessment(i, c, {
+this.config.enablePheromones && !s && Game.time % 5 == 0 && Oy.updateMetrics(i, c),
+By.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), gi.assess(i, c), Ci.checkSafeMode(i, c), this.config.enableEvolution && (Uy.updateEvolutionStage(c, i, e),
-s || Uy.updateMissingStructures(c, i)), Ny.updatePosture(c), this.config.enablePheromones && !s && by.updatePheromones(c, i),
-this.config.enableTowers && Fy.runTowerControl(i, c, u.towers);
+}), hi.assess(i, c), Si.checkSafeMode(i, c), this.config.enableEvolution && (Ny.updateEvolutionStage(c, i, e),
+s || Ny.updateMissingStructures(c, i)), Py.updatePosture(c), this.config.enablePheromones && !s && Oy.updatePheromones(c, i),
+this.config.enableTowers && By.runTowerControl(i, c, u.towers);
 var l = 0 === u.spawns.length || c.danger >= 2;
 if (this.config.enableConstruction && (!s || l)) {
-var m = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, d = jy.getConstructionInterval(m), p = Ny.allowsBuilding(c.posture), f = !p && c.danger >= 2 || s && l;
+var m = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, d = zy.getConstructionInterval(m), p = Py.allowsBuilding(c.posture), f = !p && c.danger >= 2 || s && l;
 (p || f) && function(e, t, r) {
-var o = nv(r), n = av(e);
+var o = av(r), n = iv(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, d) && (jy.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, d) && (zy.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: f
 }), function(e, t, r) {
-var o = nv(r), n = av(e);
+var o = av(r), n = iv(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, d));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && tv.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && rv.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
 var y = Game.cpu.getUsed() - n;
-Xi.recordRoom(i, y), Xi.endRoom(this.roomName, n);
-} else Xi.endRoom(this.roomName, n);
+Zi.recordRoom(i, y), Zi.endRoom(this.roomName, n);
+} else Zi.endRoom(this.roomName, n);
 }, e;
-}(), sv = function() {
+}(), cv = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -36018,7 +36029,7 @@ var e, t, r, o, n, s, c, u = Tt(), l = u.length;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-this.nodes.has(p.name) || this.nodes.set(p.name, new iv(p.name));
+this.nodes.has(p.name) || this.nodes.set(p.name, new sv(p.name));
 }
 } catch (t) {
 e = {
@@ -36054,7 +36065,7 @@ try {
 R.run(l);
 } catch (e) {
 var E = e instanceof Error ? e.message : String(e), T = e instanceof Error && e.stack ? e.stack : void 0;
-el.error("Error in room ".concat(R.roomName, ": ").concat(E), {
+tl.error("Error in room ".concat(R.roomName, ": ").concat(E), {
 subsystem: "RoomManager",
 room: R.roomName,
 meta: {
@@ -36081,13 +36092,13 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new iv(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new sv(e.name));
 var r = Tt().length, o = this.nodes.get(e.name);
 try {
 o.run(r);
 } catch (t) {
 var n = t instanceof Error ? t.message : String(t), a = t instanceof Error && t.stack ? t.stack : void 0;
-el.error("Error in room ".concat(e.name, ": ").concat(n), {
+tl.error("Error in room ".concat(e.name, ": ").concat(n), {
 subsystem: "RoomManager",
 room: e.name,
 meta: {
@@ -36097,9 +36108,9 @@ stack: a
 }
 }
 }, e;
-}(), cv = new sv, uv = new Map;
+}(), uv = new cv, lv = new Map;
 
-function lv(e) {
+function mv(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return !1;
 if (function(e) {
@@ -36112,21 +36123,21 @@ return Array.isArray(a) && a.some(function(t) {
 return t.roomName === e && Number.isFinite(t.impactTick) && t.impactTick > Game.time;
 });
 }(e.name)) return !0;
-var r = uv.get(e.name), o = Game.cpu.bucket < kr().cpu.bucketThresholds.lowMode ? 50 : 5;
+var r = lv.get(e.name), o = Game.cpu.bucket < kr().cpu.bucketThresholds.lowMode ? 50 : 5;
 if (r && Game.time - r.checkedAt < o) return r.active;
 var n = e.find(FIND_NUKES).length > 0;
-return uv.set(e.name, {
+return lv.set(e.name, {
 checkedAt: Game.time,
 active: n
 }), n;
 }
 
-function mv(e, t) {
+function dv(e, t) {
 var r, o = (null === (r = e.controller) || void 0 === r ? void 0 : r.my) ? " (owned)" : "", n = t ? " [nuke response]" : "";
 return "Room ".concat(e.name).concat(o).concat(n);
 }
 
-function dv(e, t) {
+function pv(e, t) {
 var r, o, n;
 if (t.nukeThreat || t.hostiles.length > 0) return Pe.CRITICAL;
 if (null === (r = e.controller) || void 0 === r ? void 0 : r.my) return Pe.HIGH;
@@ -36137,14 +36148,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return a && (null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.reservation) || void 0 === n ? void 0 : n.username) === a ? Pe.MEDIUM : Pe.LOW;
 }
 
-function pv(e, t) {
+function fv(e, t) {
 var r;
 if (!(null === (r = e.controller) || void 0 === r ? void 0 : r.my)) return .02;
 var o = e.controller.level;
 return t.nukeThreat || t.hostiles.length > 0 ? .12 : o <= 3 ? .04 : o <= 6 ? .06 : .08;
 }
 
-var fv, yv = function() {
+var yv, vv = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -36154,9 +36165,9 @@ var t = this.roomIndices.get(e);
 return void 0 === t && (t = this.nextRoomIndex++, this.roomIndices.set(e, t)), t;
 }, e.prototype.getRoomProcessDescriptor = function(e) {
 var t = {
-nukeThreat: lv(e),
+nukeThreat: mv(e),
 hostiles: X(e)
-}, r = dv(e, t), o = function(e, t, r) {
+}, r = pv(e, t), o = function(e, t, r) {
 var o;
 return t === Pe.CRITICAL ? {
 tickModulo: void 0,
@@ -36176,9 +36187,9 @@ tickOffset: void 0
 };
 }(e, r, this.getRoomIndex(e.name));
 return {
-name: mv(e, t.nukeThreat),
+name: dv(e, t.nukeThreat),
 priority: r,
-cpuBudget: pv(e, t),
+cpuBudget: fv(e, t),
 tickModulo: o.tickModulo,
 tickOffset: o.tickOffset,
 minBucket: this.getMinBucketForPriority(r)
@@ -36193,7 +36204,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Mi.getProcess(i), c = this.getRoomProcessDescriptor(n);
+var i = "room:".concat(o), s = _i.getProcess(i), c = this.getRoomProcessDescriptor(n);
 this.registeredRooms.has(o) ? s && this.hasDescriptorChanged(s, c) && this.updateRoomProcess(n, c) : this.registerRoomProcess(n, c);
 }
 try {
@@ -36214,7 +36225,7 @@ if (e) throw e.error;
 }, e.prototype.registerRoomProcess = function(e, t) {
 void 0 === t && (t = this.getRoomProcessDescriptor(e));
 var r = "room:".concat(e.name);
-Mi.registerProcess({
+_i.registerProcess({
 id: r,
 name: t.name,
 priority: t.priority,
@@ -36230,16 +36241,16 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && cv.runRoom(t);
+t && uv.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var o = t.tickModulo ? "(mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset, ")") : "(every tick)";
-el.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
+tl.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t) {
 var r = "room:".concat(e.name);
-Mi.unregisterProcess(r), Mi.registerProcess({
+_i.unregisterProcess(r), _i.registerProcess({
 id: r,
 name: t.name,
 priority: t.priority,
@@ -36255,17 +36266,17 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && cv.runRoom(t);
+t && uv.runRoom(t);
 }
 });
 var o = t.tickModulo ? "mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset) : "every tick";
-el.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
+tl.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.unregisterRoomProcess = function(e) {
 var t = "room:".concat(e);
-Mi.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
-uv.delete(e), el.debug("Unregistered room process: ".concat(e), {
+_i.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
+lv.delete(e), tl.debug("Unregistered room process: ".concat(e), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.getMinBucketForPriority = function(e) {
@@ -36277,8 +36288,8 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = dv(m, {
-nukeThreat: lv(m),
+var d = pv(m, {
+nukeThreat: mv(m),
 hostiles: X(m)
 }), p = null !== (r = Pe[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
@@ -36305,12 +36316,12 @@ ownedRooms: s
 this.lastSyncTick = -1, this.syncRoomProcesses();
 }, e.prototype.reset = function() {
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
-this.lastSyncTick = -1, uv.clear();
+this.lastSyncTick = -1, lv.clear();
 }, e;
-}(), vv = new yv, gv = function() {
+}(), gv = new vv, hv = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
-var e = Mi.getStatsSummary(), t = Mi.getConfig();
+var e = _i.getStatsSummary(), t = _i.getConfig();
 return function(e) {
 var t, r, o, n, i = [ "=== Kernel Stats ===", "Bucket Mode: ".concat(e.bucketMode.toUpperCase()), "CPU Bucket: ".concat(e.cpuBucket), "CPU Limit: ".concat(e.cpuLimit.toFixed(2), " (").concat((100 * e.targetCpuUsage).toFixed(0), "% of ").concat(e.gameCpuLimit, ")"), "Remaining CPU: ".concat(e.remainingCpu.toFixed(2)), "", "Processes: ".concat(e.stats.totalProcesses, " total (").concat(e.stats.activeProcesses, " active, ").concat(e.stats.suspendedProcesses, " suspended)"), "Total CPU Used: ".concat(e.stats.totalCpuUsed.toFixed(3)), "Avg CPU/Process: ".concat(e.stats.avgCpuPerProcess.toFixed(4)), "Avg Health Score: ".concat(e.stats.avgHealthScore.toFixed(1), "/100"), "", "Top CPU Consumers:" ];
 try {
@@ -36348,16 +36359,16 @@ if (o) throw o.error;
 }
 return i.join("\n");
 }({
-bucketMode: Mi.getBucketMode(),
+bucketMode: _i.getBucketMode(),
 cpuBucket: Game.cpu.bucket,
-cpuLimit: Mi.getCpuLimit(),
+cpuLimit: _i.getCpuLimit(),
 targetCpuUsage: t.targetCpuUsage,
 gameCpuLimit: Game.cpu.limit,
-remainingCpu: Mi.getRemainingCpu(),
+remainingCpu: _i.getRemainingCpu(),
 stats: e
 });
 }, e.prototype.listProcesses = function() {
-var e = Mi.getProcesses();
+var e = _i.getProcesses();
 return 0 === e.length ? "No processes registered with kernel." : function(e) {
 var t, r;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36384,11 +36395,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(vy(e.summary.byLayer)), "Groups: ".concat(vy(e.summary.byGroup)), "States: ".concat(vy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(gy(e.summary.byLayer)), "Groups: ".concat(gy(e.summary.byGroup)), "States: ".concat(gy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(gy)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(hy)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(fy(m));
+c.push(yy(m));
 }
 } catch (e) {
 t = {
@@ -36425,19 +36436,19 @@ if (o) throw o.error;
 }
 }
 return c.join("\n");
-}(Mi.getProcessTopology());
+}(_i.getProcessTopology());
 }, e.prototype.suspendProcess = function(e) {
-var t = Mi.suspendProcess(e);
+var t = _i.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = Mi.resumeProcess(e);
+var t = _i.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return Mi.resetStats(), "Kernel statistics reset.";
+return _i.resetStats(), "Kernel statistics reset.";
 }, e.prototype.showProcessHealth = function() {
-var e = Mi.getProcesses();
+var e = _i.getProcesses();
 if (0 === e.length) return "No processes registered with kernel.";
-var t = Mi.getStatsSummary();
+var t = _i.getStatsSummary();
 return function(e, t, r) {
 var o, n;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36464,7 +36475,7 @@ return c.push("", "Average Health: ".concat(r.avgHealthScore.toFixed(1), "/100")
 c.join("\n");
 }(e, Game.time, t);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = Mi.getProcesses().filter(function(e) {
+var e, t, r = _i.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -36472,7 +36483,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Mi.resumeProcess(s.id) && o++;
+_i.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -36487,7 +36498,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = py.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = fy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36506,7 +36517,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = vv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = gv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36525,7 +36536,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o = Mi.getProcesses().filter(function(e) {
+var t, r, o = _i.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (o = o.filter(function(t) {
@@ -36554,7 +36565,7 @@ if (t) throw t.error;
 }
 return n + "\nTotal: ".concat(o.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r = Mi.getProcesses().filter(function(e) {
+var e, t, r = _i.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === r.length) return "No room processes registered.";
@@ -36653,25 +36664,25 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), hv = function() {
+}(), Rv = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
-debug: vu.DEBUG,
-info: vu.INFO,
-warn: vu.WARN,
-error: vu.ERROR,
-none: vu.NONE
+debug: gu.DEBUG,
+info: gu.INFO,
+warn: gu.WARN,
+error: gu.ERROR,
+none: gu.NONE
 }[e.toLowerCase()];
-return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Du({
+return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Fu({
 level: t
 }), "Log level set to: ".concat(e.toUpperCase()));
 }, e.prototype.toggleDebug = function() {
 var e = !kr().debug;
 return Ar({
 debug: e
-}), Du({
-level: e ? vu.DEBUG : vu.INFO
+}), Fu({
+level: e ? gu.DEBUG : gu.INFO
 }), "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
 }, n([ Xr({
 name: "setLogLevel",
@@ -36686,7 +36697,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), Rv = function() {
+}(), Ev = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36726,7 +36737,7 @@ hostileCount: null !== (l = null !== (u = null !== (s = this.toNumber(null === (
 var o, n, a, i, s = this.asRecord(null === (o = this.asRecord(e)) || void 0 === o ? void 0 : o.metrics), c = this.asRecord(null == s ? void 0 : s.energy);
 return null !== (i = null !== (a = null !== (n = this.toNumber(null == s ? void 0 : s[t])) && void 0 !== n ? n : this.toNumber(null == c ? void 0 : c[r])) && void 0 !== a ? a : this.toNumber(null == s ? void 0 : s[r])) && void 0 !== i ? i : 0;
 }, e.prototype.showStats = function() {
-var e = $i.getLatestStats();
+var e = es.getLatestStats();
 return e ? "=== SwarmBot Stats (Tick ".concat(e.tick, ") ===\nCPU: ").concat(e.cpuUsed.toFixed(2), "/").concat(e.cpuLimit, " (Bucket: ").concat(e.cpuBucket, ")\nGCL: ").concat(e.gclLevel, " (").concat((100 * e.gclProgress).toFixed(1), "%)\nGPL: ").concat(e.gplLevel, "\nCreeps: ").concat(e.totalCreeps, "\nRooms: ").concat(e.totalRooms, "\n").concat(e.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks.";
@@ -36770,18 +36781,18 @@ return Re.clear(lt), "Room.find() cache cleared and statistics reset";
 var e = !kr().profiling;
 return Ar({
 profiling: e
-}), Xi.setEnabled(e), Du({
+}), Zi.setEnabled(e), Fu({
 cpuLogging: e
 }), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.enableCpuDetails = function(e, t, r) {
 var o, n, a;
 void 0 === e && (e = 500), void 0 === t && (t = 1);
-var i = Xi.enableCpuDetails(e, t, r);
+var i = Zi.enableCpuDetails(e, t, r);
 return "CPU details enabled until tick ".concat(null !== (o = i.expiresTick) && void 0 !== o ? o : "unknown", " (sampleRate=").concat(null !== (n = i.sampleRate) && void 0 !== n ? n : 1, ", labels=").concat((null !== (a = i.labels) && void 0 !== a ? a : []).join(",") || "all", ")");
 }, e.prototype.disableCpuDetails = function() {
-return Xi.disableCpuDetails(), "CPU details disabled";
+return Zi.disableCpuDetails(), "CPU details disabled";
 }, e.prototype.cpuDetails = function() {
-var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = Xi.getCpuDetailsStatus();
+var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = Zi.getCpuDetailsStatus();
 if (!u) return "CPU details ".concat(l.enabled ? "enabled" : "disabled", "; no samples published yet");
 var m = Object.entries(null !== (o = u.entries) && void 0 !== o ? o : {}), d = Array.isArray(u.labels) ? u.labels.join(",") : "", p = [ "=== CPU Details ===", "Enabled: ".concat(String(u.enabled), " | Expires: ").concat(null !== (n = u.expires_tick) && void 0 !== n ? n : "n/a", " | Sample rate: ").concat(null !== (s = u.sample_rate) && void 0 !== s ? s : 1, " | Labels: ").concat(d || "all") ];
 try {
@@ -36919,7 +36930,7 @@ I.push("");
 }
 return I.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n = Xi.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
+var e, t, r, o, n = Zi.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
 if (i += "Rooms Evaluated: ".concat(n.roomsEvaluated, "\n"), i += "Within Budget: ".concat(n.roomsWithinBudget, "\n"),
 i += "Over Budget: ".concat(n.roomsOverBudget, "\n\n"), 0 === n.alerts.length) i += "OK All rooms within budget!\n"; else {
 i += "Alerts: ".concat(n.alerts.length, "\n");
@@ -36966,7 +36977,7 @@ if (r) throw r.error;
 }
 return i;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n = Xi.detectAnomalies();
+var e, t, r, o, n = Zi.detectAnomalies();
 if (0 === n.length) return "OK No CPU anomalies detected";
 var i = "=== CPU Anomalies Detected: ".concat(n.length, " ===\n\n"), s = n.filter(function(e) {
 return "spike" === e.type;
@@ -37015,7 +37026,7 @@ return i;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n;
 void 0 === e && (e = !1);
-var i = Xi.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
+var i = Zi.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
 s += "Total: ".concat(i.cpu.used.toFixed(2), " / ").concat(i.cpu.limit, " (").concat(i.cpu.percent.toFixed(1), "%)\n"),
 s += "Bucket: ".concat(i.cpu.bucket, "\n"), s += "Heap: ".concat(i.cpu.heapUsed.toFixed(2), " MB\n\n");
 var c = Object.values(i.rooms).sort(function(e, t) {
@@ -37024,7 +37035,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 s += "Top ".concat(u.length, " Rooms by CPU:\n");
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = Xi.postureCodeToName(p);
+var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = Zi.postureCodeToName(p);
 s += "  ".concat(d.name, " (RCL").concat(d.rcl, ", ").concat(f, "): avg ").concat(d.profiler.avgCpu.toFixed(3), " | peak ").concat(d.profiler.peakCpu.toFixed(3), " | samples ").concat(d.profiler.samples, "\n");
 }
 } catch (e) {
@@ -37065,7 +37076,7 @@ return s;
 var t, r, o, n;
 if (!e) return "Error: Room name required. Usage: diagnoseRoom('W16S52')";
 if (!Game.rooms[e]) return "Error: Room ".concat(e, " not visible. Make sure you have vision in this room.");
-var s = Xi.getCurrentSnapshot(), c = s.rooms[e];
+var s = Zi.getCurrentSnapshot(), c = s.rooms[e];
 if (!c) return "Error: No stats available for ".concat(e, ". The room may not have been processed yet.");
 var u = "room:".concat(e), l = s.processes[u], m = Sr.getSwarmState(e), d = m && ("war" === m.posture || "siege" === m.posture || m.danger >= 2), p = d ? .25 : .1, f = null !== (o = null == l ? void 0 : l.tickModulo) && void 0 !== o ? o : 1, y = p * f, v = "----------------------------------------------\n";
 v += "  Room Diagnostic: ".concat(e, "\n"), v += "----------------------------------------------\n\n";
@@ -37075,7 +37086,7 @@ energyCapacityTotal: this.getRoomMetricValue(c, "energyCapacityTotal", "capacity
 constructionSites: this.getRoomMetricValue(c, "constructionSites", "construction_sites")
 };
 v += "SUMMARY Basic Info:\n", v += "  RCL: ".concat(c.rcl, "\n"), v += "  Controller Progress: ".concat(c.controller.progressPercent.toFixed(1), "%\n"),
-v += "  Posture: ".concat(Xi.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
+v += "  Posture: ".concat(Zi.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
 v += "  Hostiles: ".concat(g.hostileCount, "\n\n"), v += "CPU CPU Analysis:\n",
 v += "  Average CPU: ".concat(c.profiler.avgCpu.toFixed(3), "\n"), v += "  Peak CPU: ".concat(c.profiler.peakCpu.toFixed(3), "\n"),
 v += "  Samples: ".concat(c.profiler.samples, "\n"), v += "  Budget: ".concat(y.toFixed(3), " (base ").concat(p, ", modulo ").concat(f, ")\n");
@@ -37211,7 +37222,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Ev = function() {
+}(), Tv = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Qr.generateHelp();
@@ -37230,22 +37241,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), Tv = function() {
+}(), Cv = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? em.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? tm.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? em.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? tm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return em.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return tm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ Xr({
 name: "tasks",
 description: "Show room creep task queue",
@@ -37265,21 +37276,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), Cv = ((fv = {})[MOVE] = 50, fv[WORK] = 100, fv[CARRY] = 50, fv[ATTACK] = 80,
-fv[RANGED_ATTACK] = 150, fv[HEAL] = 250, fv[CLAIM] = 600, fv[TOUGH] = 10, fv);
+}(), Sv = ((yv = {})[MOVE] = 50, yv[WORK] = 100, yv[CARRY] = 50, yv[ATTACK] = 80,
+yv[RANGED_ATTACK] = 150, yv[HEAL] = 250, yv[CLAIM] = 600, yv[TOUGH] = 10, yv);
 
-function Sv(e, t) {
+function wv(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, Cv), t);
+var r = o(o({}, Sv), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : Cv[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : Sv[t]);
 }, 0);
 }
 
-function wv(e, t) {
+function xv(e, t) {
 void 0 === t && (t = 0);
-var r = Sv(e);
+var r = wv(e);
 return {
 parts: e,
 cost: r,
@@ -37287,7 +37298,7 @@ minCapacity: t || r
 };
 }
 
-function xv() {
+function bv() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -37295,11 +37306,11 @@ return Array(o).fill(r);
 });
 }
 
-var bv, Ov, kv, Av = {
+var Ov, kv, Av, Mv = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ wv([ WORK, CARRY ], 150), wv([ WORK, CARRY, MOVE ], 200), wv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), wv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), wv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ xv([ WORK, CARRY ], 150), xv([ WORK, CARRY, MOVE ], 200), xv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), xv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), xv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -37307,7 +37318,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ wv([ WORK, CARRY, MOVE ], 200), wv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), wv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), wv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ xv([ WORK, CARRY, MOVE ], 200), xv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), xv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), xv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37315,7 +37326,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ wv([ WORK, CARRY, MOVE, MOVE ], 250), wv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ xv([ WORK, CARRY, MOVE, MOVE ], 250), xv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37323,7 +37334,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ wv([ WORK, CARRY, MOVE ], 200), wv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), wv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), wv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), wv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ xv([ WORK, CARRY, MOVE ], 200), xv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), xv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), xv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), xv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37331,7 +37342,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ wv([ CARRY, CARRY, MOVE, MOVE ], 200), wv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), wv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ xv([ CARRY, CARRY, MOVE, MOVE ], 200), xv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), xv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37339,7 +37350,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ wv([ WORK, CARRY, MOVE ], 200), wv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), wv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), wv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ xv([ WORK, CARRY, MOVE ], 200), xv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), xv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), xv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -37347,7 +37358,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ wv([ WORK, CARRY, MOVE, MOVE ], 250), wv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), wv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ xv([ WORK, CARRY, MOVE, MOVE ], 250), xv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), xv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37355,7 +37366,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ wv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ xv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37363,7 +37374,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ wv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), wv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ xv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), xv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37371,7 +37382,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ wv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ xv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37379,7 +37390,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ wv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ xv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37387,7 +37398,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ wv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), wv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), wv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), wv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ xv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), xv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), xv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), xv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37395,7 +37406,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ wv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), wv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ xv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), xv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37403,7 +37414,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ wv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), wv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ xv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), xv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37411,16 +37422,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ wv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), wv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), wv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), wv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ xv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), xv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), xv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), xv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Mv = {
+}, _v = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ wv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), wv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), wv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), wv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ xv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), xv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), xv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), xv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37428,7 +37439,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ wv([ TOUGH, ATTACK, MOVE, MOVE ], 190), wv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), wv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ xv([ TOUGH, ATTACK, MOVE, MOVE ], 190), xv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), xv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37436,7 +37447,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ wv([ HEAL, MOVE, MOVE ], 350), wv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), wv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), wv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ xv([ HEAL, MOVE, MOVE ], 350), xv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), xv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), xv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37444,7 +37455,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ wv([ ATTACK, ATTACK, MOVE, MOVE ], 260), wv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), wv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ xv([ ATTACK, ATTACK, MOVE, MOVE ], 260), xv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), xv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37452,7 +37463,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ wv([ WORK, WORK, MOVE, MOVE ], 300), wv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), wv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ xv([ WORK, WORK, MOVE, MOVE ], 300), xv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), xv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37460,7 +37471,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ wv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), wv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), wv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), wv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ xv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), xv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), xv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), xv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37468,16 +37479,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ wv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), wv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), wv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ xv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), xv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), xv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, _v = {
+}, Uv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ wv(xv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), wv(xv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ xv(bv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), xv(bv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37485,16 +37496,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ wv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), wv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ xv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), xv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Uv = {
+}, Nv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ wv([ MOVE ], 50) ],
+bodies: [ xv([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37502,7 +37513,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ wv([ MOVE ], 50) ],
+bodies: [ xv([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37510,7 +37521,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ wv([ CLAIM, MOVE ], 650) ],
+bodies: [ xv([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37518,7 +37529,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ wv([ CLAIM, MOVE ], 650), wv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ xv([ CLAIM, MOVE ], 650), xv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37526,7 +37537,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ wv([ WORK, CARRY, MOVE, MOVE ], 250), wv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ xv([ WORK, CARRY, MOVE, MOVE ], 250), xv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37534,30 +37545,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ wv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), wv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ xv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), xv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Nv = o(o(o(o({}, Av), Mv), Uv), _v);
+}, Pv = o(o(o(o({}, Mv), _v), Nv), Uv);
 
 try {
-for (var Pv = a(Object.values(Nv)), Iv = Pv.next(); !Iv.done; Iv = Pv.next()) Iv.value.bodies.sort(function(e, t) {
+for (var Iv = a(Object.values(Pv)), Gv = Iv.next(); !Gv.done; Gv = Iv.next()) Gv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-bv = {
+Ov = {
 error: e
 };
 } finally {
 try {
-Iv && !Iv.done && (Ov = Pv.return) && Ov.call(Pv);
+Gv && !Gv.done && (kv = Iv.return) && kv.call(Iv);
 } finally {
-if (bv) throw bv.error;
+if (Ov) throw Ov.error;
 }
 }
 
-function Gv(e) {
+function Lv(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37572,11 +37583,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return Lv(o);
+return Dv(o);
 }
 
-function Lv(e) {
-var t = Sv(e);
+function Dv(e) {
+var t = wv(e);
 return {
 parts: e,
 cost: t,
@@ -37584,16 +37595,16 @@ minCapacity: t
 };
 }
 
-function Dv(e, t) {
+function Fv(e, t) {
 var r;
-return null !== (r = e.map(Lv).filter(function(e) {
+return null !== (r = e.map(Dv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Fv(e) {
+function Bv(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37607,7 +37618,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = Sv(a);
+var s = wv(a);
 return {
 parts: a,
 cost: s,
@@ -37632,8 +37643,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: Sv(p),
-minCapacity: Sv(p)
+cost: wv(p),
+minCapacity: wv(p)
 };
 }(e);
 
@@ -37644,7 +37655,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return Gv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Lv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37665,7 +37676,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return Gv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Lv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37674,13 +37685,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(Lv).filter(function(e) {
+var u = n.map(Dv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Dv(n, t);
+var l = Fv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37690,7 +37701,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Dv(n, t);
+var u = Fv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37699,14 +37710,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Dv(r, t);
+var a = Fv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Bv(e) {
+function Wv(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37717,9 +37728,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Wv(e, t) {
+function Hv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Bv(t)
+memory: Wv(t)
 });
 var r;
 }
@@ -37727,9 +37738,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(kv || (kv = {}));
+}(Av || (Av = {}));
 
-var Hv = function() {
+var Kv = function() {
 function e() {
 this.queues = new Map, this.revision = 0;
 }
@@ -37827,7 +37838,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Wv(m, d);
+var p = Hv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 _.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -37847,7 +37858,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= kv.EMERGENCY;
+return e.priority >= Av.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -37865,7 +37876,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= kv.EMERGENCY ? n.emergency++ : c.priority >= kv.HIGH ? n.high++ : c.priority >= kv.NORMAL ? n.normal++ : n.low++;
+c.priority >= Av.EMERGENCY ? n.emergency++ : c.priority >= Av.HIGH ? n.high++ : c.priority >= Av.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -37880,14 +37891,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Kv = new Hv, Yv = {
+}(), Yv = new Kv, Vv = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, Vv = {
+}, qv = {
 predictConsumption: function() {
 return 0;
 },
@@ -37906,7 +37917,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, qv = {
+}, jv = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -37924,81 +37935,81 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, jv = {
+}, zv = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function zv(e, t, r, o, n) {
-return oc(e, t, r, o, n);
+function Qv(e, t, r, o, n) {
+return nc(e, t, r, o, n);
 }
 
-var Qv = new Map, Xv = -1, Zv = null, Jv = null;
+var Xv = new Map, Zv = -1, Jv = null, $v = null;
 
-function $v() {
-Xv === Game.time && Zv === Game.creeps || (Qv.clear(), Jv = null, Xv = Game.time,
-Zv = Game.creeps);
+function eg() {
+Zv === Game.time && Jv === Game.creeps || (Xv.clear(), $v = null, Zv = Game.time,
+Jv = Game.creeps);
 }
 
-function eg(e) {
+function tg(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function tg(e, t) {
+function rg(e, t) {
 var r;
-void 0 === t && (t = !1), $v();
-var o = t ? "".concat(e, "_active") : e, n = Qv.get(o);
+void 0 === t && (t = !1), eg();
+var o = t ? "".concat(e, "_active") : e, n = Xv.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = eg(c);
+var u = tg(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return Qv.set(o, a), a;
-}
-
-function rg(e, t, r) {
-return "".concat(e).concat("").concat(t).concat("").concat(r);
+return Xv.set(o, a), a;
 }
 
 function og(e, t, r) {
+return "".concat(e).concat("").concat(t).concat("").concat(r);
+}
+
+function ng(e, t, r) {
 var o;
 return null !== (o = function() {
 var e;
-if ($v(), Jv) return Jv;
+if (eg(), $v) return $v;
 var t = new Map;
 for (var r in Game.creeps) {
 var o = Game.creeps[r].memory, n = o.homeRoom, a = o.role, i = o.targetRoom;
 if (n && a && i) {
-var s = rg(n, a, i);
+var s = og(n, a, i);
 t.set(s, (null !== (e = t.get(s)) && void 0 !== e ? e : 0) + 1);
 }
 }
-return Jv = t, t;
-}().get(rg(e, t, r))) && void 0 !== o ? o : 0;
+return $v = t, t;
+}().get(og(e, t, r))) && void 0 !== o ? o : 0;
 }
 
-function ng(e) {
+function ag(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var ag = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
-
-function ig(e) {
-return ag.includes(e);
-}
+var ig = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
 function sg(e) {
+return ig.includes(e);
+}
+
+function cg(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function cg(e, t, r, o) {
+function ug(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -38011,10 +38022,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return zv(e, t, pt(r).length, o, {
-reserved: sg(r)
+if (r) return Qv(e, t, pt(r).length, o, {
+reserved: cg(r)
 }).recommendedHaulers;
-var n = zv(e, t, 2, o, {
+var n = Qv(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -38025,7 +38036,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: ng
+filter: ag
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -38036,7 +38047,7 @@ return 2;
 }
 }
 
-function ug(e, t) {
+function lg(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -38046,13 +38057,13 @@ return null;
 }
 }
 
-function lg() {
+function mg() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function mg(e) {
-var t = lg(), r = function(e) {
+function dg(e) {
+var t = mg(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -38064,14 +38075,14 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function dg(e) {
+function pg(e) {
 var t = Sr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = lg();
+var r = mg();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function pg(e) {
+function fg(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
@@ -38079,11 +38090,11 @@ return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type ==
 });
 }
 
-function fg(e) {
+function yg(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function yg() {
+function vg() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -38093,9 +38104,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var vg = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var gg = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function gg(e, t) {
+function hg(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -38107,8 +38118,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(yg()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Kv.getPendingRequests(c).some(function(r) {
+for (var i = a(vg()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Yv.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -38128,7 +38139,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function hg() {
+function Rg() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -38149,7 +38160,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function Rg(e, t) {
+function Eg(e, t) {
 var r, o, n, c, u = Sr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -38159,15 +38170,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !gg(e.roomName, "claim");
+return !hg(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || pg(t));
+return !(!r || r.my || r.owner || r.reservation || fg(t));
 }
-return !dg(e);
+return !pg(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -38178,11 +38189,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = hg().filter(function(e) {
-return !gg(e, "claim");
+var r, o, n = Rg().filter(function(e) {
+return !hg(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = lg();
+var r, o, n = Game.rooms[e], a = mg();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -38193,7 +38204,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && vg.has(e.type);
+return e.hits > 0 && gg.has(e.type);
 });
 });
 }(n));
@@ -38205,7 +38216,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = ug(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = lg(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -38220,14 +38231,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(hg()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(Rg()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !gg(e.roomName, "claim");
+return !e.claimed && !hg(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -38239,20 +38250,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = lg();
+var l = mg();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !gg(p, "claim")) {
+if (!t.has(p) && !hg(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || mg(y)) continue;
-if (pg(f)) continue;
+if (y.owner || dg(y)) continue;
+if (fg(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !gg(p, "reserve")) return p;
-} else if (!dg(p) && !gg(p, "reserve")) return p;
+if ((!v || g < 3e3) && !hg(p, "reserve")) return p;
+} else if (!pg(p) && !hg(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -38274,22 +38285,22 @@ task: "reserve"
 } : null;
 }
 
-var Eg, Tg, Cg = new Map;
+var Tg, Cg, Sg = new Map;
 
-function Sg(e) {
+function wg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function wg(e) {
+function xg(e) {
 var t, r;
-r = Game.time, Eg === Game && Tg === r || (Cg.clear(), Eg = Game, Tg = r);
+r = Game.time, Tg === Game && Cg === r || (Sg.clear(), Tg = Game, Cg = r);
 var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}(), n = Cg.get(e.name);
+}(), n = Sg.get(e.name);
 if (n && n.fallbackEnabled === o) return n.value;
 var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
@@ -38300,7 +38311,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Sg(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += wg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38321,7 +38332,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Sg(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += wg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38335,20 +38346,20 @@ if (o) throw o.error;
 }
 return i;
 }(e)) : i;
-return Cg.set(e.name, {
+return Sg.set(e.name, {
 fallbackEnabled: o,
 value: s
 }), s;
 }
 
-var xg, bg, Og, kg = new Map;
+var bg, Og, kg, Ag = new Map;
 
-function Ag(e, t) {
+function Mg(e, t) {
 var r;
-return null !== (r = ug(e, t)) && void 0 !== r ? r : 999;
+return null !== (r = lg(e, t)) && void 0 !== r ? r : 999;
 }
 
-function Mg(e) {
+function _g(e) {
 try {
 return e.find(FIND_MY_SPAWNS).filter(function(e) {
 return !e.spawning;
@@ -38358,16 +38369,16 @@ return 0;
 }
 }
 
-function _g(e, t) {
+function Ug(e, t) {
 var r, o = null !== (r = e.energyCapacityAvailable) && void 0 !== r ? r : 0;
 if (o < 200) return null;
 var n, a, i = function(e, t) {
 var r, o;
-xg === Game && bg === Game.map && Og === Game.time || (kg.clear(), xg = Game, bg = Game.map,
-Og = Game.time);
+bg === Game && Og === Game.map && kg === Game.time || (Ag.clear(), bg = Game, Og = Game.map,
+kg = Game.time);
 var n = "".concat(e, "->").concat(t);
-if (kg.has(n)) return null !== (r = kg.get(n)) && void 0 !== r ? r : null;
-var a = Ag(e, t);
+if (Ag.has(n)) return null !== (r = Ag.get(n)) && void 0 !== r ? r : null;
+var a = Mg(e, t);
 try {
 if ("function" == typeof (null === (o = Game.map) || void 0 === o ? void 0 : o.findRoute)) {
 var i = Game.map.findRoute(e, t, {
@@ -38376,78 +38387,78 @@ return function(e, t) {
 var r;
 if (e === t) return 1;
 var o = Game.rooms[e];
-return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && mg(o.controller) || dg(e) || o && pg(o) ? 1 / 0 : 1;
+return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && dg(o.controller) || pg(e) || o && fg(o) ? 1 / 0 : 1;
 }(e, t);
 }
 });
 a = i === ERR_NO_PATH ? null : i.length;
 }
 } catch (r) {
-a = Ag(e, t);
+a = Mg(e, t);
 }
-return kg.set(n, a), a;
+return Ag.set(n, a), a;
 }(e.name, t.name);
 return null === i ? null : {
 room: e,
 routeDistance: i,
-linearDistance: Ag(e.name, t.name),
-queuePressure: (n = e.name, a = t.name, Kv.getPendingRequests(n).reduce(function(e, t) {
+linearDistance: Mg(e.name, t.name),
+queuePressure: (n = e.name, a = t.name, Yv.getPendingRequests(n).reduce(function(e, t) {
 var r;
-return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / kv.EMERGENCY;
+return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Av.EMERGENCY;
 }, 0)),
 energyCapacity: o,
-hasAvailableSpawn: Mg(e) > 0,
-hasReadyEnergy: wg(e) >= 200
+hasAvailableSpawn: _g(e) > 0,
+hasReadyEnergy: xg(e) >= 200
 };
 }
 
-function Ug(e, t) {
+function Ng(e, t) {
 return Number(t.hasReadyEnergy) - Number(e.hasReadyEnergy) || Number(t.hasAvailableSpawn) - Number(e.hasAvailableSpawn) || e.queuePressure - t.queuePressure || t.energyCapacity - e.energyCapacity || e.routeDistance - t.routeDistance || e.linearDistance - t.linearDistance || e.room.name.localeCompare(t.room.name);
 }
 
-function Ng(e) {
+function Pg(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function Pg(e) {
-return Ng(e) ? kv.EMERGENCY : kv.HIGH;
-}
-
-function Ig(e, t, r) {
-var o, n;
-if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!fg(e)) return !1;
-var a = e.name === t ? r : Sr.getSwarmState(e.name);
-return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
+function Ig(e) {
+return Pg(e) ? Av.EMERGENCY : Av.HIGH;
 }
 
 function Gg(e, t, r) {
 var o, n;
+if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
+if (!yg(e)) return !1;
+var a = e.name === t ? r : Sr.getSwarmState(e.name);
+return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
+}
+
+function Lg(e, t, r) {
+var o, n;
 return null !== (n = null === (o = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return Ig(e, t, r);
+return Gg(e, t, r);
 }).map(function(t) {
-return _g(t, e);
+return Ug(t, e);
 }).filter(function(e) {
 return null !== e;
-}).sort(Ug)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
+}).sort(Ng)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function Lg(e, t) {
+function Dg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !Ig(n, e, t)) return null;
+if (!n || !Gg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !fg(e);
+return !yg(e);
 }).filter(function(e) {
-return !pg(e);
+return !fg(e);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -38468,9 +38479,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(yg()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(vg()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Kv.getPendingRequests(d).filter(function(t) {
+i += Yv.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -38487,11 +38498,11 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (Ng(e) ? 3 : 1);
+}(e.name) < (Pg(e) ? 3 : 1);
 }).map(function(e) {
 return {
 room: e,
-homeScore: _g(n, e)
+homeScore: Ug(n, e)
 };
 }).filter(function(e) {
 return null !== e.homeScore;
@@ -38501,10 +38512,10 @@ return e.homeScore.routeDistance - t.homeScore.routeDistance || e.homeScore.line
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (Gg(u.room, e, t) === e) return {
+if (Lg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: Pg(u.room)
+priority: Ig(u.room)
 };
 }
 } catch (e) {
@@ -38521,10 +38532,10 @@ if (r) throw r.error;
 return null;
 }
 
-function Dg(e, t) {
+function Fg(e, t) {
 if (t <= 0) return null;
 try {
-var r = Fv({
+var r = Bv({
 maxEnergy: t,
 role: e
 });
@@ -38534,36 +38545,36 @@ return null;
 }
 }
 
-function Fg(e, t, r) {
-return "healer" === e || "ranger" === e && Ao(r) ? null : Dg(e, t);
-}
-
-function Bg(e) {
-return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
+function Bg(e, t, r) {
+return "healer" === e || "ranger" === e && Ao(r) ? null : Fg(e, t);
 }
 
 function Wg(e) {
+return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
+}
+
+function Hg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? X(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function Hg(e) {
+function Kg(e) {
 var t = e.defenseRequests;
-return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Bg);
+return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Wg);
 }
 
-var Kg = [ "guard", "ranger", "healer" ];
+var Yg = [ "guard", "ranger", "healer" ];
 
-function Yg(e, t) {
+function Vg(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-var Vg = null;
+var qg = null;
 
-function qg() {
-var e = Kv.getRevision();
-return Vg && Vg.game === Game && Vg.creeps === Game.creeps && Vg.tick === Game.time && Vg.queueRevision === e ? Vg : Vg = {
+function jg() {
+var e = Yv.getRevision();
+return qg && qg.game === Game && qg.creeps === Game.creeps && qg.tick === Game.time && qg.queueRevision === e ? qg : qg = {
 game: Game,
 creeps: Game.creeps,
 tick: Game.time,
@@ -38576,8 +38587,8 @@ canSpawn: new Map
 };
 }
 
-function jg(e) {
-var t = qg(), r = Game.rooms[e], o = t.threats.get(e);
+function zg(e) {
+var t = jg(), r = Game.rooms[e], o = t.threats.get(e);
 if (o && o.room === r) return o.threatProfile;
 var n = wo(e);
 return t.threats.set(e, {
@@ -38586,27 +38597,27 @@ threatProfile: n
 }), n;
 }
 
-function zg(e) {
-return Game.rooms[e.roomName] ? null !== jg(e.roomName) : Wg(e);
+function Qg(e) {
+return Game.rooms[e.roomName] ? null !== zg(e.roomName) : Hg(e);
 }
 
-function Qg(e) {
+function Xg(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === mi ? e.targetRoom : void 0;
 }
 
-function Xg(e, t) {
+function Zg(e, t) {
 var r, o;
 return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === mi && e.targetRoom === t;
 }
 
-function Zg(e, t, r) {
+function Jg(e, t, r) {
 var o = Ro(r), n = e[t];
 e[t] = n ? To(n, o) : o;
 }
 
-function Jg(e) {
-var t = qg(), r = t.assigned.get(e);
+function $g(e) {
+var t = jg(), r = t.assigned.get(e);
 if (r) return r;
 var o = function(e) {
 var t, r, o, n, i, s, c = {
@@ -38617,12 +38628,12 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = d.memory, f = null !== (i = p.role) && void 0 !== i ? i : "";
-if (Po(f) && Qg(p) === e) {
+if (Po(f) && Xg(p) === e) {
 c[f]++;
 var y = (null !== (s = d.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-y.length > 0 && Zg(u, f, y);
+y.length > 0 && Jg(u, f, y);
 }
 }
 } catch (e) {
@@ -38637,9 +38648,9 @@ if (t) throw t.error;
 }
 }
 for (var v in Game.rooms) try {
-for (var g = (o = void 0, a(Kv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
+for (var g = (o = void 0, a(Yv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Po(R.role) && Xg(R, e) && (c[R.role]++, Zg(u, R.role, R.body.parts));
+Po(R.role) && Zg(R, e) && (c[R.role]++, Jg(u, R.role, R.body.parts));
 }
 } catch (e) {
 o = {
@@ -38660,8 +38671,8 @@ power: u
 return t.assigned.set(e, o), o;
 }
 
-function $g(e) {
-var t = qg(), r = t.canSpawn.get(e.name);
+function eh(e) {
+var t = jg(), r = t.canSpawn.get(e.name);
 if (r && r.room === e) return r.value;
 var o = function(e) {
 var t;
@@ -38673,20 +38684,20 @@ value: o
 }), o;
 }
 
-function eh(e, t) {
-var r, o, n = qg(), i = function(e, t) {
+function th(e, t) {
+var r, o, n = jg(), i = function(e, t) {
 var r, o, n, a, i;
 return [ t.name, e.roomName, t.energyCapacityAvailable, Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0), Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0), null !== (a = e.urgency) && void 0 !== a ? a : "", null !== (i = e.createdAt) && void 0 !== i ? i : "" ].join(":");
 }(e, t), s = n.helperPlans.get(i);
 if (s) return s;
-var c = jg(e.roomName), u = Jg(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = No(d, c, function(e, t) {
+var c = zg(e.roomName), u = $g(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = No(d, c, function(e, t) {
 return {
-guard: Math.max(0, Yg(e, "guard") - t.guard),
-ranger: Math.max(0, Yg(e, "ranger") - t.ranger),
-healer: Math.max(0, Yg(e, "healer") - t.healer)
+guard: Math.max(0, Vg(e, "guard") - t.guard),
+ranger: Math.max(0, Vg(e, "ranger") - t.ranger),
+healer: Math.max(0, Vg(e, "healer") - t.healer)
 };
 }(e, l), m), f = function(e, t) {
-var r, o, n, i, s = qg(), c = s.capableHelpers.get(e);
+var r, o, n, i, s = jg(), c = s.capableHelpers.get(e);
 if (c) return c;
 var u = {
 guard: 0,
@@ -38696,8 +38707,8 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.rooms)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d.name !== e && $g(d)) try {
-for (var p = (n = void 0, a(Kg)), f = p.next(); !f.done; f = p.next()) {
+if (d.name !== e && eh(d)) try {
+for (var p = (n = void 0, a(Yg)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
 Mo(y, d.energyCapacityAvailable, t) && u[y]++;
 }
@@ -38727,7 +38738,7 @@ if (r) throw r.error;
 return s.capableHelpers.set(e, u), u;
 }(e.roomName, c), y = {};
 try {
-for (var v = a(Kg), g = v.next(); !g.done; g = v.next()) {
+for (var v = a(Yg), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 y[h] = Mo(h, d, c);
 }
@@ -38754,8 +38765,8 @@ helperBodies: y
 return n.helperPlans.set(i, R), R;
 }
 
-function th(e, t, r) {
-var o = Yg(e, t);
+function rh(e, t, r) {
+var o = Vg(e, t);
 if (!Po(t)) return o;
 if (!r.threatProfile) return o;
 var n = r.assignedCounts[t] + r.aggregatePlan.counts[t], a = o > 0 ? function(e, t, r) {
@@ -38770,27 +38781,27 @@ return Math.min(8, Math.max(1, i, s, u, l));
 return Math.max(o, n, a, i);
 }
 
-function rh(e, t, r) {
-void 0 === r && (r = eh(e, t));
+function oh(e, t, r) {
+void 0 === r && (r = th(e, t));
 var o = r.aggregatePlan.counts.guard + r.aggregatePlan.counts.ranger + r.aggregatePlan.counts.healer;
 if (o > 0) return o;
-var n = Kg.filter(function(t) {
-return !(th(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
+var n = Yg.filter(function(t) {
+return !(rh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
 });
 return Math.max(1, n.length);
 }
 
-function oh(e, t, r, o) {
+function nh(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : Fg("guard", wg(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : Bg("guard", xg(r), o) ? 1 : 0;
 }
 
-function nh(e, t) {
+function ah(e, t) {
 if (!function(e) {
 return Po(e);
 }(t)) return null;
 var r = Game.rooms[e];
-if (!r || !$g(r)) return null;
+if (!r || !eh(r)) return null;
 var o = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38817,15 +38828,15 @@ if (t) throw t.error;
 var n = function(e, t) {
 var r;
 void 0 === t && (t = {});
-var o = Hg(e), n = function(e) {
+var o = Kg(e), n = function(e) {
 return e.map(function(e) {
 var t, r, o, n, a;
 return [ e.roomName, Math.max(0, null !== (t = e.guardsNeeded) && void 0 !== t ? t : 0), Math.max(0, null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.healersNeeded) && void 0 !== o ? o : 0), null !== (n = e.urgency) && void 0 !== n ? n : "", null !== (a = e.createdAt) && void 0 !== a ? a : "" ].join(":");
 }).join("|");
-}(o), a = qg();
+}(o), a = jg();
 if ((null === (r = a.activeRequests) || void 0 === r ? void 0 : r.signature) === n) return t.prune && Array.isArray(e.defenseRequests) && a.activeRequests.requests.length !== o.length && (e.defenseRequests = a.activeRequests.requests),
 a.activeRequests.requests;
-var i = o.filter(zg);
+var i = o.filter(Qg);
 return a.activeRequests = {
 signature: n,
 requests: i
@@ -38836,17 +38847,17 @@ prune: !0
 }).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var o = eh(e, r);
+var o = th(e, r);
 return {
 request: e,
 plan: o,
-helperNeed: Math.max(th(e, t, o), oh(e, t, r, o.threatProfile))
+helperNeed: Math.max(rh(e, t, o), nh(e, t, r, o.threatProfile))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
 return function(e, t) {
-return Po(t) ? Jg(e).counts[t] : 0;
+return Po(t) ? $g(e).counts[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -38856,7 +38867,7 @@ return f !== y ? f - y : (null !== (m = t.request.createdAt) && void 0 !== m ? m
 }), s = n[0];
 return s ? function(e, t, r, o) {
 var n;
-void 0 === o && (o = eh(r, t));
+void 0 === o && (o = th(r, t));
 var a = function(e, t) {
 var r = function() {
 var e, t = Memory;
@@ -38874,29 +38885,29 @@ return r[o] = s, s;
 return {
 targetRoom: r.roomName,
 task: mi,
-priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? kv.EMERGENCY : kv.HIGH,
+priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Av.EMERGENCY : Av.HIGH,
 defenseSquadId: di(e, r.roomName, a.createdAt),
-defenseSquadSize: rh(r, t, o),
+defenseSquadSize: oh(r, t, o),
 defenseSquadCreatedAt: a.createdAt
 };
 }(e, r, s.request, s.plan) : null;
 }
 
-var ah = "defenseRefuel", ih = {
+var ih = "defenseRefuel", sh = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function sh(e, t) {
+function ch(e, t) {
 if ("hauler" !== t) return null;
 var r = Game.rooms[e];
 if (!r || !function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < ih.cost);
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < sh.cost);
 }(r)) return null;
-if (wg(r) >= 200) return null;
-var o, n, i = function(e) {
+if (xg(r) >= 200) return null;
+var o = function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(function(t) {
 var r, o;
 if (!t || t.roomName === e) return !1;
@@ -38907,25 +38918,28 @@ return Boolean(n && X(n).length > 0);
 });
 var t;
 }(e);
-if (0 === i.length) return null;
-if (!((0 === (n = (o = r).find(FIND_SOURCES)).length ? 0 : o.find(FIND_STRUCTURES, {
+if (0 === o.length) return null;
+if (!(function(e) {
+var t = e.find(FIND_SOURCES);
+return 0 === t.length ? 0 : e.find(FIND_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_CONTAINER && n.some(function(t) {
+return e.structureType === STRUCTURE_CONTAINER && t.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
 }
 }).reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0)) >= 100)) return null;
-var s = i.some(function(e) {
+}, 0);
+}(r) >= 100 || vi(r.terminal))) return null;
+var n = o.some(function(e) {
 var t, r, o;
 return (null !== (t = e.urgency) && void 0 !== t ? t : 1) >= 3 && ((null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0) > 0 || (null !== (o = e.healersNeeded) && void 0 !== o ? o : 0) > 0);
-}), c = s ? function(e) {
+}), i = n ? function(e) {
 var t, r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value.memory;
-"hauler" === l.role && l.homeRoom === e && l.task === ah && s++;
+"hauler" === l.role && l.homeRoom === e && l.task === ih && s++;
 }
 } catch (e) {
 t = {
@@ -38939,9 +38953,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Kv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Yv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === ah && s++;
+"hauler" === p.role && f === ih && s++;
 }
 } catch (e) {
 o = {
@@ -38974,9 +38988,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Kv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Yv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === ah && s++;
+"hauler" === p.role && f === ih && s++;
 }
 } catch (e) {
 o = {
@@ -38991,25 +39005,25 @@ if (o) throw o.error;
 }
 return s;
 }(e);
-return c >= (s ? 4 : 2) ? null : {
-task: ah,
-priority: kv.EMERGENCY,
-body: ih
+return i >= (n ? 4 : 2) ? null : {
+task: ih,
+priority: Av.EMERGENCY,
+body: sh
 };
-}
-
-function ch(e) {
-var t = Game.rooms[e];
-return t ? !!t.controller && !mg(t.controller) && !pg(t) : !dg(e);
 }
 
 function uh(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !mg(t.controller) : !dg(e);
+return t ? !!t.controller && !dg(t.controller) && !fg(t) : !pg(e);
 }
 
-function lh(e, t, r) {
-var o = Nv[t];
+function lh(e) {
+var t = Game.rooms[e];
+return (null == t ? void 0 : t.controller) ? !dg(t.controller) : !pg(e);
+}
+
+function mh(e, t, r) {
+var o = Pv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
@@ -39020,7 +39034,7 @@ var i = Sr.getCluster(r.clusterId);
 }
 (function(e) {
 return function(e) {
-var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Fs(null == e ? void 0 : e.storage), s = Fs(null == e ? void 0 : e.terminal), c = a && i < Ds, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
+var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Bs(null == e ? void 0 : e.storage), s = Bs(null == e ? void 0 : e.terminal), c = a && i < Fs, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
 return {
 controllerLevel: n,
 isMatureOwnedRoom: a,
@@ -39037,13 +39051,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function mh(e, t, r) {
+function dh(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (ch(l) && og(e, t, l) < cg(e, l, t, Game.rooms[l])) return l;
+if (uh(l) && ng(e, t, l) < ug(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -39059,10 +39073,10 @@ if (o) throw o.error;
 return null;
 }
 
-function dh(e, t, r, o) {
+function ph(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Nv[t];
+var p = Pv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -39076,32 +39090,32 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Nv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Nv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Pv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Pv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, tg(e), y)) return !1;
+}(t, rg(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (ig(t)) return !("remoteWorker" === t && function(e, t) {
-$v();
-var r = "".concat(e, ":").concat(t), o = Qv.get(r);
+if (sg(t)) return !("remoteWorker" === t && function(e, t) {
+eg();
+var r = "".concat(e, ":").concat(t), o = Xv.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return Qv.set(r, n), n;
-}(e, t) >= lh(e, t, r)) && null !== mh(e, t, r);
+return Xv.set(r, n), n;
+}(e, t) >= mh(e, t, r)) && null !== dh(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (uh(R)) {
+if (lh(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = X(E).filter(function(e) {
@@ -39109,7 +39123,7 @@ return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
 });
-if (T.length > 0 && og(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && ng(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -39126,9 +39140,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = tg(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== Lg(e, r);
-if (C >= lh(e, t, r)) return !1;
+var C = null !== (u = rg(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== Dg(e, r);
+if (C >= mh(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -39140,14 +39154,14 @@ var r = Sr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = ug(e, o);
+var a = lg(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== Rg(e, r);
+if ("claimer" === t) return null !== Eg(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -39183,7 +39197,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = Yv.getActiveRequests) || void 0 === m ? void 0 : m.call(Yv)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = Vv.getActiveRequests) || void 0 === m ? void 0 : m.call(Vv)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -39211,16 +39225,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function ph(e) {
+function fh(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function fh(e) {
-return 0 === ph(tg(e, !0));
+function yh(e) {
+return 0 === fh(rg(e, !0));
 }
 
-function yh(e) {
+function vh(e) {
 var t = pt(e);
 return [ {
 role: "harvester",
@@ -39243,14 +39257,14 @@ minCount: 1
 } ];
 }
 
-function vh(e, t) {
-var r, o, n, i, s = tg(e, !0);
-if (0 === ph(s)) return !0;
+function gh(e, t) {
+var r, o, n, i, s = rg(e, !0);
+if (0 === fh(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = tg(e, !1), u = yh(t);
+var c = rg(e, !1), u = vh(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -39270,36 +39284,36 @@ if (r) throw r.error;
 return !1;
 }
 
-var gh = [ "guard", "ranger", "healer" ];
+var hh = [ "guard", "ranger", "healer" ];
 
-function hh(e, t, r) {
+function Rh(e, t, r) {
 void 0 === r && (r = 1), e[t] += r, e.total += r;
 }
 
-function Rh(e, t) {
+function Eh(e, t) {
 var r, o;
 return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === mi ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
 }
 
-function Eh(e) {
+function Th(e) {
 var t;
-return Po(e.role) && void 0 !== Rh(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
+return Po(e.role) && void 0 !== Eh(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
 }
 
-function Th(e, t) {
+function Ch(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Ch(e, t) {
+function Sh(e, t) {
 return 0 === t.length ? e : To(e, Ro(t));
 }
 
-function Sh(e, t) {
-e.assignedPower = Ch(e.assignedPower, t);
+function wh(e, t) {
+e.assignedPower = Sh(e.assignedPower, t);
 }
 
-function wh(e, t) {
+function xh(e, t) {
 var r, o;
 if (void 0 !== t.defenseAssistReleasedAt) {
 var n = null !== (r = t.defenseAssistReleaseReason) && void 0 !== r ? r : "unknown";
@@ -39309,10 +39323,10 @@ e.released.lastReason = n);
 }
 }
 
-function xh(e, t) {
+function bh(e, t) {
 e.parityPercent = e.targetScore > 0 ? Math.min(100, t.score / e.targetScore * 100) : 0,
 e.blockReason = function(e) {
-var t = gh.filter(function(t) {
+var t = hh.filter(function(t) {
 return e.queued[t] > 0;
 });
 if (t.length > 0 && t.every(function(t) {
@@ -39324,57 +39338,57 @@ return e.requested.total > 0 && 0 === r ? "no-local-assist" : "none";
 }(e);
 }
 
-function bh(e) {
+function Oh(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Oh(e, t, r) {
-var n = lh(e.name, r.roleName, t);
+function kh(e, t, r) {
+var n = mh(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function kh(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return kv.EMERGENCY;
+function Ah(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Av.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return kv.HIGH;
-if (jv.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Av.HIGH;
+if (zv.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = co(e), n = lo(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return kv.EMERGENCY;
-if (a > 0) return kv.HIGH;
+if (a >= 100) return Av.EMERGENCY;
+if (a > 0) return Av.HIGH;
 }
 return function(e) {
-return e >= 90 ? kv.HIGH : e >= 60 ? kv.NORMAL : kv.LOW;
+return e >= 90 ? Av.HIGH : e >= 60 ? Av.NORMAL : Av.LOW;
 }(o);
 }
 
-function Ah(e, t) {
+function Mh(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u;
-bh(e);
-var l = tg(e.name), m = fh(e.name), d = [];
-if (vh(e.name, e)) {
+Oh(e);
+var l = rg(e.name), m = yh(e.name), d = [];
+if (gh(e.name, e)) {
 var p = function(e, t, r) {
 var o, n, i;
-if (0 === ph(tg(e, !0))) return _.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === fh(rg(e, !0))) return _.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = tg(e, !1), c = yh(t);
+var s = rg(e, !1), c = vh(t);
 _.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -39389,7 +39403,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = dh(e, m.role, r, !0);
+var p = ph(e, m.role, r, !0);
 if (_.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -39420,17 +39434,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return p && (g = Nv[p]) && dh(e.name, p, t, !0) ? (d.push(Oh(e, t, {
+return p && (g = Pv[p]) && ph(e.name, p, t, !0) ? (d.push(kh(e, t, {
 roleName: p,
 def: g,
 current: null !== (n = l.get(p)) && void 0 !== n ? n : 0,
-priority: kh(e, 0, p, g.priority, m),
+priority: Ah(e, 0, p, g.priority, m),
 bootstrap: !0
 })), d) : d;
 }
 try {
-for (var f = a(Object.entries(Nv)), y = f.next(); !y.done; y = f.next()) {
-var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = sh(e.name, p);
+for (var f = a(Object.entries(Pv)), y = f.next(); !y.done; y = f.next()) {
+var v = i(y.value, 2), g = (p = v[0], v[1]), h = null !== (s = l.get(p)) && void 0 !== s ? s : 0, R = ch(e.name, p);
 if (R) d.push({
 roleName: p,
 def: g,
@@ -39441,7 +39455,7 @@ priority: R.priority,
 task: R.task,
 bodyOverride: R.body
 }); else {
-var E = nh(e.name, p);
+var E = ah(e.name, p);
 if (E) d.push({
 roleName: p,
 def: g,
@@ -39455,8 +39469,8 @@ assistTarget: E.targetRoom,
 defenseSquadId: E.defenseSquadId,
 defenseSquadSize: E.defenseSquadSize,
 defenseSquadCreatedAt: E.defenseSquadCreatedAt
-}); else if (dh(e.name, p, t, m)) {
-var T = ig(p), C = T ? mh(e.name, p, t) : null, S = "claimer" === p ? Rg(e.name, t) : null, w = "pioneer" === p ? Lg(e.name, t) : null;
+}); else if (ph(e.name, p, t, m)) {
+var T = sg(p), C = T ? dh(e.name, p, t) : null, S = "claimer" === p ? Eg(e.name, t) : null, w = "pioneer" === p ? Dg(e.name, t) : null;
 T && !C || ("claimer" !== p || S) && ("pioneer" !== p || w) && (w ? d.push({
 roleName: p,
 def: g,
@@ -39466,11 +39480,11 @@ missing: 1,
 priority: w.priority,
 targetRoom: w.targetRoom,
 task: w.task
-}) : d.push(Oh(e, t, {
+}) : d.push(kh(e, t, {
 roleName: p,
 def: g,
 current: h,
-priority: kh(e, 0, p, g.priority, m),
+priority: Ah(e, 0, p, g.priority, m),
 targetRoom: null !== (u = null !== (c = null == S ? void 0 : S.targetRoom) && void 0 !== c ? c : C) && void 0 !== u ? u : void 0,
 task: null == S ? void 0 : S.task
 })));
@@ -39492,7 +39506,7 @@ return d;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Mh(e, l.value);
+var m = _h(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -39513,12 +39527,12 @@ requests: c
 };
 }
 
-function Mh(e, t) {
+function _h(e, t) {
 var r, n, i, s = e.energyCapacityAvailable;
 try {
-var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = Vv.getMaxAffordableInTicks(e, c), l = wg(e), m = t.priority >= kv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Po(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= kv.EMERGENCY, y = t.assistTarget ? wo(t.assistTarget) : null, v = d ? Mo(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = qv.getMaxAffordableInTicks(e, c), l = xg(e), m = t.priority >= Av.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Po(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Av.EMERGENCY, y = t.assistTarget ? wo(t.assistTarget) : null, v = d ? Mo(d, s, y) : null, g = d && f ? function(e, t, r, o) {
 var n;
-return null !== (n = [ Mo(e, t, r), Fg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return null !== (n = [ Mo(e, t, r), Bg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
 return function(e, t, r) {
 if (!t) return !1;
 if ("ranger" !== e) return !0;
@@ -39551,7 +39565,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, m)) && void 0 !== i ? i : Fv({
+}(t.def, m)) && void 0 !== i ? i : Bv({
 maxEnergy: m,
 role: t.roleName
 }), E = t.bodyOverride ? s : h ? f ? l : s : m;
@@ -39587,44 +39601,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var _h = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Uh = new Set([ "guard", "ranger", "healer" ]);
+var Uh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Nh = new Set([ "guard", "ranger", "healer" ]);
 
-function Nh() {
+function Ph() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Ph(e) {
+function Ih(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Ih(e) {
-var t;
-return e.priority >= kv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
-}
-
 function Gh(e) {
 var t;
-return e.priority >= kv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Av.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Lh(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = wg(e), m = So(X(e)), d = function(e) {
+function Lh(e) {
+var t;
+return e.priority >= Av.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+}
+
+function Dh(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = xg(e), m = So(X(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? kv.EMERGENCY : kv.HIGH, f = d ? u : p === kv.EMERGENCY ? l : u, y = function(e, t) {
+}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Av.EMERGENCY : Av.HIGH, f = d ? u : p === Av.EMERGENCY ? l : u, y = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Kv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Yv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || Dh(u, e) && ("guard" === u.role && (n.guards++,
-Bh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Bh(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Bh(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Fh(u, e) && ("guard" === u.role && (n.guards++,
+Wh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Wh(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Wh(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -39652,7 +39666,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Bh(n, u, l);
+0 !== l.length && Wh(n, u, l);
 }
 }
 }
@@ -39691,26 +39705,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - y.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - y.counts.healers)
-}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Fh("guard", f, m);
-if (R > 0 && E) for (var T = 0; T < R; T++) Hh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
-var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Fh("ranger", f, m);
-if (C > 0 && S) for (T = 0; T < C; T++) Hh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
-var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Fh("healer", f, m);
-if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) Hh(e, "healer", "military", kv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Bh("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) Kh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Bh("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) Kh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Bh("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) Kh(e, "healer", "military", Av.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
-if (!(t < kv.EMERGENCY || function(e, t) {
+if (!(t < Av.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Uh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Nh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Kv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Yv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < kv.EMERGENCY || Uh.has(c.role) && Dh(c, e.name) && c.body.cost <= t && n++;
+c.priority < Av.EMERGENCY || Nh.has(c.role) && Fh(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39727,7 +39741,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = Dg(t, e);
+var r = Fg(t, e);
 return r ? {
 role: t,
 body: r
@@ -39742,45 +39756,45 @@ var r = Ro(t.body.parts).score - Ro(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Hh(e, n.role, "military", kv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && Kh(e, n.role, "military", Av.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, p, l, m), (R > 0 || C > 0 || w > 0) && _.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Dh(e, t) {
+function Fh(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Fh(e, t, r) {
+function Bh(e, t, r) {
 return r ? Mo(e, t, r) : null;
 }
 
-function Bh(e, t, r) {
+function Wh(e, t, r) {
 var o = Ro(r);
 e[t] = e[t] ? To(e[t], o) : o;
 }
 
-function Wh(e, t, r) {
-return Kv.getPendingRequests(e).filter(function(e) {
+function Hh(e, t, r) {
+return Yv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Hh(e, t, r, o, n, a, i, s, c) {
+function Kh(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : Fv({
+var u = null != i ? i : Bv({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void _.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Kv.addRequest({
+Yv.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -39798,34 +39812,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Kh(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= kv.HIGH) return !1;
+function Yh(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Av.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < kv.NORMAL) {
-if (Vv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Av.NORMAL) {
+if (qv.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === kv.NORMAL && o / e.energyCapacityAvailable < .3 && Vv.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Av.NORMAL && o / e.energyCapacityAvailable < .3 && qv.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function Yh(e, t) {
+function Vh(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-bh(e);
-var s = Kv.getQueueSize(e.name);
+Oh(e);
+var s = Yv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = vh(e.name, e), u = fh(e.name) && !Kv.hasEmergencySpawns(e.name), l = co(e), m = lo(e);
+var c = gh(e.name, e), u = yh(e.name) && !Yv.hasEmergencySpawns(e.name), l = co(e), m = lo(e);
 if (c) {
-s > 0 && Kv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Lh(e, t, l, m);
+s > 0 && Yv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && Dh(e, t, l, m);
 try {
-for (var d = a(Ah(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Mh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Kv.addRequest(f);
+Yv.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -39838,8 +39852,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Lh(e, t, l, m), function(e) {
-var t, r, o = qv.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && Dh(e, t, l, m), function(e) {
+var t, r, o = jv.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -39851,17 +39865,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = kv.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = Av.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Wh(e.name, "powerHarvester", f), g = Wh(e.name, "healer", f), h = Wh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Hh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Hh(e.name, "powerHarvester", f), g = Hh(e.name, "healer", f), h = Hh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Kh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Hh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) Kh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Hh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Kh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -39890,13 +39904,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Kv.getPendingRequests(e.name).map(Ph));
+var c = new Set(Yv.getPendingRequests(e.name).map(Ih));
 try {
-for (var u = a(Ah(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= kv.HIGH, p = "claimer" === m.role && Nh(), f = Ih(m), y = Gh(m);
-if (_h.has(m.role) || d || p || f || y) {
-var v = Ph(m);
-c.has(v) || (Kv.addRequest(m), c.add(v));
+for (var u = a(Mh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Av.HIGH, p = "claimer" === m.role && Ph(), f = Gh(m), y = Lh(m);
+if (Uh.has(m.role) || d || p || f || y) {
+var v = Ih(m);
+c.has(v) || (Yv.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -39913,8 +39927,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Ah(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Kv.addRequest(f);
+for (var y = a(Mh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Yv.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -39926,32 +39940,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Kv.getQueueStats(e.name);
+var g = Yv.getQueueStats(e.name);
 _.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Kv.clearQueue(e.name);
+} else s > 0 && Yv.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Kv.getAvailableSpawns(e.name);
+var t, r, o = Yv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = wg(e);
+var n = 0, i = xg(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Kv.getNextRequest(e.name, i);
+var u = c.value, l = Yv.getNextRequest(e.name, i);
 if (!l) break;
-if (Kh(e, l, i)) {
+if (Yh(e, l, i)) {
 _.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Wv(u, l);
-m === OK ? (n++, i -= l.body.cost, Kv.markInProgress(e.name, l.id, u.id), Kv.removeRequest(e.name, l.id),
+var m = Hv(u, l);
+m === OK ? (n++, i -= l.body.cost, Yv.markInProgress(e.name, l.id, u.id), Yv.removeRequest(e.name, l.id),
 _.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Kv.removeRequest(e.name, l.id), _.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Yv.removeRequest(e.name, l.id), _.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -39967,12 +39981,12 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Kv.getQueueStats(e.name), n = function(e) {
+}(e), o = Yv.getQueueStats(e.name), n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T = Game.rooms[e];
 if (!T) return [];
-var C = wg(T), S = new Map, w = new Map, x = function(e, t) {
+var C = xg(T), S = new Map, w = new Map, x = function(e, t) {
 var r;
-w.set(e, Ch(null !== (r = w.get(e)) && void 0 !== r ? r : {
+w.set(e, Sh(null !== (r = w.get(e)) && void 0 !== r ? r : {
 partCount: 0,
 attack: 0,
 ranged: 0,
@@ -40048,7 +40062,7 @@ return function(e, t, r) {
 var o, n, i, s = wo(e.targetRoom);
 e.targetScore = null !== (i = null == s ? void 0 : s.total.score) && void 0 !== i ? i : 0;
 try {
-for (var c = a(gh), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(hh), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Mo(l, t.energyCapacityAvailable, s);
 m ? (e.bodyCost[l] = m.cost, e.affordable[l] = m.cost <= r) : e.affordable[l] = !1;
 }
@@ -40068,15 +40082,15 @@ if (o) throw o.error;
 try {
 for (var O = a(function(e, t) {
 void 0 === t && (t = {});
-var r = Hg(e), o = r.filter(Wg);
+var r = Kg(e), o = r.filter(Hg);
 return t.prune && Array.isArray(e.defenseRequests) && o.length !== r.length && (e.defenseRequests = o),
 o;
 }(Memory)), k = O.next(); !k.done; k = O.next()) if ((I = k.value).roomName !== e) {
 var A = b(I.roomName, null !== (f = I.urgency) && void 0 !== f ? f : 0);
 try {
-for (var M = (o = void 0, a(gh)), _ = M.next(); !_.done; _ = M.next()) {
+for (var M = (o = void 0, a(hh)), _ = M.next(); !_.done; _ = M.next()) {
 var U = _.value;
-hh(A.requested, U, Th(I, U));
+Rh(A.requested, U, Ch(I, U));
 }
 } catch (e) {
 o = {
@@ -40102,11 +40116,11 @@ if (t) throw t.error;
 }
 }
 try {
-for (var N = a(Kv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
+for (var N = a(Yv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
 var I;
-Eh(I = P.value) && (D = Rh(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (hh((A = b(D)).queued, I.role),
+Th(I = P.value) && (D = Eh(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Rh((A = b(D)).queued, I.role),
 A.bodyCost[I.role] = Math.max(null !== (v = A.bodyCost[I.role]) && void 0 !== v ? v : 0, I.body.cost),
-A.affordable[I.role] = I.body.cost <= C, Sh(A, I.body.parts));
+A.affordable[I.role] = I.body.cost <= C, wh(A, I.body.parts));
 }
 } catch (e) {
 c = {
@@ -40122,13 +40136,13 @@ if (c) throw c.error;
 try {
 for (var G = a(Object.values(Game.creeps)), L = G.next(); !L.done; L = G.next()) {
 var D, F = L.value, B = null !== (g = F.memory) && void 0 !== g ? g : {};
-if (B.homeRoom === e && Po(U = null !== (h = B.role) && void 0 !== h ? h : "") && (D = Rh(B))) {
+if (B.homeRoom === e && Po(U = null !== (h = B.role) && void 0 !== h ? h : "") && (D = Eh(B))) {
 A = b(D);
 var W = (null !== (R = F.body) && void 0 !== R ? R : []).filter(function(e) {
 return e.hits > 0;
 });
-F.spawning ? hh(A.spawning, U) : void 0 === B.defenseAssistReleasedAt && F.room.name === e ? (hh(A.staged, U),
-x(D, W)) : F.room.name === D ? hh(A.arrived, U) : hh(A.moving, U), wh(A, B), Sh(A, W);
+F.spawning ? Rh(A.spawning, U) : void 0 === B.defenseAssistReleasedAt && F.room.name === e ? (Rh(A.staged, U),
+x(D, W)) : F.room.name === D ? Rh(A.arrived, U) : Rh(A.moving, U), xh(A, B), wh(A, W);
 }
 }
 } catch (e) {
@@ -40144,7 +40158,7 @@ if (l) throw l.error;
 }
 var H = s([], i(S.values()), !1);
 try {
-for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) xh(A = Y.value, null !== (E = w.get(A.targetRoom)) && void 0 !== E ? E : Eo());
+for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) bh(A = Y.value, null !== (E = w.get(A.targetRoom)) && void 0 !== E ? E : Eo());
 } catch (e) {
 d = {
 error: e
@@ -40174,7 +40188,7 @@ defenseAssist: n
 }(e, t);
 }
 
-var Vh = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, qh = /^(\d{1,2})\|(.+)$/, jh = A("SS2TerminalComms"), zh = function() {
+var qh = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, jh = /^(\d{1,2})\|(.+)$/, zh = A("SS2TerminalComms"), Qh = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -40234,11 +40248,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(Vh);
+var t = e.match(qh);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(qh);
+var i = a.match(jh);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -40273,7 +40287,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-jh.warn("Missing packet in multi-packet message", {
+zh.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -40289,7 +40303,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), jh.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), zh.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -40313,7 +40327,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && jh.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && zh.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -40325,7 +40339,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return jh.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return zh.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -40333,14 +40347,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), jh.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), zh.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (jh.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (zh.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -40365,7 +40379,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-jh.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+zh.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -40377,7 +40391,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-jh.info("Completed sending multi-packet message", {
+zh.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -40385,25 +40399,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? jh.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? zh.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (jh.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (zh.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else jh.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else zh.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else jh.warn("Terminal not found for queue item, removing from queue", {
+} else zh.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -40437,7 +40451,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && jh.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && zh.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -40447,7 +40461,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-jh.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+zh.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -40538,7 +40552,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (jh.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (zh.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -40560,7 +40574,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return jh.error("Error parsing JSON", {
+return zh.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -40571,7 +40585,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), Qh = [ {
+}(), Xh = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -40591,7 +40605,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], Xh = function() {
+} ], Zh = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -40638,9 +40652,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), Zh = new Xh;
+}(), Jh = new Zh;
 
-function Jh(e) {
+function $h(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -40648,19 +40662,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function $h(e, t) {
+function eR(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function eR(e, t) {
+function tR(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var tR = {
+var rR = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -40671,9 +40685,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, rR = function() {
+}, oR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, tR), e);
+void 0 === e && (e = {}), this.config = o(o({}, rR), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -40694,7 +40708,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = Zh.getSwarmState(r.toRoom);
+var o = Jh.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return _.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -40707,7 +40721,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = Zh.getSwarmState(c);
+var l = Jh.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -40777,9 +40791,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort($h), u = n.filter(function(e) {
+}).sort(eR), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(eR), l = [], m = [], d = function(t) {
+}).sort(tR), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -40801,11 +40815,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return Jh({
+return $h({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + Jh({
+}) + $h({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -40904,7 +40918,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), oR = new rR, nR = {
+}(), nR = new oR, aR = {
 1: {
 guards: 1,
 rangers: 1,
@@ -40925,14 +40939,14 @@ siegeUnits: 1
 }
 };
 
-function aR(e) {
+function iR(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function iR(e) {
+function sR(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -40955,9 +40969,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function sR(e) {
+function cR(e) {
 var t, r, o;
-iR(e);
+sR(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -40981,20 +40995,20 @@ if (t) throw t.error;
 return n;
 }
 
-function cR(e) {
+function uR(e) {
 var t;
-iR(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = sR(e);
+sR(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = cR(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function uR(e) {
-return !!cR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function lR(e) {
+return !!uR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-iR(e);
+sR(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -41005,12 +41019,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = sR(e);
+var d = cR(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function lR(e, t) {
+function mR(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -41031,20 +41045,20 @@ if (r) throw r.error;
 return n;
 }
 
-function mR(e, t) {
+function dR(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = nR[r]) && void 0 !== t ? t : nR[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = aR[r]) && void 0 !== t ? t : aR[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = lR(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = mR(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: aR(r),
+targetComposition: iR(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -41056,7 +41070,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function dR(e) {
+function pR(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return _.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -41076,9 +41090,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function pR(e) {
+function fR(e) {
 var t = e.members.length;
-iR(e), e.members.length < t && _.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+sR(e), e.members.length < t && _.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -41092,7 +41106,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && uR(e) && (e.state = "moving", _.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && lR(e) && (e.state = "moving", _.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -41121,7 +41135,7 @@ subsystem: "Squad"
 }
 }
 
-var fR = {
+var yR = {
 harassment: {
 composition: {
 harassers: 3,
@@ -41208,7 +41222,7 @@ prioritizeDefenses: !0
 }
 };
 
-function yR(e, t) {
+function vR(e, t) {
 var r, o, n, a;
 if (!t) return _.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -41223,8 +41237,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function vR(e, t) {
-var r, o, n, i = fR[t], s = 0;
+function gR(e, t) {
+var r, o, n, i = yR[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -41250,7 +41264,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var gR, hR, RR, ER = {
+var hR, RR, ER, TR = {
 move: 50,
 work: 100,
 carry: 50,
@@ -41259,11 +41273,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, TR = new Map;
+}, CR = new Map;
 
-function CR(e, t) {
+function SR(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (TR.has(m)) _.debug("Squad ".concat(m, " already forming"), {
+if (CR.has(m)) _.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -41275,7 +41289,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = fR[p].composition;
+d = yR[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -41290,19 +41304,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (TR.set(m, y), function(e, t, r, o) {
+v ? (CR.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = fR[s].useBoosts;
+i = yR[s].useBoosts;
 }
-var c = kv.NORMAL;
-"siege" === t.type ? c = kv.HIGH : "defense" === t.type && (c = kv.EMERGENCY);
+var c = Av.NORMAL;
+"siege" === t.type ? c = Av.HIGH : "defense" === t.type && (c = Av.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = SR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + ER[t];
-}, 0), m = i ? xR(r) : [], d = {
+var u = wR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + TR[t];
+}, 0), m = i ? bR(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -41331,7 +41345,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Kv.addRequest(d), o.spawnRequests.add(d.id);
+Yv.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -41345,42 +41359,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function SR(e, t, r) {
+function wR(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return wR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return xR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return wR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return xR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return wR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return xR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return wR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return xR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return wR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return xR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return wR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return xR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function wR(e, t, r) {
+function xR(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + ER[t];
+return e + TR[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + ER[t];
+return e + TR[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function xR(e) {
+function bR(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -41411,45 +41425,45 @@ return [];
 }
 }
 
-function bR(e) {
-return TR.has(e);
-}
-
 function OR(e) {
-return cR(e) || uR(e);
+return CR.has(e);
 }
 
-(gR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, gR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-gR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (hR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-hR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, hR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-hR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (RR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-RR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, RR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-RR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, RR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+function kR(e) {
+return uR(e) || lR(e);
+}
 
-var kR = {
+(hR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, hR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+hR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (RR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+RR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, RR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+RR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (ER = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+ER[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, ER[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+ER[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, ER[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+
+var AR = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function AR(e, t) {
-var r = kR[t], o = Zh.getClusters();
+function MR(e, t) {
+var r = AR[t], o = Jh.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function MR(e, t, r) {
+function _R(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = Zh.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = Jh.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: AR(e, i.danger),
+reservedEnergy: MR(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -41539,7 +41553,7 @@ success: !1
 });
 }
 
-var _R = {
+var UR = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -41549,7 +41563,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function UR(e, t, r) {
+function NR(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -41580,7 +41594,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function NR(e, t, r, o) {
+function PR(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -41590,7 +41604,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function PR(e, t) {
+function IR(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -41611,19 +41625,19 @@ if (r) throw r.error;
 return n;
 }
 
-function IR() {
-var e = Zh.getEmpire();
+function GR() {
+var e = Jh.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function GR(e) {
-IR()[e.id] = e;
+function LR(e) {
+GR()[e.id] = e;
 }
 
-function LR(e) {
+function DR(e) {
 e.lastUpdate = Game.time;
-var t = Zh.getCluster(e.clusterId);
-if (!t) return e.state = "failed", GR(e), void _.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = Jh.getCluster(e.clusterId);
+if (!t) return e.state = "failed", LR(e), void _.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -41633,12 +41647,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (OR(r) || bR(e) || CR(0, r), OR(r));
+return !!r && (kR(r) || OR(e) || SR(0, r), kR(r));
 }) && (e.state = "executing", _.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", _.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), GR(e);
+})), LR(e);
 }(e, t);
 break;
 
@@ -41649,7 +41663,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (pR(o), dR(o)) {
+if (fR(o), pR(o)) {
 _.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -41678,7 +41692,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = Zh.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = Jh.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -41705,12 +41719,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", _.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), GR(e);
+})), LR(e);
 }(e, t);
 }
 }
 
-function DR(e, t, r) {
+function FR(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -41729,11 +41743,11 @@ score: n.score + o.score
 }
 }
 
-function FR(e, t, r) {
+function BR(e, t, r) {
 return Mo(e, t, r);
 }
 
-function BR(e, t) {
+function WR(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -41746,11 +41760,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function WR(e) {
+function HR(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function HR(e, t, r) {
+function KR(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -41763,8 +41777,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function KR(e, t, r) {
-var o = FR(t, e.energyCapacityAvailable, r);
+function YR(e, t, r) {
+var o = BR(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -41772,16 +41786,16 @@ var a = Ro(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function YR(e, t, r, o) {
+function VR(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = KR(e, t, o);
-if (s !== KR(n, t, o)) return s ? -1 : 1;
+var a, i, s = YR(e, t, o);
+if (s !== YR(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function VR(e, t) {
+function qR(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -41865,21 +41879,21 @@ if (r) throw r.error;
 return u;
 }
 
-function qR(e, t) {
+function jR(e, t) {
 return {
-guard: Math.max(0, BR(e, "guard") - t.counts.guard),
-ranger: Math.max(0, BR(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, BR(e, "healer") - t.counts.healer)
+guard: Math.max(0, WR(e, "guard") - t.counts.guard),
+ranger: Math.max(0, WR(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, WR(e, "healer") - t.counts.healer)
 };
 }
 
-function jR(e) {
+function zR(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function zR(e, t) {
+function QR(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return jR(e.role);
+return zR(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -41892,12 +41906,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function QR(e) {
+function XR(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === mi ? e.targetRoom : void 0;
 }
 
-function XR(e) {
+function ZR(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -41909,7 +41923,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-jR(m) && QR(l) === e && !u.spawning && DR(i, m, u.body.filter(function(e) {
+zR(m) && XR(l) === e && !u.spawning && FR(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -41927,7 +41941,7 @@ if (t) throw t.error;
 return i;
 }
 
-function ZR(e, t, r) {
+function JR(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -41957,16 +41971,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: zR(e, r)
+pendingAssist: QR(e, r)
 };
 }
 }
 
-function JR(e, t) {
+function $R(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = FR(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = BR(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -41987,7 +42001,7 @@ subsystem: "Cluster"
 }
 }
 
-function $R(e, t, r) {
+function eE(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -42029,20 +42043,20 @@ exitAccess: a
 };
 }
 
-function eE(e, t) {
+function tE(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function tE(e, t, r) {
+function rE(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function rE(e) {
+function oE(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function oE(e, t) {
+function nE(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -42053,7 +42067,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function nE(e, t, r) {
+function aE(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -42064,8 +42078,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = rE(g);
-h && (fi(g) || oE(v, h) && (t.assignedCreeps.includes(v.name) || eE(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = oE(g);
+h && (fi(g) || nE(v, h) && (t.assignedCreeps.includes(v.name) || tE(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -42102,7 +42116,7 @@ return e.distance - t.distance;
 });
 }
 
-function aE(e, t) {
+function iE(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -42127,21 +42141,21 @@ if (r) throw r.error;
 return i;
 }
 
-function iE(e) {
+function sE(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var sE = {
+var cE = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, cE = function() {
+}, uE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, sE), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, cE), e);
 }
 return e.prototype.run = function() {
-var e = Zh.getClusters();
+var e = Jh.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -42160,7 +42174,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: Qh.map(function(t) {
+steps: Xh.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -42179,7 +42193,7 @@ focusRoom: e.focusRoom
 }(e);
 }, e.prototype.runCluster = function(e) {
 var t, r, o = this, n = Game.cpu.getUsed(), i = this.getClusterOperationIntent(e), s = function(t) {
-Xi.measureSubsystem(t.statsKey, function() {
+Zi.measureSubsystem(t.statsKey, function() {
 o.executeClusterOperation(t.name, e);
 });
 };
@@ -42216,7 +42230,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-oR.processCluster(t);
+nR.processCluster(t);
 break;
 
 case "squads":
@@ -42248,7 +42262,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = $R(e, new RoomPosition(s, c, e.name), "defense");
+var u = eE(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -42297,9 +42311,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = Zh.getSwarmState(i);
+var i = n.value, s = Jh.getSwarmState(i);
 if (s) {
-var c = AR(i, s.danger);
+var c = MR(i, s.danger);
 c > 0 && Game.time % 100 == 0 && _.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -42330,7 +42344,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = Zh.getSwarmState(m);
+var m = l.value, d = Jh.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -42362,7 +42376,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += iE(l.controller.level));
+}).length, i += sE(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -42479,7 +42493,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-pR(i), "gathering" !== i.state || OR(i) || bR(i.id) || CR(0, i), dR(i) && (i.state = "dissolving");
+fR(i), "gathering" !== i.state || kR(i) || OR(i.id) || SR(0, i), pR(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -42504,7 +42518,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = mR(e, s);
+var s = i.value, c = dR(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -42521,7 +42535,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(IR()).filter(function(e) {
+var t = (a = e.id, Object.values(GR()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -42532,22 +42546,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, _R), n), m = [], d = Zh.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, UR), n), m = [], d = Jh.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = UR(f, y, d);
+var g = NR(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = PR(e, f);
+var h = IR(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = NR(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = PR(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = yR(f, {
+var C = vR(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -42582,29 +42596,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-vR(e, n.doctrine) ? function(e, t, r) {
+gR(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = Zh.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = Jh.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return _.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return _.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = UR(e, o, r);
+var n = NR(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (_.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return _.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (Zh.getEmpire().knownRooms || {})[t], n = null != r ? r : yR(t, {
+var o = (Jh.getEmpire().knownRooms || {})[t], n = null != r ? r : vR(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!vR(e, n)) return _.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!gR(e, n)) return _.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -42617,7 +42631,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-GR(i);
+LR(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -42631,13 +42645,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = lR(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = mR(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: aR(n),
+targetComposition: iR(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -42652,8 +42666,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), GR(i), CR(0, c), i.state = "forming", i.lastUpdate = Game.time,
-GR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), LR(i), SR(0, c), i.state = "forming", i.lastUpdate = Game.time,
+LR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 _.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), _.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -42672,11 +42686,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(TR.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(CR.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (_.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), TR.delete(c));
+}), CR.delete(c));
 }
 } catch (t) {
 e = {
@@ -42690,10 +42704,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = IR();
-for (var t in e) LR(e[t]);
+var e = GR();
+for (var t in e) DR(e[t]);
 !function() {
-var e = IR();
+var e = GR();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -42771,14 +42785,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = Zh.getCluster(t, e);
+var t = "cluster_".concat(e), r = Jh.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return _.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = Zh.getCluster(e);
+var o = Jh.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), _.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), _.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -42807,7 +42821,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && MR(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && _R(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -42824,7 +42838,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = Zh.getSwarmState(t);
+var n, a, i = Jh.getSwarmState(t);
 if (!i) return "continue";
 if (mo(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -42865,7 +42879,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = wo(g), f[g] = XR(g);
+p[g] = wo(g), f[g] = ZR(g);
 }
 } catch (e) {
 r = {
@@ -42881,7 +42895,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = ZR(E, m, t);
+d[E] = JR(E, m, t);
 }
 } catch (e) {
 n = {
@@ -42900,13 +42914,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = HR(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = KR(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = VR(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = qR(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = No(T, R, qR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = No(T, R, jR(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = YR(h, b, g.roomName, R), A = 0; A < O; A++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = VR(h, b, g.roomName, R), A = 0; A < O; A++) {
 var M = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -42918,7 +42932,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(M.roomName, "_").con
 roomName: M.roomName,
 role: b,
 family: "military",
-priority: WR(g.urgency),
+priority: HR(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -42964,7 +42978,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) JR(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) $R(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -42979,7 +42993,7 @@ if (u) throw u.error;
 C > 0 && _.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Kv);
+}(e, Yv);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -42991,7 +43005,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = aE(f, nE(e, f, t)), v = y.reduce(function(e, t) {
+var y = iE(f, aE(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -43004,7 +43018,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), tE(f, R.role, eE(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), rE(f, R.role, tE(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -43071,24 +43085,24 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), uE = new cE, lE = /^([WE])(\d+)([NS])(\d+)$/;
+}(), lE = new uE, mE = /^([WE])(\d+)([NS])(\d+)$/;
 
-function mE(e) {
-return lE.test(e);
+function dE(e) {
+return mE.test(e);
 }
 
-var dE = {
+var pE = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, pE = function() {
+}, fE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, dE), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, pE), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = kf();
-this.updateEnemyIntelligence(e), Af(e, {
+var e = Af();
+this.updateEnemyIntelligence(e), Mf(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
@@ -43151,7 +43165,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (mE(x)) {
+if (e.isAlly(x)) f.add(x); else if (dE(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -43216,14 +43230,14 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return kf().globalTargets.enemies || [];
+return Af().globalTargets.enemies || [];
 }, n([ Xe("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: Pe.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), fE = new pE, yE = function() {
+}(), yE = new fE, vE = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -43300,9 +43314,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), vE = new yE, gE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), gE = new vE, hE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function hE(e, t) {
+function RE(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -43325,22 +43339,22 @@ if (r) throw r.error;
 return n;
 }
 
-function RE(e) {
+function EE(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function EE(e, t, r) {
-if (!RE(e)) return 0;
-var o = hE(e.name, t);
+function TE(e, t, r) {
+if (!EE(e)) return 0;
+var o = RE(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
-return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += nc(e.mineralType),
-n -= 5 * o, n -= ac(e.name), n -= 15 * e.threatLevel, n += ic(e.terrain), sc(e.name) && (n += 10),
-n += cc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
-n += lc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
+return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += ac(e.mineralType),
+n -= 5 * o, n -= ic(e.name), n -= 15 * e.threatLevel, n += sc(e.terrain), cc(e.name) && (n += 10),
+n += uc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
+n += mc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function TE(e, t) {
+function CE(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -43350,13 +43364,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return X(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && gE.has(e.type);
+return e.hits > 0 && hE.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function CE(e, t, r) {
+function SE(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -43366,7 +43380,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function SE(e) {
+function wE(e) {
 return function(e) {
 var t = ee(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -43377,8 +43391,8 @@ isSK: te(t.x) && te(t.y)
 }(e);
 }
 
-function wE(e) {
-var t = SE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function xE(e) {
+var t = wE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -43397,14 +43411,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var xE = {
+var bE = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, bE = function() {
+}, OE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, xE), e);
+void 0 === e && (e = {}), this.config = o(o({}, bE), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -43495,7 +43509,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = SE(e);
+var t = wE(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -43507,14 +43521,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return wE(OE(e));
+return xE(kE(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = wE(OE(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = xE(kE(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function OE(e) {
+function kE(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = X(e), c = Z(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -43546,11 +43560,11 @@ swamps: d
 };
 }
 
-var kE = new bE, AE = /^([WE])(\d+)([NS])(\d+)$/, ME = {
+var AE = new OE, ME = /^([WE])(\d+)([NS])(\d+)$/, _E = {
 allies: []
-}, _E = function() {
+}, UE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, ME), e);
+void 0 === e && (e = {}), this.config = o(o({}, _E), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -43570,7 +43584,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!AE.test(e)) return !1;
+if (!ME.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -43678,7 +43692,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return AE.test(e);
+return ME.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -43705,7 +43719,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), UE = new _E, NE = {
+}(), NE = new UE, PE = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -43718,9 +43732,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, PE = function() {
+}, IE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, NE), e);
+void 0 === e && (e = {}), this.config = o(o({}, PE), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = Sr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -43728,27 +43742,27 @@ if (n < this.config.minBucket) Game.time % 100 == 0 && _.warn("Empire manager sk
 subsystem: "Empire"
 }); else {
 var a = this.getBucketMode(n), i = this.shouldRunDegradedModeWork(a), s = this.shouldRunNormalModeWork(a), c = this.shouldRunFullModeWork(a);
-o.lastUpdate = Game.time, s && (Xi.measureSubsystem("empire:expansion", function() {
+o.lastUpdate = Game.time, s && (Zi.measureSubsystem("empire:expansion", function() {
 t.updateExpansionQueue(o);
-}), Xi.measureSubsystem("empire:powerBanks", function() {
+}), Zi.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
-})), Xi.measureSubsystem("empire:warTargets", function() {
-UE.updateWarTargets(o);
-}), Xi.measureSubsystem("empire:objectives", function() {
+})), Zi.measureSubsystem("empire:warTargets", function() {
+NE.updateWarTargets(o);
+}), Zi.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
-}), Xi.measureSubsystem("empire:gclTracking", function() {
+}), Zi.measureSubsystem("empire:gclTracking", function() {
 t.trackGCLProgress(o);
-}), s && Xi.measureSubsystem("empire:expansionReadiness", function() {
+}), s && Zi.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
-}), i && (Xi.measureSubsystem("empire:intelRefresh", function() {
-kE.refreshRoomIntel(o);
-}), Xi.measureSubsystem("empire:roomDiscovery", function() {
-kE.discoverNearbyRooms(o);
-})), s && Xi.measureSubsystem("empire:nukeCandidates", function() {
+}), i && (Zi.measureSubsystem("empire:intelRefresh", function() {
+AE.refreshRoomIntel(o);
+}), Zi.measureSubsystem("empire:roomDiscovery", function() {
+AE.discoverNearbyRooms(o);
+})), s && Zi.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
-}), c && (Xi.measureSubsystem("empire:clusterHealth", function() {
-vE.monitorClusterHealth();
-}), Xi.measureSubsystem("empire:powerBankProfitability", function() {
+}), c && (Zi.measureSubsystem("empire:clusterHealth", function() {
+gE.monitorClusterHealth();
+}), Zi.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
 var u = Game.cpu.getUsed() - r, l = Game.cpu.limit * this.config.maxCpuBudget;
@@ -43830,22 +43844,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = TE(f, u);
+var y = Boolean(Game.rooms[f]), v = CE(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = hE(f, t);
+var g = RE(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = CE(h, u, y);
+var h = e.knownRooms[f], R = SE(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? EE(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? TE(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -43889,10 +43903,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && RE(a)) {
-var i = hE(a.name, t);
+if (a && EE(a)) {
+var i = RE(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = EE(a, t, r);
+var s = TE(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -44212,13 +44226,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), IE = new PE;
+}(), GE = new IE;
 
-function GE(e) {
+function LE(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var LE = {
+var DE = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -44226,21 +44240,21 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, DE = function() {
+}, FE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, LE), e);
+this.config = o(o({}, DE), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
 this.lastRun = Game.time, 0 === this.scanQueue.length && this.buildScanQueue(),
-Xi.measureSubsystem("intel:scanning", function() {
+Zi.measureSubsystem("intel:scanning", function() {
 e.scanRooms();
-}), Xi.measureSubsystem("intel:enemyTracking", function() {
+}), Zi.measureSubsystem("intel:enemyTracking", function() {
 e.updateEnemyTracking();
-}), Xi.measureSubsystem("intel:threatDetection", function() {
+}), Zi.measureSubsystem("intel:threatDetection", function() {
 e.detectThreats();
-}), Xi.measureSubsystem("intel:threatUpdate", function() {
+}), Zi.measureSubsystem("intel:threatUpdate", function() {
 e.updateRoomThreatLevels();
 });
 var r = Game.cpu.getUsed() - t;
@@ -44373,7 +44387,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, GE(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, LE(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -44548,9 +44562,9 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), FE = new DE, BE = function() {
+}(), BE = new FE, WE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new tc(o(o({}, Bs), e), {
+void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new rc(o(o({}, Ws), e), {
 getEmpire: function() {
 return Sr.getEmpire();
 },
@@ -44586,7 +44600,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), WE = new BE, HE = function() {
+}(), HE = new WE, KE = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = Sr.getEmpire();
@@ -44604,9 +44618,9 @@ lastScan: 0
 var e = Sr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), KE = new (function(e) {
+}(), YE = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new HE) || this;
+return void 0 === t && (t = {}), e.call(this, t, new KE) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -44616,24 +44630,24 @@ interval: 200,
 minBucket: 9e3,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Je() ], t);
-}(Ii));
+}(Gi));
 
-function YE() {
+function VE() {
 return global;
 }
 
-function VE(e) {
+function qE(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function qE(e) {
+function jE(e) {
 return Number(null != e ? e : 0);
 }
 
-var jE = function() {
+var zE = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = YE();
+var e = VE();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -44641,12 +44655,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return YE()._pixelGenerationMemory;
+return VE()._pixelGenerationMemory;
 }, e;
-}(), zE = function(e) {
+}(), QE = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new jE) || this;
+var r = e.call(this, t, new zE) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -44663,7 +44677,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(VE).length : Object.values(null != t ? t : {}).filter(VE).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(qE).length : Object.values(null != t ? t : {}).filter(qE).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -44674,9 +44688,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (qE(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (qE(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = qE(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = qE(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (jE(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (jE(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = jE(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = jE(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -44698,9 +44712,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ Je() ], t);
-}(Li), QE = new zE;
+}(Di), XE = new QE;
 
-function XE(e, t) {
+function ZE(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !j(e.controller.owner.username)) return {
 lost: !0,
@@ -44722,7 +44736,7 @@ lost: !1
 };
 }
 
-function ZE(e, t, r) {
+function JE(e, t, r) {
 var o, n = Sr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -44736,20 +44750,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var JE = kr().cpu.bucketThresholds.highMode + 1800, $E = {
+var $E = kr().cpu.bucketThresholds.highMode + 1800, eT = {
 updateInterval: 250,
-minBucket: JE,
+minBucket: $E,
 maxSitesPerRemotePerTick: 2
 };
 
-function eT(e, t) {
+function tT(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var tT = function() {
+var rT = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, $E), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, eT), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -44766,8 +44780,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = XE(l);
-m.lost && m.reason && ZE(e, u, m.reason);
+var m = ZE(l);
+m.lost && m.reason && JE(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -44785,10 +44799,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = eT("remoteInfrastructure.intent", function() {
+var i = tT("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-eT("remoteInfrastructure.execute", function() {
+tT("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -44954,13 +44968,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = eT("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = tT("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = eT("remoteInfrastructure.roomSnapshot", function() {
+u[t] = tT("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -44993,7 +45007,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = eT("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = tT("remoteInfrastructure.calculateRemoteRoads", function() {
 return Ta(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -45022,14 +45036,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = eT("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = tT("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? eT("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? tT("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -45046,7 +45060,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? eT("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? tT("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -45064,7 +45078,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return eT("remoteInfrastructure.findSources", function() {
+return tT("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -45161,10 +45175,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ Qe("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Pe.LOW,
 interval: 1e3,
-minBucket: JE,
+minBucket: $E,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ Je() ], e);
-}(), rT = new tT, oT = new (function(e) {
+}(), oT = new rT, nT = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -45176,7 +45190,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ Je() ], t);
-}(Gf)), nT = function() {
+}(Lf)), aT = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -45192,13 +45206,13 @@ e = JSON.stringify(Memory).length;
 e = 0;
 }
 var o = 2097152, n = e / o * 100;
-n > 90 ? el.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+n > 90 ? tl.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
-}) : n > 75 && el.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+}) : n > 75 && tl.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
 });
 }, e.prototype.updateMemorySegmentStats = function() {
-$i.run();
+es.run();
 }, e.prototype.runPheromoneDiffusion = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45220,7 +45234,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-by.applyDiffusion(o);
+Oy.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45229,7 +45243,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Cu.initialize(i.name);
+Su.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -45266,7 +45280,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ Je() ], e);
-}(), aT = new nT, iT = new (function() {
+}(), iT = new aT, sT = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -45287,16 +45301,16 @@ this.runProcesses(), this.processQueuedEvents();
 this.processesRegistered = !1;
 }, e;
 }())({
-kernel: Mi,
+kernel: _i,
 eventBus: Le,
 getCpuConfig: function() {
 return kr().cpu;
 },
 registerProcesses: function() {
 var e;
-el.info("Registering all processes with kernel...", {
+tl.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), _i(aT, Ms, Is, cs, IE, gc, FE, rT, xs, KE, QE, WE, Zc, ru, oT, fE, Vc, uE, bi),
+}), Ui(iT, _s, Gs, us, GE, hc, BE, oT, bs, YE, XE, HE, Jc, ou, nT, yE, qc, lE, Oi),
 function() {
 var e, t, r = kr().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -45307,7 +45321,7 @@ interval: 20,
 minBucket: 0,
 cpuBudget: .1,
 execute: function() {
-return Ms.run();
+return _s.run();
 }
 }, {
 id: "factory:manager",
@@ -45318,7 +45332,7 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return Is.run();
+return Gs.run();
 }
 }, {
 id: "link:manager",
@@ -45329,7 +45343,7 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return cs.run();
+return us.run();
 }
 }, {
 id: "empire:market",
@@ -45340,7 +45354,7 @@ interval: 300,
 minBucket: r,
 cpuBudget: .02,
 execute: function() {
-return xs.run();
+return bs.run();
 }
 }, {
 id: "cluster:manager",
@@ -45351,7 +45365,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return uE.run();
+return lE.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -45362,13 +45376,13 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .02,
 execute: function() {
-return bi.run();
+return Oi.run();
 }
 } ], n = [];
 try {
 for (var i = a(o), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-Mi.getProcess(c.id) || (Mi.registerProcess(c), n.push(c.id));
+_i.getProcess(c.id) || (_i.registerProcess(c), n.push(c.id));
 }
 } catch (t) {
 e = {
@@ -45381,20 +45395,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-n.length > 0 && el.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
+n.length > 0 && tl.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
 subsystem: "ProcessRegistry",
 meta: {
 processIds: n
 }
 });
-}(), (e = Mi.getProcess("empire:market")) && (e.interval = 300, e.minBucket = kr().cpu.bucketThresholds.lowMode),
-el.info("Registered ".concat(Mi.getProcesses().length, " processes with kernel"), {
+}(), (e = _i.getProcess("empire:market")) && (e.interval = 300, e.minBucket = kr().cpu.bucketThresholds.lowMode),
+tl.info("Registered ".concat(_i.getProcesses().length, " processes with kernel"), {
 subsystem: "ProcessRegistry"
 });
 }
 });
 
-function sT(e) {
+function cT(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -45404,20 +45418,20 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var cT = Ju("NativeCallsTracker");
+var uT = $u("NativeCallsTracker");
 
-function uT(e, t, r) {
+function lT(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) cT.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) uT.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
 }); else try {
 var a = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Xi.recordNativeCall(r), o.apply(this, e);
+return Zi.recordNativeCall(r), o.apply(this, e);
 };
 a.__nativeCallsTrackerWrapped = !0, Object.defineProperty(e, t, {
 value: a,
@@ -45426,7 +45440,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-cT.warn("Failed to wrap method", {
+uT.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -45436,30 +45450,30 @@ error: String(e)
 }
 }
 
-var lT, mT = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], dT = "shard1", pT = {
+var mT, dT = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], pT = "shard1", fT = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, fT = {
+}, yT = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, yT = {
+}, vT = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function vT() {
+function gT() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function gT() {
+function hT() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: mT,
+targetShards: dT,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -45469,12 +45483,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = mT),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = dT),
 Memory.interShardOperation;
 }
 
-function hT() {
-return kf({
+function RT() {
+return Af({
 version: 1,
 shards: {},
 globalTargets: {
@@ -45487,32 +45501,32 @@ checksum: 0
 });
 }
 
-function RT(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), Af(e, {
+function ET(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), Mf(e, {
 updatedSections: t
 });
 }
 
-function ET() {
-var e, t, r, o, n, i, s, c = hT(), u = vT();
+function TT() {
+var e, t, r, o, n, i, s, c = RT(), u = gT();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: mT,
+targetShards: dT,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : mT,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : dT,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && TT() ? "established" : "unreached",
+status: p === u && CT() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -45530,7 +45544,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === dT ? "core" : "frontier",
+role: u === pT ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -45547,24 +45561,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), RT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), ET(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function TT() {
+function CT() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function CT() {
+function ST() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function ST(e, t) {
+function wT(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -45583,9 +45597,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(CT()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(ST()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Kv.getPendingRequests(p.name).filter(function(r) {
+s += Yv.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -45604,7 +45618,7 @@ if (n) throw n.error;
 return s;
 }
 
-function wT(e) {
+function xT(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -45648,7 +45662,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = hT().shards[vT()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = RT().shards[gT()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -45658,8 +45672,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function xT(e, t) {
-if (!(ST("scout", t) >= 1)) {
+function bT(e, t) {
+if (!(wT("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -45697,13 +45711,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Kv.addRequest({
+r && Yv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: yT,
-priority: kv.LOW + 5,
+body: vT,
+priority: Av.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -45714,14 +45728,14 @@ task: "interShardPortalScout"
 }
 }
 
-function bT(e, t, r) {
-ST("interShardClaimer", t) >= 1 || Kv.addRequest({
+function OT(e, t, r) {
+wT("interShardClaimer", t) >= 1 || Yv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: pT,
-priority: kv.NORMAL + 50,
+body: fT,
+priority: Av.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45734,14 +45748,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function OT(e, t, r) {
-ST("interShardScout", t) >= 1 || Kv.addRequest({
+function kT(e, t, r) {
+wT("interShardScout", t) >= 1 || Yv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: yT,
-priority: kv.NORMAL,
+body: vT,
+priority: Av.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45754,15 +45768,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function kT(e, t, r) {
+function AT(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (ST("interShardPioneer", t.shard) >= 3 || Kv.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (wT("interShardPioneer", t.shard) >= 3 || Yv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: fT,
-priority: kv.NORMAL + 25,
+body: yT,
+priority: Av.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45775,19 +45789,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function AT(e) {
+function MT(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = vT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = gT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : mT), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : dT), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Cf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Sf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -45819,9 +45833,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(CT()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(ST()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Kv.getPendingRequests(l.name).filter(function(e) {
+n += Yv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -45840,22 +45854,22 @@ return n;
 }() < o;
 }
 
-(lT = {
-optimizeBody: Fv,
+(mT = {
+optimizeBody: Bv,
 spawnQueue: {
 addRequest: function(e) {
-return Kv.addRequest(e);
+return Yv.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: kv.LOW,
-NORMAL: kv.NORMAL,
-HIGH: kv.HIGH
+LOW: Av.LOW,
+NORMAL: Av.NORMAL,
+HIGH: Av.HIGH
 }
-}).optimizeBody && (Df.optimizeBody = lT.optimizeBody), lT.spawnQueue && (Df.spawnQueue = lT.spawnQueue),
-lT.spawnPriorities && (Df.spawnPriorities = o(o({}, Df.spawnPriorities), lT.spawnPriorities));
+}).optimizeBody && (Ff.optimizeBody = mT.optimizeBody), mT.spawnQueue && (Ff.spawnQueue = mT.spawnQueue),
+mT.spawnPriorities && (Ff.spawnPriorities = o(o({}, Ff.spawnPriorities), mT.spawnPriorities));
 
-var MT, _T = function() {
+var _T, UT = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -45899,7 +45913,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function UT(e) {
+function NT(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -45920,7 +45934,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function NT(e, t, r) {
+function PT(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -45986,16 +46000,16 @@ return u;
 });
 }
 
-function PT(e) {
+function IT(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(MT || (MT = {}));
+}(_T || (_T = {}));
 
-var IT = function() {
+var GT = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -46033,8 +46047,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = NT(h.pos, T.pos, this.logger);
-if (PT(C)) {
+var T = E.value, C = PT(h.pos, T.pos, this.logger);
+if (IT(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -46061,8 +46075,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, A = NT(k, u.pos, this.logger);
-PT(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, A = PT(k, u.pos, this.logger);
+IT(A) && (S = this.pathCache.convertRoomPositionsToPathSteps(A.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -46101,8 +46115,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = NT(e, t, this.logger);
-if (PT(n)) {
+var n = PT(e, t, this.logger);
+if (IT(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -46112,7 +46126,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), GT = function() {
+}(), LT = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -46122,7 +46136,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = UT(s);
+var c = NT(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -46148,7 +46162,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), LT = function() {
+}(), DT = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -46197,7 +46211,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), DT = {
+}(), FT = {
 debug: function(e, t) {
 return A("RemoteMining").debug(e, t);
 },
@@ -46210,7 +46224,7 @@ return A("RemoteMining").warn(e, t);
 error: function(e, t) {
 return A("RemoteMining").error(e, t);
 }
-}, FT = {
+}, BT = {
 getCachedPath: function(e, t) {
 var r = ct(e, t), o = Re.get(r, {
 namespace: st
@@ -46237,26 +46251,26 @@ direction: a
 }
 return t;
 }
-}, BT = {
+}, WT = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = Xm.MEDIUM), sd.register({
+void 0 === o && (o = Zm.MEDIUM), cd.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== Xm.CRITICAL
+skippable: o !== Zm.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, WT = new IT(FT, DT), HT = new GT(DT, BT, WT), KT = new LT(DT, FT, WT, vl.moveTo);
+}, HT = new GT(BT, FT), KT = new LT(FT, WT, HT), YT = new DT(FT, BT, HT, gl.moveTo);
 
-function YT(e, t, r, o) {
-return KT.moveToWithRemoteCache(e, t, r, o);
+function VT(e, t, r, o) {
+return YT.moveToWithRemoteCache(e, t, r, o);
 }
 
-var VT, qT = function() {
+var qT, jT = function() {
 function e() {
 this.logger = A("Pathfinding");
 }
@@ -46269,12 +46283,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), jT = function() {
+}(), zT = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 Le.on(e, t);
 }, e;
-}(), zT = function() {
+}(), QT = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -46319,28 +46333,28 @@ m.length > 0 && ut(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), QT = function() {
+}(), XT = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return UT(e);
+return NT(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-WT.precacheRemoteRoutes(e, t);
+HT.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), XT = new _T(new qT, new jT, new zT, new QT), ZT = {
+}(), ZT = new UT(new jT, new zT, new QT, new XT), JT = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, JT = function() {
+}, $T = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, ZT), e);
+this.config = o(o({}, JT), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -46349,10 +46363,10 @@ lastRun: 0
 }, e.prototype.unregisterTask = function(e) {
 this.tasks.delete(e);
 }, e.prototype.getBucketMode = function() {
-return Mi.getBucketMode();
+return _i.getBucketMode();
 }, e.prototype.updateBucketMode = function() {
 var e = this.getBucketMode();
-e !== this.currentMode && (el.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
+e !== this.currentMode && (tl.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
 subsystem: "Scheduler"
 }), this.currentMode = e);
 }, e.prototype.getCpuLimit = function() {
@@ -46400,13 +46414,13 @@ try {
 i.execute(), i.lastRun = Game.time;
 } catch (e) {
 var c = e instanceof Error ? e.message : String(e);
-el.error("Task ".concat(i.name, " failed: ").concat(c), {
+tl.error("Task ".concat(i.name, " failed: ").concat(c), {
 subsystem: "Scheduler"
 });
 }
 var u = Game.cpu.getUsed() - s;
 if (this.tickCpuUsed += u, !this.hasCpuBudget()) {
-el.warn("CPU budget exhausted, skipping remaining tasks", {
+tl.warn("CPU budget exhausted, skipping remaining tasks", {
 subsystem: "Scheduler"
 });
 break;
@@ -46434,123 +46448,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new JT, (VT = {})[FIND_STRUCTURES] = {
+new $T, (qT = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VT[FIND_MY_STRUCTURES] = {
+}, qT[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VT[FIND_HOSTILE_STRUCTURES] = {
+}, qT[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VT[FIND_SOURCES_ACTIVE] = {
+}, qT[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, VT[FIND_SOURCES] = {
+}, qT[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, VT[FIND_MINERALS] = {
+}, qT[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, VT[FIND_DEPOSITS] = {
+}, qT[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, VT[FIND_MY_CONSTRUCTION_SITES] = {
+}, qT[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VT[FIND_CONSTRUCTION_SITES] = {
+}, qT[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VT[FIND_CREEPS] = {
+}, qT[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, VT[FIND_MY_CREEPS] = {
+}, qT[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, VT[FIND_HOSTILE_CREEPS] = {
+}, qT[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, VT[FIND_DROPPED_RESOURCES] = {
+}, qT[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, VT[FIND_TOMBSTONES] = {
+}, qT[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, VT[FIND_RUINS] = {
+}, qT[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, VT[FIND_FLAGS] = {
+}, qT[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VT[FIND_MY_SPAWNS] = {
+}, qT[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, VT[FIND_HOSTILE_SPAWNS] = {
+}, qT[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, VT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, qT[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VT[FIND_NUKES] = {
+}, qT[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, VT[FIND_POWER_CREEPS] = {
+}, qT[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, VT[FIND_MY_POWER_CREEPS] = {
+}, qT[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, VT[FIND_HOSTILE_POWER_CREEPS] = {
+}, qT[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, VT[FIND_EXIT_TOP] = {
+}, qT[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VT[FIND_EXIT_RIGHT] = {
+}, qT[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VT[FIND_EXIT_BOTTOM] = {
+}, qT[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VT[FIND_EXIT_LEFT] = {
+}, qT[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, VT[FIND_EXIT] = {
+}, qT[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var $T = new pe({}, Sr), eC = new Ut({}, Sr);
+var eC = new pe({}, Sr), tC = new Ut({}, Sr);
 
-function tC(e) {
+function rC(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -46558,16 +46572,16 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var rC = !1;
+var oC = !1;
 
-function oC() {
+function nC() {
 var e, t;
-rC || (Du({
-level: (t = kr()).debug ? vu.DEBUG : vu.INFO,
+oC || (Fu({
+level: (t = kr()).debug ? gu.DEBUG : gu.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
 maxBatchSize: 50
-}), el.info("Bot initialized", {
+}), tl.info("Bot initialized", {
 subsystem: "SwarmBot",
 meta: {
 debug: t.debug,
@@ -46577,11 +46591,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (Yv.getPendingTransfers = function(e) {
+r.getPendingTransfers && (Vv.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (Yv.needsCarrier = function(e) {
+}), r.needsCarrier && (Vv.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (Yv.getActiveRequests = function() {
+}), r.getActiveRequests && (Vv.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -46595,66 +46609,66 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (Vv.predictConsumption = function(e) {
+a.predictConsumption && (qv.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (Vv.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (qv.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (Vv.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (qv.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (Vv.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (qv.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (qv.getActivePowerBanks = function() {
+i.getActivePowerBanks && (jv.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (qv.needsHarvesters = function(e) {
+}), i.needsHarvesters && (jv.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (qv.needsCarriers = function(e) {
+}), i.needsCarriers && (jv.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (qv.requestSpawns = function(e) {
+}), i.requestSpawns && (jv.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-jv.getEmergencyState = function(e) {
+zv.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: to,
-powerBankHarvestingManager: Zc,
-resourceTransferCoordinator: Bf,
-emergencyResponseManager: gi,
-kernel: Mi
+powerBankHarvestingManager: Jc,
+resourceTransferCoordinator: Wf,
+emergencyResponseManager: hi,
+kernel: _i
 }), function(e) {
 var t, r, o, n;
-ep = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : $d.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : $d.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : $d.getLabOverflow
-} : $d;
+tp = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : ep.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : ep.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : ep.getLabOverflow
+} : ep;
 }({
 getLabResourceNeeds: function(e) {
-return wu.getLabResourceNeeds(e);
+return xu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return wu.getLabResourceNeeds(e);
+return xu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return wu.getLabOverflow(e);
+return xu.getLabOverflow(e);
 }
-}), Xi.initialize(), t.profiling && (function() {
+}), Zi.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) cT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) uT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
 for (var e = [], r = 0; r < arguments.length; r++) e[r] = arguments[r];
-return Xi.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
+return Zi.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
 };
 r.__nativeCallsTrackerWrapped = !0, Object.defineProperty(PathFinder, "search", {
 value: r,
@@ -46663,7 +46677,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-cT.warn("Failed to wrap PathFinder.search", {
+uT.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -46671,11 +46685,11 @@ error: String(e)
 }
 }
 }
-}(), uT(e = Creep.prototype, "moveTo", "moveTo"), uT(e, "move", "move"), uT(e, "harvest", "harvest"),
-uT(e, "transfer", "transfer"), uT(e, "withdraw", "withdraw"), uT(e, "build", "build"),
-uT(e, "repair", "repair"), uT(e, "upgradeController", "upgradeController"), uT(e, "attack", "attack"),
-uT(e, "rangedAttack", "rangedAttack"), uT(e, "heal", "heal"), uT(e, "dismantle", "dismantle"),
-uT(e, "say", "say")), function(e) {
+}(), lT(e = Creep.prototype, "moveTo", "moveTo"), lT(e, "move", "move"), lT(e, "harvest", "harvest"),
+lT(e, "transfer", "transfer"), lT(e, "withdraw", "withdraw"), lT(e, "build", "build"),
+lT(e, "repair", "repair"), lT(e, "upgradeController", "upgradeController"), lT(e, "attack", "attack"),
+lT(e, "rangedAttack", "rangedAttack"), lT(e, "heal", "heal"), lT(e, "dismantle", "dismantle"),
+lT(e, "say", "say")), function(e) {
 void 0 === e && (e = Me);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, Te.L1, {
@@ -46862,15 +46876,15 @@ room: e.homeRoom
 }), _.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Mi, Sr, by), XT.initializePathCacheEvents(), HT.initialize(Xm.MEDIUM), om = YT,
-Zt.initialize(), oT.initialize(), rC = !0), Sr.initialize();
-var r = iT.configureForCurrentTick();
-"critical" === r && Game.time % 10 == 0 && el.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
+}(_i, Sr, Oy), ZT.initializePathCacheEvents(), KT.initialize(Zm.MEDIUM), nm = VT,
+Zt.initialize(), nT.initialize(), oC = !0), Sr.initialize();
+var r = sT.configureForCurrentTick();
+"critical" === r && Game.time % 10 == 0 && tl.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = gT();
-if (!1 !== r.enabled && (r.lastRun = Game.time, ET(), function() {
-var e, t, r, o, n = hT(), a = n.footprintOperation, i = vT(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = hT();
+if (!1 !== r.enabled && (r.lastRun = Game.time, TT(), function() {
+var e, t, r, o, n = RT(), a = n.footprintOperation, i = gT(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -46883,15 +46897,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, RT(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, ET(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = gT();
+var e, t, r, n, i, s, c = hT();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : mT), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === dT ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : dT), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === pT ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -46909,10 +46923,10 @@ d && Game.cpu.setShardLimits(m) === OK && _.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !TT())) try {
+}(), !CT())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || ry(s), "interShardPioneer" === c && ty(s);
+"interShardClaimer" !== c && "interShardScout" !== c || oy(s), "interShardPioneer" === c && ry(s);
 }
 } catch (t) {
 e = {
@@ -46927,16 +46941,16 @@ if (e) throw e.error;
 }
 }();
 var n = Tt();
-if (0 === n.length) return Game.time % 100 == 0 && el.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
+if (0 === n.length) return Game.time % 100 == 0 && tl.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), Xi.publishIdleTick(), void el.flush();
-Game.time % 10 == 0 && el.info("SwarmBot loop executing at tick ".concat(Game.time), {
+}), Zi.publishIdleTick(), void tl.flush();
+Game.time % 10 == 0 && tl.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: rC
+systemsInitialized: oC
 }
-}), iT.ensureProcessesRegistered(), Xi.startTick(), cl.clear(), iT.startEventTick(),
-Xi.measureSubsystem("taskBoard", function() {
+}), sT.ensureProcessesRegistered(), Zi.startTick(), ul.clear(), sT.startEventTick(),
+Zi.measureSubsystem("taskBoard", function() {
 var e, t, r = kr(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
 try {
 for (var i = a(function(e) {
@@ -46950,7 +46964,7 @@ rooms: n,
 interval: o
 })), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-em.refreshRoom(c);
+tm.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -46963,20 +46977,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-}), Xi.measureSubsystem("spawns", function() {
+}), Zi.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = gT();
+var e, t, r, o = hT();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = ET();
+var n = TT();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : mT), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : dT), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== vT()) try {
+if (d !== gT()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Cf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Sf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -46994,20 +47008,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = CT().sort(function(e, t) {
+var i = ST().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : mT), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : dT), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== vT()) {
+if (u !== gT()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = wT(u);
+var m = xT(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? kT(i, l, m) : AT() ? bT(i, u, m) : (OT(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (xT(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? AT(i, l, m) : MT() ? OT(i, u, m) : (kT(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (bT(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -47024,8 +47038,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = hT();
-d.footprintOperation = n, RT(d);
+var d = RT();
+d.footprintOperation = n, ET(d);
 }
 }
 })(), function(e) {
@@ -47033,10 +47047,10 @@ var t, r, o = Game.cpu.bucket < kr().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if (!o || tC(s)) {
-var c = Yh(s, Sr.getOrInitSwarmState(s.name));
-Xi.recordSpawnQueue(s.name, c.stats, c.spawned), Xi.recordDefenseAssist(s.name, c.defenseAssist);
-} else Xi.recordDefenseAssist(s.name, []);
+if (!o || rC(s)) {
+var c = Vh(s, Sr.getOrInitSwarmState(s.name));
+Zi.recordSpawnQueue(s.name, c.stats, c.spawned), Zi.recordDefenseAssist(s.name, c.defenseAssist);
+} else Zi.recordDefenseAssist(s.name, []);
 }
 } catch (e) {
 t = {
@@ -47050,21 +47064,21 @@ if (t) throw t.error;
 }
 }
 }(n);
-}), vl.preTick(), Xi.measureSubsystem("processSync", function() {
-py.syncCreepProcesses(), vv.syncRoomProcesses();
-}), Xi.measureSubsystem("kernel", function() {
-iT.runProcesses();
-}), Xi.measureSubsystem("eventQueue", function() {
-iT.processQueuedEvents();
-}), Xi.measureSubsystem("ss2PacketQueue", function() {
-zh.processQueue();
-}), Mi.hasCpuBudget() && Xi.measureSubsystem("powerCreeps", function() {
+}), gl.preTick(), Zi.measureSubsystem("processSync", function() {
+fy.syncCreepProcesses(), gv.syncRoomProcesses();
+}), Zi.measureSubsystem("kernel", function() {
+sT.runProcesses();
+}), Zi.measureSubsystem("eventQueue", function() {
+sT.processQueuedEvents();
+}), Zi.measureSubsystem("ss2PacketQueue", function() {
+Qh.processQueue();
+}), _i.hasCpuBudget() && Zi.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && oy(n);
+void 0 !== n.ticksToLive && ny(n);
 }
 } catch (t) {
 e = {
@@ -47078,18 +47092,18 @@ if (e) throw e.error;
 }
 }
 }();
-}), sT({
-hasCpuBudget: Mi.hasCpuBudget(),
+}), cT({
+hasCpuBudget: _i.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && Xi.measureSubsystem("visualizations", function() {
+}) && Zi.measureSubsystem("visualizations", function() {
 var e;
 !function(e, t) {
 var r, o;
 if (kr().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = $T.getConfig(), s = eC.getConfig();
-$T.setConfig(n.roomVisualizerConfig), n.renderMap && eC.setConfig(n.mapVisualizerConfig);
+var i = eC.getConfig(), s = tC.getConfig();
+eC.setConfig(n.roomVisualizerConfig), n.renderMap && tC.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -47100,10 +47114,10 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-$T.draw(m);
+eC.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
-el.error("Visualization error in ".concat(m.name, ": ").concat(d), {
+tl.error("Visualization error in ".concat(m.name, ": ").concat(d), {
 subsystem: "visualizations",
 room: m.name
 });
@@ -47122,19 +47136,19 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-eC.draw();
+tC.draw();
 } catch (e) {
-d = e instanceof Error ? e.message : String(e), el.error("Map visualization error: ".concat(d), {
+d = e instanceof Error ? e.message : String(e), tl.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-$T.setConfig(i), eC.setConfig(s);
+eC.setConfig(i), tC.setConfig(s);
 }
 }
 }
 }(n, (e = {
-hasCpuBudget: Mi.hasCpuBudget(),
+hasCpuBudget: _i.hasCpuBudget(),
 bucketMode: r,
 bucket: Game.cpu.bucket,
 ownedRoomCount: n.length
@@ -47214,19 +47228,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), vl.reconcileTraffic(), sT({
-hasCpuBudget: Mi.hasCpuBudget(),
+}), gl.reconcileTraffic(), cT({
+hasCpuBudget: _i.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && Xi.measureSubsystem("scheduledTasks", function() {
+}) && Zi.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), sd.run(e);
-}), Sr.persistHeapCache(), Xi.collectProcessStats(Mi.getProcesses().reduce(function(e, t) {
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), cd.run(e);
+}), Sr.persistHeapCache(), Zi.collectProcessStats(_i.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
-}, new Map)), Xi.collectKernelBudgetStats(Mi), Xi.setSkippedProcesses(Mi.getSkippedProcessesThisTick()),
-Xi.finalizeTick(), el.flush();
+}, new Map)), Zi.collectKernelBudgetStats(_i), Zi.setSkippedProcesses(_i.getSkippedProcessesThisTick()),
+Zi.finalizeTick(), tl.flush();
 }
 
-var nC = function() {
+var aC = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !kr().visualizations;
@@ -47234,15 +47248,6 @@ return Ar({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = $T.getConfig(), r = Object.keys(t).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof t[e];
-});
-if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
-var o = e;
-$T.toggle(o);
-var n = $T.getConfig()[o];
-return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t = eC.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
@@ -47250,9 +47255,18 @@ if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.
 var o = e;
 eC.toggle(o);
 var n = eC.getConfig()[o];
+return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t = tC.getConfig(), r = Object.keys(t).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof t[e];
+});
+if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
+var o = e;
+tC.toggle(o);
+var n = tC.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = eC.getConfig();
+var e = tC.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -47375,15 +47389,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), aC = function() {
+}(), iC = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = oT.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = nT.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = oT.getAllShards();
+var e, t, r = nT.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -47405,9 +47419,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (oT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (nT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = oT.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = nT.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -47432,19 +47446,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = oT.getOptimalPortalRoute(e, t);
+var r, o = nT.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (oT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (nT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (oT.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (nT.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Bf.getActiveRequests();
+var e, t, r = Wf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -47465,7 +47479,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = oT.getCurrentShardState();
+var e, t, r = nT.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -47486,7 +47500,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = oT.getActiveTransferTasks();
+var e, t, r, o = nT.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -47507,16 +47521,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = oT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(xf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = nT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(bf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = oT.getMemoryStats();
+var e = nT.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return oT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return nT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = hT().footprintOperation;
+var e, t, r, o = RT().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -47622,9 +47636,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), iC = new aC;
+}(), sC = new iC;
 
-function sC(e) {
+function cC(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -47654,10 +47668,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? sC(e.metadata.usage) : void 0
+params: e.metadata.usage ? cC(e.metadata.usage) : void 0
 };
 });
-return vd({
+return gd({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -47708,12 +47722,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return vd.apply(void 0, s([], i(o), !1));
+return gd.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return pd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return fd("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return yd.form("spawnCreep", [ {
+return vd.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -47747,20 +47761,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return pd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return fd("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += pd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += pd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += yd.button({
+o += '<div style="margin-bottom: 10px;">', o += fd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += fd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += vd.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += yd.button({
+}), o += " ", (o += vd.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return yd.form("configureLogging", [ {
+return vd.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -47785,7 +47799,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return yd.form("configureVisualization", [ {
+return vd.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -47809,18 +47823,18 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += yd.button({
+e += vd.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += yd.button({
+}), e += " ", (e += vd.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += pd("✓ Success message", "green", !0) + "\n", e += pd("⚠ Warning message", "yellow", !0) + "\n",
-e += pd("✗ Error message", "red", !0) + "\n", e += pd("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + pd("colored text", "green") + " normal text\n") + "Bold text: " + pd("important", null, !0) + "\n";
+return e += fd("✓ Success message", "green", !0) + "\n", e += fd("⚠ Warning message", "yellow", !0) + "\n",
+e += fd("✗ Error message", "red", !0) + "\n", e += fd("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + fd("colored text", "green") + " normal text\n") + "Bold text: " + fd("important", null, !0) + "\n";
 }, n([ Xr({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -47866,39 +47880,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var cC = new hv, uC = new nC, lC = new Rv, mC = new tl, dC = new gv, pC = new Ev, fC = new Tv, yC = "__screepsGlobalRuntimeDiagnostics";
+var uC = new Rv, lC = new aC, mC = new Ev, dC = new rl, pC = new hv, fC = new Tv, yC = new Cv, vC = "__screepsGlobalRuntimeDiagnostics";
 
-function vC() {
+function gC() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function gC(e, t) {
+function hC(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function hC(e, t) {
+function RC(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function RC(e) {
+function EC(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function EC(e) {
+function TC(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: gC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: gC(n.switchCount, 0),
-lastTick: hC(n.lastTick, Game.time),
-lastResetTick: hC(n.lastResetTick, Game.time),
-lastSwitchTick: RC(n.lastSwitchTick),
-lastSwitchPreviousTick: RC(n.lastSwitchPreviousTick),
-lastWarningTick: RC(n.lastWarningTick)
+resetCount: hC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: hC(n.switchCount, 0),
+lastTick: RC(n.lastTick, Game.time),
+lastResetTick: RC(n.lastResetTick, Game.time),
+lastSwitchTick: EC(n.lastSwitchTick),
+lastSwitchPreviousTick: EC(n.lastSwitchPreviousTick),
+lastWarningTick: EC(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -47912,19 +47926,19 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var TC = Ju("Main");
+var CC = $u("Main");
 
 xr.register(), function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Qr.initialize(), Zr(cC), Zr(uC), Zr(lC), Zr(mC), Zr(dC), Zr(pC), Zr(fC), Zr(ku),
-Zr(Au), Zr(Mu), Zr(iC), Zr(oo), Zr(Rc), Zr(zc), global.tooangel = qc;
+Qr.initialize(), Zr(uC), Zr(lC), Zr(mC), Zr(dC), Zr(pC), Zr(fC), Zr(yC), Zr(Au),
+Zr(Mu), Zr(_u), Zr(sC), Zr(oo), Zr(Ec), Zr(Qc), global.tooangel = jc;
 var e = global;
 e.botConfig = {
 getConfig: kr,
 updateConfig: Ar
 }, e.botLogger = {
-configureLogger: Du
+configureLogger: Fu
 }, e.botVisualizationManager = f, e.botCacheManager = Re, Qr.exposeToGlobal();
 };
 e ? (Qr.initialize(), Qr.enableLazyLoading(t), Qr.exposeToGlobal()) : t();
@@ -47933,12 +47947,12 @@ try {
 xr.run(), function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : vC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[yC];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : gC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[vC];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[yC] = s, function(e, t) {
-var r, o = EC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[vC] = s, function(e, t) {
+var r, o = TC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -47956,7 +47970,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = EC(e.heapId);
+var n, a = TC(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -47977,14 +47991,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = EC(s.heapId);
+var u = TC(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 }({
-logger: TC
-}), oC();
+logger: CC
+}), nC();
 } catch (e) {
-throw TC.error("Critical error in main loop: ".concat(String(e)), {
+throw CC.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-defense/README.md
+++ b/packages/screeps-defense/README.md
@@ -252,6 +252,15 @@ Emergency manager:
 - Activates safe mode for critical threats
 - Coordinates evacuation if needed
 
+### Emergency helper-room refuel
+
+When a visible urgent defense request cannot afford a defender body, the spawn and
+roles packages may create a `defenseRefuel` hauler demand. Source-adjacent
+containers remain the first source. If those are empty, the hauler may withdraw
+from its own terminal only while at least 5,000 energy remains after the bounded
+100-energy refill action. This keeps the response useful during spawnless-room
+recovery without turning normal terminal reserves into general spawn fuel.
+
 ## Dependencies
 
 This package is a framework package in the screeps monorepo. It should not depend on `packages/screeps-bot` implementation details.

--- a/packages/screeps-defense/src/coordination/defenseRefuelPolicy.ts
+++ b/packages/screeps-defense/src/coordination/defenseRefuelPolicy.ts
@@ -1,0 +1,16 @@
+/**
+ * Emergency energy policy for helper rooms spawning defense reinforcements.
+ *
+ * A terminal may be tapped only during an active defense-refuel assignment and
+ * only above a bounded floor. The fixed CARRY/MOVE refuel body withdraws at
+ * most 100 energy per action, so one action cannot cross the reserve floor.
+ */
+export const DEFENSE_REFUEL_TERMINAL_FLOOR_ENERGY = 5_000;
+const DEFENSE_REFUEL_HAULER_CAPACITY = 100;
+
+export function hasEmergencyDefenseRefuelEnergy(
+  terminal: StructureTerminal | null | undefined,
+): boolean {
+  const energy = terminal?.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0;
+  return energy >= DEFENSE_REFUEL_TERMINAL_FLOOR_ENERGY + DEFENSE_REFUEL_HAULER_CAPACITY;
+}

--- a/packages/screeps-defense/src/index.ts
+++ b/packages/screeps-defense/src/index.ts
@@ -143,6 +143,11 @@ export {
   type DefenseAssistStagingOptions,
 } from "./coordination/defenseAssistStaging";
 
+export {
+  DEFENSE_REFUEL_TERMINAL_FLOOR_ENERGY,
+  hasEmergencyDefenseRefuelEnergy,
+} from "./coordination/defenseRefuelPolicy";
+
 // Emergency Response
 export {
   emergencyResponseManager,

--- a/packages/screeps-defense/test/defenseRefuelPolicy.test.ts
+++ b/packages/screeps-defense/test/defenseRefuelPolicy.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import {
+  DEFENSE_REFUEL_TERMINAL_FLOOR_ENERGY,
+  hasEmergencyDefenseRefuelEnergy,
+} from '../src/coordination/defenseRefuelPolicy';
+
+describe('defense refuel terminal policy', () => {
+  const terminalWithEnergy = (energy: number): StructureTerminal => ({
+    store: {
+      getUsedCapacity: () => energy,
+    },
+  } as unknown as StructureTerminal);
+
+  it('requires enough energy for the bounded refill while preserving the floor', () => {
+    expect(DEFENSE_REFUEL_TERMINAL_FLOOR_ENERGY).to.equal(5_000);
+    expect(hasEmergencyDefenseRefuelEnergy(terminalWithEnergy(5_099))).to.equal(false);
+    expect(hasEmergencyDefenseRefuelEnergy(terminalWithEnergy(5_100))).to.equal(true);
+  });
+
+  it('rejects missing terminals and stores with no energy', () => {
+    expect(hasEmergencyDefenseRefuelEnergy(undefined)).to.equal(false);
+    expect(hasEmergencyDefenseRefuelEnergy(terminalWithEnergy(0))).to.equal(false);
+  });
+});

--- a/packages/screeps-spawn/src/spawn-demand/defenseRefuelDemand.ts
+++ b/packages/screeps-spawn/src/spawn-demand/defenseRefuelDemand.ts
@@ -1,4 +1,7 @@
-import { getActualHostileCreeps } from "@ralphschuler/screeps-defense";
+import {
+  getActualHostileCreeps,
+  hasEmergencyDefenseRefuelEnergy
+} from "@ralphschuler/screeps-defense";
 import type { SwarmCreepMemory } from "@ralphschuler/screeps-memory";
 import type { BodyTemplate } from "../roleDefinitions";
 import { getEffectiveRoomEnergyAvailable } from "../roomEnergy";
@@ -128,7 +131,7 @@ export function getDefenseRefuelSpawnAssignment(homeRoom: string, role: string):
   if (getEffectiveRoomEnergyAvailable(home) >= DEFENSE_REFUEL_ENERGY_THRESHOLD) return null;
   const emergencyRequests = getVisibleEmergencyDefenseRequests(homeRoom);
   if (emergencyRequests.length === 0) return null;
-  if (!canRefuelFromLocalSourceContainers(home)) return null;
+  if (!canRefuelFromLocalSourceContainers(home) && !hasEmergencyDefenseRefuelEnergy(home.terminal)) return null;
 
   const scaleDedicatedRefuel = needsScaledDefenseRefuel(emergencyRequests);
   const refuelerCount = scaleDedicatedRefuel

--- a/packages/screeps-spawn/test/defenseSpawning.test.ts
+++ b/packages/screeps-spawn/test/defenseSpawning.test.ts
@@ -1102,6 +1102,48 @@ describe("defense spawn throttling", () => {
     if (firstAssistIndex >= 0) assert.isBelow(refuelIndex, firstAssistIndex);
   });
 
+  it("keeps emergency refuel visible when source containers are empty but terminal reserve can be tapped", () => {
+    const helper = createRoom([], "W17S29", 2300, 21, 6);
+    const attacked = createRoom([createHostile([RANGED_ATTACK, MOVE, HEAL, MOVE])], "W18S28", 0, 0, 5, false);
+    const terminal = {
+      store: createStore(13_000),
+      cooldown: 0
+    } as unknown as StructureTerminal;
+    (helper as unknown as { terminal: StructureTerminal }).terminal = terminal;
+    const originalFind = helper.find.bind(helper);
+    (helper as unknown as { find: Room["find"] }).find = ((type: FindConstant) => {
+      if (type === FIND_SOURCES) return [createSource()];
+      if (type === FIND_STRUCTURES) return [];
+      return originalFind(type as never);
+    }) as Room["find"];
+    Game.rooms.W17S29 = helper;
+    Game.rooms.W18S28 = attacked;
+    Game.creeps = {
+      hauler1: { spawning: false, memory: { role: "hauler", homeRoom: "W17S29" } },
+      harvester1: { spawning: false, memory: { role: "harvester", homeRoom: "W17S29" } },
+      upgrader1: { spawning: false, memory: { role: "upgrader", homeRoom: "W17S29" } }
+    } as unknown as typeof Game.creeps;
+    (Memory as unknown as { defenseRequests: unknown[] }).defenseRequests = [
+      {
+        roomName: "W18S28",
+        guardsNeeded: 1,
+        rangersNeeded: 1,
+        healersNeeded: 1,
+        urgency: 3,
+        createdAt: Game.time,
+        threat: "spawnless ranged-heal attack"
+      }
+    ];
+
+    const { createSpawnPlan } = require("../src/spawnIntentCompiler") as typeof import("../src/spawnIntentCompiler");
+    const requests = createSpawnPlan(helper, { danger: 0, posture: "eco" } as any).requests;
+    const refuel = requests.find(request => request.role === "hauler" && request.additionalMemory?.task === "defenseRefuel");
+
+    assert.isOk(refuel, "terminal energy should create a visible emergency refuel request");
+    assert.equal(refuel!.priority, SpawnPriority.EMERGENCY);
+    assert.deepEqual(refuel!.body.parts, [CARRY, MOVE]);
+  });
+
   it("scales dedicated defense refuelers when ranged/healer assists are still energy-blocked", () => {
     const helper = createRoom([], "W18S29", 2300, 177, 6);
     const attacked = createRoom([


### PR DESCRIPTION
## Summary

Closes #3210 (recovery slice); follow-up #3364 adds private-server coverage.

## Research

- Local Screeps typings confirm `Creep.withdraw(target, resourceType, amount?)` supports terminal structures.
- Official API reference was reachable directly for `Creep.withdraw` and `StructureTerminal`; SearXNG was attempted but returned HTTP 403 from both configured and local instances.
- Live read-only shard1 evidence showed hostile spawnless recovery while helper terminal energy remained available and local spawn energy was insufficient for defender bodies.

## Changes

- Add shared emergency terminal-refuel policy in `@ralphschuler/screeps-defense`.
- Preserve source-container-first refuel behavior.
- Permit `defenseRefuel` terminal withdrawal only above a 5,000-energy floor and only in the existing urgent defense path.
- Add spawn-planner and hauler behavior coverage.
- Document the cross-package policy.

## Defense impact

- Threat detection: unchanged; existing ally-safe hostile filtering remains authoritative.
- Defensive response: closes helper-room energy starvation before defense-assist spawning.
- Construction adaptation: unchanged; spawn-site recovery can continue after defender refuel.
- Recovery: bounded terminal fallback prevents a safe helper from idling while a spawnless room is under attack.
- CPU/Memory: no new per-room scans or persistent Memory fields.

## Tests

- `npm test -w @ralphschuler/screeps-spawn -- --grep refuel`
- `npm test -w @ralphschuler/screeps-roles -- --grep defenseRefuel`
- `npm run lint -w @ralphschuler/screeps-spawn -- --max-warnings=0`
- `npm run lint -w @ralphschuler/screeps-roles -- --max-warnings=0`
- `npm run lint -w @ralphschuler/screeps-defense -- --max-warnings=0`

Pending broader validation and private-server coverage are tracked separately; the known CI smoke skip blocker is #3347.

## Live evidence

Sanitized only. Current bounded read-only snapshot: one owned mid-level recovery room had non-allied hostile pressure, no built spawn/tower, an active spawn site, and healthy shard CPU/full bucket. Exact room/player/body/coordinate details remain local.

## Deployment impact

No deployment performed from this branch yet. Merge/deploy remains gated on required checks.
