### PR TITLE
fix(intershard): step onto portal tiles

### DIFF
--- a/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
+++ b/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
@@ -65,6 +65,8 @@ export interface CreepState {
   targetId?: Id<_HasId>;
   /** Serialized target position for actions without a persistent object */
   targetPos?: { x: number; y: number; roomName: string };
+  /** Exact movement range when the action supplied one */
+  targetRange?: number;
   /** Room name target (for moveToRoom actions) */
   targetRoom?: string;
   /** Tick when this state was entered */

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/interShardPioneer.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/interShardPioneer.ts
@@ -26,7 +26,9 @@ function moveToPortal(ctx: CreepContext, memory: InterShardMemoryFields): CreepA
   if (ctx.room.name !== memory.portalRoom) return { type: "moveToRoom", roomName: memory.portalRoom };
   const portal = findPortal(ctx.room, memory.targetShard);
   if (!portal) return { type: "idle" };
-  return { type: "moveTo", target: portal.pos };
+  // A portal only transfers a creep standing on its tile. Cartographer's
+  // default target range is 1, which leaves inter-shard pioneers adjacent forever.
+  return { type: "moveTo", target: { pos: portal.pos, range: 0 } };
 }
 
 function getSpawnConstructionSite(ctx: CreepContext): ConstructionSite | undefined {

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/interShardClaim.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/interShardClaim.ts
@@ -46,7 +46,9 @@ function moveToPortal(ctx: CreepContext, memory: InterShardClaimMemory): CreepAc
   if (ctx.room.name !== memory.portalRoom) return { type: "moveToRoom", roomName: memory.portalRoom };
   const portal = findPortal(ctx.room, memory.targetShard);
   if (!portal) return { type: "idle" };
-  return { type: "moveTo", target: portal.pos };
+  // A portal only transfers a creep standing on its tile. Cartographer's
+  // default target range is 1, which leaves inter-shard creeps adjacent forever.
+  return { type: "moveTo", target: { pos: portal.pos, range: 0 } };
 }
 
 function isSafeNeutralClaimRoom(room: Room): boolean {

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/stateMachine.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/stateMachine.ts
@@ -268,7 +268,7 @@ function isStateComplete(state: CreepState | undefined, ctx: CreepContext): bool
           state.targetPos.y,
           state.targetPos.roomName
         );
-        return ctx.creep.pos.inRangeTo(targetPos, 1);
+        return ctx.creep.pos.inRangeTo(targetPos, state.targetRange ?? 1);
       }
 
       return false;
@@ -303,10 +303,14 @@ function actionToState(action: CreepAction, _ctx: CreepContext): CreepState {
     state.targetRoom = action.roomName;
   }
 
-  // Store serialized target position for moveTo actions without stable IDs (e.g., RoomPosition)
+  // Store serialized target position for move actions without stable IDs.
   if (action.type === "moveTo" || action.type === "remoteMoveTo") {
-    const pos = "pos" in action.target ? action.target.pos : action.target;
+    const target = action.target;
+    const pos = "pos" in target ? target.pos : target;
     state.targetPos = { x: pos.x, y: pos.y, roomName: pos.roomName };
+    if ("range" in target && typeof target.range === "number") {
+      state.targetRange = target.range;
+    }
   }
 
   // Store additional data based on action type
@@ -404,7 +408,13 @@ function stateToAction(state: CreepState): CreepAction | null {
           state.targetPos.y,
           state.targetPos.roomName
         );
-        return { type: "moveTo", target: targetPos };
+        return {
+          type: "moveTo",
+          target:
+            state.targetRange === undefined
+              ? targetPos
+              : { pos: targetPos, range: state.targetRange }
+        };
       }
 
       return null;

--- a/packages/@ralphschuler/screeps-roles/src/crossShardCarrier.ts
+++ b/packages/@ralphschuler/screeps-roles/src/crossShardCarrier.ts
@@ -204,11 +204,12 @@ function handleEnteringPortal(
     return;
   }
 
-  // Move to portal
-  cachedMoveTo(creep, targetPortal, { cacheTtl: 20 });
+  // Move onto the portal tile. A default object target stops at range 1 and
+  // never triggers cross-shard traversal.
+  cachedMoveTo(creep, { pos: targetPortal.pos, range: 0 }, { cacheTtl: 20 });
 
