### PR TITLE
fix(ci): fail closed when private-server evidence is missing

### DIFF
--- a/packages/screeps-server/package.json
+++ b/packages/screeps-server/package.json
@@ -27,7 +27,7 @@
     "cpu:snapshot": "node scripts/export-live-structural-snapshot.js",
     "cpu:benchmark": "node scripts/run-cpu-benchmark.js",
     "cpu:arena": "node scripts/run-arena-benchmark.js",
-    "posttest": "node scripts/analyze-tests.js"
+    "posttest": "node scripts/analyze-tests.js --mode=smoke"
   },
   "keywords": [
     "screeps",

--- a/packages/screeps-server/scripts/analyze-tests.d.ts
+++ b/packages/screeps-server/scripts/analyze-tests.d.ts
@@ -1,3 +1,7 @@
 export function applyHarnessSummary(report: any, harnessSummary: any): any;
 export function buildEmptyReport(): any;
+export function buildReport(options?: any): any;
+export function inferHarnessMode(): string | null;
+export function generateMarkdown(report: any): string;
 export function generateReport(): any;
+export function markMissingHarnessEvidence(report: any, mode: string | null): any;

--- a/packages/screeps-server/scripts/analyze-tests.js
+++ b/packages/screeps-server/scripts/analyze-tests.js
@@ -8,7 +8,7 @@
  * and writes machine-readable + human-readable artifacts.
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
@@ -30,71 +30,40 @@ function safeReadJson(path) {
   }
 }
 
