### PR TITLE
fix(ci): preserve private-server exit diagnostics

### DIFF
--- a/packages/screeps-server/README.md
+++ b/packages/screeps-server/README.md
@@ -108,6 +108,8 @@ Expected files:
 - `docker.log`
 - `scenario-<name>.json` for each configured runtime scenario
 
+Failed runs also preserve best-effort Docker/process logs in `docker.log`, stopped-service state and exit codes under `metrics.containerDiagnostics`, and separate assertion/transport outcomes under `metrics.validation`.
+
 `summary.json`/`summary.md` preserve merged and source-specific in-game assertion results:
 
 - `metrics.screepsmodTesting` merged from player sandbox + backend cronjob

--- a/packages/screeps-server/scripts/private-server-harness.d.ts
+++ b/packages/screeps-server/scripts/private-server-harness.d.ts
@@ -36,6 +36,10 @@ export function inspectMemorySnapshot(memory: any, summary: any, now?: Date, opt
 export function prepareArtifactsDir(options: { artifactsDir: string }): void;
 export function formatHarnessError(error: unknown): string;
 export function recordHarnessError(summary: any, error: unknown): string;
+export function summarizeContainerState(output: string): any[];
+export function isTransportFailure(error: unknown): boolean;
+export function updateValidationStatus(summary: any, transportError?: unknown): any;
+export function collectLogs(options: HarnessOptions, summary: any, log: (message: string) => unknown, runShellFn?: (...args: any[]) => Promise<any>): Promise<void>;
 export function writeFailedSummaryForError(options: HarnessOptions, summary: any, error: unknown): Promise<any>;
 export function resolveAvailablePorts(options: {
   serverPort: number;

--- a/packages/screeps-server/scripts/private-server-harness.js
+++ b/packages/screeps-server/scripts/private-server-harness.js
@@ -426,12 +426,17 @@ function runShell(command, commandArgs, options, log, runOptions = {}) {
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0) resolve({ stdout, stderr });
-      else
-        reject(
-          new Error(
-            `${command} ${commandArgs.join(" ")} exited ${code}\n${stderr}`,
-          ),
+      else {
+        const error = new Error(
+          `${command} ${commandArgs.join(" ")} exited ${code}\n${stderr}`,
         );
+        error.command = command;
+        error.commandArgs = commandArgs;
+        error.exitCode = code;
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+      }
     });
   });
 }
@@ -644,6 +649,66 @@ async function collectModSummaryFromCli(options, summary) {
   summary.checks.modResultsPresent = true;
 }
 
+export function summarizeContainerState(output) {
+  const text = String(output ?? "").trim();
+  if (!text) return [];
+
+  const rows = [];
+  for (const line of text.split(/\r?\n/).map(value => value.trim()).filter(Boolean)) {
+    try {
+      const parsed = JSON.parse(line);
+      if (Array.isArray(parsed)) rows.push(...parsed);
+      else if (parsed && typeof parsed === "object") rows.push(parsed);
+    } catch {
+      // Keep malformed Docker output in the raw artifact; do not discard diagnostics.
+    }
+  }
+  if (!rows.length) {
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) return parsed;
+      if (parsed && typeof parsed === "object") return [parsed];
+    } catch {
+      // Non-JSON `docker compose ps` output is still preserved by the caller.
+    }
+  }
+  return rows;
+}
+
+export function isTransportFailure(error) {
+  const message = formatHarnessError(error);
+  return /ECONNREFUSED|ECONNRESET|EPIPE|ETIMEDOUT|Timed out waiting|game time did not advance|API authentication|docker .* exited|server .* (stopped|exited|unavailable)/i.test(message);
+}
+
+export function updateValidationStatus(summary, transportError) {
+  const testSummary = summary.metrics.screepsmodTesting ?? {};
+  const total = Number(testSummary.total ?? 0);
+  const failed = Number(testSummary.failed ?? 0);
+  const skipped = Number(testSummary.skipped ?? 0);
+  const assertionStatus = failed > 0
+    ? "failed"
+    : total <= 0
+      ? "unknown"
+      : skipped > 0
+        ? "incomplete"
+        : "passed";
+
+  summary.metrics.validation = {
+    assertions: {
+      status: assertionStatus,
+      total,
+      passed: Number(testSummary.passed ?? Math.max(0, total - failed - skipped)),
+      failed,
+      skipped,
+    },
+    transport: {
+      status: transportError ? "failed" : "passed",
+      error: transportError ? String(transportError?.message ?? formatHarnessError(transportError)) : null,
+    },
+  };
+  return summary.metrics.validation;
+}
+
 export function summarizeServerLogDiagnostics(logText, sampleLimit = 3) {
   const lines = String(logText ?? "")
     .split(/\r?\n/)
@@ -700,64 +765,93 @@ export function summarizeServerLogDiagnostics(logText, sampleLimit = 3) {
   };
 }
 