-  // Check if we're adjacent to portal (about to enter)
-  if (creep.pos.isNearTo(targetPortal)) {
+  // Report only after the creep reaches the exact traversal tile.
+  if (creep.pos.isEqualTo(targetPortal.pos)) {
     logger.info(
       `CrossShardCarrier ${creep.name} entering portal to ${request.targetShard}`,
       { subsystem: "CrossShardCarrier" }

--- a/packages/@ralphschuler/screeps-roles/src/framework/types.ts
+++ b/packages/@ralphschuler/screeps-roles/src/framework/types.ts
@@ -33,8 +33,24 @@ export interface CreepState {
   action: string;
   /** Target ID for the action */
   targetId?: Id<_HasId>;
+  /** Serialized target position for movement actions */
+  targetPos?: { x: number; y: number; roomName: string };
+  /** Exact movement range when the action supplied one */
+  targetRange?: number;
   /** State-specific data */
   data?: unknown;
+}
+
+/**
+ * A movement target with an explicit acceptable range.
+ *
+ * Portal traversal requires range 0 because a creep must step onto the
+ * portal tile; the movement libraries otherwise default object/position
+ * targets to range 1.
+ */
+export interface CreepMoveTarget {
+  pos: RoomPosition;
+  range: number;
 }
 
 /**
@@ -73,9 +89,9 @@ export type CreepAction =
   | { type: "attackController"; target: StructureController }
 
   // Movement actions
-  | { type: "moveTo"; target: RoomPosition | RoomObject }
+  | { type: "moveTo"; target: RoomPosition | RoomObject | CreepMoveTarget }
   | { type: "moveToRoom"; roomName: string }
-  | { type: "remoteMoveTo"; target: RoomPosition | RoomObject; routeType: RemoteMoveRouteType }
+  | { type: "remoteMoveTo"; target: RoomPosition | RoomObject | CreepMoveTarget; routeType: RemoteMoveRouteType }
   | { type: "remoteMoveToRoom"; roomName: string; routeType: RemoteMoveRouteType }
   | { type: "flee"; from: RoomPosition[] }
   | { type: "wait"; position: RoomPosition }

--- a/packages/@ralphschuler/screeps-roles/src/utils/movement.ts
+++ b/packages/@ralphschuler/screeps-roles/src/utils/movement.ts
@@ -6,7 +6,7 @@
  * supported by cartographer, so we strip it out before passing to cartographer.
  */
 
-import { moveTo as cartographerMoveTo } from "screeps-cartographer";
+import { moveTo as cartographerMoveTo, type MoveTarget } from "screeps-cartographer";
 
 export interface ExtendedMoveToOpts extends MoveToOpts {
   /** Cache TTL in ticks - stripped before passing to cartographer */
@@ -15,7 +15,7 @@ export interface ExtendedMoveToOpts extends MoveToOpts {
 
 export function cachedMoveTo(
   creep: Creep,
-  target: RoomPosition | { pos: RoomPosition },
+  target: RoomPosition | { pos: RoomPosition } | MoveTarget,
   opts?: ExtendedMoveToOpts
 ): ScreepsReturnCode {
   // Strip out cacheTtl since cartographer doesn't support it

--- a/packages/@ralphschuler/screeps-roles/test/interShardPortalMovement.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/interShardPortalMovement.test.ts
@@ -1,0 +1,133 @@
+import { expect } from "chai";
+import { evaluateWithStateMachine } from "../src/behaviors/stateMachine";
+import { interShardClaimer } from "../src/behaviors/interShardClaim";
+import { interShardPioneer } from "../src/behaviors/economy/interShardPioneer";
+import type { CreepAction, CreepContext } from "../src/behaviors/types";
+import { createMockCreep, createMockRoom, resetMockGame } from "./setup";
+
+function createContext(creep: Creep, room: Room): CreepContext {
+  return {
+    creep,
+    room,
+    memory: creep.memory as CreepContext["memory"],
+    swarmState: undefined,
+    squadMemory: undefined,
+    homeRoom: creep.memory.homeRoom ?? room.name,
+    isInHomeRoom: creep.memory.homeRoom === room.name,
+    isFull: false,
+    isEmpty: true,
+    isWorking: false,
+    assignedSource: null,
+    assignedMineral: null,
+    energyAvailable: false,
+    nearbyEnemies: false,
+    constructionSiteCount: 0,
+    damagedStructureCount: 0,
+    droppedResources: [],
+    containers: [],
+    sourceContainers: [],
+    depositContainers: [],
+    spawnStructures: [],
+    towers: [],
+    storage: undefined,
+    terminal: undefined,
+    hostiles: [],
+    damagedAllies: [],
+    prioritizedSites: [],
+    repairTargets: [],
+    labs: [],
+    factory: undefined,
+    tombstones: [],
+    mineralContainers: [],
+  };
+}
+
+function createPortalRoom() {
+  const room = createMockRoom("W20S20");
+  const portal = {
+    structureType: STRUCTURE_PORTAL,
+    pos: new RoomPosition(29, 12, room.name),
+    destination: { shard: "shard0", room: room.name },
+  } as unknown as StructurePortal;
+  room.find = (_type: number, options?: { filter?: (value: Structure) => boolean }) =>
+    options?.filter ? [portal].filter(options.filter) : [portal];
+  return { room, portal };
+}
+
+describe("inter-shard portal movement", () => {
+  beforeEach(() => {
+    resetMockGame();
+    (globalThis.Game as typeof Game & { shard?: { name: string } }).shard = { name: "shard1" };
+  });
+
+  it("asks claim scouts to step onto the portal tile", () => {
+    const { room, portal } = createPortalRoom();
+    const creep = createMockCreep("interShardScout", {
+      room,
+      memory: {
+        role: "interShardScout",
+        homeRoom: "W1N1",
+        targetShard: "shard0",
+        portalRoom: room.name,
+      },
+    });
+
+    const action = interShardClaimer(createContext(creep, room));
+
+    expect(action.type).to.equal("moveTo");
+    expect((action as Extract<CreepAction, { type: "moveTo" }>).target).to.deep.equal({
+      pos: portal.pos,
+      range: 0,
+    });
+  });
+
+  it("asks pioneers to step onto the portal tile", () => {
+    const { room, portal } = createPortalRoom();
+    const creep = createMockCreep("interShardPioneer", {
+      room,
+      memory: {
+        role: "interShardPioneer",
+        homeRoom: "W1N1",
+        targetShard: "shard0",
+        portalRoom: room.name,
+      },
+    });
+
+    const action = interShardPioneer(createContext(creep, room));
+
+    expect(action.type).to.equal("moveTo");
+    expect((action as Extract<CreepAction, { type: "moveTo" }>).target).to.deep.equal({
+      pos: portal.pos,
+      range: 0,
+    });
+  });
+
+  it("preserves an exact portal range when reconstructing a movement state", () => {
+    const room = createMockRoom("W20S20");
+    const creep = createMockCreep("interShardScout", {
+      room,
+      memory: {
+        role: "interShardScout",
+        homeRoom: "W1N1",
+        state: {
+          action: "moveTo",
+          targetPos: { x: 29, y: 12, roomName: room.name },
+          targetRange: 0,
+          startTick: Game.time,
+          timeout: 25,
+        },
+      },
+    });
+    creep.pos.inRangeTo = (_target: RoomPosition, range: number) => range > 0;
+
+    const action = evaluateWithStateMachine(createContext(creep, room), () => {
+      throw new Error("state should still be active");
+    });
+
+    expect(action.type).to.equal("moveTo");
+    expect((action as Extract<CreepAction, { type: "moveTo" }>).target).to.deep.equal({
+      pos: new RoomPosition(29, 12, room.name),
+      range: 0,
+    });
+  });
+});

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -26062,12 +26062,12 @@ timeout: 25
 if ("target" in e && e.target && "id" in e.target && (r.targetId = e.target.id),
 "moveToRoom" !== e.type && "remoteMoveToRoom" !== e.type || (r.targetRoom = e.roomName),
 "moveTo" === e.type || "remoteMoveTo" === e.type) {
-var n = "pos" in e.target ? e.target.pos : e.target;
+var n = e.target, a = "pos" in n ? n.pos : n;
 r.targetPos = {
-x: n.x,
-y: n.y,
-roomName: n.roomName
-};
+x: a.x,
+y: a.y,
+roomName: a.roomName
+}, "range" in n && "number" == typeof n.range && (r.targetRange = n.range);
 }
 return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
@@ -26132,31 +26132,32 @@ valid: !0
 };
 }(a);
 if (a && s.valid) if (function(e, t) {
+var r, o, n;
 if (!e) return !0;
 switch (e.action) {
 case "harvest":
 case "harvestMineral":
 case "pickup":
 case "withdraw":
-return !!t.isFull || !(!e.targetId || (r = Game.getObjectById(e.targetId)));
+return !!t.isFull || !(!e.targetId || (a = Game.getObjectById(e.targetId)));
 
 case "harvestDeposit":
 if (t.isFull) return !0;
 if (e.targetId) {
-if (!(r = Game.getObjectById(e.targetId))) return !0;
-if ("object" == typeof r && "cooldown" in r && r.cooldown > 100) return !0;
+if (!(a = Game.getObjectById(e.targetId))) return !0;
+if ("object" == typeof a && "cooldown" in a && a.cooldown > 100) return !0;
 }
 return !1;
 
 case "transfer":
 case "build":
-return !!t.isEmpty || !(!e.targetId || (r = Game.getObjectById(e.targetId)));
+return !!t.isEmpty || !(!e.targetId || (a = Game.getObjectById(e.targetId)));
 
 case "repair":
 if (t.isEmpty) return !0;
 if (e.targetId) {
-if (!(r = Game.getObjectById(e.targetId))) return !0;
-if ("object" == typeof (i = r) && null !== i && "hits" in i && "hitsMax" in i && r.hits >= r.hitsMax) return !0;
+if (!(a = Game.getObjectById(e.targetId))) return !0;
+if ("object" == typeof (n = a) && null !== n && "hits" in n && "hitsMax" in n && a.hits >= a.hitsMax) return !0;
 }
 return !1;
 
@@ -26165,18 +26166,18 @@ return t.isEmpty;
 
 case "moveToRoom":
 case "remoteMoveToRoom":
-return void 0 !== e.targetRoom && t.room.name === e.targetRoom && !(0 === (a = t.creep.pos).x || 49 === a.x || 0 === a.y || 49 === a.y);
+return void 0 !== e.targetRoom && t.room.name === e.targetRoom && !(0 === (o = t.creep.pos).x || 49 === o.x || 0 === o.y || 49 === o.y);
 
 case "moveTo":
 case "remoteMoveTo":
-var r;
-if (e.targetId && (r = Game.getObjectById(e.targetId)) && "object" == typeof r && "pos" in r) {
-var o = r;
-return t.creep.pos.inRangeTo(o.pos, 1);
+var a;
+if (e.targetId && (a = Game.getObjectById(e.targetId)) && "object" == typeof a && "pos" in a) {
+var i = a;
+return t.creep.pos.inRangeTo(i.pos, 1);
 }
 if (e.targetPos) {
-var n = new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName);
-return t.creep.pos.inRangeTo(n, 1);
+var s = new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName);
+return t.creep.pos.inRangeTo(s, null !== (r = e.targetRange) && void 0 !== r ? r : 1);
 }
 return !1;
 
@@ -26186,7 +26187,6 @@ return !0;
 default:
 return !1;
 }
-var a, i;
 }(a, e)) Tm.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
@@ -26267,13 +26267,21 @@ target: i
 } : null;
 
 case "moveTo":
-return i ? {
+if (i) return {
 type: "moveTo",
 target: i
-} : e.targetPos ? {
+};
+if (e.targetPos) {
+var u = new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName);
+return {
 type: "moveTo",
-target: new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName)
-} : null;
+target: void 0 === e.targetRange ? u : {
+pos: u,
+range: e.targetRange
+}
+};
+}
+return null;
 
 case "moveToRoom":
 return e.targetRoom ? {
@@ -26282,22 +26290,22 @@ roomName: e.targetRoom
 } : null;
 
 case "remoteMoveTo":
