### PR TITLE
fix(kernel): refresh inherited adaptive budgets

### DIFF
--- a/packages/@ralphschuler/screeps-kernel/src/kernel.ts
+++ b/packages/@ralphschuler/screeps-kernel/src/kernel.ts
@@ -364,6 +364,8 @@ interface FrequencyDefaults { interval: number; minBucket: number; cpuBudget: nu
 export class Kernel {
   private config: KernelConfig;
   private processes: Map<string, Process> = new Map();
+  /** Processes whose CPU budget was inherited from frequency defaults. */
+  private defaultBudgetProcessIds: Set<string> = new Set();
   private bucketMode: BucketMode = "normal";
   private tickCpuUsed = 0;
   private initialized = false;
@@ -478,6 +480,11 @@ export class Kernel {
     };
 
     this.processes.set(options.id, process);
+    if (options.cpuBudget === undefined) {
+      this.defaultBudgetProcessIds.add(options.id);
+    } else {
+      this.defaultBudgetProcessIds.delete(options.id);
+    }
     this.queueDirty = true; // Mark queue for rebuild
     logger.debug(`Kernel: Registered process "${process.name}" (${process.id})`, { subsystem: "Kernel" });
   }
@@ -488,6 +495,7 @@ export class Kernel {
   public unregisterProcess(id: string): boolean {
     const deleted = this.processes.delete(id);
     if (deleted) {
+      this.defaultBudgetProcessIds.delete(id);
       this.queueDirty = true; // Mark queue for rebuild
       logger.debug(`Kernel: Unregistered process ${id}`, { subsystem: "Kernel" });
     }
@@ -760,6 +768,10 @@ export class Kernel {
     // NOTE: This mutates the config object - see method documentation
     this.config.frequencyCpuBudgets = adaptiveBudgets;
     this.frequencyDefaults = this.buildFrequencyDefaults();
+
+    if (this.hasFrequencyBudgetChanges(previousBudgets, adaptiveBudgets)) {
+      this.synchronizeDefaultBudgetProcesses();
+    }
 
     // Log budget changes periodically for visibility
     if (Game.time % 500 === 0) {
@@ -1678,6 +1690,24 @@ export class Kernel {
     return { ...this.config };
   }
 
+  private hasFrequencyBudgetChanges(
+    previousBudgets: Record<ProcessFrequency, number>,
+    nextBudgets: Record<ProcessFrequency, number>
+  ): boolean {
+    return (Object.keys(nextBudgets) as ProcessFrequency[]).some(
+      (frequency) => previousBudgets[frequency] !== nextBudgets[frequency]
+    );
+  }
+
+  private synchronizeDefaultBudgetProcesses(): void {
+    for (const processId of this.defaultBudgetProcessIds) {
+      const process = this.processes.get(processId);
+      if (process) {
+        process.cpuBudget = this.frequencyDefaults[process.frequency].cpuBudget;
+      }
+    }
+  }
+
   /**
    * Get frequency defaults for a process frequency
    */
@@ -1692,6 +1722,7 @@ export class Kernel {
     this.config = { ...this.config, ...config };
     this.validateConfig();
     this.frequencyDefaults = this.buildFrequencyDefaults();
+    this.synchronizeDefaultBudgetProcesses();
   }
 
   /**

--- a/packages/@ralphschuler/screeps-kernel/test/kernel-scheduling.test.ts
+++ b/packages/@ralphschuler/screeps-kernel/test/kernel-scheduling.test.ts
@@ -403,6 +403,77 @@ describe("Kernel Process Scheduling", () => {
       expect(kernel.hasCpuBudget()).to.be.false;
     });
 
+    it("should update registered default budgets without changing explicit overrides", () => {
+      kernel.registerProcess({
+        id: "default-high",
+        name: "Default High",
+        frequency: "high",
+        execute: () => {}
+      });
+      kernel.registerProcess({
+        id: "default-medium",
+        name: "Default Medium",
+        frequency: "medium",
+        execute: () => {}
+      });
+      kernel.registerProcess({
+        id: "default-low",
+        name: "Default Low",
+        frequency: "low",
+        execute: () => {}
+      });
+      kernel.registerProcess({
+        id: "explicit-budget",
+        name: "Explicit Budget",
+        frequency: "high",
+        cpuBudget: 0,
+        execute: () => {}
+      });
+
+      kernel.updateConfig({
+        frequencyCpuBudgets: {
+          high: 0.01,
+          medium: 0.02,
+          low: 0.03
+        }
+      });
+
+      expect(kernel.getProcess("default-high")!.cpuBudget).to.equal(0.01);
+      expect(kernel.getProcess("default-medium")!.cpuBudget).to.equal(0.02);
+      expect(kernel.getProcess("default-low")!.cpuBudget).to.equal(0.03);
+      expect(kernel.getProcess("explicit-budget")!.cpuBudget).to.equal(0);
+    });
+
+    it("should synchronize registered default budgets after adaptive updates", () => {
+      const originalGetUsed = Game.cpu.getUsed;
+      let used = 0;
+      Game.cpu.getUsed = () => used;
+      Game.cpu.limit = 100;
+
+      kernel.registerProcess({
+        id: "adaptive-proc",
+        name: "Adaptive",
+        frequency: "high",
+        interval: 1,
+        execute: () => {
+          used += 70;
+        }
+      });
+
+      try {
+        used = 0;
+        kernel.run();
+        Game.time++;
+        used = 0;
+        kernel.run();
+
+        const process = kernel.getProcess("adaptive-proc")!;
+        expect(process.cpuBudget).to.equal(kernel.getConfig().frequencyCpuBudgets.high);
+      } finally {
+        Game.cpu.getUsed = originalGetUsed;
+      }
+    });
+
     it("should adapt high-frequency budget downward after heavy utilization", () => {
       const originalGetUsed = Game.cpu.getUsed;
       let used = 0;

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -2981,9 +2981,10 @@ frequencyCpuBudgets: u
 
 var We, He, Ke = function() {
 function e(e) {
-this.processes = new Map, this.bucketMode = "normal", this.tickCpuUsed = 0, this.initialized = !1,
-this.lastExecutedProcessId = null, this.lastExecutedIndex = -1, this.processQueue = [],
-this.queueDirty = !0, this.skippedProcessesThisTick = 0, this.tickFrequencyCpuUsed = {
+this.processes = new Map, this.defaultBudgetProcessIds = new Set, this.bucketMode = "normal",
+this.tickCpuUsed = 0, this.initialized = !1, this.lastExecutedProcessId = null,
+this.lastExecutedIndex = -1, this.processQueue = [], this.queueDirty = !0, this.skippedProcessesThisTick = 0,
+this.tickFrequencyCpuUsed = {
 high: 0,
 medium: 0,
 low: 0
@@ -3034,12 +3035,13 @@ suspensionReason: null,
 consecutiveCpuSkips: 0
 }
 };
-this.processes.set(e.id, m), this.queueDirty = !0, _e.debug('Kernel: Registered process "'.concat(m.name, '" (').concat(m.id, ")"), {
+this.processes.set(e.id, m), void 0 === e.cpuBudget ? this.defaultBudgetProcessIds.add(e.id) : this.defaultBudgetProcessIds.delete(e.id),
+this.queueDirty = !0, _e.debug('Kernel: Registered process "'.concat(m.name, '" (').concat(m.id, ")"), {
 subsystem: "Kernel"
 });
 }, e.prototype.unregisterProcess = function(e) {
 var t = this.processes.delete(e);
-return t && (this.queueDirty = !0, _e.debug("Kernel: Unregistered process ".concat(e), {
+return t && (this.defaultBudgetProcessIds.delete(e), this.queueDirty = !0, _e.debug("Kernel: Unregistered process ".concat(e), {
 subsystem: "Kernel"
 })), t;
 }, e.prototype.getProcess = function(e) {
@@ -3202,6 +3204,7 @@ low: W("low", e, t, r, o)
 var r;
 }(this.config.adaptiveBudgetConfig, this.frequencyUtilization);
 if (this.config.frequencyCpuBudgets = t, this.frequencyDefaults = this.buildFrequencyDefaults(),
+this.hasFrequencyBudgetChanges(e, t) && this.synchronizeDefaultBudgetProcesses(),
 Game.time % 500 == 0) {
 var r = Object.keys(Game.rooms).length, n = Game.cpu.bucket, a = this.formatFrequencyUtilization(this.frequencyUtilization);
 _e.info("Adaptive budgets updated: rooms=".concat(r, ", bucket=").concat(n, ", ") + "high=".concat(t.high.toFixed(3), " (").concat(this.formatBudgetDelta(e.high, t.high), "), ") + "medium=".concat(t.medium.toFixed(3), " (").concat(this.formatBudgetDelta(e.medium, t.medium), "), ") + "low=".concat(t.low.toFixed(3), " (").concat(this.formatBudgetDelta(e.low, t.low), "), ") + "util=".concat(a), {
@@ -3635,10 +3638,33 @@ estimatedCpuReduction: d
 };
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
+}, e.prototype.hasFrequencyBudgetChanges = function(e, t) {
+return Object.keys(t).some(function(r) {
+return e[r] !== t[r];
+});
+}, e.prototype.synchronizeDefaultBudgetProcesses = function() {
+var e, t;
+try {
+for (var r = a(this.defaultBudgetProcessIds), o = r.next(); !o.done; o = r.next()) {
+var n = o.value, i = this.processes.get(n);
+i && (i.cpuBudget = this.frequencyDefaults[i.frequency].cpuBudget);
+}
+} catch (t) {
+e = {
+error: t
+};
+} finally {
+try {
+o && !o.done && (t = r.return) && t.call(r);
+} finally {
+if (e) throw e.error;
+}
+}
 }, e.prototype.getFrequencyDefaults = function(e) {
 return o({}, this.frequencyDefaults[e]);
 }, e.prototype.updateConfig = function(e) {
-this.config = o(o({}, this.config), e), this.validateConfig(), this.frequencyDefaults = this.buildFrequencyDefaults();
+this.config = o(o({}, this.config), e), this.validateConfig(), this.frequencyDefaults = this.buildFrequencyDefaults(),
+this.synchronizeDefaultBudgetProcesses();
 }, e.prototype.updateFromCpuConfig = function(e) {
 this.updateConfig(Fe(e));
 }, e.prototype.on = function(e, t, r) {


### PR DESCRIPTION
## Summary

Refresh CPU budgets on already-registered processes when adaptive frequency defaults change, while preserving explicit process budgets.

## Linked issue

Fixes #3372

## Research

- Repository evidence: `Kernel.registerProcess()` snapshots frequency defaults into `Process.cpuBudget`; adaptive updates previously rebuilt only `frequencyDefaults`.
- Local Screeps CPU references checked: `node_modules/@types/screeps/index.d.ts` and ROADMAP Sections 2/18. This change does not alter `Game.cpu.tickLimit`, bucket mechanics, or process admission policy.
- SearXNG was attempted but the configured backend and local container returned HTTP 403; implementation relies on local types, repository code, and deterministic tests.

## Changes

- Track whether each registered process inherited its budget or supplied an explicit override.
- Synchronize inherited process budgets after adaptive updates and configuration changes.
- Preserve explicit values, including `cpuBudget: 0`.
- Add regression coverage for high/medium/low frequencies and adaptive runtime refresh.

## Defense impact

- Low-bucket/siege scheduling telemetry and budget warnings now reflect effective inherited budgets instead of stale registration values.
- No targeting, ally classification, combat, or Memory schema behavior changed.
- Permanent allies remain protected by existing filters.

## Tests

- `npm test -w @ralphschuler/screeps-kernel` — 103 passing
- `npm run build -w @ralphschuler/screeps-kernel` — pass
- `npm run lint -w @ralphschuler/screeps-kernel -- --max-warnings=0` — pass (existing module-type warning only)
- `git diff --check` — pass
- Full root build started; no errors observed before PR creation.

## Live evidence

The current sanitized shard observation continues to show active non-ally pressure in a spawnless recovery-room alias; Memory CPU/bucket telemetry is blocked by API HTTP 429. That evidence informed prioritization but this kernel fix is validated locally rather than claimed as live-verified.

## Follow-ups

- #3375 — spawnless recovery under hostile pressure
- #3121 — live Memory API rate limiting
- #3371 — unify nuke observation consumers
