### PR TITLE
fix(ci): fail private-server validation on transport errors

### DIFF
--- a/packages/screeps-server/docs/README.md
+++ b/packages/screeps-server/docs/README.md
@@ -5,3 +5,14 @@ This directory contains documentation for the Screeps Server package.
 ## Overview
 
 Add documentation files here to be included in the project's combined documentation.
+
+## Harness validation and diagnostics
+
+Private-server summaries are valid only when assertion counts satisfy
+`passed + failed + skipped === total`, the harness status is `passed`, and
+transport status is `passed`. Transport failures remain failures even when all
+observed assertions passed.
+
+Failure diagnostics are best-effort and bounded by `diagnosticTimeoutMs` and
+`diagnosticMaxOutputBytes`. Persisted JSON, Markdown, command output, and error
+text use the shared redaction policy for secret-like fields.

--- a/packages/screeps-server/scripts/analyze-tests.d.ts
+++ b/packages/screeps-server/scripts/analyze-tests.d.ts
@@ -1,0 +1,3 @@
+export function applyHarnessSummary(report: any, harnessSummary: any): any;
+export function buildEmptyReport(): any;
+export function generateReport(): any;

--- a/packages/screeps-server/scripts/analyze-tests.js
+++ b/packages/screeps-server/scripts/analyze-tests.js
@@ -12,6 +12,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from '
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+import { deriveValidation, normalizeAssertionCounts } from './validation-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -114,65 +115,71 @@ function durationSecondsFromSummary(summary) {
   return Math.max(0, (finish - start) / 1000);
 }
 