-return "harvester" !== (u = null === (n = e.data) || void 0 === n ? void 0 : n.routeType) && "hauler" !== u && "reserver" !== u && "guard" !== u ? null : i ? {
+return "harvester" !== (l = null === (n = e.data) || void 0 === n ? void 0 : n.routeType) && "hauler" !== l && "reserver" !== l && "guard" !== l ? null : i ? {
 type: "remoteMoveTo",
 target: i,
-routeType: u
+routeType: l
 } : e.targetPos ? {
 type: "remoteMoveTo",
-target: new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName),
-routeType: u
+target: u = new RoomPosition(e.targetPos.x, e.targetPos.y, e.targetPos.roomName),
+routeType: l
 } : null;
 
 case "remoteMoveToRoom":
-var u;
-return "harvester" !== (u = null === (a = e.data) || void 0 === a ? void 0 : a.routeType) && "hauler" !== u && "reserver" !== u && "guard" !== u ? null : e.targetRoom ? {
+var l;
+return "harvester" !== (l = null === (a = e.data) || void 0 === a ? void 0 : a.routeType) && "hauler" !== l && "reserver" !== l && "guard" !== l ? null : e.targetRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.targetRoom,
-routeType: u
+routeType: l
 } : null;
 
 case "idle":
@@ -28123,7 +28131,10 @@ return "shard" in t && t.shard === o;
 }));
 return n ? {
 type: "moveTo",
-target: n.pos
+target: {
+pos: n.pos,
+range: 0
+}
 } : {
 type: "idle"
 };
