### PR TITLE
fix(memory): prune expired nuke tracking records

### DIFF
--- a/packages/@ralphschuler/screeps-memory/src/pruner.ts
+++ b/packages/@ralphschuler/screeps-memory/src/pruner.ts
@@ -67,6 +67,7 @@ export class MemoryPruner {
     stats.eventLogs = this.pruneEventLogs(MAX_EVENT_LOG_ENTRIES);
     stats.staleIntel = this.pruneStaleIntel(MAX_INTEL_AGE);
     stats.marketHistory = this.pruneMarketHistory(MAX_MARKET_HISTORY_AGE);
+    this.pruneOldNukes();
     this.pruneStaleRoomMemory();
 
     const sizeAfter = this.getRawMemorySize();
@@ -238,18 +239,18 @@ export class MemoryPruner {
 
     let pruned = 0;
 
-    // Remove landed nukes from tracking
+    // Remove landed nukes from tracking while keeping the array dense.
+    // Entries at the current tick remain available to impact-time handling;
+    // only records strictly older than the current tick are expired.
     if (empire.nukesInFlight) {
-      for (const nukeId in empire.nukesInFlight) {
-        const nuke = empire.nukesInFlight[nukeId];
-        if (nuke.impactTick < Game.time) {
-          delete empire.nukesInFlight[nukeId];
-          pruned++;
-        }
-      }
+      const initialCount = empire.nukesInFlight.length;
+      empire.nukesInFlight = empire.nukesInFlight.filter(
+        nuke => nuke.impactTick >= Game.time
+      );
+      pruned += initialCount - empire.nukesInFlight.length;
     }
 
-    // Remove old incoming nuke alerts
+    // Remove old incoming nuke alerts using the same impact boundary.
     if (empire.incomingNukes) {
       const initialCount = empire.incomingNukes.length;
       empire.incomingNukes = empire.incomingNukes.filter(

--- a/packages/@ralphschuler/screeps-memory/test/pruner.test.ts
+++ b/packages/@ralphschuler/screeps-memory/test/pruner.test.ts
@@ -1,0 +1,80 @@
+import { assert } from "chai";
+import type { EmpireMemory, IncomingNukeAlert, NukeInFlight } from "../src/schemas/empireSchemas.ts";
+import { MemoryPruner } from "../src/pruner.ts";
+
+const createNukeAlert = (impactTick: number): IncomingNukeAlert => ({
+  nukeId: `nuke-${impactTick}`,
+  roomName: "W1N1",
+  landingPos: { x: 25, y: 25 },
+  impactTick,
+  timeToLand: Math.max(0, impactTick - 1000),
+  detectedAt: 500,
+  evacuationTriggered: false
+});
+
+const createNukeInFlight = (impactTick: number): NukeInFlight => ({
+  id: `nuke-${impactTick}`,
+  sourceRoom: "W2N2",
+  targetRoom: "W1N1",
+  targetPos: { x: 25, y: 25 },
+  launchTick: 0,
+  impactTick
+});
+
+describe("MemoryPruner nuke tracking", () => {
+  let pruner: MemoryPruner;
+
+  beforeEach(() => {
+    (globalThis as any).Game = {
+      time: 1000,
+      rooms: {},
+      creeps: {},
+      getObjectById: () => null
+    };
+    (globalThis as any).Memory = { creeps: {}, rooms: {} };
+    pruner = new MemoryPruner();
+  });
+
+  it("removes expired nuke records while preserving current and future impacts", () => {
+    const empire = {
+      nukesInFlight: [
+        createNukeInFlight(999),
+        createNukeInFlight(1000),
+        createNukeInFlight(1001)
+      ],
+      incomingNukes: [
+        createNukeAlert(999),
+        createNukeAlert(1000),
+        createNukeAlert(1001)
+      ]
+    } as EmpireMemory;
+    (globalThis as any).Memory.empire = empire;
+
+    const pruned = pruner.pruneOldNukes();
+
+    assert.equal(pruned, 2);
+    assert.deepEqual(empire.nukesInFlight?.map(nuke => nuke.impactTick), [1000, 1001]);
+    assert.deepEqual(empire.incomingNukes?.map(alert => alert.impactTick), [1000, 1001]);
+    assert.equal(Object.keys(empire.nukesInFlight ?? {}).length, 2);
+  });
+
+  it("runs nuke cleanup through the regular pruneAll maintenance path", () => {
+    const empire = {
+      nukesInFlight: [createNukeInFlight(999)],
+      incomingNukes: [createNukeAlert(999)]
+    } as EmpireMemory;
+    (globalThis as any).Memory.empire = empire;
+
+    pruner.pruneAll();
+
+    assert.deepEqual(empire.nukesInFlight, []);
+    assert.deepEqual(empire.incomingNukes, []);
+  });
+
+  it("handles missing empire and nuke arrays safely", () => {
+    assert.equal(pruner.pruneOldNukes(), 0);
+
+    (globalThis as any).Memory.empire = {};
+    assert.equal(pruner.pruneOldNukes(), 0);
+  });
+});

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -5342,7 +5342,7 @@ marketHistory: 0,
 bytesSaved: 0
 };
 t.deadCreeps = this.pruneDeadCreeps(), t.eventLogs = this.pruneEventLogs(20), t.staleIntel = this.pruneStaleIntel(fr),
-t.marketHistory = this.pruneMarketHistory(5e3), this.pruneStaleRoomMemory();
+t.marketHistory = this.pruneMarketHistory(5e3), this.pruneOldNukes(), this.pruneStaleRoomMemory();
 var r = this.getRawMemorySize();
 return t.bytesSaved = Math.max(0, e - r), t.bytesSaved > 0 && U.info("Memory pruning complete", {
 subsystem: "MemoryPruner",
@@ -5413,15 +5413,15 @@ return e.decayTick > Game.time;
 var e = Memory.empire;
 if (!e) return 0;
 var t = 0;
-if (e.nukesInFlight) for (var r in e.nukesInFlight) e.nukesInFlight[r].impactTick < Game.time && (delete e.nukesInFlight[r],
-t++);
-if (e.incomingNukes) {
-var o = e.incomingNukes.length;
-e.incomingNukes = e.incomingNukes.filter(function(e) {
+if (e.nukesInFlight) {
+var r = e.nukesInFlight.length;
+e.nukesInFlight = e.nukesInFlight.filter(function(e) {
 return e.impactTick >= Game.time;
-}), t += o - e.incomingNukes.length;
+}), t += r - e.nukesInFlight.length;
 }
-return t;
+return e.incomingNukes && (r = e.incomingNukes.length, e.incomingNukes = e.incomingNukes.filter(function(e) {
+return e.impactTick >= Game.time;
+}), t += r - e.incomingNukes.length), t;
 }, e.prototype.pruneStaleRoomMemory = function() {
 var e, t, r, o;
 if (!Memory.rooms) return 0;


### PR DESCRIPTION
## Summary

Prune expired nuke tracking records through the normal framework memory-maintenance path and keep tracking arrays dense.

## Linked issue

Closes #3369

## Research

- Local Screeps types: `node_modules/@types/screeps/index.d.ts` (`Nuke.timeToLand`, `Nuke.id`, `FIND_NUKES`).
- Official API reference discovered through local SearXNG: https://docs.screeps.com/api/
- Official docs/types confirm incoming nukes remain visible until landing and current impact-time handling must retain the current tick.
- Repository evidence: `MemoryManager.initialize()` invokes `MemoryPruner.pruneAll()` periodically; nuke policy separately maintains `incomingNukes` and `nukesInFlight`.

## Changes

- Invoke `pruneOldNukes()` from `MemoryPruner.pruneAll()`.
- Replace sparse-array index deletion with dense filtering.
- Retain current/future impacts and remove only strictly expired records in both arrays.
- Add package-local regression tests for boundary behavior, integration, dense arrays, and missing state.

## Defense impact

- Threat detection: no change to detection or ally filtering.
- Defensive response: removes stale nuke state before it can influence later recovery decisions.
- Construction adaptation: no change.
- Recovery: current-tick nuke records remain available to impact handling.
- CPU/Memory impact: bounded linear filtering during existing periodic pruning; prevents stale growth.

## Tests

- `npm test -w @ralphschuler/screeps-memory` — 27 passing.
- `npm run build -w @ralphschuler/screeps-memory` — passed.
- `npm run lint -w @ralphschuler/screeps-memory` — passed.
- Bot Memory Pruner/CoreProcessManager unit subset — 11 passing.
- Broad `npm run build`, typecheck, lint, workspace tests, alliance safety, bundle drift, and deep-import checks — passed.
- Private-server smoke reached server/mod readiness but failed on the existing CLI timeout diagnostics blocker tracked by #3347; no assertion result was claimed from that run.
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities.
- Full dev audit remains tracked by #3335 (6 high advisories).

## Live evidence

A bounded read-only shard1 observation found no incoming nuke in the sampled structural view. Memory telemetry was rate-limited (`429`), so no CPU/task/defense conclusion was inferred. Ally entities were excluded from threat conclusions.

## Follow-ups

- #3360: observer/non-visible nuke discovery coverage.
- #3347: private-server smoke diagnostics/CLI timeout reliability.
- #3335: dev-tool dependency advisories.