-async function collectLogs(options, summary, log) {
-  try {
-    const composeLogs = await runShell(
-      "docker",
-      [
-        "compose",
-        "-f",
-        "docker-compose.ci.yml",
-        "-p",
-        options.projectName,
-        "logs",
-        "--no-color",
-      ],
-      options,
-      log,
-      { cwd: options.serverRoot, capture: true },
-    );
-    let processLogs = { stdout: "", stderr: "" };
+export async function collectLogs(options, summary, log, runShellFn = runShell) {
+  const runBestEffort = async (command, commandArgs, label) => {
     try {
-      processLogs = await runShell(
-        "docker",
-        [
-          "compose",
-          "-f",
-          "docker-compose.ci.yml",
-          "-p",
-          options.projectName,
-          "exec",
-          "-T",
-          "screeps",
-          "sh",
-          "-lc",
-          "cat /screeps/logs/*.log 2>/dev/null || true",
-        ],
+      const result = await runShellFn(
+        command,
+        commandArgs,
         options,
         log,
         { cwd: options.serverRoot, capture: true },
       );
+      return { label, ok: true, exitCode: 0, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
     } catch (error) {
-      summary.errors.push(`process log collection skipped: ${error.message}`);
+      return {
+        label,
+        ok: false,
+        exitCode: Number.isInteger(error?.exitCode) ? error.exitCode : null,
+        stdout: error?.stdout ?? "",
+        stderr: error?.stderr ?? "",
+        error: formatHarnessError(error),
+      };
     }
-    const sanitized =
-      `${composeLogs.stdout}${composeLogs.stderr}\n${processLogs.stdout}${processLogs.stderr}`.replace(
-        /(token|password|secret|key)=([^\s]+)/gi,
-        "$1=[REDACTED]",
-      );
-    fs.writeFileSync(path.join(options.artifactsDir, "docker.log"), sanitized);
-    summary.metrics.serverLogDiagnostics = summarizeServerLogDiagnostics(sanitized);
-    if (!sanitized.includes("[screepsmod-testing] Mod loaded")) {
-      throw new Error(
-        "screepsmod-testing load marker not found in server logs",
-      );
-    }
-    summary.checks.modLoaded = true;
-  } catch (error) {
+  };
+
+  const projectArgs = ["compose", "-f", "docker-compose.ci.yml", "-p", options.projectName];
+  const composeLogs = await runBestEffort(
+    "docker",
+    [...projectArgs, "logs", "--no-color"],
+    "compose logs",
+  );
+  const composeState = await runBestEffort(
+    "docker",
+    [...projectArgs, "ps", "-a", "--format", "json"],
+    "compose ps",
+  );
+  const processLogs = await runBestEffort(
+    "docker",
+    [
+      ...projectArgs,
+      "exec",
+      "-T",
+      "screeps",
+      "sh",
+      "-lc",
+      "cat /screeps/logs/*.log 2>/dev/null || true",
+    ],
+    "process logs",
+  );
+
+  const redact = value => String(value ?? "").replace(
+    /(token|password|secret|key)=([^\s]+)/gi,
+    "$1=[REDACTED]",
+  );
+  const commandOutput = result => [
+    `=== ${result.label} (ok=${result.ok}, exitCode=${result.exitCode ?? "unknown"}) ===`,
+    redact(result.stdout),
+    redact(result.stderr),
+    result.error ? `error: ${redact(result.error)}` : "",
+  ].filter(Boolean).join("\n");
+  const sanitized = [commandOutput(composeLogs), commandOutput(composeState), commandOutput(processLogs)].join("\n\n");
+  fs.writeFileSync(path.join(options.artifactsDir, "docker.log"), sanitized);
+
+  const containerRows = summarizeContainerState(composeState.stdout);
+  summary.metrics.containerDiagnostics = {
+    capturedAt: new Date().toISOString(),
+    composePsRaw: redact(composeState.stdout),
+    containers: containerRows.map(row => ({
+      name: row.Name ?? row.name ?? null,
+      service: row.Service ?? row.service ?? null,
+      state: row.State ?? row.state ?? null,
+      status: row.Status ?? row.status ?? null,
+      exitCode: row.ExitCode ?? row.exitCode ?? null,
+    })),
+    commands: [composeLogs, composeState, processLogs].map(result => ({
+      label: result.label,
+      ok: result.ok,
+      exitCode: result.exitCode,
+      error: result.error ? redact(result.error) : null,
+    })),
+  };
+  summary.metrics.serverLogDiagnostics = summarizeServerLogDiagnostics(sanitized);
+
+  if (!sanitized.includes("[screepsmod-testing] Mod loaded")) {
+    const error = new Error("screepsmod-testing load marker not found in server logs");
     summary.errors.push(`log collection failed: ${error.message}`);
     throw error;
   }
+  summary.checks.modLoaded = true;
 }
 
 export function shouldContinuePolling({ nowMs, endAtMs, polls, maxTicks, ticksAdvanced }) {
@@ -993,13 +1087,17 @@ export async function runPrivateServerTest(options = parseHarnessArgs()) {
       criticalConsoleErrors: summary.metrics.criticalConsoleErrors ?? 0
     };
     validateSmokeSummary(summary, options);
+    updateValidationStatus(summary, null);
     await writeSummary(options, summary, "passed");
     return summary;
   } catch (error) {
     recordHarnessError(summary, error);
-    try {
-      await collectLogs(options, summary, log);
-    } catch {}
+    if (!summary.metrics.containerDiagnostics) {
+      try {
+        await collectLogs(options, summary, log);
+      } catch {}
+    }
+    updateValidationStatus(summary, isTransportFailure(error) ? error : null);
     await writeFailedSummaryForError(options, summary, error);
     throw error;
   } finally {

--- a/packages/screeps-server/test/scripts/private-server-harness.test.ts
+++ b/packages/screeps-server/test/scripts/private-server-harness.test.ts
@@ -7,10 +7,12 @@ import zlib from "node:zlib";
 import {
   buildEnsureBotUserCommand,
   buildSeedRuntimeScenariosCommand,
+  collectLogs,
   createInitialSummary,
   decodeMemoryData,
   hasSmokeValidationEvidence,
   inspectMemorySnapshot,
+  isTransportFailure,
   parseHarnessArgs,
   parseRuntimeWarmupTicks,
   parseScenarioList,
@@ -22,8 +24,10 @@ import {
   resolveScreepsApiConstructor,
   restartScreepsRuntime,
   shouldContinuePolling,
+  summarizeContainerState,
   summarizeServerLogDiagnostics,
   updatePollingProgress,
+  updateValidationStatus,
   validateSmokeSummary,
   writeFailedSummaryForError,
 } from "../../scripts/private-server-harness.js";
@@ -313,6 +317,73 @@ describe("private-server harness module", () => {
     expect(diagnostics.samples.unhandledRejectionsUnknown[0]).to.include("something else exploded");
     expect(diagnostics.samples.dbErrors[0]).to.include("DBERR");
     expect(diagnostics.samples.typeErrors[0]).to.include("reading 'cpu'");
+  });
+
+  it("parses stopped Docker containers without losing exit codes", () => {
+    expect(summarizeContainerState(JSON.stringify({
+      Name: "screeps-ci-screeps-1",
+      Service: "screeps",
+      State: "exited",
+      Status: "Exited (137)",
+      ExitCode: 137,
+    }))).to.deep.equal([{
+      Name: "screeps-ci-screeps-1",
+      Service: "screeps",
+      State: "exited",
+      Status: "Exited (137)",
+      ExitCode: 137,
+    }]);
+    expect(summarizeContainerState("not-json")).to.deep.equal([]);
+  });
+
+  it("separates passed assertions from a failed transport after the server exits", () => {
+    const summary = createInitialSummary(parseHarnessArgs([], {}));
+    summary.metrics.screepsmodTesting = { total: 43, passed: 43, failed: 0, skipped: 0 };
+
+    updateValidationStatus(summary, new Error("connect ECONNREFUSED 127.0.0.1:21027"));
+
+    expect(summary.metrics.validation).to.deep.equal({
+      assertions: { status: "passed", total: 43, passed: 43, failed: 0, skipped: 0 },
+      transport: {
+        status: "failed",
+        error: "connect ECONNREFUSED 127.0.0.1:21027",
+      },
+    });
+    expect(isTransportFailure(new Error("screepsmod-testing skipped 4 runtime checks after warmup"))).to.equal(false);
+  });
+
+  it("keeps incomplete assertions distinct from a transport failure", () => {
+    const summary = createInitialSummary(parseHarnessArgs([], {}));
+    summary.metrics.screepsmodTesting = { total: 47, passed: 43, failed: 0, skipped: 4 };
+
+    updateValidationStatus(summary, new Error("connect ECONNRESET 127.0.0.1:21027"));
+
+    expect(summary.metrics.validation.assertions).to.deep.equal({
+      status: "incomplete",
+      total: 47,
+      passed: 43,
+      failed: 0,
+      skipped: 4,
+    });
+    expect(summary.metrics.validation.transport.status).to.equal("failed");
+  });
+
+  it("preserves Docker state and logs when the service has already exited", async () => {
+    const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "screeps-harness-diagnostics-"));
+    const options = parseHarnessArgs([`--artifactsDir=${artifactsDir}`], {});
+    const summary = createInitialSummary(options);
+    const runShellFn = async (_command: string, args: string[]) => {
+      if (args.includes("logs")) return { stdout: "[screepsmod-testing] Mod loaded\\nserver output", stderr: "" };
+      if (args.includes("ps")) return { stdout: JSON.stringify({ Name: "screeps", State: "exited", ExitCode: 137 }), stderr: "" };
+      return { stdout: "process log", stderr: "" };
+    };
+
+    await collectLogs(options, summary, () => {}, runShellFn);
+
+    const state = summary.metrics.containerDiagnostics;
+    expect(state.containers).to.deep.equal([{ name: "screeps", service: null, state: "exited", status: null, exitCode: 137 }]);
+    expect(fs.readFileSync(path.join(artifactsDir, "docker.log"), "utf8")).to.include("server output");
+    expect(fs.readFileSync(path.join(artifactsDir, "docker.log"), "utf8")).to.include("ExitCode");
   });
 
   it("records mod results, task-board rooms, and critical console errors from Memory", () => {


### PR DESCRIPTION
## Summary

Preserve private-server diagnostics when the Screeps service exits or polling/transport fails after runtime assertions have been collected.

## Linked issue

Refs #3347

## Research

- Local harness evidence from repeated smoke runs showed assertion results were present while final polling/transport could fail before cleanup.
- Local Docker Compose behavior and repository harness contracts were verified.
- SearXNG was attempted for current infrastructure research but remains blocked by the configured backend returning HTTP 403; tracked in #3378.

## Changes

- Capture `docker compose ps -a --format json` before teardown, including container state and exit codes.
- Preserve best-effort Compose and in-container logs in `docker.log` with redaction.
- Record separate assertion completeness and transport outcomes in `metrics.validation`.
- Preserve strict smoke validation; skipped/failed assertions still fail the run.
- Add regression coverage for stopped containers, exit-code parsing, assertion/transport separation, and diagnostics artifacts.
- Document failure artifacts.

## Defense/runtime impact

No game behavior or targeting changes. This improves confidence in private-server defense and recovery gates without weakening them or changing ally safety.

## Tests

- `npx mocha --no-config --require tsx packages/screeps-server/test/scripts/private-server-harness.test.ts --grep "private-server harness module"` — 48 passing
- `npm run check-versions` — pass under Node 24.18.0/npm 11.16.0
- `npm run sync:deps:check` — pass
- `npm run typecheck -w @ralphschuler/screeps-server` — pass
- `npm run test:packages -w @ralphschuler/screeps-server` — 93 passing, 10 pending
- Isolated `spawnless-siege` smoke reached 1,347 ticks, 36 passed/0 failed/1 skipped; correctly failed closed on the existing skipped-runtime gate while preserving `docker.log`, `containerDiagnostics`, and `metrics.validation`.

## Follow-ups

- #3377: unify escort/defender requirement math and strengthen adversarial recovery assertions.