@@ -31931,7 +31942,10 @@ return "shard" in t && t.shard === o;
 }));
 return n ? {
 type: "moveTo",
-target: n.pos
+target: {
+pos: n.pos,
+range: 0
+}
 } : {
 type: "idle"
 };

--- a/packages/screeps-bot/docs/portal-navigation.md
+++ b/packages/screeps-bot/docs/portal-navigation.md
@@ -48,7 +48,10 @@ moveTo(creep, target, {
 
 ### Cross-Shard Movement
 
-For explicit cross-shard carrier roles, see `src/roles/crossShardCarrier.ts` for production example:
+Cartographer can route through intrashard portals, but explicit cross-shard
+movement must target the exact portal tile (`range: 0`). A normal object target
+uses range 1 and leaves the creep adjacent to the portal. For carrier roles,
+see `src/roles/crossShardCarrier.ts` for the production example:
 
 ```typescript
 import { moveTo } from "screeps-cartographer";
@@ -58,10 +61,11 @@ const creep = Game.creeps["MyCreep"];
 // Move to portal room
 moveTo(creep, new RoomPosition(25, 25, portalRoom));
 
-// Move to portal (Cartographer handles portal entry automatically)
+// Move onto the portal tile. A default object target stops at range 1,
+// which does not trigger cross-shard traversal.
 const portal = Game.getObjectById(portalId);
 if (portal) {
-  moveTo(creep, portal);
+  moveTo(creep, { pos: portal.pos, range: 0 });
 }
 ```
 


### PR DESCRIPTION
## Summary

Cross-shard creeps were stopping one tile before portals and never traversing. This blocked shard footprint scouting and bootstrap.

## Linked issue

Closes #3391

## Research

- Live read-only API reproduction: an `interShardScout` remained adjacent to a portal while the room exposed destinations on multiple shards.
- Local `screeps-cartographer` 1.8.15 types/source: bare position/object targets normalize to range 1; explicit `MoveTarget.range = 0` reaches the portal tile.
- Official Screeps API reference and local `@types/screeps` confirm portal destinations and positions.
- SearXNG was unavailable (HTTP 403); no external claim depends on it.

## Changes

- Add typed exact movement targets to the roles action contract.
- Persist exact movement range through creep state serialization/reconstruction.
- Make inter-shard scouts/claimers, pioneers, and carriers target portal tiles with `range: 0`.
- Correct carrier traversal logging to report only on the exact tile.
- Update portal navigation documentation.
- Refresh the tracked bot bundle.

## Defense / empire impact

- Threat detection: unchanged.
- Cross-shard redundancy: scouts can now cross and continue footprint discovery.
- Recovery: pioneers/claimers can reach target shards and find claim/bootstrap rooms.
- Allies: no targeting or classification behavior changed.
- CPU/Memory: one bounded numeric state field only; no new scans.

## Tests

- `npm test -w @ralphschuler/screeps-roles` — 186 passing.
- `npm run test:unit -w screeps-typescript-starter` — 2427 passing.
- Roles and memory TypeScript no-emit checks — passed.
- Roles lint — passed.
- Bot build/bundle-size check — passed; 1.30 MB / 2 MB.
- Node 24 checks: versions, dependency sync, alliance safety, deep-dist imports, diff check — passed.
- `npm run test:server:smoke` — passed; 47/47 runtime assertions, 0 skipped.

## Live evidence

Sanitized live evidence is recorded on #3391. Memory endpoints were rate-limited (HTTP 429), so no unsupported Memory/task-board claims are made.

## Deployment impact

After merge, deploy the refreshed main bundle and recheck the previously stalled portal scout plus target-shard footprint status.

## Follow-up

- Immediate post-deploy read-only verification of portal crossing and target-shard footing.
- Broader multi-shard private-server scenario remains a follow-up because the current harness runs one shard.