-function applyHarnessSummary(report, harnessSummary) {
+export function applyHarnessSummary(report, harnessSummary) {
   const summary = harnessSummary?.summary;
-  if (!summary) return;
+  if (!summary) return report;
 
   const testSummary =
     summary.metrics?.screepsmodTesting
     || summary.metrics?.screepsmodTestingPlayer
     || null;
   const backendSummary = summary.metrics?.screepsmodTestingBackend || null;
+  const validation = deriveValidation(summary, testSummary);
+  const validationFailures = [];
 
-  if (testSummary && Number.isFinite(Number(testSummary.total))) {
-    const total = Number(testSummary.total || 0);
-    const failed = Number(testSummary.failed || 0);
-    const skipped = Number(testSummary.skipped || 0);
-    const passed = Math.max(0, total - failed - skipped);
+  if (summary.status && summary.status !== 'passed') validationFailures.push(`harness status: ${summary.status}`);
+  if (validation.transport.status !== 'passed') validationFailures.push('transport failed');
+  if (validation.assertions.status !== 'passed') {
+    validationFailures.push(`assertions ${validation.assertions.status}`);
+  }
+  if (backendSummary) {
+    const backendAssertions = normalizeAssertionCounts(backendSummary);
+    if (backendAssertions.status !== 'passed') {
+      validationFailures.push(`backend assertions ${backendAssertions.status}`);
+    }
+  }
 
+  if (testSummary) {
+    const counts = validation.assertions;
     report.integration.tests.push({
       name: testSummary.source || 'screepsmod-testing',
-      total,
-      passed,
-      failed,
-      skipped,
+      ...counts,
     });
-
     report.integration.passed =
-      failed === 0
+      counts.status === 'passed'
       && summary.checks?.modResultsPresent === true
+      && validation.transport.status === 'passed'
       && summary.status === 'passed';
-
-    report.summary.total += total;
-    report.summary.passed += passed;
-    report.summary.failed += failed;
-    report.summary.skipped += skipped;
+    report.summary.total += counts.total;
+    report.summary.passed += counts.passed;
+    report.summary.failed += counts.failed;
+    report.summary.skipped += counts.skipped;
   }
 
-  if (backendSummary && Number.isFinite(Number(backendSummary.total))) {
-    const total = Number(backendSummary.total || 0);
-    const failed = Number(backendSummary.failed || 0);
-    const skipped = Number(backendSummary.skipped || 0);
-    const passed = Math.max(0, total - failed - skipped);
-
+  if (backendSummary) {
+    const counts = normalizeAssertionCounts(backendSummary);
     report.performance.tests.push({
       name: backendSummary.source || 'screepsmod-testing-backend',
-      total,
-      passed,
-      failed,
-      skipped,
+      ...counts,
     });
-
     report.performance.passed =
-      failed === 0
+      counts.status === 'passed'
       && summary.checks?.modResultsPresent === true
+      && validation.transport.status === 'passed'
       && summary.status === 'passed';
-
-    report.summary.total += total;
-    report.summary.passed += passed;
-    report.summary.failed += failed;
-    report.summary.skipped += skipped;
+    report.summary.total += counts.total;
+    report.summary.passed += counts.passed;
+    report.summary.failed += counts.failed;
+    report.summary.skipped += counts.skipped;
   }
+
+  if (validationFailures.length > 0 && report.summary.failed === 0) report.summary.failed = 1;
+  report.validation = {
+    status: validationFailures.length === 0 ? 'passed' : 'failed',
+    failures: validationFailures,
+    assertions: validation.assertions,
+    transport: validation.transport,
+  };
 
   const elapsedSeconds = durationSecondsFromSummary(summary);
   if (elapsedSeconds > 0) {
@@ -181,9 +188,10 @@ function applyHarnessSummary(report, harnessSummary) {
     report.performance.duration = elapsedSeconds;
     report.packages.duration = elapsedSeconds;
   }
+  return report;
 }
 
-function buildEmptyReport() {
+export function buildEmptyReport() {
   return {
     timestamp: new Date().toISOString(),
     summary: {
@@ -216,7 +224,7 @@ function buildEmptyReport() {
   };
 }
 
-function generateReport() {
+export function generateReport() {
   const report = buildEmptyReport();
 
   const mode = inferHarnessMode();
@@ -318,18 +326,20 @@ function generateAndHandleBaselineComparison(report) {
   }
 }
 
-try {
-  const report = generateReport();
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const report = generateReport();
 
-  if (report.summary.failed > 0) {
-    console.error('❌ Some tests failed');
+    if (report.summary.failed > 0 || report.validation?.status === 'failed') {
+      console.error('❌ Validation failed');
+      process.exit(1);
+    } else {
+      console.log('✅ All tests passed');
+      generateAndHandleBaselineComparison(report);
+      process.exit(0);
+    }
+  } catch (error) {
+    console.error('Error generating report:', error);
     process.exit(1);
-  } else {
-    console.log('✅ All tests passed');
-    generateAndHandleBaselineComparison(report);
-    process.exit(0);
   }
-} catch (error) {
-  console.error('Error generating report:', error);
-  process.exit(1);
 }

--- a/packages/screeps-server/scripts/private-server-harness.d.ts
+++ b/packages/screeps-server/scripts/private-server-harness.d.ts
@@ -3,6 +3,8 @@ export interface HarnessOptions {
   durationMinutes?: number;
   maxTicks?: number;
   tickPollMs?: number;
+  diagnosticTimeoutMs?: number;
+  diagnosticMaxOutputBytes?: number;
   tickRate?: number;
   runtimeWarmupTicks?: number;
   serverPort?: number;
@@ -36,6 +38,7 @@ export function inspectMemorySnapshot(memory: any, summary: any, now?: Date, opt
 export function prepareArtifactsDir(options: { artifactsDir: string }): void;
 export function formatHarnessError(error: unknown): string;
 export function recordHarnessError(summary: any, error: unknown): string;
+export function runShell(command: string, args: string[], options: HarnessOptions, log: (message: string) => unknown, runOptions?: Record<string, unknown>): Promise<any>;
 export function summarizeContainerState(output: string): any[];
 export function isTransportFailure(error: unknown): boolean;
 export function updateValidationStatus(summary: any, transportError?: unknown): any;

--- a/packages/screeps-server/scripts/private-server-harness.js
+++ b/packages/screeps-server/scripts/private-server-harness.js
@@ -8,6 +8,12 @@ import zlib from "node:zlib";
 import { appendCpuBenchmarkSample } from "./cpu-benchmark-model.js";
 import { ensureLiveCloneAuth, seedLiveCloneSnapshot } from "./live-clone-seeder.js";
 import { createServerControlPlane, parseTickRate } from "./server-control-plane.js";
+import {
+  deriveValidation,
+  limitOutput,
+  redactSensitive,
+  redactString,
+} from "./validation-utils.js";
 
 const legacyApiRequire = createRequire(new URL("../../../package.json", import.meta.url));
 const ScreepsAPI = resolveScreepsApiConstructor(legacyApiRequire("screeps-api"));
@@ -61,6 +67,8 @@ export function createLegacyScreepsApiAdapter(ScreepsHttpClient) {
 const DEFAULT_RUNTIME_WARMUP_TICKS = 100;
 const DEFAULT_SMOKE_DURATION_MINUTES = 15;
 const DEFAULT_SMOKE_MAX_TICKS = 10000;
+const DEFAULT_DIAGNOSTIC_TIMEOUT_MS = 30_000;
+const DEFAULT_DIAGNOSTIC_MAX_OUTPUT_BYTES = 256_000;
 const DEFAULT_RUNTIME_SCENARIOS = [
   "default-bootstrap",
   "construction-economy",
@@ -86,6 +94,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_SERVER_ROOT = path.resolve(__dirname, "..");
 const DEFAULT_REPO_ROOT = path.resolve(DEFAULT_SERVER_ROOT, "../..");
+
+function parsePositiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 function parseArgMap(argv) {
   const args = new Map();
@@ -162,6 +175,14 @@ export function parseHarnessArgs(
     ),
     maxTicks: Number(args.get("maxTicks") ?? (mode === "long" ? 72000 : DEFAULT_SMOKE_MAX_TICKS)),
     tickPollMs: Number(args.get("tickPollMs") ?? 10000),
+    diagnosticTimeoutMs: parsePositiveNumber(
+      args.get("diagnosticTimeoutMs"),
+      DEFAULT_DIAGNOSTIC_TIMEOUT_MS,
+    ),
+    diagnosticMaxOutputBytes: parsePositiveNumber(
+      args.get("diagnosticMaxOutputBytes"),
+      DEFAULT_DIAGNOSTIC_MAX_OUTPUT_BYTES,
+    ),
     tickRate: parseTickRate(args.get("tickRate") ?? env.SCREEPS_TICK_RATE ?? 20),
     runtimeWarmupTicks: parseRuntimeWarmupTicks(
       args.get("runtimeWarmupTicks"),
@@ -253,6 +274,8 @@ export function createInitialSummary(options, now = new Date()) {
     tickRate: options.tickRate,
     roomName: options.roomName,
     scenarios: options.scenarios ?? [],
+    diagnosticTimeoutMs: options.diagnosticTimeoutMs,
+    diagnosticMaxOutputBytes: options.diagnosticMaxOutputBytes,
     liveCloneSnapshot: options.liveCloneSnapshot ?? null,
     botBundle: options.botBundle ?? null,
     checks: {},
@@ -293,9 +316,7 @@ export function parseScenarioSeedConfirmationOutput(output) {
 }
 
 function sanitizeScenarioSeedOutput(output) {
-  return String(output ?? "")
-    .replace(/(token|password|secret|key)=([^\s]+)/gi, "$1=[REDACTED]")
-    .slice(0, 4000);
+  return limitOutput(redactString(output), 4000).value;
 }
 
 export function recordScenarioSeedConfirmation(options, summary, output) {
@@ -313,7 +334,7 @@ export function recordScenarioSeedConfirmation(options, summary, output) {
   summary.metrics.scenarioSeedConfirmation = confirmation;
   fs.writeFileSync(
     path.join(options.artifactsDir, SCENARIO_SEED_CONFIRMATION_FILENAME),
-    JSON.stringify(confirmation, null, 2),
+    JSON.stringify(redactSensitive(confirmation), null, 2),
   );
   return confirmation;
 }
@@ -387,7 +408,7 @@ export function formatHarnessError(error) {
 }
 
 export function recordHarnessError(summary, error) {
-  const message = formatHarnessError(error);
+  const message = limitOutput(redactString(formatHarnessError(error)), 4000).value;
   if (!summary.errors.includes(message)) summary.errors.push(message);
   return message;
 }
@@ -403,7 +424,7 @@ function createLogger(options) {
   };
 }
 
-function runShell(command, commandArgs, options, log, runOptions = {}) {
+export function runShell(command, commandArgs, options, log, runOptions = {}) {
   log(`$ ${command} ${commandArgs.join(" ")}`);
   return new Promise((resolve, reject) => {
     const child = spawn(command, commandArgs, {
@@ -412,32 +433,71 @@ function runShell(command, commandArgs, options, log, runOptions = {}) {
       stdio: runOptions.capture ? ["ignore", "pipe", "pipe"] : "inherit",
     });
 
+    const maxOutputBytes = runOptions.maxOutputBytes ?? Number.POSITIVE_INFINITY;
     let stdout = "";
     let stderr = "";
-    if (child.stdout)
-      child.stdout.on("data", (chunk) => {
-        stdout += chunk.toString();
-      });
-    if (child.stderr)
-      child.stderr.on("data", (chunk) => {
-        stderr += chunk.toString();
-      });
+    let outputTruncated = false;
+    let settled = false;
+    let timeout;
 
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve({ stdout, stderr });
-      else {
+    const append = (current, chunk) => {
+      const result = limitOutput(`${current}${chunk.toString()}`, maxOutputBytes);
+      outputTruncated ||= result.truncated;
+      return result.value;
+    };
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      child.removeListener("error", onError);
+      child.removeListener("close", onClose);
+    };
+    const settleReject = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onError = (error) => settleReject(error);
+    const onClose = (code, signal) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (code === 0) {
+        resolve({ stdout, stderr, outputTruncated });
+        return;
+      }
+      const error = new Error(
+        `${command} ${commandArgs.join(" ")} exited ${code ?? "unknown"}${signal ? ` (${signal})` : ""}\n${stderr}`,
+      );
+      error.command = command;
+      error.commandArgs = commandArgs;
+      error.exitCode = code;
+      error.signal = signal;
+      error.stdout = stdout;
+      error.stderr = stderr;
+      error.outputTruncated = outputTruncated;
+      settleReject(error);
+    };
+
+    if (child.stdout) child.stdout.on("data", (chunk) => { stdout = append(stdout, chunk); });
+    if (child.stderr) child.stderr.on("data", (chunk) => { stderr = append(stderr, chunk); });
+    child.once("error", onError);
+    child.once("close", onClose);
+
+    if (Number.isFinite(runOptions.timeoutMs) && runOptions.timeoutMs > 0) {
+      timeout = setTimeout(() => {
         const error = new Error(
-          `${command} ${commandArgs.join(" ")} exited ${code}\n${stderr}`,
+          `Timed out running ${command} ${commandArgs.join(" ")} after ${runOptions.timeoutMs}ms`,
         );
         error.command = command;
         error.commandArgs = commandArgs;
-        error.exitCode = code;
         error.stdout = stdout;
         error.stderr = stderr;
-        reject(error);
-      }
-    });
+        error.outputTruncated = outputTruncated;
+        error.timedOut = true;
+        child.kill("SIGTERM");
+        settleReject(error);
+      }, runOptions.timeoutMs);
+    }
   });
 }
 
@@ -677,35 +737,11 @@ export function summarizeContainerState(output) {
 
 export function isTransportFailure(error) {
   const message = formatHarnessError(error);
-  return /ECONNREFUSED|ECONNRESET|EPIPE|ETIMEDOUT|Timed out waiting|game time did not advance|API authentication|docker .* exited|server .* (stopped|exited|unavailable)/i.test(message);
+  return /ECONNREFUSED|ECONNRESET|EPIPE|ETIMEDOUT|Timed out (?:waiting|running)|game time did not advance|API authentication|docker .* exited|server .* (stopped|exited|unavailable)/i.test(message);
 }
 
 export function updateValidationStatus(summary, transportError) {
-  const testSummary = summary.metrics.screepsmodTesting ?? {};
-  const total = Number(testSummary.total ?? 0);
-  const failed = Number(testSummary.failed ?? 0);
-  const skipped = Number(testSummary.skipped ?? 0);
-  const assertionStatus = failed > 0
-    ? "failed"
-    : total <= 0
-      ? "unknown"
-      : skipped > 0
-        ? "incomplete"
-        : "passed";
-
-  summary.metrics.validation = {
-    assertions: {
-      status: assertionStatus,
-      total,
-      passed: Number(testSummary.passed ?? Math.max(0, total - failed - skipped)),
-      failed,
-      skipped,
-    },
-    transport: {
-      status: transportError ? "failed" : "passed",
-      error: transportError ? String(transportError?.message ?? formatHarnessError(transportError)) : null,
-    },
-  };
+  summary.metrics.validation = deriveValidation(summary, summary.metrics.screepsmodTesting, transportError);
   return summary.metrics.validation;
 }
 
@@ -773,9 +809,21 @@ export async function collectLogs(options, summary, log, runShellFn = runShell) 
         commandArgs,
         options,
         log,
-        { cwd: options.serverRoot, capture: true },
+        {
+          cwd: options.serverRoot,
+          capture: true,
+          timeoutMs: options.diagnosticTimeoutMs ?? DEFAULT_DIAGNOSTIC_TIMEOUT_MS,
+          maxOutputBytes: options.diagnosticMaxOutputBytes ?? DEFAULT_DIAGNOSTIC_MAX_OUTPUT_BYTES,
+        },
       );
-      return { label, ok: true, exitCode: 0, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+      return {
+        label,
+        ok: true,
+        exitCode: 0,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+        outputTruncated: result.outputTruncated === true,
+      };
     } catch (error) {
       return {
         label,
@@ -783,6 +831,7 @@ export async function collectLogs(options, summary, log, runShellFn = runShell) 
         exitCode: Number.isInteger(error?.exitCode) ? error.exitCode : null,
         stdout: error?.stdout ?? "",
         stderr: error?.stderr ?? "",
+        outputTruncated: error?.outputTruncated === true,
         error: formatHarnessError(error),
       };
     }
@@ -813,23 +862,21 @@ export async function collectLogs(options, summary, log, runShellFn = runShell) 
     "process logs",
   );
 
-  const redact = value => String(value ?? "").replace(
-    /(token|password|secret|key)=([^\s]+)/gi,
-    "$1=[REDACTED]",
-  );
+  const maxOutputBytes = options.diagnosticMaxOutputBytes ?? DEFAULT_DIAGNOSTIC_MAX_OUTPUT_BYTES;
+  const sanitize = (value) => limitOutput(redactString(value), maxOutputBytes).value;
   const commandOutput = result => [
-    `=== ${result.label} (ok=${result.ok}, exitCode=${result.exitCode ?? "unknown"}) ===`,
-    redact(result.stdout),
-    redact(result.stderr),
-    result.error ? `error: ${redact(result.error)}` : "",
+    `=== ${result.label} (ok=${result.ok}, exitCode=${result.exitCode ?? "unknown"}, truncated=${result.outputTruncated === true}) ===`,
+    sanitize(result.stdout),
+    sanitize(result.stderr),
+    result.error ? `error: ${sanitize(result.error)}` : "",
   ].filter(Boolean).join("\n");
   const sanitized = [commandOutput(composeLogs), commandOutput(composeState), commandOutput(processLogs)].join("\n\n");
-  fs.writeFileSync(path.join(options.artifactsDir, "docker.log"), sanitized);
+  fs.writeFileSync(path.join(options.artifactsDir, "docker.log"), sanitize(sanitized));
 
   const containerRows = summarizeContainerState(composeState.stdout);
   summary.metrics.containerDiagnostics = {
     capturedAt: new Date().toISOString(),
-    composePsRaw: redact(composeState.stdout),
+    composePsRaw: sanitize(composeState.stdout),
     containers: containerRows.map(row => ({
       name: row.Name ?? row.name ?? null,
       service: row.Service ?? row.service ?? null,
@@ -841,7 +888,7 @@ export async function collectLogs(options, summary, log, runShellFn = runShell) 
       label: result.label,
       ok: result.ok,
       exitCode: result.exitCode,
-      error: result.error ? redact(result.error) : null,
+      error: result.error ? sanitize(result.error) : null,
     })),
   };
   summary.metrics.serverLogDiagnostics = summarizeServerLogDiagnostics(sanitized);
@@ -980,9 +1027,10 @@ export function validateSmokeSummary(summary, options = {}) {
 async function writeSummary(options, summary, status) {
   summary.status = status;
   summary.finishedAt = new Date().toISOString();
+  const persistedSummary = redactSensitive(summary);
   fs.writeFileSync(
     path.join(options.artifactsDir, "summary.json"),
-    JSON.stringify(summary, null, 2),
+    JSON.stringify(persistedSummary, null, 2),
   );
 
   const testSummary = summary.metrics.screepsmodTesting;
@@ -992,13 +1040,17 @@ async function writeSummary(options, summary, status) {
     );
     fs.writeFileSync(
       path.join(options.artifactsDir, `scenario-${scenario}.json`),
-      JSON.stringify({ scenario, status, failures: scenarioResults, summary: testSummary ?? null }, null, 2),
+      JSON.stringify(
+        redactSensitive({ scenario, status, failures: scenarioResults, summary: testSummary ?? null }),
+        null,
+        2,
+      ),
     );
   }
 
   fs.writeFileSync(
     path.join(options.artifactsDir, "summary.md"),
-    `# Screeps ${options.mode} run\n\nStatus: ${status}\n\nStarted: ${summary.startedAt}\nFinished: ${summary.finishedAt}\n\nChecks:\n\n\`\`\`json\n${JSON.stringify(summary.checks, null, 2)}\n\`\`\`\n\nMetrics:\n\n\`\`\`json\n${JSON.stringify(summary.metrics, null, 2)}\n\`\`\`\n\nErrors:\n\n${summary.errors.map((e) => `- ${e}`).join("\n") || "- none"}\n`,
+    `# Screeps ${options.mode} run\n\nStatus: ${status}\n\nStarted: ${summary.startedAt}\nFinished: ${summary.finishedAt}\n\nChecks:\n\n\`\`\`json\n${JSON.stringify(persistedSummary.checks, null, 2)}\n\`\`\`\n\nMetrics:\n\n\`\`\`json\n${JSON.stringify(persistedSummary.metrics, null, 2)}\n\`\`\`\n\nErrors:\n\n${persistedSummary.errors.map((e) => `- ${e}`).join("\n") || "- none"}\n`,
   );
 }
 

--- a/packages/screeps-server/scripts/validation-utils.d.ts
+++ b/packages/screeps-server/scripts/validation-utils.d.ts
@@ -1,0 +1,16 @@
+export interface AssertionCounts {
+  status: "passed" | "failed" | "incomplete" | "unknown" | "inconsistent";
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+export function redactString(value: unknown): string;
+export function redactSensitive(value: unknown): unknown;
+export function limitOutput(value: unknown, maxBytes?: number): { value: string; truncated: boolean };
+export function normalizeAssertionCounts(testSummary?: any): AssertionCounts;
+export function deriveValidation(summary?: any, testSummary?: any, transportError?: unknown): {
+  assertions: AssertionCounts;
+  transport: { status: "passed" | "failed"; error: string | null };
+};

--- a/packages/screeps-server/scripts/validation-utils.js
+++ b/packages/screeps-server/scripts/validation-utils.js
@@ -1,0 +1,82 @@
+const SENSITIVE_KEY = /(?:token|password|secret|api[_-]?key|access[_-]?token|authorization|key)/i;
+const SENSITIVE_ASSIGNMENT = /((?:token|password|secret|api[_-]?key|access[_-]?token|authorization|key)\s*[=:]\s*)(["']?)([^\s,}\]]+)\2/gi;
+const SENSITIVE_JSON = /("?(?:token|password|secret|api[_-]?key|access[_-]?token|authorization|key)"?\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\s]+)/gi;
+const REDACTED = "[REDACTED]";
+
+export function redactString(value) {
+  return String(value ?? "")
+    .replace(SENSITIVE_ASSIGNMENT, `$1${REDACTED}`)
+    .replace(SENSITIVE_JSON, `$1"${REDACTED}"`);
+}
+
+export function redactSensitive(value, seen = new WeakSet()) {
+  if (typeof value === "string") return redactString(value);
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+
+  if (Array.isArray(value)) return value.map((item) => redactSensitive(item, seen));
+
+  const redacted = {};
+  for (const [key, item] of Object.entries(value)) {
+    redacted[key] = SENSITIVE_KEY.test(key) ? REDACTED : redactSensitive(item, seen);
+  }
+  return redacted;
+}
+
+export function limitOutput(value, maxBytes = 256_000) {
+  const text = String(value ?? "");
+  if (maxBytes === Number.POSITIVE_INFINITY) return { value: text, truncated: false };
+  if (!Number.isFinite(maxBytes) || maxBytes < 1) return { value: "", truncated: text.length > 0 };
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return { value: text, truncated: false };
+  return {
+    value: Buffer.from(text, "utf8").subarray(0, maxBytes).toString("utf8"),
+    truncated: true,
+  };
+}
+
+function count(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function normalizeAssertionCounts(testSummary = {}) {
+  const total = count(testSummary.total, 0);
+  const failed = count(testSummary.failed, 0);
+  const skipped = count(testSummary.skipped, 0);
+  const inferredPassed = total !== null && failed !== null && skipped !== null
+    ? Math.max(0, total - failed - skipped)
+    : null;
+  const passed = count(testSummary.passed, inferredPassed ?? 0);
+  const valid = [total, passed, failed, skipped].every((value) => value !== null)
+    && passed + failed + skipped === total;
+
+  let status = "inconsistent";
+  if (valid) {
+    status = total <= 0
+      ? "unknown"
+      : failed > 0
+        ? "failed"
+        : skipped > 0
+          ? "incomplete"
+          : "passed";
+  }
+
+  return { status, total: total ?? 0, passed: passed ?? 0, failed: failed ?? 0, skipped: skipped ?? 0 };
+}
+
+export function deriveValidation(summary = {}, testSummary = summary.metrics?.screepsmodTesting, transportError = null) {
+  const assertions = normalizeAssertionCounts(testSummary ?? {});
+  const existingTransport = summary.metrics?.validation?.transport ?? {};
+  const transportFailed = Boolean(transportError) || existingTransport.status === "failed";
+  return {
+    assertions,
+    transport: {
+      status: transportFailed ? "failed" : "passed",
+      error: transportError
+        ? limitOutput(redactString(transportError?.message ?? String(transportError)), 4000).value
+        : existingTransport.error ?? null,
+    },
+  };
+}

--- a/packages/screeps-server/test/scripts/analyze-tests.test.ts
+++ b/packages/screeps-server/test/scripts/analyze-tests.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import { applyHarnessSummary, buildEmptyReport } from "../../scripts/analyze-tests.js";
+
+describe("server test report validation", () => {
+  it("fails the report when transport fails despite zero assertion failures", () => {
+    const report = buildEmptyReport();
+
+    applyHarnessSummary(report, {
+      mode: "smoke",
+      summary: {
+        status: "failed",
+        checks: { modResultsPresent: true },
+        metrics: {
+          screepsmodTesting: { source: "server", total: 43, passed: 43, failed: 0, skipped: 0 },
+          validation: {
+            assertions: { status: "passed", total: 43, passed: 43, failed: 0, skipped: 0 },
+            transport: { status: "failed", error: "connect ECONNRESET" },
+          },
+        },
+      },
+    });
+
+    expect(report.validation.status).to.equal("failed");
+    expect(report.validation.failures).to.include("transport failed");
+    expect(report.summary.failed).to.equal(1);
+    expect(report.integration.passed).to.equal(false);
+  });
+
+  it("fails the report when assertion counts are inconsistent", () => {
+    const report = buildEmptyReport();
+
+    applyHarnessSummary(report, {
+      mode: "smoke",
+      summary: {
+        status: "passed",
+        checks: { modResultsPresent: true },
+        metrics: {
+          screepsmodTesting: { source: "server", total: 10, passed: 8, failed: 0, skipped: 0 },
+        },
+      },
+    });
+
+    expect(report.validation.status).to.equal("failed");
+    expect(report.validation.failures).to.include("assertions inconsistent");
+    expect(report.integration.passed).to.equal(false);
+    expect(report.summary.failed).to.equal(1);
+  });
+});

--- a/packages/screeps-server/test/scripts/private-server-harness.test.ts
+++ b/packages/screeps-server/test/scripts/private-server-harness.test.ts
@@ -23,6 +23,7 @@ import {
   resolveAvailablePorts,
   resolveScreepsApiConstructor,
   restartScreepsRuntime,
+  runShell,
   shouldContinuePolling,
   summarizeContainerState,
   summarizeServerLogDiagnostics,
@@ -31,8 +32,23 @@ import {
   validateSmokeSummary,
   writeFailedSummaryForError,
 } from "../../scripts/private-server-harness.js";
+import { redactSensitive } from "../../scripts/validation-utils.js";
 
 describe("private-server harness module", () => {
+  it("redacts sensitive object fields and JSON-like strings", () => {
+    const value = redactSensitive({
+      password: "server-secret",
+      nested: { token: "api-secret" },
+      message: '{"password":"server-secret","token":"api-secret"} key=raw-secret',
+    }) as any;
+
+    expect(value.password).to.equal("[REDACTED]");
+    expect(value.nested.token).to.equal("[REDACTED]");
+    expect(value.message).to.not.include("server-secret");
+    expect(value.message).to.not.include("api-secret");
+    expect(value.message).to.not.include("raw-secret");
+  });
+
   it("resolves screeps-api constructors from CommonJS and ESM namespace shapes", () => {
     class Api {}
 
@@ -118,6 +134,8 @@ describe("private-server harness module", () => {
     expect(options.durationMinutes).to.equal(15);
     expect(options.maxTicks).to.equal(10000);
     expect(options.tickPollMs).to.equal(10000);
+    expect(options.diagnosticTimeoutMs).to.equal(30000);
+    expect(options.diagnosticMaxOutputBytes).to.equal(256000);
     expect(options.tickRate).to.equal(20);
     expect(options.serverPort).to.equal(21025);
     expect(options.cliPort).to.equal(21026);
@@ -190,6 +208,13 @@ describe("private-server harness module", () => {
       baseCliPort: 21026,
       attemptedPairs: 1,
     });
+  });
+
+  it("falls back to bounded diagnostic defaults for invalid limits", () => {
+    const options = parseHarnessArgs(["--diagnosticTimeoutMs=invalid", "--diagnosticMaxOutputBytes=0"], {});
+
+    expect(options.diagnosticTimeoutMs).to.equal(30000);
+    expect(options.diagnosticMaxOutputBytes).to.equal(256000);
   });
 
   it("parses long defaults and environment overrides", () => {
@@ -352,6 +377,21 @@ describe("private-server harness module", () => {
     expect(isTransportFailure(new Error("screepsmod-testing skipped 4 runtime checks after warmup"))).to.equal(false);
   });
 
+  it("rejects inconsistent assertion counts instead of marking them passed", () => {
+    const summary = createInitialSummary(parseHarnessArgs([], {}));
+    summary.metrics.screepsmodTesting = { total: 10, passed: 8, failed: 0, skipped: 0 };
+
+    updateValidationStatus(summary, null);
+
+    expect(summary.metrics.validation.assertions).to.deep.equal({
+      status: "inconsistent",
+      total: 10,
+      passed: 8,
+      failed: 0,
+      skipped: 0,
+    });
+  });
+
   it("keeps incomplete assertions distinct from a transport failure", () => {
     const summary = createInitialSummary(parseHarnessArgs([], {}));
     summary.metrics.screepsmodTesting = { total: 47, passed: 43, failed: 0, skipped: 4 };
@@ -366,6 +406,40 @@ describe("private-server harness module", () => {
       skipped: 4,
     });
     expect(summary.metrics.validation.transport.status).to.equal("failed");
+  });
+
+  it("captures stream output after process exit and bounds diagnostic output", async () => {
+    const options = parseHarnessArgs([], {});
+    const result = await runShell(
+      process.execPath,
+      ["-e", "process.stdout.write('tail'.repeat(100)); process.exit(0)"],
+      options,
+      () => {},
+      { capture: true, maxOutputBytes: 32, timeoutMs: 1000 },
+    );
+
+    expect(result.stdout).to.include("tail");
+    expect(Buffer.byteLength(result.stdout)).to.be.at.most(32);
+    expect(result.outputTruncated).to.equal(true);
+  });
+
+  it("terminates bounded diagnostic commands that exceed their timeout", async () => {
+    const options = parseHarnessArgs([], {});
+    let error: any;
+    try {
+      await runShell(
+        process.execPath,
+        ["-e", "setTimeout(() => {}, 1000)"],
+        options,
+        () => {},
+        { capture: true, timeoutMs: 20, maxOutputBytes: 32 },
+      );
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error?.timedOut).to.equal(true);
+    expect(error?.message).to.match(/Timed out running/);
   });
 
   it("preserves Docker state and logs when the service has already exited", async () => {


### PR DESCRIPTION
## Summary

Private-server validation now fails closed when transport/harness failures occur, even if assertion counts are zero-failure.

## Linked issue

Closes #3381

## Research

- Local Screeps types confirm nuke/event APIs; this change is test infrastructure only.
- SearXNG was unavailable (configured backend returned HTTP 403); no external dependency was added.
- Existing harness contracts and #3347 diagnostics flow were used as the compatibility boundary.

## Changes

- Shared validation/redaction utilities enforce `passed + failed + skipped === total`.
- Transport/harness status is consumed by `analyze-tests.js`; false-green reports exit nonzero.
- `runShell` waits for child `close`, bounds captured output, and supports diagnostic timeouts.
- Persisted JSON/Markdown/docker diagnostics redact secret-like key/value and JSON fields.
- Added focused harness/report tests and package documentation.

## Defense impact

- Threat detection: no game-runtime behavior changed.
- Defensive response: validation failures can no longer mask defense/runtime regressions.
- Construction adaptation: unchanged.
- Recovery: unchanged.
- CPU/Memory impact: diagnostics only; captured output and command duration are bounded.

## Tests

- `npx mocha --no-config --require tsx packages/screeps-server/test/scripts/private-server-harness.test.ts packages/screeps-server/test/scripts/analyze-tests.test.ts` — 55 passing.
- `npm run test:packages -w @ralphschuler/screeps-server` — 99 passing, 10 pending.
- `npm run typecheck -w @ralphschuler/screeps-server` — passed.
- `npm run build` — passed.
- `npm run lint:all` — passed for configured workspaces.
- `npm run check:alliance-safety` — passed.
- `npm run sync:deps:check` — passed.
- `npm run check:no-deep-dist-imports` — passed.
- Private-server smoke — running; result will be added after completion.

## Follow-up issues

- Existing #3375/#3364 remain the live spawnless-recovery and adversarial scenario workstream.
- Existing #3378 tracks SearXNG access restoration.