-function inferHarnessMode() {
+export function inferHarnessMode() {
+  let original = [];
   try {
-    const argvRaw = process.env.npm_config_argv;
-    if (argvRaw) {
-      const parsed = JSON.parse(argvRaw);
-      const tokens = [
-        ...(Array.isArray(parsed?.original) ? parsed.original : []),
-        process.env.npm_lifecycle_event,
-        ...process.argv,
-      ]
-        .filter(Boolean)
-        .map((value) => String(value).toLowerCase());
-
-      if (tokens.some((token) => token.includes('test:smoke') || token === 'smoke')) return 'smoke';
-      if (tokens.some((token) => token.includes('test:long') || token === 'long')) return 'long';
-      if (tokens.some((token) => token.includes('test:integration'))) return 'smoke';
-      if (tokens.some((token) => token.includes('smoke-alt'))) return 'smoke-alt';
-      if (tokens.some((token) => token.includes('test:packages'))) return 'packages';
-      if (tokens.some((token) => token.includes('test:performance'))) return 'long';
-      if (tokens.some((token) => token.includes('test:server'))) return 'long';
-      const modeArg = tokens
-        .filter((token) => token.startsWith('--mode='))
-        .map((token) => token.replace(/^--mode=/, ''))[0];
-      if (modeArg) return modeArg;
-      const hasModeFlag = tokens.indexOf('--mode');
-      if (hasModeFlag >= 0 && tokens[hasModeFlag + 1]) {
-        return tokens[hasModeFlag + 1];
-      }
-    }
+    const parsed = process.env.npm_config_argv ? JSON.parse(process.env.npm_config_argv) : null;
+    original = Array.isArray(parsed?.original) ? parsed.original : [];
   } catch {
-    // fallthrough
+    // Ignore malformed npm metadata and rely on lifecycle/process arguments.
+  }
+
+  const tokens = [
+    ...original,
+    process.env.npm_lifecycle_event,
+    ...process.argv,
+  ]
+    .filter(Boolean)
+    .map((value) => String(value).toLowerCase());
+
+  if (tokens.some((token) => token.includes('test:smoke') || token === 'smoke')) return 'smoke';
+  if (tokens.some((token) => token.includes('test:long') || token === 'long')) return 'long';
+  if (tokens.some((token) => token.includes('test:integration'))) return 'smoke';
+  if (tokens.some((token) => token.includes('smoke-alt'))) return 'smoke-alt';
+  if (tokens.some((token) => token.includes('test:packages'))) return 'packages';
+  if (tokens.some((token) => token.includes('test:performance'))) return 'long';
+  if (tokens.some((token) => token.includes('test:server'))) return 'long';
+  const modeArg = tokens
+    .filter((token) => token.startsWith('--mode='))
+    .map((token) => token.replace(/^--mode=/, ''))[0];
+  if (modeArg) return modeArg;
+  const hasModeFlag = tokens.indexOf('--mode');
+  if (hasModeFlag >= 0 && tokens[hasModeFlag + 1]) {
+    return tokens[hasModeFlag + 1];
   }
 
   return null;
-}
-
-function inferModeFromArtifacts() {
-  if (!existsSync(ARTIFACT_DIR)) return null;
-  let selected = null;
-  let bestMtime = -1;
-
-  try {
-    const entries = readdirSync(ARTIFACT_DIR, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
-
-    for (const entry of entries) {
-      const summaryPath = join(ARTIFACT_DIR, entry, 'summary.json');
-      if (!existsSync(summaryPath)) continue;
-
-      const { mtimeMs } = statSync(summaryPath);
-      if (mtimeMs <= bestMtime) continue;
-
-      const summary = safeReadJson(summaryPath);
-      if (!summary || typeof summary !== 'object') continue;
-      if (!['smoke', 'long', 'packages', 'integration', 'performance', 'smoke-alt'].includes(entry)) continue;
-
-      selected = entry;
-      bestMtime = mtimeMs;
-    }
-  } catch {
-    return null;
-  }
-
-  return selected;
 }
 
 function readHarnessSummary(mode) {
@@ -127,7 +96,10 @@ export function applyHarnessSummary(report, harnessSummary) {
   const validation = deriveValidation(summary, testSummary);
   const validationFailures = [];
 
-  if (summary.status && summary.status !== 'passed') validationFailures.push(`harness status: ${summary.status}`);
+  if (summary.status !== 'passed') {
+    validationFailures.push(`harness status: ${summary.status ?? 'missing'}`);
+  }
+  if (summary.checks?.modResultsPresent !== true) validationFailures.push('mod results missing');
   if (validation.transport.status !== 'passed') validationFailures.push('transport failed');
   if (validation.assertions.status !== 'passed') {
     validationFailures.push(`assertions ${validation.assertions.status}`);
@@ -191,6 +163,21 @@ export function applyHarnessSummary(report, harnessSummary) {
   return report;
 }
 
+export function markMissingHarnessEvidence(report, mode) {
+  const reason = mode
+    ? `harness summary missing for mode: ${mode}`
+    : 'harness mode could not be inferred; required harness evidence is missing';
+
+  report.summary.failed = Math.max(1, report.summary.failed);
+  report.validation = {
+    status: 'failed',
+    failures: [reason],
+    assertions: normalizeAssertionCounts(),
+    transport: { status: 'unknown', error: null },
+  };
+  return report;
+}
+
 export function buildEmptyReport() {
   return {
     timestamp: new Date().toISOString(),
@@ -224,30 +211,31 @@ export function buildEmptyReport() {
   };
 }
 
-export function generateReport() {
+export function buildReport({ mode = inferHarnessMode(), harnessSummary = readHarnessSummary(mode) } = {}) {
   const report = buildEmptyReport();
-
-  const mode = inferHarnessMode();
-  const harnessSummary = readHarnessSummary(mode);
-
-  if (harnessSummary && harnessSummary.summary && mode !== 'packages') {
-    applyHarnessSummary(report, harnessSummary);
-  }
+  report.mode = mode;
 
   if (mode === 'packages') {
-    // package suite output is intentionally left as placeholders until package runner JSON reporting is added.
+    // Package-only runs are explicit and do not require the private-server harness summary.
     report.packages.passed = true;
+  } else if (harnessSummary && harnessSummary.summary) {
+    applyHarnessSummary(report, harnessSummary);
+  } else {
+    markMissingHarnessEvidence(report, mode);
   }
 
-  if (report.integration.tests.length === 0) {
+  if (report.integration.tests.length === 0 && mode !== 'packages' && report.validation?.status !== 'failed') {
     report.integration.passed = true;
   }
-  if (report.performance.tests.length === 0) {
+  if (report.performance.tests.length === 0 && mode !== 'packages' && report.validation?.status !== 'failed') {
     report.performance.passed = true;
   }
-  if (report.packages.tests.length === 0 && !report.packages.passed) {
-    report.packages.passed = true;
-  }
+
+  return report;
+}
+
+export function generateReport() {
+  const report = buildReport();
 
   writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2));
   console.log(`✅ Test results written to ${REPORT_PATH}`);
@@ -265,9 +253,18 @@ function formatMetric(value, decimals, fallback = 'N/A') {
     : fallback;
 }
 
-function generateMarkdown(report) {
+export function generateMarkdown(report) {
   const passed = report.summary.failed === 0;
   const emoji = passed ? '✅' : '❌';
+  const integrationStatus = report.integration.tests.length === 0
+    ? 'Not run'
+    : report.integration.passed ? 'Passed' : 'Failed';
+  const performanceStatus = report.performance.tests.length === 0
+    ? 'Not run'
+    : report.performance.passed ? 'Passed' : 'Failed';
+  const packagesStatus = report.mode === 'packages'
+    ? report.packages.passed ? 'Passed' : 'Failed'
+    : report.packages.tests.length === 0 ? 'Not run' : report.packages.passed ? 'Passed' : 'Failed';
 
   return `# 🧪 Server Test Results ${emoji}
 
@@ -281,15 +278,20 @@ function generateMarkdown(report) {
 - **Skipped**: ⏭️ ${report.summary.skipped}
 - **Duration**: ${report.summary.duration.toFixed(2)}s
 
+## Validation
+
+${report.validation?.status === 'failed' ? '❌' : '✅'} **Status**: ${report.validation?.status ?? 'not required'}
+${report.validation?.failures?.length ? report.validation.failures.map((failure) => `- ${failure}`).join('\n') : '- none'}
+
 ## Integration Tests
 
-${report.integration.passed ? '✅' : '❌'} **Status**: ${report.integration.passed ? 'Passed' : 'Failed'}
+${integrationStatus === 'Passed' ? '✅' : integrationStatus === 'Failed' ? '❌' : '⏭️'} **Status**: ${integrationStatus}
 - **Duration**: ${report.integration.duration.toFixed(2)}s
 - **Tests**: ${report.integration.tests.length}
 
 ## Performance Tests
 
-${report.performance.passed ? '✅' : '❌'} **Status**: ${report.performance.passed ? 'Passed' : 'Failed'}
+${performanceStatus === 'Passed' ? '✅' : performanceStatus === 'Failed' ? '❌' : '⏭️'} **Status**: ${performanceStatus}
 - **Duration**: ${report.performance.duration.toFixed(2)}s
 - **Tests**: ${report.performance.tests.length}
 
@@ -301,7 +303,7 @@ ${report.performance.passed ? '✅' : '❌'} **Status**: ${report.performance.pa
 
 ## Framework Package Tests
 
-${report.packages.passed ? '✅' : '❌'} **Status**: ${report.packages.passed ? 'Passed' : 'Failed'}
+${packagesStatus === 'Passed' ? '✅' : packagesStatus === 'Failed' ? '❌' : '⏭️'} **Status**: ${packagesStatus}
 - **Duration**: ${report.packages.duration.toFixed(2)}s
 - **Tests**: ${report.packages.tests.length}
 

--- a/packages/screeps-server/test/scripts/analyze-tests.test.ts
+++ b/packages/screeps-server/test/scripts/analyze-tests.test.ts
@@ -1,5 +1,11 @@
 import { expect } from "chai";
-import { applyHarnessSummary, buildEmptyReport } from "../../scripts/analyze-tests.js";
+import {
+  applyHarnessSummary,
+  buildEmptyReport,
+  buildReport,
+  generateMarkdown,
+  inferHarnessMode,
+} from "../../scripts/analyze-tests.js";
 
 describe("server test report validation", () => {
   it("fails the report when transport fails despite zero assertion failures", () => {
@@ -44,5 +50,84 @@ describe("server test report validation", () => {
     expect(report.validation.failures).to.include("assertions inconsistent");
     expect(report.integration.passed).to.equal(false);
     expect(report.summary.failed).to.equal(1);
+  });
+
+  it("fails closed when a required harness summary is missing", () => {
+    const report = buildReport({ mode: "smoke", harnessSummary: null });
+
+    expect(report.validation.status).to.equal("failed");
+    expect(report.validation.failures).to.deep.equal(["harness summary missing for mode: smoke"]);
+    expect(report.summary.failed).to.equal(1);
+    expect(report.integration.passed).to.equal(false);
+    expect(generateMarkdown(report)).to.include("harness summary missing for mode: smoke");
+  });
+
+  it("fails closed when a harness summary has zero assertions", () => {
+    const report = buildReport({
+      mode: "long",
+      harnessSummary: {
+        mode: "long",
+        summary: {
+          status: "passed",
+          checks: { modResultsPresent: true },
+          metrics: {
+            screepsmodTesting: { source: "server", total: 0, passed: 0, failed: 0, skipped: 0 },
+          },
+        },
+      },
+    });
+
+    expect(report.validation.status).to.equal("failed");
+    expect(report.validation.failures).to.include("assertions unknown");
+    expect(report.summary.failed).to.equal(1);
+    expect(report.integration.passed).to.equal(false);
+  });
+
+  it("fails closed when required harness status or mod evidence is missing", () => {
+    const report = buildReport({
+      mode: "smoke",
+      harnessSummary: {
+        mode: "smoke",
+        summary: {
+          checks: { modResultsPresent: false },
+          metrics: {
+            screepsmodTesting: { source: "server", total: 1, passed: 1, failed: 0, skipped: 0 },
+          },
+        },
+      },
+    });
+
+    expect(report.validation.status).to.equal("failed");
+    expect(report.validation.failures).to.include("harness status: missing");
+    expect(report.validation.failures).to.include("mod results missing");
+    expect(report.summary.failed).to.equal(1);
+  });
+
+  it("recognizes an explicit mode without npm_config_argv metadata", () => {
+    const originalArgv = process.argv;
+    const originalNpmArgv = process.env.npm_config_argv;
+    const originalLifecycle = process.env.npm_lifecycle_event;
+
+    try {
+      process.argv = ["node", "analyze-tests.js", "--mode=packages"];
+      delete process.env.npm_config_argv;
+      delete process.env.npm_lifecycle_event;
+      expect(inferHarnessMode()).to.equal("packages");
+    } finally {
+      process.argv = originalArgv;
+      if (originalNpmArgv === undefined) delete process.env.npm_config_argv;
+      else process.env.npm_config_argv = originalNpmArgv;
+      if (originalLifecycle === undefined) delete process.env.npm_lifecycle_event;
+      else process.env.npm_lifecycle_event = originalLifecycle;
+    }
+  });
+
+  it("keeps package-only reporting explicitly valid without a harness summary", () => {
+    const report = buildReport({ mode: "packages", harnessSummary: null });
+
+    expect(report.validation).to.equal(undefined);
+    expect(report.packages.passed).to.equal(true);
+    expect(report.summary.failed).to.equal(0);
+    expect(generateMarkdown(report)).to.include("⏭️ **Status**: Not run");
   });
 });


### PR DESCRIPTION
## Summary

Make private-server report generation fail closed instead of treating missing or empty harness evidence as green.

## Linked issue

Closes #3383

## Research

- Local `packages/screeps-server` harness and validation contracts are authoritative for this CI path.
- SearXNG was attempted for external research but was unavailable: configured backend returned HTTP 403. No external mechanics assumptions were needed.
- Review identified and addressed stale artifact inference, direct-mode argument handling, missing status/mod evidence, and package-only report clarity.

## Changes

- Require an explicit/current harness mode; do not select arbitrary stale summaries by mtime.
- Fail reports when the required summary is missing, status is absent/non-passed, mod results are absent, transport fails, or assertions are zero/inconsistent.
- Expose validation failure reasons in JSON and Markdown reports.
- Keep explicit package-only reporting valid and mark unrelated sections as not run.
- Add TypeScript declarations and behavior tests.

## Defense impact

- Strengthens the release gate for private-server defense/runtime validation.
- Prevents false-green smoke/long/performance validation from masking defense regressions.
- No live game behavior or ally classification changed.

## Tests

- `npx mocha --no-config --require tsx packages/screeps-server/test/scripts/analyze-tests.test.ts` — 7 passing
- `npm run test:packages -w @ralphschuler/screeps-server` — 105 passing, 10 pending (Node 24)
- `npm run typecheck -w @ralphschuler/screeps-server` — passed
- `npm run lint:all -- --max-warnings=0` — passed
- `npm run test:server:smoke` — passed: player 23/23, backend 24/24, runtime warmed
- `npm run build` — passed under Node 24
- Full `npm run verify` is running under Node 24.

## Live evidence

Read-only shard1 observation remained structurally available but Memory-backed diagnostics returned HTTP 429; existing #3121 was updated. No hostile, nuke, or destruction trend was observed; permanent allies were not classified hostile.

## Follow-up issues

- #3384 tracks active-defender counting for safe-mode/evacuation decisions.
- #3121 remains open for recurring live Memory API diagnostics rate limiting.
