### PR TITLE
fix(defense): reconcile structure loss on room cadence

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -33850,9 +33850,8 @@ var o = X(e), n = Js(e), a = this.getDefensePostureIntent(e, t, r, o, n);
 this.executeDefensePostureIntent(e, t, o, a), $s(Sr.getEmpire(), e, t, n);
 }, e.prototype.getDefensePostureIntent = function(e, t, r, o, n) {
 return void 0 === o && (o = X(e)), void 0 === n && (n = Js(e)), function(e, t) {
-if (e.time % 5 == 0) {
 var r = e.currentStructures.spawns.length + e.currentStructures.towers.length, o = e.previousStructures;
-o && o.lastTick < e.time && r < o.lastStructureCount && (e.currentStructures.spawns.length < o.spawns.length && t.kernelEvents.push({
+o && o.lastTick < e.time && (e.currentStructures.spawns.length < o.spawns.length && t.kernelEvents.push({
 type: "structure.destroyed",
 payload: {
 roomName: e.roomName,
@@ -33874,7 +33873,6 @@ spawns: s([], i(e.currentStructures.spawns), !1),
 towers: s([], i(e.currentStructures.towers), !1),
 lastTick: e.time
 };
-}
 }(c = this.getDefensePostureSnapshot(e, t, r, o, n), u = {
 nextDanger: c.currentDanger,
 nextNukeDetected: c.nukeDetected,

--- a/packages/screeps-bot/src/core/managers/roomDefensePostureModule.ts
+++ b/packages/screeps-bot/src/core/managers/roomDefensePostureModule.ts
@@ -155,12 +155,13 @@ export function planDefensePostureIntent(snapshot: DefensePostureSnapshot): Defe
 }
 
 function planStructureEvents(snapshot: DefensePostureSnapshot, intent: DefensePostureIntent): void {
-  if (snapshot.time % 5 !== 0) return;
-
+  // The room process is already cadence- and offset-aware. Applying a global
+  // modulo here would skip structure-loss detection for distributed rooms whose
+  // scheduler offset does not match zero.
   const currentStructureCount = snapshot.currentStructures.spawns.length + snapshot.currentStructures.towers.length;
   const previous = snapshot.previousStructures;
 
-  if (previous && previous.lastTick < snapshot.time && currentStructureCount < previous.lastStructureCount) {
+  if (previous && previous.lastTick < snapshot.time) {
     if (snapshot.currentStructures.spawns.length < previous.spawns.length) {
       intent.kernelEvents.push({
         type: "structure.destroyed",

--- a/packages/screeps-bot/test/unit/processManagerBucketPolicy.test.ts
+++ b/packages/screeps-bot/test/unit/processManagerBucketPolicy.test.ts
@@ -288,6 +288,28 @@ describe("Process manager bucket policy", () => {
     expect(process?.name).to.not.include("nuke response");
   });
 
+  it("assigns distinct scheduler offsets to distributed owned rooms", () => {
+    const room = (name: string) =>
+      ({
+        name,
+        controller: { my: true, level: 8 },
+        find: () => []
+      }) as unknown as Room;
+
+    global.Game.rooms = {
+      W1N1: room("W1N1"),
+      W1N2: room("W1N2")
+    };
+    global.Game.spawns = {};
+
+    roomProcessManager.syncRoomProcesses();
+
+    expect(kernel.getProcess("room:W1N1")?.tickModulo).to.equal(5);
+    expect(kernel.getProcess("room:W1N1")?.tickOffset).to.equal(0);
+    expect(kernel.getProcess("room:W1N2")?.tickModulo).to.equal(5);
+    expect(kernel.getProcess("room:W1N2")?.tickOffset).to.equal(1);
+  });
+
   it("bounds nuke priority scans while the bucket is low", () => {
     const { lowMode } = getConfig().cpu.bucketThresholds;
     let nukeScans = 0;

--- a/packages/screeps-bot/test/unit/roomDefensePostureModule.test.ts
+++ b/packages/screeps-bot/test/unit/roomDefensePostureModule.test.ts
@@ -110,6 +110,93 @@ describe("Room defense posture Module", () => {
     });
   });
 
+  it("plans structure loss on every distributed room-process offset", () => {
+    for (const time of [101, 102, 103, 104]) {
+      const intent = planDefensePostureIntent(
+        snapshot({
+          time,
+          previousStructures: {
+            lastStructureCount: 3,
+            spawns: ["spawn1", "spawn2"],
+            towers: ["tower1"],
+            lastTick: time - 1
+          },
+          currentStructures: {
+            spawns: ["spawn1"],
+            towers: []
+          }
+        })
+      );
+
+      assert.deepEqual(intent.kernelEvents, [
+        {
+          type: "structure.destroyed",
+          payload: { roomName: "W1N1", structureType: STRUCTURE_SPAWN, structureId: "unknown", source: "W1N1" }
+        },
+        {
+          type: "structure.destroyed",
+          payload: { roomName: "W1N1", structureType: STRUCTURE_TOWER, structureId: "unknown", source: "W1N1" }
+        }
+      ]);
+      assert.deepEqual(intent.nextStructureTracking, {
+        lastStructureCount: 1,
+        spawns: ["spawn1"],
+        towers: [],
+        lastTick: time
+      });
+    }
+  });
+
+  it("detects a spawn loss even when another structure is added in the same tick", () => {
+    const intent = planDefensePostureIntent(
+      snapshot({
+        time: 101,
+        previousStructures: {
+          lastStructureCount: 2,
+          spawns: ["spawn1"],
+          towers: ["tower1"],
+          lastTick: 100
+        },
+        currentStructures: {
+          spawns: [],
+          towers: ["tower1", "tower2"]
+        }
+      })
+    );
+
+    assert.deepEqual(intent.kernelEvents, [
+      {
+        type: "structure.destroyed",
+        payload: { roomName: "W1N1", structureType: STRUCTURE_SPAWN, structureId: "unknown", source: "W1N1" }
+      }
+    ]);
+    assert.deepEqual(intent.nextStructureTracking, {
+      lastStructureCount: 2,
+      spawns: [],
+      towers: ["tower1", "tower2"],
+      lastTick: 101
+    });
+  });
+
+  it("does not re-emit structure loss for the same room tick", () => {
+    const intent = planDefensePostureIntent(
+      snapshot({
+        previousStructures: {
+          lastStructureCount: 2,
+          spawns: ["spawn1"],
+          towers: ["tower1"],
+          lastTick: 100
+        },
+        currentStructures: {
+          spawns: [],
+          towers: []
+        }
+      })
+    );
+
+    assert.deepEqual(intent.kernelEvents, []);
+  });
+
   it("plans first nuke detection on every room-process offset", () => {
     for (const time of [100, 101, 102, 103, 104]) {
       const detected = planDefensePostureIntent(


### PR DESCRIPTION
## Summary

Remove the conflicting global modulo gate from owned-room structure-loss reconciliation and compare structure categories independently.

## Linked issue

Closes #3396

## Research

- Local kernel contract: distributed processes execute on scheduler-owned `(Game.time + tickOffset) % tickModulo` cadence.
- Local room scheduler: owned economic rooms are distributed across five offsets.
- Local Screeps types: structure snapshots use `Room.find(FIND_MY_STRUCTURES)`-derived spawn/tower collections.
- SearXNG was attempted for current Screeps mechanics research but the configured backend returned HTTP 403; no external result is claimed. Fallback evidence is local source/types/tests.

## Changes

- Removed the posture planner's `time % 5` gate.
- Detect spawn/tower loss independently, including loss with same-tick structure replacement.
- Preserve previous-tick guard for same-tick deduplication.
- Added distributed-offset, same-count replacement, and same-tick deduplication tests.
- Refreshed the tracked bot bundle.

## Defense impact

- Threat detection: structure-loss recovery events no longer depend on offset zero.
- Defensive response: destroyed spawn/tower events reach kernel, pheromone, cache, and recovery consumers on the room's scheduled tick.
- Construction adaptation: unchanged; identity-preserving event work remains follow-up #3388.
- Recovery: improves detection of spawn/tower loss for all distributed room offsets.
- CPU/Memory impact: removes a branch; no new persistent state or scans.

## Tests

- Focused posture/process tests: 28 passing.
- `npm run build`: passed.
- `npm run check-versions`: passed under Node 24.18.0/npm 11.16.0.
- `npm run sync:deps:check`: passed.
- `npm run typecheck`: passed.
- `npm run lint:all`: passed (existing Node module-type warnings only).
- `npm run quality:baseline`: passed budgets.
- `npm run test:all`: passed; private-server smoke validation reported 47/47 assertions and 71/71 total checks.
- `npm run check:alliance-safety`: passed.
- `npm run check:no-deep-dist-imports`: passed.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- `git diff --check`: passed.

## Live evidence

Sanitized read-only shard1 observation artifacts show the existing spawnless recovery pressure remains tracked under #3375; Memory endpoints were rate-limited (HTTP 429), and no live state-changing action was performed. No live claim is made for this source-only cadence fix before deployment.

## Deployment impact

Tracked bundle is regenerated. Deploy after required PR checks pass.

## Follow-up issues

- #3388 — preserve exact structure-loss identity for recovery telemetry.
- #3205 — intermittent private-server runtime checks skipped after warmup.
- #3375/#3364 — spawnless recovery convergence and repeated-wave private-server coverage.
