### PR TITLE
fix(empire): correct signed hostile approach prediction

### DIFF
--- a/packages/@ralphschuler/screeps-empire/README.md
+++ b/packages/@ralphschuler/screeps-empire/README.md
@@ -105,7 +105,7 @@ pixelGen.run();
 
 ### Threat Predictor
 
-Analyzes hostile creep patterns and predicts potential threats to owned rooms.
+Analyzes hostile creep patterns and predicts potential threats to owned rooms. Adjacent-room predictions use signed room geometry and require an observed movement vector toward the owned room; hostiles already inside an owned room remain immediate threats.
 
 ```typescript
 import { 

--- a/packages/@ralphschuler/screeps-empire/src/threat/threatGeometry.ts
+++ b/packages/@ralphschuler/screeps-empire/src/threat/threatGeometry.ts
@@ -1,0 +1,53 @@
+import { parseRoomName } from "@ralphschuler/screeps-core";
+
+export interface TrackedHostileMovement {
+  lastPos: { roomName: string };
+  vector?: { dx: number; dy: number };
+}
+
+/**
+ * Return a valid Screeps room name for signed map coordinates.
+ *
+ * Screeps crosses from W0/E0 and N0/S0 at zero, so string arithmetic on the
+ * room-name indices is incorrect at those boundaries.
+ */
+function formatRoomName(x: number, y: number): string {
+  const xName = x < 0 ? `W${Math.abs(x) - 1}` : `E${x}`;
+  const yName = y < 0 ? `N${Math.abs(y) - 1}` : `S${y}`;
+  return `${xName}${yName}`;
+}
+
+/** Get the four rooms adjacent to a valid room name. */
+export function getAdjacentRooms(roomName: string): string[] {
+  const coordinates = parseRoomName(roomName);
+  if (!coordinates) return [];
+
+  return [
+    formatRoomName(coordinates.x, coordinates.y - 1),
+    formatRoomName(coordinates.x, coordinates.y + 1),
+    formatRoomName(coordinates.x + 1, coordinates.y),
+    formatRoomName(coordinates.x - 1, coordinates.y)
+  ];
+}
+
+/**
+ * Check whether a tracked hostile is moving toward a target room.
+ *
+ * A hostile already inside the target room is an active threat regardless of
+ * its local movement. For an adjacent room, direction is unknown without an
+ * intra-room movement vector and must not be escalated speculatively.
+ */
+export function isHostileApproachingRoom(track: TrackedHostileMovement, targetRoom: string): boolean {
+  if (track.lastPos.roomName === targetRoom) return true;
+
+  const source = parseRoomName(track.lastPos.roomName);
+  const target = parseRoomName(targetRoom);
+  if (!source || !target || !track.vector) return false;
+
+  const deltaX = target.x - source.x;
+  const deltaY = target.y - source.y;
+  if (Math.abs(deltaX) + Math.abs(deltaY) !== 1) return false;
+
+  if (deltaX !== 0) return Math.sign(track.vector.dx) === Math.sign(deltaX);
+  return Math.sign(track.vector.dy) === Math.sign(deltaY);
+}

--- a/packages/@ralphschuler/screeps-empire/src/threat/threatPredictor.ts
+++ b/packages/@ralphschuler/screeps-empire/src/threat/threatPredictor.ts
@@ -11,6 +11,7 @@
 import { logger } from "@ralphschuler/screeps-core";
 import { getActualHostileCreeps } from "@ralphschuler/screeps-defense";
 import { unifiedStats } from "@ralphschuler/screeps-stats";
+import { getAdjacentRooms, isHostileApproachingRoom } from "./threatGeometry";
 
 /**
  * Hostile creep tracking
@@ -232,7 +233,7 @@ export class ThreatPredictor {
 
         for (const track of tracks) {
           // Check if hostile is approaching owned room
-          if (this.isApproaching(track, ownedRoom.name)) {
+          if (isHostileApproachingRoom(track, ownedRoom.name)) {
             threateningCount++;
             totalStrength += this.calculateCreepStrength(track);
           }
@@ -252,44 +253,6 @@ export class ThreatPredictor {
         }
       }
     }
-  }
-
-  /**
-   * Check if hostile is approaching target room
-   */
-  private isApproaching(track: HostileCreepTrack, targetRoom: string): boolean {
-    if (!track.vector) return false;
-    if (track.lastPos.roomName === targetRoom) return true;
-
-    // Check if movement vector points towards target room
-    // This is a simplified check - a more sophisticated implementation
-    // would use pathfinding to determine actual approach
-    return this.getAdjacentRooms(track.lastPos.roomName).includes(targetRoom);
-  }
-
-  /**
-   * Get adjacent room names
-   */
-  private getAdjacentRooms(roomName: string): string[] {
-    const match = roomName.match(/([EW])(\d+)([NS])(\d+)/);
-    if (!match) return [];
-
-    const [, ewDir, xStr, nsDir, yStr] = match;
-    const x = parseInt(xStr, 10);
-    const y = parseInt(yStr, 10);
-
-    const adjacent: string[] = [];
-
-    // North
-    adjacent.push(`${ewDir}${x}${nsDir}${nsDir === "N" ? y + 1 : y - 1}`);
-    // South
-    adjacent.push(`${ewDir}${x}${nsDir}${nsDir === "N" ? y - 1 : y + 1}`);
-    // East
-    adjacent.push(`${ewDir === "E" ? x + 1 : x - 1}${nsDir}${y}`);
-    // West
-    adjacent.push(`${ewDir === "E" ? x - 1 : x + 1}${nsDir}${y}`);
-
-    return adjacent;
   }
 
   /**
@@ -331,7 +294,7 @@ export class ThreatPredictor {
         let hostileCount = 0;
 
         // Check adjacent rooms for hostile forces
-        const adjacentRooms = this.getAdjacentRooms(ownedRoom.name);
+        const adjacentRooms = getAdjacentRooms(ownedRoom.name);
         adjacentRooms.push(ownedRoom.name); // Include the room itself
 
         for (const adjacentRoom of adjacentRooms) {
@@ -339,6 +302,8 @@ export class ThreatPredictor {
           if (!tracks) continue;
 
           for (const track of tracks) {
+            if (!isHostileApproachingRoom(track, ownedRoom.name)) continue;
+
             totalStrength += this.calculateCreepStrength(track);
             hostileCount++;
           }

--- a/packages/@ralphschuler/screeps-empire/test/threatPredictor.test.ts
+++ b/packages/@ralphschuler/screeps-empire/test/threatPredictor.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+
+import {
+  getAdjacentRooms,
+  isHostileApproachingRoom,
+  type TrackedHostileMovement
+} from "../src/threat/threatGeometry.ts";
+
+function track(roomName: string, vector?: { dx: number; dy: number }): TrackedHostileMovement {
+  return {
+    lastPos: { roomName },
+    vector
+  };
+}
+
+describe("ThreatPredictor room approach geometry", () => {
+  it("returns valid neighbors across both zero boundaries", () => {
+    expect(getAdjacentRooms("W0N0")).to.deep.equal(["W0N1", "W0S0", "E0N0", "W1N0"]);
+    expect(getAdjacentRooms("E0S0")).to.deep.equal(["E0N0", "E0S1", "E1S0", "W0S0"]);
+    expect(getAdjacentRooms("not-a-room")).to.deep.equal([]);
+  });
+
+  it("recognizes movement toward east and west target rooms", () => {
+    expect(isHostileApproachingRoom(track("W0N0", { dx: 1, dy: 0 }), "E0N0")).to.equal(true);
+    expect(isHostileApproachingRoom(track("E0N0", { dx: -1, dy: 0 }), "W0N0")).to.equal(true);
+    expect(isHostileApproachingRoom(track("W0N0", { dx: -1, dy: 0 }), "E0N0")).to.equal(false);
+  });
+
+  it("recognizes movement toward north and south target rooms", () => {
+    expect(isHostileApproachingRoom(track("E0N1", { dx: 0, dy: 1 }), "E0N0")).to.equal(true);
+    expect(isHostileApproachingRoom(track("E0S0", { dx: 0, dy: -1 }), "E0N0")).to.equal(true);
+    expect(isHostileApproachingRoom(track("E0N1", { dx: 0, dy: -1 }), "E0N0")).to.equal(false);
+  });
+
+  it("does not escalate adjacent hostiles with unknown, stationary, or opposite movement", () => {
+    expect(isHostileApproachingRoom(track("W0N0"), "E0N0")).to.equal(false);
+    expect(isHostileApproachingRoom(track("W0N0", { dx: 0, dy: 0 }), "E0N0")).to.equal(false);
+    expect(isHostileApproachingRoom(track("W0N0", { dx: 1, dy: 1 }), "E0N0")).to.equal(true);
+    expect(isHostileApproachingRoom(track("W0N0", { dx: -1, dy: 1 }), "E0N0")).to.equal(false);
+    expect(isHostileApproachingRoom(track("W0N0", { dx: 1, dy: 0 }), "E1N0")).to.equal(false);
+  });
+
+  it("treats a hostile already inside the target room as present regardless of vector", () => {
+    expect(isHostileApproachingRoom(track("E0N0"), "E0N0")).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes signed room adjacency and hostile approach classification in the framework threat predictor.

## Linked issue

Closes #3389

## Research

- SearXNG was unavailable: configured backend returned HTTP 403; existing issue #3378 tracks restoration.
- Official Screeps API docs were reachable at https://docs.screeps.com/api/.
- Local `@types/screeps` and shared `parseRoomName()` geometry were used for API/coordinate facts.

## Changes

- Add pure signed-coordinate room geometry for valid N/S/E/W neighbors, including zero boundaries.
- Require adjacent hostile movement vectors to point toward the target room.
- Apply the predicate consistently to movement analysis and prediction generation.
- Keep hostiles already inside the target room as immediate threats.
- Add deterministic tests and package documentation.

## Defense impact

- Threat detection: removes invalid zero-boundary room names and avoids directionally false adjacent escalations.
- Defensive response: preserves same-room alerts while reducing false-positive adjacent-room escalation.
- Construction/recovery: unchanged.
- CPU/Memory: bounded pure arithmetic; no new Memory state.

## Tests

- `npm test -w @ralphschuler/screeps-empire` — 9 passing
- `npm run build:empire` — passed
- empire lint — passed
- empire test typecheck — passed
- Node 24 broad validation running in local process; private-server smoke hit the existing CLI timeout blocker tracked by #3347.

## Live evidence

No live state was changed. Current sanitized live observations were recorded on #3375 and #3121; no tactical room details are included here.

## Follow-up issues

- #3347 — preserve diagnostics when smoke server exits after assertions pass
- #3378 — restore SearXNG access
