### PR TITLE
fix(defense): fail closed for allied tower targets

### DIFF
--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -820,15 +820,17 @@ return !n(e);
 });
 }
 
-function X(e) {
-return function(e, t) {
-return void 0 === t && (t = {}), function(e, t) {
+function X(e, t) {
 return void 0 === t && (t = {}), Q(e, t);
-}(e.find(FIND_HOSTILE_CREEPS), t);
-}(e);
 }
 
 function Z(e) {
+return function(e, t) {
+return void 0 === t && (t = {}), X(e.find(FIND_HOSTILE_CREEPS), t);
+}(e);
+}
+
+function J(e) {
 return function(e, t) {
 return void 0 === t && (t = {}), function(e, t) {
 return void 0 === t && (t = {}), Q(e, t);
@@ -836,10 +838,10 @@ return void 0 === t && (t = {}), Q(e, t);
 }(e);
 }
 
-var J = /^([WE])(\d+)([NS])(\d+)$/;
+var $ = /^([WE])(\d+)([NS])(\d+)$/;
 
-function $(e) {
-var t = J.exec(e);
+function ee(e) {
+var t = $.exec(e);
 if (!t) return null;
 var r = Number.parseInt(t[2], 10), o = Number.parseInt(t[4], 10);
 return {
@@ -850,36 +852,36 @@ yDir: t[3]
 };
 }
 
-function ee(e) {
-var t = J.exec(e);
+function te(e) {
+var t = $.exec(e);
 return t ? {
 x: Number.parseInt(t[2], 10),
 y: Number.parseInt(t[4], 10)
 } : null;
 }
 
-function te(e) {
+function re(e) {
 var t = function(e) {
 return (e % 10 + 10) % 10;
 }(e);
 return t >= 4 && t <= 6;
 }
 
-function re(e) {
+function oe(e) {
 return e % 10 == 0;
 }
 
-function oe(e) {
-var t = ee(e);
-return !!t && (re(t.x) || re(t.y));
-}
-
 function ne(e) {
-var t = ee(e);
-return !!t && te(t.x) && te(t.y);
+var t = te(e);
+return !!t && (oe(t.x) || oe(t.y));
 }
 
-var ae = {
+function ae(e) {
+var t = te(e);
+return !!t && re(t.x) && re(t.y);
+}
+
+var ie = {
 expand: "#00ff00",
 harvest: "#ffff00",
 build: "#ff8800",
@@ -891,16 +893,16 @@ logistics: "#00ffff",
 nukeTarget: "#ff0088"
 };
 
-function ie(e) {
+function se(e) {
 var t;
-return null !== (t = ae[e]) && void 0 !== t ? t : "#888888";
+return null !== (t = ie[e]) && void 0 !== t ? t : "#888888";
 }
 
-function se(e, t, r) {
+function ce(e, t, r) {
 return void 0 === r && (r = 100), Math.min(1, e / r) * t;
 }
 
-function ce(e) {
+function ue(e) {
 var t, r, o, n = 0;
 try {
 for (var i = a(null !== (o = e.body) && void 0 !== o ? o : []), s = i.next(); !s.done; s = i.next()) {
@@ -943,7 +945,7 @@ if (t) throw t.error;
 return n;
 }
 
-function ue(e) {
+function le(e) {
 return {
 color: e > 30 ? "#ff0000" : e > 10 ? "#ff8800" : "#ffff00",
 radius: .4 + e / 100,
@@ -952,7 +954,7 @@ animated: e > 20
 };
 }
 
-function le(e) {
+function me(e) {
 switch (e) {
 case STRUCTURE_RAMPART:
 return .8;
@@ -976,7 +978,7 @@ return .7;
 }
 }
 
-function me(e) {
+function de(e) {
 return Object.keys(e).filter(function(t) {
 var r;
 return (null !== (r = e[t]) && void 0 !== r ? r : 0) > 1e3;
@@ -986,7 +988,7 @@ return (null !== (o = e[r]) && void 0 !== o ? o : 0) - (null !== (n = e[t]) && v
 }).slice(0, 3);
 }
 
-var de = {
+var pe = {
 showPheromones: !0,
 showPaths: !1,
 showCombat: !0,
@@ -995,9 +997,9 @@ showSpawnQueue: !0,
 showRoomStats: !0,
 showStructures: !1,
 opacity: .5
-}, pe = function() {
+}, fe = function() {
 function t(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, de), e), this.memoryManager = t;
+void 0 === e && (e = {}), this.config = o(o({}, pe), e), this.memoryManager = t;
 }
 return t.prototype.setMemoryManager = function(e) {
 this.memoryManager = e;
@@ -1057,7 +1059,7 @@ align: "left",
 font: "0.4 monospace",
 color: null !== (c = [ "#00ff00", "#ffff00", "#ff8800", "#ff0000" ][null !== (s = r.danger) && void 0 !== s ? s : 0]) && void 0 !== c ? c : "#ffffff"
 }), l += m);
-var h = t.find(FIND_MY_CREEPS).length, R = X(t).length;
+var h = t.find(FIND_MY_CREEPS).length, R = Z(t).length;
 e.text("Creeps: ".concat(h, " | Hostiles: ").concat(R), u, l, {
 align: "left",
 font: "0.4 monospace",
@@ -1082,7 +1084,7 @@ font: "0.5 monospace",
 color: "#ffffff"
 }), n += .6, t.pheromones) try {
 for (var s = a(Object.entries(t.pheromones)), c = s.next(); !c.done; c = s.next()) {
-var u = i(c.value, 2), l = u[0], m = u[1], d = ie(l), p = se(m, 6);
+var u = i(c.value, 2), l = u[0], m = u[1], d = se(l), p = ce(m, 6);
 e.rect(42, n, 6, .4, {
 fill: "#333333",
 opacity: .8
@@ -1131,7 +1133,7 @@ if (r) throw r.error;
 return n ? {
 name: n,
 value: s,
-color: ie(n),
+color: se(n),
 opacity: .15 * Math.min(1, s / 100)
 } : null;
 }(t.pheromones);
@@ -1149,10 +1151,10 @@ color: "#ffffff"
 }));
 }
 }, t.prototype.drawCombatInfo = function(e, t) {
-var r, o, n, i, s = X(t);
+var r, o, n, i, s = Z(t);
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = ce(l), d = ue(m);
+var l = u.value, m = ue(l), d = le(m);
 e.circle(l.pos, {
 radius: d.radius,
 fill: d.color,
@@ -1297,7 +1299,7 @@ var C = t.controller;
 if (C && this.drawFlowingArrow(e, m.pos, C.pos, "#00ffff", .3), m.store.getUsedCapacity() > 0) {
 var S = .8, w = -.8;
 try {
-for (var x = a(me(m.store)), b = x.next(); !b.done; b = x.next()) {
+for (var x = a(de(m.store)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
 e.resource(O, m.pos.x + S, m.pos.y + w, .3), S += .6;
 }
@@ -1317,7 +1319,7 @@ var k = t.terminal;
 if (k && k.store.getUsedCapacity() > 0) {
 S = .8, w = -.8;
 try {
-for (var M = a(me(k.store)), A = M.next(); !A.done; A = M.next()) O = A.value, e.resource(O, k.pos.x + S, k.pos.y + w, .3),
+for (var M = a(de(k.store)), A = M.next(); !A.done; A = M.next()) O = A.value, e.resource(O, k.pos.x + S, k.pos.y + w, .3),
 S += .6;
 } catch (e) {
 u = {
@@ -1362,7 +1364,7 @@ lineStyle: "dashed"
 var r, o, n, i, s, c, u = f.getCachedStructures(t.name);
 if (u) try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = le(d.type);
+var d = m.value, p = me(d.type);
 e.structure(d.x, d.y, d.type, {
 opacity: p
 });
@@ -1382,7 +1384,7 @@ var y = t.find(FIND_STRUCTURES), v = [];
 try {
 for (var g = a(y), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-p = le(R.structureType), e.structure(R.pos.x, R.pos.y, R.structureType, {
+p = me(R.structureType), e.structure(R.pos.x, R.pos.y, R.structureType, {
 opacity: p
 }), v.push({
 x: R.pos.x,
@@ -1538,9 +1540,9 @@ opacity: .8
 }, t;
 }();
 
-new pe;
+new fe;
 
-var fe = function() {
+var ye = function() {
 function e(e) {
 void 0 === e && (e = "default"), this.namespace = e;
 }
@@ -1588,7 +1590,7 @@ if (e) throw e.error;
 }
 return o;
 }, e;
-}(), ye = function() {
+}(), ve = function() {
 function e(e, t) {
 void 0 === e && (e = "default"), void 0 === t && (t = 10), this.lastPersistTick = 0,
 this.namespace = e, this.persistInterval = t;
@@ -1732,18 +1734,18 @@ return o.lastSync = Game.time, this.lastPersistTick = Game.time, n;
 }, e.CACHE_VERSION = 1, e;
 }();
 
-function ve(e, t) {
+function ge(e, t) {
 return !!(e.includes("path:") || e.includes(":path:") || e.includes("scan:") || e.includes("roomFind:") || e.includes("target:") || e.includes("role:"));
 }
 
-var ge = function() {
+var he = function() {
 function e(e, t) {
 var r, o, n;
 void 0 === e && (e = "default"), void 0 === t && (t = {}), this.lastPersistTick = 0,
 this.lastSizeCheck = 0, this.namespace = e, this.config = {
 syncInterval: null !== (r = t.syncInterval) && void 0 !== r ? r : 10,
 maxMemoryBytes: null !== (o = t.maxMemoryBytes) && void 0 !== o ? o : 102400,
-persistenceFilter: null !== (n = t.persistenceFilter) && void 0 !== n ? n : ve
+persistenceFilter: null !== (n = t.persistenceFilter) && void 0 !== n ? n : ge
 };
 }
 return e.prototype.getHeap = function() {
@@ -1945,13 +1947,13 @@ memoryBudgetBytes: this.config.maxMemoryBytes,
 budgetUtilization: e.memoryUsageBytes / this.config.maxMemoryBytes
 };
 }, e.CACHE_VERSION = 1, e;
-}(), he = function() {
+}(), Re = function() {
 function e(e) {
 void 0 === e && (e = "heap"), this.stores = new Map, this.stats = new Map, this.defaultStore = e;
 }
 return e.prototype.getStore = function(e, t) {
 var r = null != t ? t : this.defaultStore, o = "".concat(e, ":").concat(r), n = this.stores.get(o);
-return n || (n = "memory" === r ? new ye(e) : "hybrid" === r ? new ge(e) : new fe(e),
+return n || (n = "memory" === r ? new ve(e) : "hybrid" === r ? new he(e) : new ye(e),
 this.stores.set(o, n)), n;
 }, e.prototype.getStats = function(e) {
 var t = this.stats.get(e);
@@ -2256,23 +2258,23 @@ if (e) throw e.error;
 }
 return r;
 }, e;
-}(), Re = new he("heap");
+}(), Ee = new Re("heap");
 
-function Ee(e) {
+function Te(e) {
 return e.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-var Te, Ce = function() {
+var Ce, Se = function() {
 function e(e) {
 void 0 === e && (e = 100), this.maxSize = e, this.patterns = new Map;
 }
 return e.prototype.forRoom = function(e) {
-var t = Ee(e);
+var t = Te(e);
 return this.get("(^|:)".concat(t, "($|:)"));
 }, e.prototype.forCreep = function(e) {
-return this.get(Ee(e));
+return this.get(Te(e));
 }, e.prototype.forStructure = function(e, t) {
-var r = "".concat(Ee(e), ".*").concat(t);
+var r = "".concat(Te(e), ".*").concat(t);
 return this.get(r);
 }, e.prototype.get = function(e) {
 var t = this.patterns.get(e);
@@ -2286,16 +2288,16 @@ void 0 !== e && this.patterns.delete(e);
 }, e;
 }();
 
-function Se(e, t) {
+function we(e, t) {
 var r;
 return null !== (r = t[e]) && void 0 !== r ? r : t.default;
 }
 
-function we(e, t) {
+function xe(e, t) {
 var r, o, n = 0;
 try {
 for (var i = a(e), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = c.manager.getCacheStats(c.namespace), l = Se(c.namespace, t);
+var c = s.value, u = c.manager.getCacheStats(c.namespace), l = we(c.namespace, t);
 n += u.size * l;
 }
 } catch (e) {
@@ -2312,13 +2314,13 @@ if (r) throw r.error;
 return n;
 }
 
-function xe(e, t, r) {
+function be(e, t, r) {
 if (e <= 0 || t <= 0) return 0;
 var o = Math.ceil(t / r), n = Math.max(1, Math.floor(.1 * e));
 return Math.min(e, Math.max(n, o));
 }
 
-function be(e, t) {
+function Oe(e, t) {
 if (t <= 0) return 0;
 if ("function" == typeof e.manager.evictLRU) return e.manager.evictLRU(e.namespace, t);
 for (var r = 0, o = 0; o < t; o++) {
@@ -2331,13 +2333,13 @@ return r;
 
 !function(e) {
 e.L1 = "L1", e.L2 = "L2", e.L3 = "L3";
-}(Te || (Te = {}));
+}(Ce || (Ce = {}));
 
-var Oe, ke = function() {
+var ke, Me = function() {
 function e() {
 this.registeredCaches = new Map, this.invalidationCount = 0, this.lastCleanupTick = 0,
 this.CLEANUP_INTERVAL = 10, this.DEFAULT_MEMORY_BUDGET = 52428800, this.totalMemoryBudget = this.DEFAULT_MEMORY_BUDGET,
-this.invalidationPatterns = new Ce, this.estimatedBytesPerEntry = {
+this.invalidationPatterns = new Se, this.estimatedBytesPerEntry = {
 object: 512,
 bodypart: 256,
 path: 2048,
@@ -2360,13 +2362,13 @@ maxMemory: o.maxMemory
 this.registeredCaches.set(e, a);
 }, e.prototype.getDefaultPriority = function(e) {
 switch (e) {
-case Te.L1:
+case Ce.L1:
 return 100;
 
-case Te.L2:
+case Ce.L2:
 return 50;
 
-case Te.L3:
+case Ce.L3:
 return 25;
 }
 }, e.prototype.invalidate = function(e) {
@@ -2417,7 +2419,7 @@ if (t) throw t.error;
 return this.invalidationCount += n, n;
 }, e.prototype.enforceMemoryLimits = function() {
 return function(e, t, r) {
-var o, n, i = Array.from(e), s = we(i, r);
+var o, n, i = Array.from(e), s = xe(i, r);
 if (s <= t) return 0;
 var c = s - t, u = 0, l = i.sort(function(e, t) {
 return e.priority - t.priority;
@@ -2428,7 +2430,7 @@ var p = d.value;
 if (c <= 0) break;
 var f = p.manager.getCacheStats(p.namespace);
 if (0 !== f.size) {
-var y = Se(p.namespace, r), v = be(p, xe(f.size, c, y));
+var y = we(p.namespace, r), v = Oe(p, be(f.size, c, y));
 u += v, c -= v * y;
 }
 }
@@ -2446,23 +2448,23 @@ if (o) throw o.error;
 return u;
 }(this.registeredCaches.values(), this.totalMemoryBudget, this.estimatedBytesPerEntry);
 }, e.prototype.estimateTotalMemory = function() {
-return we(this.registeredCaches.values(), this.estimatedBytesPerEntry);
+return xe(this.registeredCaches.values(), this.estimatedBytesPerEntry);
 }, e.prototype.setMemoryEstimate = function(e, t) {
 this.estimatedBytesPerEntry[e] = t;
 }, e.prototype.getCacheStats = function() {
-var e, t, r, o, n, i = 0, s = 0, c = 0, u = ((e = {})[Te.L1] = {
+var e, t, r, o, n, i = 0, s = 0, c = 0, u = ((e = {})[Ce.L1] = {
 size: 0,
 hits: 0,
 misses: 0,
 hitRate: 0,
 evictions: 0
-}, e[Te.L2] = {
+}, e[Ce.L2] = {
 size: 0,
 hits: 0,
 misses: 0,
 hitRate: 0,
 evictions: 0
-}, e[Te.L3] = {
+}, e[Ce.L3] = {
 size: 0,
 hits: 0,
 misses: 0,
@@ -2488,7 +2490,7 @@ if (t) throw t.error;
 }
 var y = i + s, v = y > 0 ? i / y : 0;
 try {
-for (var g = a(Object.values(Te)), h = g.next(); !h.done; h = g.next()) {
+for (var g = a(Object.values(Ce)), h = g.next(); !h.done; h = g.next()) {
 var R, E = u[R = h.value].hits + u[R].misses;
 u[R].hitRate = E > 0 ? u[R].hits / E : 0;
 }
@@ -2536,7 +2538,7 @@ var e, t, r = 0;
 try {
 for (var o = a(this.registeredCaches.values()), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-i.layer === Te.L3 && (r += i.manager.persist());
+i.layer === Ce.L3 && (r += i.manager.persist());
 }
 } catch (t) {
 e = {
@@ -2580,48 +2582,48 @@ this.totalMemoryBudget = e;
 }, e.prototype.getMemoryBudget = function() {
 return this.totalMemoryBudget;
 }, e;
-}(), Me = new ke, Ae = {
-cacheManager: Re,
-coherenceManager: Me
+}(), Ae = new Me, Ue = {
+cacheManager: Ee,
+coherenceManager: Ae
 };
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(Oe || (Oe = {}));
+}(ke || (ke = {}));
 
-var Ue, _e = new (function() {
+var _e, Ne = new (function() {
 function e() {
-this.level = Oe.INFO;
+this.level = ke.INFO;
 }
 return e.prototype.setLevel = function(e) {
 this.level = e;
 }, e.prototype.debug = function(e, t) {
-this.level <= Oe.DEBUG && console.log(JSON.stringify(o({
+this.level <= ke.DEBUG && console.log(JSON.stringify(o({
 level: "DEBUG",
 message: e,
 tick: Game.time
 }, t)));
 }, e.prototype.info = function(e, t) {
-this.level <= Oe.INFO && console.log(JSON.stringify(o({
+this.level <= ke.INFO && console.log(JSON.stringify(o({
 level: "INFO",
 message: e,
 tick: Game.time
 }, t)));
 }, e.prototype.warn = function(e, t) {
-this.level <= Oe.WARN && console.log(JSON.stringify(o({
+this.level <= ke.WARN && console.log(JSON.stringify(o({
 level: "WARN",
 message: e,
 tick: Game.time
 }, t)));
 }, e.prototype.error = function(e, t) {
-this.level <= Oe.ERROR && console.log(JSON.stringify(o({
+this.level <= ke.ERROR && console.log(JSON.stringify(o({
 level: "ERROR",
 message: e,
 tick: Game.time
 }, t)));
 }, e;
-}()), Ne = {
+}()), Pe = {
 maxEventsPerTick: 50,
 maxQueueSize: 200,
 lowBucketThreshold: 2e3,
@@ -2635,32 +2637,32 @@ enableEventCoalescing: !0
 !function(e) {
 e[e.CRITICAL = 100] = "CRITICAL", e[e.HIGH = 75] = "HIGH", e[e.NORMAL = 50] = "NORMAL",
 e[e.LOW = 25] = "LOW", e[e.BACKGROUND = 10] = "BACKGROUND";
-}(Ue || (Ue = {}));
+}(_e || (_e = {}));
 
-var Pe, Ie = {
-"hostile.detected": Ue.CRITICAL,
-"nuke.detected": Ue.CRITICAL,
-"safemode.activated": Ue.CRITICAL,
-"structure.destroyed": Ue.HIGH,
-"hostile.cleared": Ue.HIGH,
-"creep.died": Ue.HIGH,
-"energy.critical": Ue.HIGH,
-"spawn.emergency": Ue.HIGH,
-"posture.change": Ue.HIGH,
-"spawn.completed": Ue.NORMAL,
-"rcl.upgrade": Ue.NORMAL,
-"construction.complete": Ue.NORMAL,
-"remote.lost": Ue.NORMAL,
-"squad.formed": Ue.NORMAL,
-"squad.dissolved": Ue.NORMAL,
-"market.transaction": Ue.LOW,
-"pheromone.update": Ue.LOW,
-"cluster.update": Ue.LOW,
-"expansion.candidate": Ue.LOW,
-"powerbank.discovered": Ue.LOW,
-"cpu.spike": Ue.BACKGROUND,
-"bucket.modeChange": Ue.BACKGROUND
-}, Ge = function() {
+var Ie, Ge = {
+"hostile.detected": _e.CRITICAL,
+"nuke.detected": _e.CRITICAL,
+"safemode.activated": _e.CRITICAL,
+"structure.destroyed": _e.HIGH,
+"hostile.cleared": _e.HIGH,
+"creep.died": _e.HIGH,
+"energy.critical": _e.HIGH,
+"spawn.emergency": _e.HIGH,
+"posture.change": _e.HIGH,
+"spawn.completed": _e.NORMAL,
+"rcl.upgrade": _e.NORMAL,
+"construction.complete": _e.NORMAL,
+"remote.lost": _e.NORMAL,
+"squad.formed": _e.NORMAL,
+"squad.dissolved": _e.NORMAL,
+"market.transaction": _e.LOW,
+"pheromone.update": _e.LOW,
+"cluster.update": _e.LOW,
+"expansion.candidate": _e.LOW,
+"powerbank.discovered": _e.LOW,
+"cpu.spike": _e.BACKGROUND,
+"bucket.modeChange": _e.BACKGROUND
+}, Le = function() {
 function e(e) {
 void 0 === e && (e = {}), this.handlers = new Map, this.eventQueue = [], this.coalescedQueueMap = new Map,
 this.handlerIdCounter = 0, this.queueBudgetTick = null, this.queueBudgetRemaining = 0,
@@ -2671,21 +2673,21 @@ eventsDeferred: 0,
 eventsDropped: 0,
 eventsCoalesced: 0,
 handlersInvoked: 0
-}, this.config = o(o({}, Ne), e);
+}, this.config = o(o({}, Pe), e);
 }
 return e.prototype.on = function(e, t, r) {
 var o, n, a, i, s = this;
 void 0 === r && (r = {});
 var c = {
 handler: t,
-priority: null !== (o = r.priority) && void 0 !== o ? o : Ue.NORMAL,
+priority: null !== (o = r.priority) && void 0 !== o ? o : _e.NORMAL,
 minBucket: null !== (n = r.minBucket) && void 0 !== n ? n : 0,
 once: null !== (a = r.once) && void 0 !== a && a,
 id: "handler_".concat(++this.handlerIdCounter)
 }, u = null !== (i = this.handlers.get(e)) && void 0 !== i ? i : [];
 return u.push(c), u.sort(function(e, t) {
 return t.priority - e.priority;
-}), this.handlers.set(e, u), this.config.enableLogging && _e.debug('EventBus: Registered handler for "'.concat(e, '" (id: ').concat(c.id, ")"), {
+}), this.handlers.set(e, u), this.config.enableLogging && Ne.debug('EventBus: Registered handler for "'.concat(e, '" (id: ').concat(c.id, ")"), {
 subsystem: "EventBus"
 }), function() {
 return s.off(e, c.id);
@@ -2700,12 +2702,12 @@ if (r) {
 var o = r.findIndex(function(e) {
 return e.id === t;
 });
--1 !== o && (r.splice(o, 1), this.config.enableLogging && _e.debug('EventBus: Unregistered handler "'.concat(t, '" from "').concat(e, '"'), {
+-1 !== o && (r.splice(o, 1), this.config.enableLogging && Ne.debug('EventBus: Unregistered handler "'.concat(t, '" from "').concat(e, '"'), {
 subsystem: "EventBus"
 }));
 }
 }, e.prototype.offAll = function(e) {
-this.handlers.delete(e), this.config.enableLogging && _e.debug('EventBus: Removed all handlers for "'.concat(e, '"'), {
+this.handlers.delete(e), this.config.enableLogging && Ne.debug('EventBus: Removed all handlers for "'.concat(e, '"'), {
 subsystem: "EventBus"
 });
 }, e.prototype.emit = function(e, t, r) {
@@ -2713,13 +2715,13 @@ var n, a, i;
 void 0 === r && (r = {});
 var s = o(o({}, t), {
 tick: Game.time
-}), c = null !== (a = null !== (n = r.priority) && void 0 !== n ? n : Ie[e]) && void 0 !== a ? a : Ue.NORMAL, u = null !== (i = r.immediate) && void 0 !== i ? i : c >= Ue.CRITICAL;
-this.stats.eventsEmitted++, this.config.enableLogging && _e.debug('EventBus: Emitting "'.concat(e, '" (priority: ').concat(c, ", immediate: ").concat(String(u), ")"), {
+}), c = null !== (a = null !== (n = r.priority) && void 0 !== n ? n : Ge[e]) && void 0 !== a ? a : _e.NORMAL, u = null !== (i = r.immediate) && void 0 !== i ? i : c >= _e.CRITICAL;
+this.stats.eventsEmitted++, this.config.enableLogging && Ne.debug('EventBus: Emitting "'.concat(e, '" (priority: ').concat(c, ", immediate: ").concat(String(u), ")"), {
 subsystem: "EventBus"
 });
 var l = Game.cpu.bucket;
-u || l >= this.config.lowBucketThreshold ? this.processEvent(e, s) : l >= this.config.criticalBucketThreshold ? this.queueEvent(e, s, c) : c >= Ue.CRITICAL ? this.processEvent(e, s) : (this.stats.eventsDropped++,
-this.config.enableLogging && _e.warn('EventBus: Dropped event "'.concat(e, '" due to critical bucket'), {
+u || l >= this.config.lowBucketThreshold ? this.processEvent(e, s) : l >= this.config.criticalBucketThreshold ? this.queueEvent(e, s, c) : c >= _e.CRITICAL ? this.processEvent(e, s) : (this.stats.eventsDropped++,
+this.config.enableLogging && Ne.warn('EventBus: Dropped event "'.concat(e, '" due to critical bucket'), {
 subsystem: "EventBus"
 }));
 }, e.prototype.getCoalescingKey = function(e, t, r) {
@@ -2766,7 +2768,7 @@ if (!(c < d.minBucket)) try {
 d.handler(t), this.stats.handlersInvoked++, d.once && u.push(d.id);
 } catch (t) {
 var p = t instanceof Error ? t.message : String(t);
-_e.error('EventBus: Handler error for "'.concat(e, '": ').concat(p), {
+Ne.error('EventBus: Handler error for "'.concat(e, '": ').concat(p), {
 subsystem: "EventBus"
 });
 }
@@ -2813,7 +2815,7 @@ event: e,
 index: t
 };
 }).filter(function(e) {
-return e.event.priority < Ue.HIGH;
+return e.event.priority < _e.HIGH;
 }).sort(function(e, t) {
 return e.event.queuedAt - t.event.queuedAt;
 })[0];
@@ -2901,12 +2903,12 @@ return this.getHandlerCount(e) > 0;
 }, e.prototype.logStats = function() {
 if (Game.time % this.config.statsLogInterval === 0) {
 var e = this.getStats();
-_e.debug("EventBus stats: ".concat(e.eventsEmitted, " emitted, ").concat(e.eventsProcessed, " processed, ") + "".concat(e.eventsDeferred, " deferred, ").concat(e.eventsDropped, " dropped, ") + "".concat(e.eventsCoalesced, " coalesced, ").concat(e.queueSize, " queued, ") + "".concat(e.handlerCount, " handlers"), {
+Ne.debug("EventBus stats: ".concat(e.eventsEmitted, " emitted, ").concat(e.eventsProcessed, " processed, ") + "".concat(e.eventsDeferred, " deferred, ").concat(e.eventsDropped, " dropped, ") + "".concat(e.eventsCoalesced, " coalesced, ").concat(e.queueSize, " queued, ") + "".concat(e.handlerCount, " handlers"), {
 subsystem: "EventBus"
 });
 }
 }, e;
-}(), Le = new Ge, De = o({}, {
+}(), De = new Le, Be = o({}, {
 enableAdaptiveBudgets: !0,
 cpu: {
 bucketThresholds: {
@@ -2937,9 +2939,9 @@ overmind: 1
 !function(e) {
 e[e.CRITICAL = 100] = "CRITICAL", e[e.HIGH = 75] = "HIGH", e[e.MEDIUM = 50] = "MEDIUM",
 e[e.LOW = 25] = "LOW", e[e.IDLE = 10] = "IDLE";
-}(Pe || (Pe = {}));
+}(Ie || (Ie = {}));
 
-var Be = {
+var Fe = {
 targetCpuUsage: .98,
 reservedCpuFraction: .02,
 enableStats: !0,
@@ -2953,7 +2955,7 @@ priorityDecayRate: 1,
 maxPriorityBoost: 50
 };
 
-function Fe(e) {
+function We(e) {
 var t, r, n = e.bucketThresholds.highMode, a = e.bucketThresholds.lowMode, i = function(e) {
 return Math.max(0, Math.floor(e / 2));
 }(a), s = (t = e.taskFrequencies, {
@@ -2969,7 +2971,7 @@ high: (r = e.budgets).rooms,
 medium: r.strategic,
 low: Math.max(r.market, r.visualization)
 };
-return o(o({}, Be), {
+return o(o({}, Fe), {
 lowBucketThreshold: a,
 highBucketThreshold: n,
 criticalBucketThreshold: i,
@@ -2979,7 +2981,7 @@ frequencyCpuBudgets: u
 });
 }
 
-var We, He, Ke = function() {
+var He, Ke, Ye = function() {
 function e(e) {
 this.processes = new Map, this.defaultBudgetProcessIds = new Set, this.bucketMode = "normal",
 this.tickCpuUsed = 0, this.initialized = !1, this.lastExecutedProcessId = null,
@@ -2998,17 +3000,17 @@ this.frequencyDefaults = this.buildFrequencyDefaults();
 return e.prototype.registerProcess = function(e) {
 var t, r, n, a, i, s = null !== (t = e.frequency) && void 0 !== t ? t : "medium", c = this.frequencyDefaults[s];
 if (void 0 !== e.tickModulo) {
-if (e.tickModulo < 0) throw _e.error('Kernel: Cannot register process "'.concat(e.name, '" - tickModulo must be non-negative (got ').concat(e.tickModulo, ")"), {
+if (e.tickModulo < 0) throw Ne.error('Kernel: Cannot register process "'.concat(e.name, '" - tickModulo must be non-negative (got ').concat(e.tickModulo, ")"), {
 subsystem: "Kernel"
 }), new Error("Invalid tickModulo: ".concat(e.tickModulo, " (must be >= 0)"));
-if (e.tickModulo > 0 && void 0 !== e.tickOffset && e.tickOffset >= e.tickModulo) throw _e.error('Kernel: Cannot register process "'.concat(e.name, '" - tickOffset (').concat(e.tickOffset, ") must be less than tickModulo (").concat(e.tickModulo, ")"), {
+if (e.tickModulo > 0 && void 0 !== e.tickOffset && e.tickOffset >= e.tickModulo) throw Ne.error('Kernel: Cannot register process "'.concat(e.name, '" - tickOffset (').concat(e.tickOffset, ") must be less than tickModulo (").concat(e.tickModulo, ")"), {
 subsystem: "Kernel"
 }), new Error("Invalid tickOffset: ".concat(e.tickOffset, " (must be < tickModulo ").concat(e.tickModulo, ")"));
 }
 var u = null !== (r = e.interval) && void 0 !== r ? r : c.interval, l = void 0 === e.tickModulo && u > 1 && u <= 20 ? this.resolveIntervalJitterOffset(u, e.id) : void 0, m = {
 id: e.id,
 name: e.name,
-priority: null !== (n = e.priority) && void 0 !== n ? n : Pe.MEDIUM,
+priority: null !== (n = e.priority) && void 0 !== n ? n : Ie.MEDIUM,
 frequency: s,
 minBucket: null !== (a = e.minBucket) && void 0 !== a ? a : c.minBucket,
 cpuBudget: null !== (i = e.cpuBudget) && void 0 !== i ? i : c.cpuBudget,
@@ -3036,12 +3038,12 @@ consecutiveCpuSkips: 0
 }
 };
 this.processes.set(e.id, m), void 0 === e.cpuBudget ? this.defaultBudgetProcessIds.add(e.id) : this.defaultBudgetProcessIds.delete(e.id),
-this.queueDirty = !0, _e.debug('Kernel: Registered process "'.concat(m.name, '" (').concat(m.id, ")"), {
+this.queueDirty = !0, Ne.debug('Kernel: Registered process "'.concat(m.name, '" (').concat(m.id, ")"), {
 subsystem: "Kernel"
 });
 }, e.prototype.unregisterProcess = function(e) {
 var t = this.processes.delete(e);
-return t && (this.defaultBudgetProcessIds.delete(e), this.queueDirty = !0, _e.debug("Kernel: Unregistered process ".concat(e), {
+return t && (this.defaultBudgetProcessIds.delete(e), this.queueDirty = !0, Ne.debug("Kernel: Unregistered process ".concat(e), {
 subsystem: "Kernel"
 })), t;
 }, e.prototype.getProcess = function(e) {
@@ -3116,24 +3118,24 @@ byState: C
 }
 };
 }, e.prototype.initialize = function() {
-this.initialized || (_e.info("Kernel initialized with ".concat(this.processes.size, " processes"), {
+this.initialized || (Ne.info("Kernel initialized with ".concat(this.processes.size, " processes"), {
 subsystem: "Kernel"
 }), this.initialized = !0);
 }, e.prototype.updateBucketMode = function() {
 var e, t = Game.cpu.bucket;
-if ((e = t < this.config.criticalBucketThreshold ? "critical" : t < this.config.lowBucketThreshold ? "low" : t > this.config.highBucketThreshold ? "high" : "normal") !== this.bucketMode && (_e.info("Kernel: Bucket mode changed from ".concat(this.bucketMode, " to ").concat(e, " (bucket: ").concat(t, ")"), {
+if ((e = t < this.config.criticalBucketThreshold ? "critical" : t < this.config.lowBucketThreshold ? "low" : t > this.config.highBucketThreshold ? "high" : "normal") !== this.bucketMode && (Ne.info("Kernel: Bucket mode changed from ".concat(this.bucketMode, " to ").concat(e, " (bucket: ").concat(t, ")"), {
 subsystem: "Kernel"
 }), this.bucketMode = e), Game.time % 100 == 0 && ("low" === this.bucketMode || "critical" === this.bucketMode)) {
 var r = this.processes.size;
-_e.info("Bucket ".concat(this.bucketMode.toUpperCase(), " mode: ").concat(t, "/10000 bucket. ") + "Core work remains enabled; optional processes below their minBucket are deferred. " + "".concat(r, " processes registered."), {
+Ne.info("Bucket ".concat(this.bucketMode.toUpperCase(), " mode: ").concat(t, "/10000 bucket. ") + "Core work remains enabled; optional processes below their minBucket are deferred. " + "".concat(r, " processes registered."), {
 subsystem: "Kernel"
 });
 }
 }, e.prototype.validateConfig = function() {
-this.config.criticalBucketThreshold >= this.config.lowBucketThreshold && (_e.warn("Kernel: Adjusting critical bucket threshold ".concat(this.config.criticalBucketThreshold, " to stay below low threshold ").concat(this.config.lowBucketThreshold), {
+this.config.criticalBucketThreshold >= this.config.lowBucketThreshold && (Ne.warn("Kernel: Adjusting critical bucket threshold ".concat(this.config.criticalBucketThreshold, " to stay below low threshold ").concat(this.config.lowBucketThreshold), {
 subsystem: "Kernel"
 }), this.config.criticalBucketThreshold = Math.max(0, this.config.lowBucketThreshold - 1)),
-this.config.lowBucketThreshold >= this.config.highBucketThreshold && (_e.warn("Kernel: Adjusting high bucket threshold ".concat(this.config.highBucketThreshold, " to stay above low threshold ").concat(this.config.lowBucketThreshold), {
+this.config.lowBucketThreshold >= this.config.highBucketThreshold && (Ne.warn("Kernel: Adjusting high bucket threshold ".concat(this.config.highBucketThreshold, " to stay above low threshold ").concat(this.config.lowBucketThreshold), {
 subsystem: "Kernel"
 }), this.config.highBucketThreshold = this.config.lowBucketThreshold + 1);
 }, e.prototype.buildFrequencyDefaults = function() {
@@ -3207,7 +3209,7 @@ if (this.config.frequencyCpuBudgets = t, this.frequencyDefaults = this.buildFreq
 this.hasFrequencyBudgetChanges(e, t) && this.synchronizeDefaultBudgetProcesses(),
 Game.time % 500 == 0) {
 var r = Object.keys(Game.rooms).length, n = Game.cpu.bucket, a = this.formatFrequencyUtilization(this.frequencyUtilization);
-_e.info("Adaptive budgets updated: rooms=".concat(r, ", bucket=").concat(n, ", ") + "high=".concat(t.high.toFixed(3), " (").concat(this.formatBudgetDelta(e.high, t.high), "), ") + "medium=".concat(t.medium.toFixed(3), " (").concat(this.formatBudgetDelta(e.medium, t.medium), "), ") + "low=".concat(t.low.toFixed(3), " (").concat(this.formatBudgetDelta(e.low, t.low), "), ") + "util=".concat(a), {
+Ne.info("Adaptive budgets updated: rooms=".concat(r, ", bucket=").concat(n, ", ") + "high=".concat(t.high.toFixed(3), " (").concat(this.formatBudgetDelta(e.high, t.high), "), ") + "medium=".concat(t.medium.toFixed(3), " (").concat(this.formatBudgetDelta(e.medium, t.medium), "), ") + "low=".concat(t.low.toFixed(3), " (").concat(this.formatBudgetDelta(e.low, t.low), "), ") + "util=".concat(a), {
 subsystem: "Kernel"
 });
 }
@@ -3287,11 +3289,11 @@ k && !k.done && (u = O.return) && u.call(O);
 if (c) throw c.error;
 }
 }
-y.size > 0 && _e.warn("Kernel: Dependency cycle detected, falling back to priority-only execution for ".concat(T.size, " process(es)."), {
+y.size > 0 && Ne.warn("Kernel: Dependency cycle detected, falling back to priority-only execution for ".concat(T.size, " process(es)."), {
 subsystem: "Kernel"
 });
 }
-return f.size > 0 && _e.warn("Kernel: Some process dependencies were invalid and ignored for: ".concat(Array.from(f).join(", ")), {
+return f.size > 0 && Ne.warn("Kernel: Some process dependencies were invalid and ignored for: ".concat(Array.from(f).join(", ")), {
 subsystem: "Kernel"
 }), E;
 }, e.prototype.resolveIntervalJitterOffset = function(e, t) {
@@ -3340,7 +3342,7 @@ var r = Math.max(1, e.interval + (null !== (t = e.intervalJitterOffset) && void 
 return Game.time - e.stats.lastRunTick >= r;
 }, e.prototype.shouldRunProcess = function(e) {
 var t, r;
-if (Game.cpu.bucket < e.minBucket) return Game.time % 100 == 0 && _e.debug('Kernel: Process "'.concat(e.name, '" skipped (bucket: ').concat(Game.cpu.bucket, "/").concat(e.minBucket, ")"), {
+if (Game.cpu.bucket < e.minBucket) return Game.time % 100 == 0 && Ne.debug('Kernel: Process "'.concat(e.name, '" skipped (bucket: ').concat(Game.cpu.bucket, "/").concat(e.minBucket, ")"), {
 subsystem: "Kernel"
 }), !1;
 if ("suspended" === e.state) {
@@ -3348,7 +3350,7 @@ if (null === e.stats.suspendedUntil) return !1;
 if (Game.time >= e.stats.suspendedUntil) {
 e.state = "idle", e.stats.suspendedUntil = null;
 var o = e.stats.suspensionReason;
-return e.stats.suspensionReason = null, _e.info('Kernel: Process "'.concat(e.name, '" automatically resumed after suspension. ') + "Previous reason: ".concat(o, ". Consecutive errors: ").concat(e.stats.consecutiveErrors), {
+return e.stats.suspensionReason = null, Ne.info('Kernel: Process "'.concat(e.name, '" automatically resumed after suspension. ') + "Previous reason: ".concat(o, ". Consecutive errors: ").concat(e.stats.consecutiveErrors), {
 subsystem: "Kernel",
 processId: e.id
 }), this.emit("process.recovered", {
@@ -3362,7 +3364,7 @@ priority: 50
 }
 if (Game.time % 100 == 0) {
 var n = e.stats.suspendedUntil - Game.time;
-_e.debug('Kernel: Process "'.concat(e.name, '" suspended (').concat(n, " ticks remaining)"), {
+Ne.debug('Kernel: Process "'.concat(e.name, '" suspended (').concat(n, " ticks remaining)"), {
 subsystem: "Kernel"
 });
 }
@@ -3373,9 +3375,9 @@ var a = null !== (t = e.tickOffset) && void 0 !== t ? t : 0;
 if ((Game.time + a) % e.tickModulo !== 0) return !1;
 }
 if (!this.isIntervalReady(e)) {
-if (e.stats.runCount > 0 && Game.time % 100 == 0 && e.priority >= Pe.HIGH) {
+if (e.stats.runCount > 0 && Game.time % 100 == 0 && e.priority >= Ie.HIGH) {
 var i = Game.time - e.stats.lastRunTick, s = Math.max(1, e.interval + (null !== (r = e.intervalJitterOffset) && void 0 !== r ? r : 0));
-_e.debug('Kernel: Process "'.concat(e.name, '" skipped (interval: ').concat(i, "/").concat(s, " ticks)"), {
+Ne.debug('Kernel: Process "'.concat(e.name, '" skipped (interval: ').concat(i, "/").concat(s, " ticks)"), {
 subsystem: "Kernel"
 });
 }
@@ -3396,14 +3398,14 @@ e.stats.lastSuccessfulRunTick = Game.time;
 } catch (t) {
 e.state = "error", e.stats.errorCount++, e.stats.consecutiveErrors++;
 var r = t instanceof Error ? t.message : String(t);
-_e.error('Kernel: Process "'.concat(e.name, '" error: ').concat(r), {
+Ne.error('Kernel: Process "'.concat(e.name, '" error: ').concat(r), {
 subsystem: "Kernel"
-}), t instanceof Error && t.stack && _e.error(t.stack, {
+}), t instanceof Error && t.stack && Ne.error(t.stack, {
 subsystem: "Kernel"
 });
 var o = e.stats.consecutiveErrors;
 if (o >= 10) e.stats.suspendedUntil = Number.MAX_SAFE_INTEGER, e.stats.suspensionReason = "Circuit breaker: ".concat(o, " consecutive failures (permanent)"),
-e.state = "suspended", _e.error('Kernel: Process "'.concat(e.name, '" permanently suspended after ').concat(o, " consecutive failures"), {
+e.state = "suspended", Ne.error('Kernel: Process "'.concat(e.name, '" permanently suspended after ').concat(o, " consecutive failures"), {
 subsystem: "Kernel",
 processId: e.id
 }), this.emit("process.suspended", {
@@ -3418,7 +3420,7 @@ priority: 100
 }); else if (o >= 3) {
 var n = Math.min(1e3, Math.pow(2, o));
 e.stats.suspendedUntil = Game.time + n, e.stats.suspensionReason = "".concat(o, " consecutive failures (auto-resume in ").concat(n, " ticks)"),
-e.state = "suspended", _e.warn('Kernel: Process "'.concat(e.name, '" suspended for ').concat(n, " ticks after ").concat(o, " consecutive failures"), {
+e.state = "suspended", Ne.warn('Kernel: Process "'.concat(e.name, '" suspended for ').concat(n, " ticks after ").concat(o, " consecutive failures"), {
 subsystem: "Kernel",
 processId: e.id,
 meta: {
@@ -3443,16 +3445,16 @@ this.config.enableStats && (e.stats.totalCpu += a, e.stats.runCount++, e.stats.a
 e.stats.maxCpu = Math.max(e.stats.maxCpu, a), e.stats.lastRunTick = Game.time, e.stats.healthScore = this.calculateHealthScore(e.stats)),
 this.tickCpuUsed += a, this.tickFrequencyCpuUsed[e.frequency] += a, this.tickFrequencyRunCount[e.frequency] += 1;
 var i = this.getCpuLimit() * e.cpuBudget, s = a / i;
-s > this.config.budgetWarningThreshold && Game.time % this.config.budgetWarningInterval === 0 && _e.warn('Kernel: Process "'.concat(e.name, '" exceeded CPU budget: ').concat(a.toFixed(3), " > ").concat(i.toFixed(3), " (").concat((100 * s).toFixed(0), "%)"), {
+s > this.config.budgetWarningThreshold && Game.time % this.config.budgetWarningInterval === 0 && Ne.warn('Kernel: Process "'.concat(e.name, '" exceeded CPU budget: ').concat(a.toFixed(3), " > ").concat(i.toFixed(3), " (").concat((100 * s).toFixed(0), "%)"), {
 subsystem: "Kernel"
 });
 }, e.prototype.run = function() {
 if (this.updateBucketMode(), this.updateAdaptiveBudgets(), this.tickCpuUsed = 0,
-this.skippedProcessesThisTick = 0, this.resetFrequencyTracking(), Le.processQueue(),
-this.queueDirty && (this.rebuildProcessQueue(), _e.info("Kernel: Rebuilt process queue with ".concat(this.processQueue.length, " processes"), {
+this.skippedProcessesThisTick = 0, this.resetFrequencyTracking(), De.processQueue(),
+this.queueDirty && (this.rebuildProcessQueue(), Ne.info("Kernel: Rebuilt process queue with ".concat(this.processQueue.length, " processes"), {
 subsystem: "Kernel"
 })), 0 !== this.processQueue.length) {
-Game.time % 10 == 0 && _e.info("Kernel: Running ".concat(this.processQueue.length, " registered processes"), {
+Game.time % 10 == 0 && Ne.info("Kernel: Running ".concat(this.processQueue.length, " registered processes"), {
 subsystem: "Kernel"
 });
 for (var e = 0, t = 0, r = 0, o = 0, n = (this.lastExecutedIndex + 1) % this.processQueue.length, a = 0; a < this.processQueue.length; a++) {
@@ -3463,7 +3465,7 @@ if (this.config.enablePriorityDecay) for (var c = a; c < this.processQueue.lengt
 var u = (n + c) % this.processQueue.length, l = this.processQueue[u];
 this.shouldRunProcess(l) && l.stats.consecutiveCpuSkips++;
 }
-r = this.processQueue.length - e - t, _e.warn("Kernel: CPU budget exhausted after ".concat(e, " processes. ").concat(r, " processes deferred to next tick. Used: ").concat(Game.cpu.getUsed().toFixed(2), "/").concat(this.getCpuLimit().toFixed(2)), {
+r = this.processQueue.length - e - t, Ne.warn("Kernel: CPU budget exhausted after ".concat(e, " processes. ").concat(r, " processes deferred to next tick. Used: ").concat(Game.cpu.getUsed().toFixed(2), "/").concat(this.getCpuLimit().toFixed(2)), {
 subsystem: "Kernel"
 }), this.config.enablePriorityDecay && r > 0 && (this.queueDirty = !0);
 break;
@@ -3473,13 +3475,13 @@ this.executeProcess(s), e++, this.lastExecutedProcessId = s.id, this.lastExecute
 s.stats.runCount > 0 && !this.isIntervalReady(s) && o++;
 }
 this.collectFrequencyUtilization(), this.config.enableStats && Game.time % this.config.statsLogInterval === 0 && (this.logStats(e, t, o, r),
-Le.logStats());
-} else _e.warn("Kernel: No processes registered in queue", {
+De.logStats());
+} else Ne.warn("Kernel: No processes registered in queue", {
 subsystem: "Kernel"
 });
 }, e.prototype.logStats = function(e, t, r, o) {
 var n = this, a = Game.cpu.bucket, i = (a / 1e4 * 100).toFixed(1), s = Game.cpu.getUsed(), c = this.getCpuLimit();
-if (_e.info("Kernel: ".concat(e, " ran, ").concat(t, " skipped (interval: ").concat(r, ", CPU: ").concat(o, "), ") + "CPU: ".concat(s.toFixed(2), "/").concat(c.toFixed(2), " (").concat((s / c * 100).toFixed(1), "%), bucket: ").concat(a, "/10000 (").concat(i, "%), mode: ").concat(this.bucketMode), {
+if (Ne.info("Kernel: ".concat(e, " ran, ").concat(t, " skipped (interval: ").concat(r, ", CPU: ").concat(o, "), ") + "CPU: ".concat(s.toFixed(2), "/").concat(c.toFixed(2), " (").concat((s / c * 100).toFixed(1), "%), bucket: ").concat(a, "/10000 (").concat(i, "%), mode: ").concat(this.bucketMode), {
 subsystem: "Kernel"
 }), this.config.enablePriorityDecay && o > 0) {
 var u = this.processQueue.filter(function(e) {
@@ -3487,7 +3489,7 @@ return e.stats.consecutiveCpuSkips >= 5;
 }).sort(function(e, t) {
 return t.stats.consecutiveCpuSkips - e.stats.consecutiveCpuSkips;
 }).slice(0, 3);
-u.length > 0 && _e.info("Kernel: Priority decay active: ".concat(u.map(function(e) {
+u.length > 0 && Ne.info("Kernel: Priority decay active: ".concat(u.map(function(e) {
 return "".concat(e.name, "(base:").concat(e.priority, ", boost:+").concat(n.calculatePriorityBoost(e.stats.consecutiveCpuSkips), ", skips:").concat(e.stats.consecutiveCpuSkips, ")");
 }).join(", ")), {
 subsystem: "Kernel"
@@ -3499,7 +3501,7 @@ return e.stats.skippedCount > 100;
 }).sort(function(e, t) {
 return t.stats.skippedCount - e.stats.skippedCount;
 }).slice(0, 5);
-l.length > 0 && _e.warn("Kernel: Top skipped processes: ".concat(l.map(function(e) {
+l.length > 0 && Ne.warn("Kernel: Top skipped processes: ".concat(l.map(function(e) {
 return "".concat(e.name, "(").concat(e.stats.skippedCount, ", interval:").concat(e.interval, ")");
 }).join(", ")), {
 subsystem: "Kernel"
@@ -3511,7 +3513,7 @@ return this.tickCpuUsed;
 return this.skippedProcessesThisTick;
 }, e.prototype.suspendProcess = function(e) {
 var t = this.processes.get(e);
-return !!t && (t.state = "suspended", _e.info('Kernel: Suspended process "'.concat(t.name, '"'), {
+return !!t && (t.state = "suspended", Ne.info('Kernel: Suspended process "'.concat(t.name, '"'), {
 subsystem: "Kernel"
 }), !0);
 }, e.prototype.resumeProcess = function(e) {
@@ -3519,7 +3521,7 @@ var t = this.processes.get(e);
 if (t && "suspended" === t.state) {
 t.state = "idle", t.stats.suspendedUntil = null;
 var r = t.stats.suspensionReason;
-return t.stats.suspensionReason = null, _e.info('Kernel: Manually resumed process "'.concat(t.name, '". ') + "Previous reason: ".concat(r, ". Consecutive errors: ").concat(t.stats.consecutiveErrors), {
+return t.stats.suspensionReason = null, Ne.info('Kernel: Manually resumed process "'.concat(t.name, '". ') + "Previous reason: ".concat(r, ". Consecutive errors: ").concat(t.stats.consecutiveErrors), {
 subsystem: "Kernel",
 processId: e
 }), this.emit("process.recovered", {
@@ -3599,7 +3601,7 @@ o && !o.done && (t = r.return) && t.call(r);
 if (e) throw e.error;
 }
 }
-_e.info("Kernel: Reset all process statistics", {
+Ne.info("Kernel: Reset all process statistics", {
 subsystem: "Kernel"
 });
 }, e.prototype.getDistributionStats = function() {
@@ -3666,33 +3668,33 @@ return o({}, this.frequencyDefaults[e]);
 this.config = o(o({}, this.config), e), this.validateConfig(), this.frequencyDefaults = this.buildFrequencyDefaults(),
 this.synchronizeDefaultBudgetProcesses();
 }, e.prototype.updateFromCpuConfig = function(e) {
-this.updateConfig(Fe(e));
+this.updateConfig(We(e));
 }, e.prototype.on = function(e, t, r) {
-return void 0 === r && (r = {}), Le.on(e, t, r);
+return void 0 === r && (r = {}), De.on(e, t, r);
 }, e.prototype.once = function(e, t, r) {
-return void 0 === r && (r = {}), Le.once(e, t, r);
+return void 0 === r && (r = {}), De.once(e, t, r);
 }, e.prototype.emit = function(e, t, r) {
-void 0 === r && (r = {}), Le.emit(e, t, r);
+void 0 === r && (r = {}), De.emit(e, t, r);
 }, e.prototype.offAll = function(e) {
-Le.offAll(e);
+De.offAll(e);
 }, e.prototype.processEvents = function() {
-Le.processQueue();
+De.processQueue();
 }, e.prototype.getEventStats = function() {
-return Le.getStats();
+return De.getStats();
 }, e.prototype.hasEventHandlers = function(e) {
-return Le.hasHandlers(e);
+return De.hasHandlers(e);
 }, e.prototype.getEventBus = function() {
-return Le;
+return De;
 }, e;
 }();
 
-new Ke(Fe(o({}, De).cpu));
+new Ye(We(o({}, Be).cpu));
 
-var Ye, Ve = globalThis, qe = null !== (We = Ve.__screepsKernelProcessMetadataStore) && void 0 !== We ? We : Ve.__screepsKernelProcessMetadataStore = [], je = null !== (He = Ve.__screepsKernelRegisteredProcessClasses) && void 0 !== He ? He : Ve.__screepsKernelRegisteredProcessClasses = new Set;
+var Ve, qe = globalThis, je = null !== (He = qe.__screepsKernelProcessMetadataStore) && void 0 !== He ? He : qe.__screepsKernelProcessMetadataStore = [], ze = null !== (Ke = qe.__screepsKernelRegisteredProcessClasses) && void 0 !== Ke ? Ke : qe.__screepsKernelRegisteredProcessClasses = new Set;
 
-function ze(e) {
+function Qe(e) {
 return function(t, r, o) {
-qe.push({
+je.push({
 options: e,
 methodName: String(r),
 target: t
@@ -3700,46 +3702,46 @@ target: t
 };
 }
 
-function Qe(e, t, r) {
-return ze(o({
+function Xe(e, t, r) {
+return Qe(o({
 id: e,
 name: t,
-priority: Pe.MEDIUM,
+priority: Ie.MEDIUM,
 frequency: "medium",
 cpuBudget: .15,
 interval: 5
 }, r));
 }
 
-function Xe(e, t, r) {
-return ze(o({
+function Ze(e, t, r) {
+return Qe(o({
 id: e,
 name: t,
-priority: Pe.LOW,
+priority: Ie.LOW,
 frequency: "low",
 cpuBudget: .1,
 interval: 20
 }, r));
 }
 
-function Ze(e, t, r) {
-return ze(o({
+function Je(e, t, r) {
+return Qe(o({
 id: e,
 name: t,
-priority: Pe.IDLE,
+priority: Ie.IDLE,
 frequency: "low",
 cpuBudget: .05,
 interval: 100
 }, r));
 }
 
-function Je() {
+function $e() {
 return function(e) {
-return je.add(e), e;
+return ze.add(e), e;
 };
 }
 
-function $e(e) {
+function et(e) {
 var t = Math.floor(.1 * e), r = Math.floor(Math.random() * (2 * t + 1)) - t;
 return {
 interval: Math.max(1, e + r),
@@ -3747,27 +3749,27 @@ jitter: r
 };
 }
 
-function et(e, t) {
+function tt(e, t) {
 var r = Object.getPrototypeOf(t);
 return !!r && (e.target === r || Object.getPrototypeOf(e.target) === r || e.target === Object.getPrototypeOf(r));
 }
 
-function tt(e, t) {
+function rt(e, t) {
 var r, o, n, i;
 try {
-for (var s = a(qe), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(je), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (et(u, t)) {
+if (tt(u, t)) {
 var l = t[u.methodName];
 if ("function" == typeof l) {
 var m = l.bind(t), d = u.options.interval, p = void 0 === d ? {
 interval: void 0,
 jitter: 0
-} : $e(d), f = p.interval, y = p.jitter;
+} : et(d), f = p.interval, y = p.jitter;
 e.registerProcess({
 id: u.options.id,
 name: u.options.name,
-priority: null !== (n = u.options.priority) && void 0 !== n ? n : Pe.MEDIUM,
+priority: null !== (n = u.options.priority) && void 0 !== n ? n : Ie.MEDIUM,
 frequency: null !== (i = u.options.frequency) && void 0 !== i ? i : "medium",
 minBucket: u.options.minBucket,
 cpuBudget: u.options.cpuBudget,
@@ -3775,7 +3777,7 @@ interval: f,
 execute: m
 });
 var v = void 0 === d ? "default interval" : "interval ".concat(f, " (base: ").concat(d, ", jitter: ").concat(y > 0 ? "+" : "").concat(y, ")");
-_e.debug('Registered decorated process "'.concat(u.options.name, '" (').concat(u.options.id, ") with ").concat(v), {
+Ne.debug('Registered decorated process "'.concat(u.options.name, '" (').concat(u.options.id, ") with ").concat(v), {
 subsystem: "ProcessDecorators"
 });
 }
@@ -3794,10 +3796,10 @@ if (r) throw r.error;
 }
 }
 
-function rt(e) {
+function ot(e) {
 for (var t, r, o = [], n = 1; n < arguments.length; n++) o[n - 1] = arguments[n];
 try {
-for (var i = a(o), s = i.next(); !s.done; s = i.next()) tt(e, s.value);
+for (var i = a(o), s = i.next(); !s.done; s = i.next()) rt(e, s.value);
 } catch (e) {
 t = {
 error: e
@@ -3809,45 +3811,45 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-_e.info("Registered decorated processes from ".concat(o.length, " instance(s)"), {
+Ne.info("Registered decorated processes from ".concat(o.length, " instance(s)"), {
 subsystem: "ProcessDecorators"
 });
 }
 
 !function(e) {
 e.RUNNING = "running", e.DEAD = "dead", e.SUSPENDED = "suspended";
-}(Ye || (Ye = {}));
+}(Ve || (Ve = {}));
 
-var ot, nt = M("CacheEvents"), at = new WeakMap, it = "object", st = "path";
+var nt, at = M("CacheEvents"), it = new WeakMap, st = "object", ct = "path";
 
-function ct(e, t) {
+function ut(e, t) {
 return "".concat(e.roomName, ":").concat(e.x, ",").concat(e.y, ":").concat(t.roomName, ":").concat(t.x, ",").concat(t.y);
 }
 
-function ut(e, t, r, o) {
+function lt(e, t, r, o) {
 void 0 === o && (o = {});
-var n = ct(e, t), a = Room.serializePath(r);
-Re.set(n, a, {
-namespace: st,
+var n = ut(e, t), a = Room.serializePath(r);
+Ee.set(n, a, {
+namespace: ct,
 ttl: o.ttl,
 maxSize: 1e3
 });
 }
 
-var lt = "roomFind", mt = ((ot = {})[FIND_SOURCES] = 5e3, ot[FIND_MINERALS] = 5e3,
-ot[FIND_DEPOSITS] = 100, ot[FIND_STRUCTURES] = 50, ot[FIND_MY_STRUCTURES] = 50,
-ot[FIND_HOSTILE_STRUCTURES] = 20, ot[FIND_MY_SPAWNS] = 100, ot[FIND_MY_CONSTRUCTION_SITES] = 20,
-ot[FIND_CONSTRUCTION_SITES] = 20, ot[FIND_CREEPS] = 5, ot[FIND_MY_CREEPS] = 5, ot[FIND_HOSTILE_CREEPS] = 3,
-ot[FIND_DROPPED_RESOURCES] = 5, ot[FIND_TOMBSTONES] = 10, ot[FIND_RUINS] = 10, ot[FIND_FLAGS] = 50,
-ot[FIND_NUKES] = 20, ot[FIND_POWER_CREEPS] = 10, ot[FIND_MY_POWER_CREEPS] = 10,
-ot);
+var mt = "roomFind", dt = ((nt = {})[FIND_SOURCES] = 5e3, nt[FIND_MINERALS] = 5e3,
+nt[FIND_DEPOSITS] = 100, nt[FIND_STRUCTURES] = 50, nt[FIND_MY_STRUCTURES] = 50,
+nt[FIND_HOSTILE_STRUCTURES] = 20, nt[FIND_MY_SPAWNS] = 100, nt[FIND_MY_CONSTRUCTION_SITES] = 20,
+nt[FIND_CONSTRUCTION_SITES] = 20, nt[FIND_CREEPS] = 5, nt[FIND_MY_CREEPS] = 5, nt[FIND_HOSTILE_CREEPS] = 3,
+nt[FIND_DROPPED_RESOURCES] = 5, nt[FIND_TOMBSTONES] = 10, nt[FIND_RUINS] = 10, nt[FIND_FLAGS] = 50,
+nt[FIND_NUKES] = 20, nt[FIND_POWER_CREEPS] = 10, nt[FIND_MY_POWER_CREEPS] = 10,
+nt);
 
-function dt(e, t, r) {
+function pt(e, t, r) {
 var o, n, a = function(e, t, r) {
 return r ? "".concat(e, ":").concat(t, ":").concat(r) : "".concat(e, ":").concat(t);
-}(e.name, t, null == r ? void 0 : r.filterKey), i = Re.get(a, {
-namespace: lt,
-ttl: null !== (n = null !== (o = null == r ? void 0 : r.ttl) && void 0 !== o ? o : mt[t]) && void 0 !== n ? n : 20,
+}(e.name, t, null == r ? void 0 : r.filterKey), i = Ee.get(a, {
+namespace: mt,
+ttl: null !== (n = null !== (o = null == r ? void 0 : r.ttl) && void 0 !== o ? o : dt[t]) && void 0 !== n ? n : 20,
 compute: function() {
 return (null == r ? void 0 : r.filter) ? e.find(t, {
 filter: r.filter
@@ -3857,30 +3859,30 @@ filter: r.filter
 return null != i ? i : [];
 }
 
-function pt(e) {
-return dt(e, FIND_SOURCES);
+function ft(e) {
+return pt(e, FIND_SOURCES);
 }
 
-function ft(e, t) {
-return t ? dt(e, FIND_MY_STRUCTURES, {
+function yt(e, t) {
+return t ? pt(e, FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
 },
 filterKey: t
-}) : dt(e, FIND_MY_STRUCTURES);
+}) : pt(e, FIND_MY_STRUCTURES);
 }
 
-var yt = "closest";
+var vt = "closest";
 
-function vt(e, t) {
+function gt(e, t) {
 return "".concat(e, ":").concat(t);
 }
 
-function gt(e, t, r, o) {
-if (void 0 === o && (o = 10), 0 === t.length) return ht(e, r), null;
+function ht(e, t, r, o) {
+if (void 0 === o && (o = 10), 0 === t.length) return Rt(e, r), null;
 if (1 === t.length) return t[0];
-var n = vt(e.name, r), a = Re.get(n, {
-namespace: yt,
+var n = gt(e.name, r), a = Ee.get(n, {
+namespace: vt,
 ttl: o
 });
 if (a) {
@@ -3890,32 +3892,32 @@ return e.id === i.id;
 }) && e.pos.getRangeTo(i.pos) <= 20) return i;
 }
 var s = e.pos.findClosestByRange(t);
-return s ? Re.set(n, s.id, {
-namespace: yt,
+return s ? Ee.set(n, s.id, {
+namespace: vt,
 ttl: o
-}) : ht(e, r), s;
+}) : Rt(e, r), s;
 }
 
-function ht(e, t) {
+function Rt(e, t) {
 if (t) {
-var r = vt(e.name, t);
-Re.invalidate(r, yt);
+var r = gt(e.name, t);
+Ee.invalidate(r, vt);
 } else {
 var o = new RegExp("^".concat(e.name, ":"));
-Re.invalidatePattern(o, yt);
+Ee.invalidatePattern(o, vt);
 }
 }
 
-function Rt(e) {
-ht(e);
+function Et(e) {
+Rt(e);
 }
 
-var Et = "game";
+var Tt = "game";
 
-function Tt() {
+function Ct() {
 var e;
-return null !== (e = Re.get("ownedRooms", {
-namespace: Et,
+return null !== (e = Ee.get("ownedRooms", {
+namespace: Tt,
 ttl: 0,
 compute: function() {
 return Object.values(Game.rooms).filter(function(e) {
@@ -3926,10 +3928,10 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) && void 0 !== e ? e : [];
 }
 
-function Ct() {
+function St() {
 var e;
-return null !== (e = Re.get("visibleRooms", {
-namespace: Et,
+return null !== (e = Ee.get("visibleRooms", {
+namespace: Tt,
 ttl: 0,
 compute: function() {
 return Object.values(Game.rooms);
@@ -3937,7 +3939,7 @@ return Object.values(Game.rooms);
 })) && void 0 !== e ? e : [];
 }
 
-var St = "#ffffff", wt = [ "#00ff00", "#ffff00", "#ff8800", "#ff0000" ], xt = {
+var wt = "#ffffff", xt = [ "#00ff00", "#ffff00", "#ff8800", "#ff0000" ], bt = {
 eco: "#00ff00",
 expand: "#00ffff",
 defense: "#ffff00",
@@ -3946,25 +3948,25 @@ siege: "#ff0000",
 evacuate: "#ff00ff"
 };
 
-function bt(e) {
-var t, r = e ? Math.min(Math.max(e, 0), 3) : 0;
-return null !== (t = wt[r]) && void 0 !== t ? t : St;
-}
-
 function Ot(e) {
-var t;
-return null !== (t = xt[e]) && void 0 !== t ? t : St;
+var t, r = e ? Math.min(Math.max(e, 0), 3) : 0;
+return null !== (t = xt[r]) && void 0 !== t ? t : wt;
 }
 
-function kt(e, t) {
+function kt(e) {
+var t;
+return null !== (t = bt[e]) && void 0 !== t ? t : wt;
+}
+
+function Mt(e, t) {
 return e + 2 * t;
 }
 
-function Mt(e) {
+function At(e) {
 return e > 10 ? "#ff0000" : "#ff8800";
 }
 
-function At(e) {
+function Ut(e) {
 var t, r, o = e.match(/[WE](\d+)[NS](\d+)/);
 if (!o) return {
 isHighway: !1,
@@ -3977,7 +3979,7 @@ showSourceKeeperLabel: i && n % 10 == 0 && a % 10 == 0
 };
 }
 
-var Ut = {
+var _t = {
 showRoomStatus: !0,
 showConnections: !0,
 showThreats: !0,
@@ -3985,9 +3987,9 @@ showExpansion: !1,
 showResourceFlow: !1,
 showHighways: !1,
 opacity: .6
-}, _t = function() {
+}, Nt = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, Ut), e), this.memoryManager = t;
+void 0 === e && (e = {}), this.config = o(o({}, _t), e), this.memoryManager = t;
 }
 return e.prototype.setMemoryManager = function(e) {
 this.memoryManager = e;
@@ -4015,10 +4017,10 @@ this.config.showResourceFlow && this.drawResourceFlow(e), this.config.showHighwa
 }, e.prototype.drawRoomStatus = function(e) {
 var t, r, o;
 try {
-for (var n = a(Tt()), i = n.next(); !i.done; i = n.next()) {
+for (var n = a(Ct()), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.controller;
 if (null == c ? void 0 : c.my) {
-var u = null === (o = this.memoryManager) || void 0 === o ? void 0 : o.getOrInitSwarmState(s.name), l = c.level, m = bt(null == u ? void 0 : u.danger), d = {
+var u = null === (o = this.memoryManager) || void 0 === o ? void 0 : o.getOrInitSwarmState(s.name), l = c.level, m = Ot(null == u ? void 0 : u.danger), d = {
 radius: 10,
 fill: m,
 opacity: .5 * this.config.opacity,
@@ -4030,7 +4032,7 @@ color: "#ffffff",
 fontSize: 8,
 align: "center"
 }), u && u.posture && "eco" !== u.posture) {
-var p = u.posture, f = Ot(p);
+var p = u.posture, f = kt(p);
 e.text(p.toUpperCase(), new RoomPosition(25, 30, s.name), {
 color: f,
 fontSize: 6,
@@ -4083,9 +4085,9 @@ if (r) throw r.error;
 }
 }
 if (m && ("war" === m.posture || "siege" === m.posture)) {
-var g = Ct().filter(function(e) {
+var g = St().filter(function(e) {
 var r = i.getSafeRoomLinearDistance(t.name, e.name);
-return X(e).length > 0 && null !== r && r <= 5;
+return Z(e).length > 0 && null !== r && r <= 5;
 });
 try {
 for (var h = (u = void 0, a(g)), R = h.next(); !R.done; R = h.next()) {
@@ -4110,7 +4112,7 @@ if (u) throw u.error;
 }
 }, c = this;
 try {
-for (var u = a(Tt()), l = u.next(); !l.done; l = u.next()) s(l.value);
+for (var u = a(Ct()), l = u.next(); !l.done; l = u.next()) s(l.value);
 } catch (e) {
 t = {
 error: e
@@ -4125,10 +4127,10 @@ if (t) throw t.error;
 }, e.prototype.drawThreats = function(e) {
 var t, r;
 try {
-for (var o = a(Ct()), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = X(i), c = Z(i);
+for (var o = a(St()), n = o.next(); !n.done; n = o.next()) {
+var i = n.value, s = Z(i), c = J(i);
 if (s.length > 0 || c.length > 0) {
-var u = kt(s.length, c.length), l = Mt(u);
+var u = Mt(s.length, c.length), l = At(u);
 e.rect(new RoomPosition(20, 20, i.name), 10, 10, {
 fill: l,
 opacity: .5 * this.config.opacity,
@@ -4169,7 +4171,7 @@ if (t) throw t.error;
 }
 }
 }, e.prototype.drawExpansionCandidates = function(e) {
-var t, r, o = this, n = Tt(), i = function(t) {
+var t, r, o = this, n = Ct(), i = function(t) {
 if (!t.controller || t.controller.my || t.controller.owner) return "continue";
 n.some(function(e) {
 var r = o.getSafeRoomLinearDistance(e.name, t.name);
@@ -4188,7 +4190,7 @@ align: "center"
 }));
 }, s = this;
 try {
-for (var c = a(Ct()), u = c.next(); !u.done; u = c.next()) i(u.value);
+for (var c = a(St()), u = c.next(); !u.done; u = c.next()) i(u.value);
 } catch (e) {
 t = {
 error: e
@@ -4201,7 +4203,7 @@ if (t) throw t.error;
 }
 }
 }, e.prototype.drawResourceFlow = function(e) {
-var t, r, o = Tt();
+var t, r, o = Ct();
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
@@ -4233,8 +4235,8 @@ if (t) throw t.error;
 }, e.prototype.drawHighways = function(e) {
 var t, r;
 try {
-for (var o = a(Ct()), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = At(i.name);
+for (var o = a(St()), n = o.next(); !n.done; n = o.next()) {
+var i = n.value, s = Ut(i.name);
 s.isHighway && (e.rect(new RoomPosition(0, 0, i.name), 50, 50, {
 fill: "#444444",
 opacity: .2 * this.config.opacity
@@ -4279,11 +4281,11 @@ var t = this.config[e];
 }, e;
 }();
 
-new _t;
+new Nt;
 
-var Nt, Pt = "#555555", It = "#AAAAAA", Gt = "#FFE87B", Lt = "#F53547", Dt = "#181818", Bt = "#8FBB93", Ft = !1;
+var Pt, It = "#555555", Gt = "#AAAAAA", Lt = "#FFE87B", Dt = "#F53547", Bt = "#181818", Ft = "#8FBB93", Wt = !1;
 
-function Wt(e, t) {
+function Ht(e, t) {
 return {
 id: e,
 coreRoom: t,
@@ -4306,7 +4308,7 @@ lastUpdate: 0
 };
 }
 
-"undefined" == typeof RoomVisual || Ft || (Ft = !0, RoomVisual.prototype.structure = function(e, t, r, n) {
+"undefined" == typeof RoomVisual || Wt || (Wt = !0, RoomVisual.prototype.structure = function(e, t, r, n) {
 void 0 === n && (n = {});
 var a = o({
 opacity: 1
@@ -4315,13 +4317,13 @@ switch (r) {
 case STRUCTURE_EXTENSION:
 this.circle(e, t, {
 radius: .5,
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .35,
-fill: Pt,
+fill: It,
 opacity: a.opacity
 });
 break;
@@ -4329,13 +4331,13 @@ break;
 case STRUCTURE_SPAWN:
 this.circle(e, t, {
 radius: .65,
-fill: Dt,
+fill: Bt,
 stroke: "#CCCCCC",
 strokeWidth: .1,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .4,
-fill: Gt,
+fill: Lt,
 opacity: a.opacity
 });
 break;
@@ -4343,13 +4345,13 @@ break;
 case STRUCTURE_POWER_SPAWN:
 this.circle(e, t, {
 radius: .65,
-fill: Dt,
-stroke: Lt,
+fill: Bt,
+stroke: Dt,
 strokeWidth: .1,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .4,
-fill: Gt,
+fill: Lt,
 opacity: a.opacity
 });
 break;
@@ -4357,16 +4359,16 @@ break;
 case STRUCTURE_TOWER:
 this.circle(e, t, {
 radius: .6,
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .45,
-fill: Pt,
+fill: It,
 opacity: a.opacity
 }), this.rect(e - .2, t - .3, .4, .6, {
-fill: It,
+fill: Gt,
 opacity: a.opacity
 });
 break;
@@ -4375,12 +4377,12 @@ case STRUCTURE_STORAGE:
 this.poly([ [ -.45, -.55 ], [ 0, -.65 ], [ .45, -.55 ], [ .55, 0 ], [ .45, .55 ], [ 0, .65 ], [ -.45, .55 ], [ -.55, 0 ] ].map(function(r) {
 return [ r[0] + e, r[1] + t ];
 }), {
-stroke: Bt,
+stroke: Ft,
 strokeWidth: .05,
-fill: Dt,
+fill: Bt,
 opacity: a.opacity
 }), this.rect(e - .35, t - .45, .7, .9, {
-fill: Gt,
+fill: Lt,
 opacity: .6 * a.opacity
 });
 break;
@@ -4389,16 +4391,16 @@ case STRUCTURE_TERMINAL:
 this.poly([ [ -.45, -.55 ], [ 0, -.65 ], [ .45, -.55 ], [ .55, 0 ], [ .45, .55 ], [ 0, .65 ], [ -.45, .55 ], [ -.55, 0 ] ].map(function(r) {
 return [ r[0] + e, r[1] + t ];
 }), {
-stroke: Bt,
+stroke: Ft,
 strokeWidth: .05,
-fill: Dt,
+fill: Bt,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .3,
-fill: It,
+fill: Gt,
 opacity: a.opacity
 }), this.rect(e - .15, t - .15, .3, .3, {
-fill: Pt,
+fill: It,
 opacity: a.opacity
 });
 break;
@@ -4406,16 +4408,16 @@ break;
 case STRUCTURE_LAB:
 this.circle(e, t, {
 radius: .55,
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .4,
-fill: Pt,
+fill: It,
 opacity: a.opacity
 }), this.rect(e - .15, t + .1, .3, .25, {
-fill: It,
+fill: Gt,
 opacity: a.opacity
 });
 break;
@@ -4423,13 +4425,13 @@ break;
 case STRUCTURE_LINK:
 this.circle(e, t, {
 radius: .5,
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .35,
-fill: It,
+fill: Gt,
 opacity: a.opacity
 });
 break;
@@ -4437,7 +4439,7 @@ break;
 case STRUCTURE_NUKER:
 this.circle(e, t, {
 radius: .65,
-fill: Dt,
+fill: Bt,
 stroke: "#ff0000",
 strokeWidth: .1,
 opacity: a.opacity
@@ -4451,8 +4453,8 @@ break;
 case STRUCTURE_OBSERVER:
 this.circle(e, t, {
 radius: .6,
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.circle(e, t, {
@@ -4464,13 +4466,13 @@ break;
 
 case STRUCTURE_CONTAINER:
 this.rect(e - .45, t - .45, .9, .9, {
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.rect(e - .35, t - .35, .7, .7, {
 fill: "transparent",
-stroke: Pt,
+stroke: It,
 strokeWidth: .05,
 opacity: a.opacity
 });
@@ -4495,8 +4497,8 @@ break;
 
 case STRUCTURE_WALL:
 this.rect(e - .45, t - .45, .9, .9, {
-fill: Dt,
-stroke: It,
+fill: Bt,
+stroke: Gt,
 strokeWidth: .05,
 opacity: a.opacity
 });
@@ -4505,13 +4507,13 @@ break;
 case STRUCTURE_EXTRACTOR:
 this.circle(e, t, {
 radius: .6,
-fill: Dt,
-stroke: Bt,
+fill: Bt,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 }), this.circle(e, t, {
 radius: .45,
-fill: Pt,
+fill: It,
 opacity: a.opacity
 });
 break;
@@ -4519,8 +4521,8 @@ break;
 default:
 this.circle(e, t, {
 radius: .5,
-fill: Pt,
-stroke: Bt,
+fill: It,
+stroke: Ft,
 strokeWidth: .05,
 opacity: a.opacity
 });
@@ -4557,13 +4559,13 @@ opacity: p
 }, RoomVisual.prototype.resource = function(e, t, r, o) {
 var n, a;
 void 0 === o && (o = .25);
-var i = null !== (a = ((n = {})[RESOURCE_ENERGY] = Gt, n[RESOURCE_POWER] = Lt, n[RESOURCE_HYDROGEN] = "#FFFFFF",
+var i = null !== (a = ((n = {})[RESOURCE_ENERGY] = Lt, n[RESOURCE_POWER] = Dt, n[RESOURCE_HYDROGEN] = "#FFFFFF",
 n[RESOURCE_OXYGEN] = "#DDDDDD", n[RESOURCE_UTRIUM] = "#48C5E5", n[RESOURCE_LEMERGIUM] = "#24D490",
 n[RESOURCE_KEANIUM] = "#9269EC", n[RESOURCE_ZYNTHIUM] = "#D9B478", n[RESOURCE_CATALYST] = "#F26D6F",
 n[RESOURCE_GHODIUM] = "#FFFFFF", n)[e]) && void 0 !== a ? a : "#CCCCCC";
 this.circle(t, r, {
 radius: o,
-fill: Dt,
+fill: Bt,
 opacity: .9
 }), this.circle(t, r, {
 radius: .8 * o,
@@ -4572,7 +4574,7 @@ opacity: .8
 });
 var s = e.length <= 2 ? e : e.substring(0, 2).toUpperCase();
 this.text(s, t, r + .03, {
-color: Dt,
+color: Bt,
 font: "".concat(1.2 * o, " monospace"),
 align: "center",
 opacity: .9
@@ -4581,19 +4583,19 @@ opacity: .9
 e[e.None = 0] = "None", e[e.Pheromones = 1] = "Pheromones", e[e.Paths = 2] = "Paths",
 e[e.Traffic = 4] = "Traffic", e[e.Defense = 8] = "Defense", e[e.Economy = 16] = "Economy",
 e[e.Construction = 32] = "Construction", e[e.Performance = 64] = "Performance";
-}(Nt || (Nt = {}));
+}(Pt || (Pt = {}));
 
-var Ht = -1;
+var Kt = -1;
 
-function Kt(e) {
+function Yt(e) {
 return void 0 !== e.value;
 }
 
-function Yt(e, t) {
-return void 0 !== e.ttl && e.ttl !== Ht && t - e.lastModified > e.ttl;
+function Vt(e, t) {
+return void 0 !== e.ttl && e.ttl !== Kt && t - e.lastModified > e.ttl;
 }
 
-function Vt(e, t) {
+function qt(e, t) {
 return void 0 === t && (t = !1), {
 value: e.value,
 lastModified: e.lastModified,
@@ -4602,7 +4604,7 @@ ttl: e.ttl
 };
 }
 
-function qt(e) {
+function jt(e) {
 return {
 value: e.value,
 lastModified: e.lastModified,
@@ -4610,11 +4612,11 @@ ttl: e.ttl
 };
 }
 
-function jt(e) {
+function zt(e) {
 return !e.startsWith("memory:");
 }
 
-function zt() {
+function Qt() {
 var e = global;
 return e._heapCache && e._heapCache.tick === Game.time || (e._heapCache ? e._heapCache.tick = Game.time : e._heapCache = {
 tick: Game.time,
@@ -4623,7 +4625,7 @@ rehydrated: !1
 }), e._heapCache;
 }
 
-function Qt() {
+function Xt() {
 return Memory._heapCache || (Memory._heapCache = {
 version: 1,
 lastSync: Game.time,
@@ -4631,19 +4633,19 @@ data: {}
 }), Memory._heapCache;
 }
 
-var Xt = function() {
+var Zt = function() {
 function e() {
 this.lastPersistenceTick = 0;
 }
 return e.prototype.initialize = function() {
-var e = zt();
+var e = Qt();
 e.rehydrated || (this.rehydrateFromMemory(), e.rehydrated = !0);
 }, e.prototype.rehydrateFromMemory = function() {
-var e, t, r = zt(), o = Qt(), n = 0, s = 0;
+var e, t, r = Qt(), o = Xt(), n = 0, s = 0;
 try {
 for (var c = a(Object.entries(o.data)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
-Kt(d) ? Yt(d, Game.time) ? s++ : (r.entries.set(m, Vt(d)), n++) : (delete o.data[m],
+Yt(d) ? Vt(d, Game.time) ? s++ : (r.entries.set(m, qt(d)), n++) : (delete o.data[m],
 s++);
 }
 } catch (t) {
@@ -4665,32 +4667,32 @@ expiredCount: s
 }
 });
 }, e.prototype.get = function(e) {
-var t = zt(), r = t.entries.get(e);
-if (r) return Yt(r, Game.time) ? void t.entries.delete(e) : r.value;
-var o = Qt(), n = o.data[e];
-return n ? Kt(n) ? Yt(n, Game.time) ? void delete o.data[e] : (t.entries.set(e, Vt(n)),
+var t = Qt(), r = t.entries.get(e);
+if (r) return Vt(r, Game.time) ? void t.entries.delete(e) : r.value;
+var o = Xt(), n = o.data[e];
+return n ? Yt(n) ? Vt(n, Game.time) ? void delete o.data[e] : (t.entries.set(e, qt(n)),
 n.value) : void delete o.data[e] : void 0;
 }, e.prototype.set = function(e, t, r) {
-void 0 !== t ? zt().entries.set(e, {
+void 0 !== t ? Qt().entries.set(e, {
 value: t,
 lastModified: Game.time,
 dirty: !0,
 ttl: null != r ? r : 1e3
 }) : this.delete(e);
 }, e.prototype.delete = function(e) {
-zt().entries.delete(e), delete Qt().data[e];
+Qt().entries.delete(e), delete Xt().data[e];
 }, e.prototype.has = function(e) {
 return void 0 !== this.get(e);
 }, e.prototype.clear = function() {
-zt().entries.clear(), Qt().data = {};
+Qt().entries.clear(), Xt().data = {};
 }, e.prototype.persist = function(e) {
 var t, r;
 if (void 0 === e && (e = !1), !e && Game.time - this.lastPersistenceTick < 10) return 0;
-var o = zt(), n = Qt(), s = 0;
+var o = Qt(), n = Xt(), s = 0;
 try {
 for (var c = a(o.entries), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
-Kt(d) ? jt(m) ? d.dirty && (n.data[m] = qt(d), d.dirty = !1, s++) : (delete n.data[m],
+Yt(d) ? zt(m) ? d.dirty && (n.data[m] = jt(d), d.dirty = !1, s++) : (delete n.data[m],
 d.dirty = !1) : (o.entries.delete(m), delete n.data[m]);
 }
 } catch (e) {
@@ -4706,7 +4708,7 @@ if (t) throw t.error;
 }
 return n.lastSync = Game.time, this.lastPersistenceTick = Game.time, s;
 }, e.prototype.getStats = function() {
-var e, t, r = zt(), o = Qt(), n = 0;
+var e, t, r = Qt(), o = Xt(), n = 0;
 try {
 for (var i = a(r.entries.values()), s = i.next(); !s.done; s = i.next()) s.value.dirty && n++;
 } catch (t) {
@@ -4727,19 +4729,19 @@ dirtyEntries: n,
 lastSync: o.lastSync
 };
 }, e.prototype.keys = function() {
-var e = zt();
+var e = Qt();
 return Array.from(e.entries.keys());
 }, e.prototype.values = function() {
-var e = zt();
+var e = Qt();
 return Array.from(e.entries.values()).map(function(e) {
 return e.value;
 });
 }, e.prototype.cleanExpired = function() {
-var e, t, r, o, n = zt(), s = Qt(), c = 0;
+var e, t, r, o, n = Qt(), s = Xt(), c = 0;
 try {
 for (var u = a(n.entries), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0];
-Yt(m[1], Game.time) && (n.entries.delete(d), c++);
+Vt(m[1], Game.time) && (n.entries.delete(d), c++);
 }
 } catch (t) {
 e = {
@@ -4755,7 +4757,7 @@ if (e) throw e.error;
 try {
 for (var p = a(Object.entries(s.data)), f = p.next(); !f.done; f = p.next()) {
 var y = i(f.value, 2);
-d = y[0], Yt(y[1], Game.time) && (delete s.data[d], c++);
+d = y[0], Vt(y[1], Game.time) && (delete s.data[d], c++);
 }
 } catch (e) {
 r = {
@@ -4770,7 +4772,7 @@ if (r) throw r.error;
 }
 return c;
 }, e;
-}(), Zt = new Xt, Jt = M("MemoryMonitor"), $t = 2097152, er = new (function() {
+}(), Jt = new Zt, $t = M("MemoryMonitor"), er = 2097152, tr = new (function() {
 function e() {
 this.lastCheckTick = 0, this.lastStatus = "normal";
 }
@@ -4778,31 +4780,31 @@ return e.prototype.getRawMemorySize = function() {
 var e = globalThis.RawMemory;
 return "function" == typeof (null == e ? void 0 : e.get) ? e.get().length : JSON.stringify(null !== Memory && void 0 !== Memory ? Memory : {}).length;
 }, e.prototype.checkMemoryUsage = function() {
-var e = this.getRawMemorySize(), t = e / $t, r = "normal";
-t >= .9 ? r = "critical" : t >= .8 && (r = "warning"), r !== this.lastStatus && ("critical" === r ? (Game.notify("CRITICAL: Memory at ".concat((100 * t).toFixed(1), "% (").concat(this.formatBytes(e), "/").concat(this.formatBytes($t), ")")),
-Jt.error("Memory usage critical", {
+var e = this.getRawMemorySize(), t = e / er, r = "normal";
+t >= .9 ? r = "critical" : t >= .8 && (r = "warning"), r !== this.lastStatus && ("critical" === r ? (Game.notify("CRITICAL: Memory at ".concat((100 * t).toFixed(1), "% (").concat(this.formatBytes(e), "/").concat(this.formatBytes(er), ")")),
+$t.error("Memory usage critical", {
 meta: {
 used: e,
-limit: $t,
+limit: er,
 percentage: t
 }
-})) : "warning" === r ? Jt.warn("Memory usage warning", {
+})) : "warning" === r ? $t.warn("Memory usage warning", {
 meta: {
 used: e,
-limit: $t,
+limit: er,
 percentage: t
 }
-}) : Jt.info("Memory usage normal", {
+}) : $t.info("Memory usage normal", {
 meta: {
 used: e,
-limit: $t,
+limit: er,
 percentage: t
 }
 }), this.lastStatus = r);
 var o = this.getMemoryBreakdown();
 return {
 used: e,
-limit: $t,
+limit: er,
 percentage: t,
 status: r,
 breakdown: o
@@ -4824,14 +4826,14 @@ return null == e ? 0 : JSON.stringify(e).length;
 return e < 1024 ? "".concat(e, "B") : e < 1048576 ? "".concat((e / 1024).toFixed(1), "KB") : "".concat((e / 1048576).toFixed(2), "MB");
 }, e.prototype.logBreakdown = function() {
 var e = this.getMemoryBreakdown(), t = this.checkMemoryUsage();
-Jt.info("Memory Usage", {
+$t.info("Memory Usage", {
 meta: {
 used: this.formatBytes(t.used),
 limit: this.formatBytes(t.limit),
 percentage: "".concat((100 * t.percentage).toFixed(1), "%"),
 status: t.status.toUpperCase()
 }
-}), Jt.info("Memory Breakdown", {
+}), $t.info("Memory Breakdown", {
 meta: {
 empire: "".concat(this.formatBytes(e.empire), " (").concat((e.empire / e.total * 100).toFixed(1), "%)"),
 rooms: "".concat(this.formatBytes(e.rooms), " (").concat((e.rooms / e.total * 100).toFixed(1), "%)"),
@@ -4859,7 +4861,7 @@ return t.sort(function(e, t) {
 return t.size - e.size;
 }).slice(0, e);
 }, e;
-}()), tr = {
+}()), rr = {
 ACTIVE_ROOMS: {
 start: 0,
 end: 9
@@ -4888,7 +4890,7 @@ STATS: {
 start: 90,
 end: 99
 }
-}, rr = function() {
+}, or = function() {
 function e() {
 this.activeSegments = new Set, this.segmentCache = new Map;
 }
@@ -5019,7 +5021,7 @@ return t ? t.length : 0;
 }, e.prototype.getActiveSegments = function() {
 return Array.from(this.activeSegments);
 }, e.prototype.suggestSegmentForType = function(e) {
-for (var t = tr[e], r = t.start; r <= t.end; r++) if (!this.isSegmentLoaded(r) || this.getSegmentSize(r) < 92160) return r;
+for (var t = rr[e], r = t.start; r <= t.end; r++) if (!this.isSegmentLoaded(r) || this.getSegmentSize(r) < 92160) return r;
 return t.start;
 }, e.prototype.migrateToSegment = function(e, t, r) {
 var o, n, i = e.split("."), s = Memory;
@@ -5066,9 +5068,9 @@ dataSize: JSON.stringify(s).length
 }
 }), m;
 }, e;
-}(), or = new rr, nr = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof self ? self : {};
+}(), nr = new or, ar = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof self ? self : {};
 
-function ar(e) {
+function ir(e) {
 if (Object.prototype.hasOwnProperty.call(e, "__esModule")) return e;
 var t = e.default;
 if ("function" == typeof t) {
@@ -5094,9 +5096,9 @@ return e[t];
 }), r;
 }
 
-var ir, sr, cr, ur, lr = {
+var sr, cr, ur, lr, mr = {
 exports: {}
-}, mr = (ir || (ir = 1, sr = lr, cr = function() {
+}, dr = (sr || (sr = 1, cr = mr, ur = function() {
 var e = String.fromCharCode, t = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=", r = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$", o = {};
 function n(e, t) {
 if (!o[e]) {
@@ -5285,13 +5287,13 @@ v.push(y), m[p++] = a + y.charAt(0), a = y, 0 == --d && (d = Math.pow(2, f), f++
 }
 };
 return a;
-}(), null != sr ? sr.exports = cr : "undefined" != typeof angular && null != angular && angular.module("LZString", []).factory("LZString", function() {
-return cr;
-})), lr.exports), dr = function() {
+}(), null != cr ? cr.exports = ur : "undefined" != typeof angular && null != angular && angular.module("LZString", []).factory("LZString", function() {
+return ur;
+})), mr.exports), pr = function() {
 function e() {}
 return e.prototype.compress = function(e, t) {
 void 0 === t && (t = 1);
-var r = JSON.stringify(e), o = r.length, n = mr.compressToUTF16(r);
+var r = JSON.stringify(e), o = r.length, n = dr.compressToUTF16(r);
 return {
 compressed: n,
 originalSize: o,
@@ -5301,7 +5303,7 @@ version: t
 };
 }, e.prototype.decompress = function(e) {
 try {
-var t = "string" == typeof e ? e : e.compressed, r = mr.decompressFromUTF16(t);
+var t = "string" == typeof e ? e : e.compressed, r = dr.decompressFromUTF16(t);
 return r ? JSON.parse(r) : (U.error("Decompression returned null", {
 subsystem: "MemoryCompressor"
 }), null);
@@ -5357,7 +5359,7 @@ return "".concat(this.formatBytes(e.originalSize), " → ").concat(this.formatBy
 }, e.prototype.formatBytes = function(e) {
 return e < 1024 ? "".concat(e, "B") : e < 1048576 ? "".concat((e / 1024).toFixed(1), "KB") : "".concat((e / 1048576).toFixed(2), "MB");
 }, e;
-}(), pr = new dr, fr = 1e4, yr = function() {
+}(), fr = new pr, yr = 1e4, vr = function() {
 function e() {}
 return e.prototype.getRawMemorySize = function() {
 var e = globalThis.RawMemory;
@@ -5370,7 +5372,7 @@ staleIntel: 0,
 marketHistory: 0,
 bytesSaved: 0
 };
-t.deadCreeps = this.pruneDeadCreeps(), t.eventLogs = this.pruneEventLogs(20), t.staleIntel = this.pruneStaleIntel(fr),
+t.deadCreeps = this.pruneDeadCreeps(), t.eventLogs = this.pruneEventLogs(20), t.staleIntel = this.pruneStaleIntel(yr),
 t.marketHistory = this.pruneMarketHistory(5e3), this.pruneOldNukes(), this.pruneStaleRoomMemory();
 var r = this.getRawMemorySize();
 return t.bytesSaved = Math.max(0, e - r), t.bytesSaved > 0 && U.info("Memory pruning complete", {
@@ -5454,7 +5456,7 @@ return e.impactTick >= Game.time;
 }, e.prototype.pruneStaleRoomMemory = function() {
 var e, t, r, o;
 if (!Memory.rooms) return 0;
-var n = 0, a = Game.time - fr;
+var n = 0, a = Game.time - yr;
 for (var i in Memory.rooms) {
 var s = Memory.rooms[i], c = null == s ? void 0 : s.swarm, u = null !== (r = null === (t = null === (e = Game.rooms[i]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && void 0 !== r && r, l = null !== (o = null == c ? void 0 : c.lastUpdate) && void 0 !== o ? o : 0;
 !u && l < a && (delete Memory.rooms[i], n++);
@@ -5469,18 +5471,18 @@ var o = Memory.rooms[r], n = null == o ? void 0 : o.swarm;
 (null == n ? void 0 : n.eventLog) && n.eventLog.length > 40 && e.push("Room ".concat(r, " has ").concat(n.eventLog.length, " event log entries (recommended max: ").concat(20, ")"));
 }
 if (null == t ? void 0 : t.knownRooms) {
-var a = 0, i = Game.time - fr;
+var a = 0, i = Game.time - yr;
 for (var r in t.knownRooms) {
 var s = t.knownRooms[r];
 s.lastSeen < i && !s.isHighway && !s.hasPortal && a++;
 }
-a > 50 && e.push("".concat(a, " stale intel entries (older than ").concat(fr, " ticks)"));
+a > 50 && e.push("".concat(a, " stale intel entries (older than ").concat(yr, " ticks)"));
 }
 var c = 0;
 for (var u in Memory.creeps) u in Game.creeps || c++;
 return c > 10 && e.push("".concat(c, " dead creeps in memory")), e;
 }, e;
-}(), vr = new yr, gr = [ {
+}(), gr = new vr, hr = [ {
 version: 4,
 description: "Move historical intel to memory segments",
 migrate: function(e) {
@@ -5492,14 +5494,14 @@ var c = o.knownRooms[s];
 c.lastSeen >= i || (null === (r = null === (t = Game.rooms[s]) || void 0 === t ? void 0 : t.controller) || void 0 === r ? void 0 : r.my) || c.isHighway || c.hasPortal ? n[s] = c : a[s] = c;
 }
 if (Object.keys(a).length > 0) {
-var u = or.suggestSegmentForType("HISTORICAL_INTEL");
-if (!or.isSegmentLoaded(u)) return or.requestSegment(u), void U.info("Segment not loaded, migration will continue next tick", {
+var u = nr.suggestSegmentForType("HISTORICAL_INTEL");
+if (!nr.isSegmentLoaded(u)) return nr.requestSegment(u), void U.info("Segment not loaded, migration will continue next tick", {
 subsystem: "MemoryMigrations",
 meta: {
 segmentId: u
 }
 });
-if (!or.writeSegment(u, "historicalIntel", a)) return void U.error("Failed to write historical intel to segment", {
+if (!nr.writeSegment(u, "historicalIntel", a)) return void U.error("Failed to write historical intel to segment", {
 subsystem: "MemoryMigrations",
 meta: {
 segmentId: u
@@ -5523,8 +5525,8 @@ migrate: function(e) {
 var t = e.empire;
 if (t) {
 var r = t, o = r.portals;
-if (o && !pr.isCompressed(o)) {
-var n = pr.compressPortalMap(o);
+if (o && !fr.isCompressed(o)) {
+var n = fr.compressPortalMap(o);
 r.compressedPortals = n, delete r.portals, U.info("Compressed portal map data", {
 subsystem: "MemoryMigrations",
 meta: {
@@ -5544,14 +5546,14 @@ var t = e.empire;
 if (null == t ? void 0 : t.market) {
 var r = t.market, o = r.priceHistory;
 if (o) {
-var n = pr.compressMarketHistory(o), a = or.suggestSegmentForType("MARKET_HISTORY");
-if (!or.isSegmentLoaded(a)) return or.requestSegment(a), void U.info("Segment not loaded, migration will continue next tick", {
+var n = fr.compressMarketHistory(o), a = nr.suggestSegmentForType("MARKET_HISTORY");
+if (!nr.isSegmentLoaded(a)) return nr.requestSegment(a), void U.info("Segment not loaded, migration will continue next tick", {
 subsystem: "MemoryMigrations",
 meta: {
 segmentId: a
 }
 });
-or.writeSegment(a, "priceHistory", n) ? (delete r.priceHistory, U.info("Migrated market history to segments", {
+nr.writeSegment(a, "priceHistory", n) ? (delete r.priceHistory, U.info("Migrated market history to segments", {
 subsystem: "MemoryMigrations",
 meta: {
 originalSize: n.originalSize,
@@ -5588,10 +5590,10 @@ clustersProcessed: Object.keys(t).length
 });
 }
 }
-} ], hr = function() {
+} ], Rr = function() {
 function e() {}
 return e.prototype.runMigrations = function() {
-var e, t, r, o = Memory, n = null !== (r = o.memoryVersion) && void 0 !== r ? r : 0, i = gr.filter(function(e) {
+var e, t, r, o = Memory, n = null !== (r = o.memoryVersion) && void 0 !== r ? r : 0, i = hr.filter(function(e) {
 return e.version > n;
 });
 if (0 !== i.length) {
@@ -5637,14 +5639,14 @@ if (e) throw e.error;
 var e;
 return null !== (e = Memory.memoryVersion) && void 0 !== e ? e : 0;
 }, e.prototype.getLatestVersion = function() {
-return 0 === gr.length ? 0 : Math.max.apply(Math, s([], i(gr.map(function(e) {
+return 0 === hr.length ? 0 : Math.max.apply(Math, s([], i(hr.map(function(e) {
 return e.version;
 })), !1));
 }, e.prototype.hasPendingMigrations = function() {
 return this.getCurrentVersion() < this.getLatestVersion();
 }, e.prototype.getPendingMigrations = function() {
 var e = this.getCurrentVersion();
-return gr.filter(function(t) {
+return hr.filter(function(t) {
 return t.version > e;
 });
 }, e.prototype.rollbackToVersion = function(e) {
@@ -5657,20 +5659,20 @@ toVersion: e
 }
 }), t.memoryVersion = e, Game.notify("Memory version rolled back to ".concat(e, ". Data may be inconsistent!"));
 }, e;
-}(), Rr = new hr, Er = "empire", Tr = "clusters", Cr = function() {
+}(), Er = new Rr, Tr = "empire", Cr = "clusters", Sr = function() {
 function e() {
 this.lastInitializeTick = null, this.lastCleanupTick = 0, this.lastPruningTick = 0,
 this.lastMonitoringTick = 0, this.deadCreepCleanupCursor = 0, this.deadCreepCleanupCandidates = [];
 }
 return e.prototype.initialize = function() {
-this.lastInitializeTick !== Game.time && (this.lastInitializeTick = Game.time, Zt.initialize(),
-Rr.runMigrations(), this.ensureEmpireMemory(), this.ensureClustersMemory(), Game.time - this.lastCleanupTick >= 10 && (this.cleanDeadCreeps(),
-this.lastCleanupTick = Game.time), Game.time - this.lastPruningTick >= 100 && (vr.pruneAll(),
-this.lastPruningTick = Game.time), Game.time - this.lastMonitoringTick >= 50 && (er.checkMemoryUsage(),
+this.lastInitializeTick !== Game.time && (this.lastInitializeTick = Game.time, Jt.initialize(),
+Er.runMigrations(), this.ensureEmpireMemory(), this.ensureClustersMemory(), Game.time - this.lastCleanupTick >= 10 && (this.cleanDeadCreeps(),
+this.lastCleanupTick = Game.time), Game.time - this.lastPruningTick >= 100 && (gr.pruneAll(),
+this.lastPruningTick = Game.time), Game.time - this.lastMonitoringTick >= 50 && (tr.checkMemoryUsage(),
 this.lastMonitoringTick = Game.time));
 }, e.prototype.ensureEmpireMemory = function() {
 var e = Memory;
-e[Er] || (e[Er] = {
+e[Tr] || (e[Tr] = {
 knownRooms: {},
 clusters: [],
 warTargets: [],
@@ -5700,28 +5702,28 @@ lastUpdate: 0
 });
 }, e.prototype.ensureClustersMemory = function() {
 var e = Memory;
-e[Tr] || (e[Tr] = {});
+e[Cr] || (e[Cr] = {});
 }, e.prototype.getEmpire = function() {
-var e = "memory:".concat(Er), t = Zt.get(e);
+var e = "memory:".concat(Tr), t = Jt.get(e);
 this.ensureEmpireMemory();
 var r = Memory;
-return t && t === r[Er] || (Zt.set(e, r[Er], Ht), t = r[Er]), t;
+return t && t === r[Tr] || (Jt.set(e, r[Tr], Kt), t = r[Tr]), t;
 }, e.prototype.getClusters = function() {
-var e = "memory:".concat(Tr), t = Zt.get(e);
+var e = "memory:".concat(Cr), t = Jt.get(e);
 if (!t) {
 this.ensureClustersMemory();
 var r = Memory;
-Zt.set(e, r[Tr], Ht), t = r[Tr];
+Jt.set(e, r[Cr], Kt), t = r[Cr];
 }
 return t;
 }, e.prototype.getCluster = function(e, t) {
 var r = this.getClusters();
-return !r[e] && t && (r[e] = Wt(e, t)), r[e];
+return !r[e] && t && (r[e] = Ht(e, t)), r[e];
 }, e.prototype.getSwarmState = function(e) {
-var t, r = "memory:room:".concat(e, ":swarm"), o = Zt.get(r), n = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
+var t, r = "memory:room:".concat(e, ":swarm"), o = Jt.get(r), n = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 if (n) {
 var a = n.swarm;
-if (a) return o && o === a || (Zt.set(r, a, Ht), o = a), o;
+if (a) return o && o === a || (Jt.set(r, a, Kt), o = a), o;
 }
 }, e.prototype.initSwarmState = function(e) {
 var t = "memory:room:".concat(e, ":swarm");
@@ -5773,7 +5775,7 @@ energyNeed: 0
 },
 lastUpdate: 0,
 lastHostileTick: 0
-}), Zt.set(t, r.swarm, Ht), r.swarm;
+}), Jt.set(t, r.swarm, Kt), r.swarm;
 }, e.prototype.getOrInitSwarmState = function(e) {
 var t;
 return null !== (t = this.getSwarmState(e)) && void 0 !== t ? t : this.initSwarmState(e);
@@ -5820,21 +5822,21 @@ return JSON.stringify(Memory).length;
 }, e.prototype.isMemoryNearLimit = function() {
 return this.getMemorySize() > 1887436.8;
 }, e.prototype.persistHeapCache = function() {
-Zt.persist();
+Jt.persist();
 }, e.prototype.getHeapCache = function() {
-return Zt;
+return Jt;
 }, e.prototype.isRoomHostile = function(e) {
-var t, r, o, n = "memory:room:".concat(e, ":hostile"), a = Zt.get(n);
+var t, r, o, n = "memory:room:".concat(e, ":hostile"), a = Jt.get(n);
 if (void 0 !== a) return !0 === a;
 var i = null !== (o = null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.hostile) && void 0 !== o && o;
-return Zt.set(n, !!i || null, 100), i;
+return Jt.set(n, !!i || null, 100), i;
 }, e.prototype.setRoomHostile = function(e, t) {
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[e] || (Memory.rooms[e] = {}),
 Memory.rooms[e].hostile = t;
 var r = "memory:room:".concat(e, ":hostile");
-Zt.set(r, !!t || null, 100);
+Jt.set(r, !!t || null, 100);
 }, e;
-}(), Sr = new Cr, wr = function() {
+}(), wr = new Sr, xr = function() {
 function e(e) {
 void 0 === e && (e = globalThis), this.scope = e;
 }
@@ -5863,7 +5865,7 @@ return void 0 !== e && void 0 !== this.lastRunTick && e <= this.lastRunTick;
 var e, t = null === (e = this.scope.Game) || void 0 === e ? void 0 : e.time;
 return "number" == typeof t && Number.isFinite(t) ? t : void 0;
 }, e;
-}(), xr = new wr, br = {
+}(), br = new xr, Or = {
 pheromone: {
 updateInterval: 5,
 decayFactors: {
@@ -5970,8 +5972,8 @@ scanInterval: 100,
 tradeCooldown: 10
 },
 spawn: {
-bodyCosts: (ur = {}, ur[MOVE] = 50, ur[WORK] = 100, ur[CARRY] = 50, ur[ATTACK] = 80,
-ur[RANGED_ATTACK] = 150, ur[HEAL] = 250, ur[CLAIM] = 600, ur[TOUGH] = 10, ur),
+bodyCosts: (lr = {}, lr[MOVE] = 50, lr[WORK] = 100, lr[CARRY] = 50, lr[ATTACK] = 80,
+lr[RANGED_ATTACK] = 150, lr[HEAL] = 250, lr[CLAIM] = 600, lr[TOUGH] = 10, lr),
 minCreepCounts: {
 harvester: 2,
 hauler: 2,
@@ -6005,41 +6007,41 @@ debug: !1,
 profiling: !0,
 visualizations: !0,
 lazyLoadConsoleCommands: !0
-}, Or = o({}, br);
+}, kr = o({}, Or);
 
-function kr() {
-return Or;
+function Mr() {
+return kr;
 }
 
-function Mr(e) {
-Or = o(o({}, Or), e);
+function Ar(e) {
+kr = o(o({}, kr), e);
 }
 
-var Ar = [];
+var Ur = [];
 
-function Ur(e, t, r) {
-Ar.some(function(o) {
+function _r(e, t, r) {
+Ur.some(function(o) {
 return o.target === r && o.methodName === t && o.metadata.name === e.name;
-}) || Ar.push({
+}) || Ur.push({
 metadata: e,
 methodName: t,
 target: r
 });
 }
 
-var _r, Nr = "General";
-
-function Pr(e, t) {
-return e === t ? 0 : e === Nr ? -1 : t === Nr ? 1 : e.localeCompare(t);
-}
+var Nr, Pr = "General";
 
 function Ir(e, t) {
-var r = t.metadata;
-e.push("  ".concat(Lr(r.name, r.usage))), e.push("    ".concat(r.description)),
-Gr(e, r.examples, "      ", "    Examples:", !1), e.push("");
+return e === t ? 0 : e === Pr ? -1 : t === Pr ? 1 : e.localeCompare(t);
 }
 
-function Gr(e, t, r, o, n) {
+function Gr(e, t) {
+var r = t.metadata;
+e.push("  ".concat(Dr(r.name, r.usage))), e.push("    ".concat(r.description)),
+Lr(e, r.examples, "      ", "    Examples:", !1), e.push("");
+}
+
+function Lr(e, t, r, o, n) {
 var i, s;
 if (void 0 === o && (o = "Examples:"), void 0 === n && (n = !0), t && 0 !== t.length) {
 n && e.push(""), e.push(o);
@@ -6062,11 +6064,11 @@ if (i) throw i.error;
 }
 }
 
-function Lr(e, t) {
+function Dr(e, t) {
 return null != t ? t : "".concat(e, "()");
 }
 
-function Dr(e) {
+function Br(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return e.metadata.name.localeCompare(t.metadata.name);
 });
@@ -6075,26 +6077,26 @@ return e.metadata.name.localeCompare(t.metadata.name);
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(_r || (_r = {}));
+}(Nr || (Nr = {}));
 
-var Br, Fr = (Br = "console", {
+var Fr, Wr = (Fr = "console", {
 debug: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Br, "]"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Fr, "]"), e ], i(t), !1));
 },
 info: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Br, "]"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Fr, "]"), e ], i(t), !1));
 },
 warn: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Br, "] WARN:"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Fr, "] WARN:"), e ], i(t), !1));
 },
 error: function(e) {
 for (var t = [], r = 1; r < arguments.length; r++) t[r - 1] = arguments[r];
-return console.log.apply(console, s([ "[".concat(Br, "] ERROR:"), e ], i(t), !1));
+return console.log.apply(console, s([ "[".concat(Fr, "] ERROR:"), e ], i(t), !1));
 }
-}), Wr = {
+}), Hr = {
 getProcesses: function() {
 return [];
 },
@@ -6124,7 +6126,7 @@ getRemainingCpu: function() {
 return 0;
 },
 resetStats: function() {}
-}, Hr = {
+}, Kr = {
 run: function() {},
 getMetricSeries: function(e) {
 return null;
@@ -6132,7 +6134,7 @@ return null;
 getLatestStats: function() {
 return {};
 }
-}, Kr = {
+}, Yr = {
 getSnapshot: function() {
 return {};
 },
@@ -6152,7 +6154,7 @@ return {};
 postureCodeToName: function(e) {
 return "unknown";
 }
-}, Yr = {
+}, Vr = {
 setEnabled: function(e) {},
 isEnabled: function() {
 return !1;
@@ -6162,7 +6164,7 @@ getConfig: function() {
 return {};
 },
 toggle: function(e) {}
-}, Vr = {
+}, qr = {
 setEnabled: function(e) {},
 isEnabled: function() {
 return !1;
@@ -6171,16 +6173,6 @@ getConfig: function() {
 return {};
 },
 toggle: function(e) {}
-}, qr = {
-getProcessInfo: function(e) {
-return null;
-},
-listProcesses: function() {
-return [];
-},
-getStats: function() {
-return {};
-}
 }, jr = {
 getProcessInfo: function(e) {
 return null;
@@ -6191,26 +6183,36 @@ return [];
 getStats: function() {
 return {};
 }
-}, zr = function() {
+}, zr = {
+getProcessInfo: function(e) {
+return null;
+},
+listProcesses: function() {
+return [];
+},
+getStats: function() {
+return {};
+}
+}, Qr = function() {
 function e() {
 this.commands = new Map, this.initialized = !1, this.lazyLoadEnabled = !1, this.commandsRegistered = !1,
 this.commandsExposed = !1;
 }
 return e.prototype.register = function(e, t) {
 var r;
-this.commands.has(e.name) && Fr.warn('Command "'.concat(e.name, '" is already registered, overwriting'), {
+this.commands.has(e.name) && Wr.warn('Command "'.concat(e.name, '" is already registered, overwriting'), {
 subsystem: "CommandRegistry"
 }), this.commands.set(e.name, {
 metadata: o(o({}, e), {
 category: null !== (r = e.category) && void 0 !== r ? r : "General"
 }),
 handler: t
-}), Fr.debug('Registered command "'.concat(e.name, '"'), {
+}), Wr.debug('Registered command "'.concat(e.name, '"'), {
 subsystem: "CommandRegistry"
 });
 }, e.prototype.unregister = function(e) {
 var t = this.commands.delete(e);
-return t && Fr.debug('Unregistered command "'.concat(e, '"'), {
+return t && Wr.debug('Unregistered command "'.concat(e, '"'), {
 subsystem: "CommandRegistry"
 }), t;
 }, e.prototype.getCommand = function(e) {
@@ -6266,20 +6268,20 @@ try {
 return o.handler.apply(o, s([], i(t), !1));
 } catch (t) {
 var n = t instanceof Error ? t.message : String(t);
-return Fr.error('Error executing command "'.concat(e, '": ').concat(n), {
+return Wr.error('Error executing command "'.concat(e, '": ').concat(n), {
 subsystem: "CommandRegistry"
 }), "Error: ".concat(n);
 }
 }, e.prototype.generateHelp = function() {
 return function(e) {
-var t, r, o, n, i = [ "=== Available Console Commands ===", "" ], s = Array.from(e.keys()).sort(Pr);
+var t, r, o, n, i = [ "=== Available Console Commands ===", "" ], s = Array.from(e.keys()).sort(Ir);
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = e.get(l);
 if (m && 0 !== m.length) {
 i.push("--- ".concat(l, " ---"));
 try {
-for (var d = (o = void 0, a(Dr(m))), p = d.next(); !p.done; p = d.next()) Ir(i, p.value);
+for (var d = (o = void 0, a(Br(m))), p = d.next(); !p.done; p = d.next()) Gr(i, p.value);
 } catch (e) {
 o = {
 error: e
@@ -6310,8 +6312,8 @@ return i.join("\n");
 this.lazyLoadEnabled && !this.commandsRegistered && this.triggerLazyLoad();
 var t = this.commands.get(e);
 return t ? function(e) {
-var t, r = e.metadata, o = [ "=== ".concat(r.name, " ==="), "", "Description: ".concat(r.description), "Usage: ".concat(Lr(r.name, r.usage)), "Category: ".concat(null !== (t = r.category) && void 0 !== t ? t : Nr) ];
-return Gr(o, r.examples, "  "), o.join("\n");
+var t, r = e.metadata, o = [ "=== ".concat(r.name, " ==="), "", "Description: ".concat(r.description), "Usage: ".concat(Dr(r.name, r.usage)), "Category: ".concat(null !== (t = r.category) && void 0 !== t ? t : Pr) ];
+return Lr(o, r.examples, "  "), o.join("\n");
 }(t) : 'Command "'.concat(e, '" not found. Use help() to see available commands.');
 }, e.prototype.exposeToGlobal = function() {
 var e, t, r = this, o = global;
@@ -6331,7 +6333,7 @@ s && !s.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-this.commandsExposed = !0, Fr.debug("Exposed ".concat(this.commands.size, " commands to global scope"), {
+this.commandsExposed = !0, Wr.debug("Exposed ".concat(this.commands.size, " commands to global scope"), {
 subsystem: "CommandRegistry"
 }), o.help = function(e) {
 return r.lazyLoadEnabled && !r.commandsRegistered && r.triggerLazyLoad(), e ? r.generateCommandHelp(e) : r.generateHelp();
@@ -6348,15 +6350,15 @@ category: "System"
 for (var t = [], r = 0; r < arguments.length; r++) t[r] = arguments[r];
 var o = t[0];
 return void 0 !== o ? e.generateCommandHelp(String(o)) : e.generateHelp();
-}), this.initialized = !0, Fr.info("Command registry initialized", {
+}), this.initialized = !0, Wr.info("Command registry initialized", {
 subsystem: "CommandRegistry"
 }));
 }, e.prototype.enableLazyLoading = function(e) {
-this.lazyLoadEnabled = !0, this.registrationCallback = e, Fr.info("Console commands lazy loading enabled", {
+this.lazyLoadEnabled = !0, this.registrationCallback = e, Wr.info("Console commands lazy loading enabled", {
 subsystem: "CommandRegistry"
 });
 }, e.prototype.triggerLazyLoad = function() {
-!this.commandsRegistered && this.registrationCallback && (Fr.debug("Lazy loading console commands on first access", {
+!this.commandsRegistered && this.registrationCallback && (Wr.debug("Lazy loading console commands on first access", {
 subsystem: "CommandRegistry"
 }), this.commandsRegistered = !0, this.registrationCallback(), this.exposeToGlobal());
 }, e.prototype.getCommandCount = function() {
@@ -6369,25 +6371,25 @@ this.commandsExposed = !1, this.registrationCallback = void 0;
 }, e.prototype.clear = function() {
 this.reset();
 }, e;
-}(), Qr = new zr;
+}(), Xr = new Qr;
 
-function Xr(e) {
+function Zr(e) {
 return function(t, r, o) {
-if ("object" != typeof r) Ur(e, String(r), t); else {
+if ("object" != typeof r) _r(e, String(r), t); else {
 var n = r, a = String(n.name);
 n.addInitializer(function() {
-"object" == typeof this && null !== this && Ur(e, a, Object.getPrototypeOf(this));
+"object" == typeof this && null !== this && _r(e, a, Object.getPrototypeOf(this));
 });
 }
 };
 }
 
-function Zr(e) {
+function Jr(e) {
 var t, r;
 try {
 for (var o = a(function(e) {
 var t = Object.getPrototypeOf(e);
-return Ar.filter(function(e) {
+return Ur.filter(function(e) {
 return function(e, t) {
 return null !== t && (e === t || Object.getPrototypeOf(e) === t || e === Object.getPrototypeOf(t));
 }(e.target, t);
@@ -6396,7 +6398,7 @@ return null !== t && (e === t || Object.getPrototypeOf(e) === t || e === Object.
 var i = n.value, s = e[i.methodName];
 if ("function" == typeof s) {
 var c = s.bind(e);
-Qr.register(i.metadata, c), Fr.debug('Registered decorated command "'.concat(i.metadata.name, '"'), {
+Xr.register(i.metadata, c), Wr.debug('Registered decorated command "'.concat(i.metadata.name, '"'), {
 subsystem: "CommandRegistry"
 });
 }
@@ -6418,22 +6420,22 @@ if (t) throw t.error;
 function e() {}
 e.prototype.setLogLevel = function(e) {
 return void 0 === {
-debug: _r.DEBUG,
-info: _r.INFO,
-warn: _r.WARN,
-error: _r.ERROR,
-none: _r.NONE
+debug: Nr.DEBUG,
+info: Nr.INFO,
+warn: Nr.WARN,
+error: Nr.ERROR,
+none: Nr.NONE
 }[e.toLowerCase()] ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : "Log level set to: ".concat(e.toUpperCase());
 }, e.prototype.toggleDebug = function() {
 var e = !{}.debug;
-return e ? _r.DEBUG : _r.INFO, "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
-}, n([ Xr({
+return e ? Nr.DEBUG : Nr.INFO, "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
+}, n([ Zr({
 name: "setLogLevel",
 description: "Set the log level for the bot",
 usage: "setLogLevel(level)",
 examples: [ "setLogLevel('debug')", "setLogLevel('info')", "setLogLevel('warn')", "setLogLevel('error')", "setLogLevel('none')" ],
 category: "Logging"
-}) ], e.prototype, "setLogLevel", null), n([ Xr({
+}) ], e.prototype, "setLogLevel", null), n([ Zr({
 name: "toggleDebug",
 description: "Toggle debug mode on/off (affects log level and debug features)",
 usage: "toggleDebug()",
@@ -6445,19 +6447,8 @@ function e() {}
 e.prototype.toggleVisualizations = function() {
 return "Visualizations: ".concat({}.visualizations ? "DISABLED" : "ENABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t, r, o = null === (t = Yr.getConfig) || void 0 === t ? void 0 : t.call(Yr);
-if (!o) return "RoomVisualizer.getConfig is not implemented";
-var n = Object.keys(o).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof o[e];
-});
-if (!n.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(n.join(", "));
-var a = e;
-Yr.toggle && Yr.toggle(String(a));
-var i = null === (r = Yr.getConfig) || void 0 === r ? void 0 : r.call(Yr), s = null == i ? void 0 : i[a];
-return "Room visualization '".concat(e, "': ").concat(s ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t, r, o = null === (t = Vr.getConfig) || void 0 === t ? void 0 : t.call(Vr);
-if (!o) return "MapVisualizer.getConfig is not implemented";
+if (!o) return "RoomVisualizer.getConfig is not implemented";
 var n = Object.keys(o).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof o[e];
 });
@@ -6465,9 +6456,20 @@ if (!n.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(n.
 var a = e;
 Vr.toggle && Vr.toggle(String(a));
 var i = null === (r = Vr.getConfig) || void 0 === r ? void 0 : r.call(Vr), s = null == i ? void 0 : i[a];
+return "Room visualization '".concat(e, "': ").concat(s ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t, r, o = null === (t = qr.getConfig) || void 0 === t ? void 0 : t.call(qr);
+if (!o) return "MapVisualizer.getConfig is not implemented";
+var n = Object.keys(o).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof o[e];
+});
+if (!n.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(n.join(", "));
+var a = e;
+qr.toggle && qr.toggle(String(a));
+var i = null === (r = qr.getConfig) || void 0 === r ? void 0 : r.call(qr), s = null == i ? void 0 : i[a];
 return "Map visualization '".concat(e, "': ").concat(s ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e, t = null === (e = Vr.getConfig) || void 0 === e ? void 0 : e.call(Vr);
+var e, t = null === (e = qr.getConfig) || void 0 === e ? void 0 : e.call(qr);
 return t ? Object.entries(t).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -6537,55 +6539,55 @@ return c;
 }, e.prototype.clearVisCache = function(e) {
 return require("../visuals/visualizationManager").visualizationManager.clearCache(e),
 e ? "Visualization cache cleared for room: ".concat(e) : "All visualization caches cleared";
-}, n([ Xr({
+}, n([ Zr({
 name: "toggleVisualizations",
 description: "Toggle all visualizations on/off",
 usage: "toggleVisualizations()",
 examples: [ "toggleVisualizations()" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualizations", null), n([ Xr({
+}) ], e.prototype, "toggleVisualizations", null), n([ Zr({
 name: "toggleVisualization",
 description: "Toggle a specific room visualization feature",
 usage: "toggleVisualization(key)",
 examples: [ "toggleVisualization('showPheromones')", "toggleVisualization('showPaths')", "toggleVisualization('showCombat')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualization", null), n([ Xr({
+}) ], e.prototype, "toggleVisualization", null), n([ Zr({
 name: "toggleMapVisualization",
 description: "Toggle a specific map visualization feature",
 usage: "toggleMapVisualization(key)",
 examples: [ "toggleMapVisualization('showRoomStatus')", "toggleMapVisualization('showConnections')", "toggleMapVisualization('showThreats')", "toggleMapVisualization('showExpansion')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleMapVisualization", null), n([ Xr({
+}) ], e.prototype, "toggleMapVisualization", null), n([ Zr({
 name: "showMapConfig",
 description: "Show current map visualization configuration",
 usage: "showMapConfig()",
 examples: [ "showMapConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showMapConfig", null), n([ Xr({
+}) ], e.prototype, "showMapConfig", null), n([ Zr({
 name: "setVisMode",
 description: "Set visualization mode preset (debug, presentation, minimal, performance)",
 usage: "setVisMode(mode)",
 examples: [ "setVisMode('debug')", "setVisMode('presentation')", "setVisMode('minimal')", "setVisMode('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "setVisMode", null), n([ Xr({
+}) ], e.prototype, "setVisMode", null), n([ Zr({
 name: "toggleVisLayer",
 description: "Toggle a specific visualization layer",
 usage: "toggleVisLayer(layer)",
 examples: [ "toggleVisLayer('pheromones')", "toggleVisLayer('paths')", "toggleVisLayer('defense')", "toggleVisLayer('economy')", "toggleVisLayer('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisLayer", null), n([ Xr({
+}) ], e.prototype, "toggleVisLayer", null), n([ Zr({
 name: "showVisPerf",
 description: "Show visualization performance metrics",
 usage: "showVisPerf()",
 examples: [ "showVisPerf()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisPerf", null), n([ Xr({
+}) ], e.prototype, "showVisPerf", null), n([ Zr({
 name: "showVisConfig",
 description: "Show current visualization configuration",
 usage: "showVisConfig()",
 examples: [ "showVisConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisConfig", null), n([ Xr({
+}) ], e.prototype, "showVisConfig", null), n([ Zr({
 name: "clearVisCache",
 description: "Clear visualization cache",
 usage: "clearVisCache(roomName?)",
@@ -6595,7 +6597,7 @@ category: "Visualization"
 }(), function() {
 function e() {}
 e.prototype.showStats = function() {
-var e, t = null === (e = Hr.getLatestStats) || void 0 === e ? void 0 : e.call(Hr);
+var e, t = null === (e = Kr.getLatestStats) || void 0 === e ? void 0 : e.call(Kr);
 return t ? t ? "=== SwarmBot Stats (Tick ".concat(t.tick, ") ===\nCPU: ").concat(t.cpuUsed.toFixed(2), "/").concat(t.cpuLimit, " (Bucket: ").concat(t.cpuBucket, ")\nGCL: ").concat(t.gclLevel, " (").concat((100 * t.gclProgress).toFixed(1), "%)\nGPL: ").concat(t.gplLevel, "\nCreeps: ").concat(t.totalCreeps, "\nRooms: ").concat(t.totalRooms, "\n").concat(t.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks." : "MemorySegmentStats.getLatestStats is not implemented";
@@ -6611,7 +6613,7 @@ return "=== Room.find() Cache Statistics ===\nCached Rooms: ".concat(e.rooms, "\
 return (0, require("../utils/roomFindCache").clearRoomFindCache)(), "Room.find() cache cleared and statistics reset";
 }, e.prototype.toggleProfiling = function() {
 var e = !{}.profiling;
-return Kr.setEnabled && Kr.setEnabled(e), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
+return Yr.setEnabled && Yr.setEnabled(e), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.cpuBreakdown = function(e) {
 var t, r, o, n, i, s, c, u, l = Memory.stats;
 if (!l) return "No stats available. Stats collection may be disabled.";
@@ -6723,7 +6725,7 @@ d.push("");
 }
 return d.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n, i = null === (n = Kr.validateBudgets) || void 0 === n ? void 0 : n.call(Kr);
+var e, t, r, o, n, i = null === (n = Yr.validateBudgets) || void 0 === n ? void 0 : n.call(Yr);
 if (!i) return "unifiedStats.validateBudgets is not implemented";
 var s = "=== CPU Budget Report (Tick ".concat(i.tick, ") ===\n");
 if (s += "Rooms Evaluated: ".concat(i.roomsEvaluated, "\n"), s += "Within Budget: ".concat(i.roomsWithinBudget, "\n"),
@@ -6772,7 +6774,7 @@ if (r) throw r.error;
 }
 return s;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n, i = null === (n = Kr.detectAnomalies) || void 0 === n ? void 0 : n.call(Kr);
+var e, t, r, o, n, i = null === (n = Yr.detectAnomalies) || void 0 === n ? void 0 : n.call(Yr);
 if (!i) return "unifiedStats.detectAnomalies is not implemented";
 if (0 === i.length) return "✓ No CPU anomalies detected";
 var s = "=== CPU Anomalies Detected: ".concat(i.length, " ===\n\n"), c = i.filter(function(e) {
@@ -6822,7 +6824,7 @@ return s;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n, i, s, c;
 void 0 === e && (e = !1);
-var u = null === (i = Kr.getCurrentSnapshot) || void 0 === i ? void 0 : i.call(Kr);
+var u = null === (i = Yr.getCurrentSnapshot) || void 0 === i ? void 0 : i.call(Yr);
 if (!u) return "unifiedStats.getCurrentSnapshot is not implemented";
 var l = "=== CPU Profile (Tick ".concat(u.tick, ") ===\n");
 l += "Total: ".concat(u.cpu.used.toFixed(2), " / ").concat(u.cpu.limit, " (").concat(u.cpu.percent.toFixed(1), "%)\n"),
@@ -6833,7 +6835,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 l += "Top ".concat(d.length, " Rooms by CPU:\n");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (c = null === (s = Kr.postureCodeToName) || void 0 === s ? void 0 : s.call(Kr, y.brain.postureCode)) && void 0 !== c ? c : "unknown";
+var y = f.value, v = null !== (c = null === (s = Yr.postureCodeToName) || void 0 === s ? void 0 : s.call(Yr, y.brain.postureCode)) && void 0 !== c ? c : "unknown";
 l += "  ".concat(y.name, " (RCL").concat(y.rcl, ", ").concat(v, "): avg ").concat(y.profiler.avgCpu.toFixed(3), " | peak ").concat(y.profiler.peakCpu.toFixed(3), " | samples ").concat(y.profiler.samples, "\n");
 }
 } catch (e) {
@@ -6870,61 +6872,61 @@ if (o) throw o.error;
 }
 }
 return l;
-}, n([ Xr({
+}, n([ Zr({
 name: "showStats",
 description: "Show current bot statistics from memory segment",
 usage: "showStats()",
 examples: [ "showStats()" ],
 category: "Statistics"
-}) ], e.prototype, "showStats", null), n([ Xr({
+}) ], e.prototype, "showStats", null), n([ Zr({
 name: "cacheStats",
 description: "Show object cache statistics (hits, misses, hit rate, CPU savings)",
 usage: "cacheStats()",
 examples: [ "cacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "cacheStats", null), n([ Xr({
+}) ], e.prototype, "cacheStats", null), n([ Zr({
 name: "resetCacheStats",
 description: "Reset cache statistics counters (for benchmarking)",
 usage: "resetCacheStats()",
 examples: [ "resetCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "resetCacheStats", null), n([ Xr({
+}) ], e.prototype, "resetCacheStats", null), n([ Zr({
 name: "roomFindCacheStats",
 description: "Show room.find() cache statistics (hits, misses, hit rate)",
 usage: "roomFindCacheStats()",
 examples: [ "roomFindCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "roomFindCacheStats", null), n([ Xr({
+}) ], e.prototype, "roomFindCacheStats", null), n([ Zr({
 name: "clearRoomFindCache",
 description: "Clear all room.find() cache entries and reset stats",
 usage: "clearRoomFindCache()",
 examples: [ "clearRoomFindCache()" ],
 category: "Statistics"
-}) ], e.prototype, "clearRoomFindCache", null), n([ Xr({
+}) ], e.prototype, "clearRoomFindCache", null), n([ Zr({
 name: "toggleProfiling",
 description: "Toggle CPU profiling on/off",
 usage: "toggleProfiling()",
 examples: [ "toggleProfiling()" ],
 category: "Statistics"
-}) ], e.prototype, "toggleProfiling", null), n([ Xr({
+}) ], e.prototype, "toggleProfiling", null), n([ Zr({
 name: "cpuBreakdown",
 description: "Show detailed CPU breakdown by process, room, creep, and subsystem",
 usage: "cpuBreakdown(type?)",
 examples: [ "cpuBreakdown() // Show all breakdowns", "cpuBreakdown('process') // Show only process breakdown", "cpuBreakdown('room') // Show only room breakdown", "cpuBreakdown('creep') // Show only creep breakdown", "cpuBreakdown('subsystem') // Show only subsystem breakdown" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBreakdown", null), n([ Xr({
+}) ], e.prototype, "cpuBreakdown", null), n([ Zr({
 name: "cpuBudget",
 description: "Show CPU budget status and violations for all rooms",
 usage: "cpuBudget()",
 examples: [ "cpuBudget()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBudget", null), n([ Xr({
+}) ], e.prototype, "cpuBudget", null), n([ Zr({
 name: "cpuAnomalies",
 description: "Detect and show CPU usage anomalies (spikes and sustained high usage)",
 usage: "cpuAnomalies()",
 examples: [ "cpuAnomalies()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuAnomalies", null), n([ Xr({
+}) ], e.prototype, "cpuAnomalies", null), n([ Zr({
 name: "cpuProfile",
 description: "Show comprehensive CPU profiling breakdown by room and subsystem",
 usage: "cpuProfile(showAll?)",
@@ -6935,11 +6937,11 @@ category: "Statistics"
 function e() {}
 e.prototype.showConfig = function() {
 var e = {}, t = {
-level: _r.INFO,
+level: Nr.INFO,
 categories: {}
 };
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(_r[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
-}, n([ Xr({
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(Nr[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+}, n([ Zr({
 name: "showConfig",
 description: "Show current bot configuration",
 usage: "showConfig()",
@@ -6949,11 +6951,11 @@ category: "Configuration"
 }(), function() {
 function e() {}
 e.prototype.showKernelStats = function() {
-var e, t, r, o, n, i, s, c, u, l, m, d, p, f = null === (n = Wr.getStatsSummary) || void 0 === n ? void 0 : n.call(Wr);
+var e, t, r, o, n, i, s, c, u, l, m, d, p, f = null === (n = Hr.getStatsSummary) || void 0 === n ? void 0 : n.call(Hr);
 if (!f) return "kernel.getStatsSummary is not implemented";
-var y = null !== (s = null === (i = Wr.getConfig) || void 0 === i ? void 0 : i.call(Wr)) && void 0 !== s ? s : {
+var y = null !== (s = null === (i = Hr.getConfig) || void 0 === i ? void 0 : i.call(Hr)) && void 0 !== s ? s : {
 targetCpuUsage: 0
-}, v = null !== (u = null === (c = Wr.getBucketMode) || void 0 === c ? void 0 : c.call(Wr)) && void 0 !== u ? u : "normal", g = "=== Kernel Stats ===\nBucket Mode: ".concat(v.toUpperCase(), "\nCPU Bucket: ").concat(Game.cpu.bucket, "\nCPU Limit: ").concat((null !== (m = null === (l = Wr.getCpuLimit) || void 0 === l ? void 0 : l.call(Wr)) && void 0 !== m ? m : 0).toFixed(2), " (").concat((100 * y.targetCpuUsage).toFixed(0), "% of ").concat(Game.cpu.limit, ")\nRemaining CPU: ").concat((null !== (p = null === (d = Wr.getRemainingCpu) || void 0 === d ? void 0 : d.call(Wr)) && void 0 !== p ? p : 0).toFixed(2), "\n\nProcesses: ").concat(f.totalProcesses, " total (").concat(f.activeProcesses, " active, ").concat(f.suspendedProcesses, " suspended)\nTotal CPU Used: ").concat(f.totalCpuUsed.toFixed(3), "\nAvg CPU/Process: ").concat(f.avgCpuPerProcess.toFixed(4), "\nAvg Health Score: ").concat(f.avgHealthScore.toFixed(1), "/100\n\nTop CPU Consumers:");
+}, v = null !== (u = null === (c = Hr.getBucketMode) || void 0 === c ? void 0 : c.call(Hr)) && void 0 !== u ? u : "normal", g = "=== Kernel Stats ===\nBucket Mode: ".concat(v.toUpperCase(), "\nCPU Bucket: ").concat(Game.cpu.bucket, "\nCPU Limit: ").concat((null !== (m = null === (l = Hr.getCpuLimit) || void 0 === l ? void 0 : l.call(Hr)) && void 0 !== m ? m : 0).toFixed(2), " (").concat((100 * y.targetCpuUsage).toFixed(0), "% of ").concat(Game.cpu.limit, ")\nRemaining CPU: ").concat((null !== (p = null === (d = Hr.getRemainingCpu) || void 0 === d ? void 0 : d.call(Hr)) && void 0 !== p ? p : 0).toFixed(2), "\n\nProcesses: ").concat(f.totalProcesses, " total (").concat(f.activeProcesses, " active, ").concat(f.suspendedProcesses, " suspended)\nTotal CPU Used: ").concat(f.totalCpuUsed.toFixed(3), "\nAvg CPU/Process: ").concat(f.avgCpuPerProcess.toFixed(4), "\nAvg Health Score: ").concat(f.avgHealthScore.toFixed(1), "/100\n\nTop CPU Consumers:");
 try {
 for (var h = a(f.topCpuProcesses), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
@@ -6989,7 +6991,7 @@ if (r) throw r.error;
 }
 return g;
 }, e.prototype.listProcesses = function() {
-var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E = Wr.getProcesses();
+var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E = Hr.getProcesses();
 if (0 === E.length) return "No processes registered with kernel.";
 var T = "=== Registered Processes ===\n";
 T += "ID | Name | Priority | Frequency | State | Runs | Avg CPU | Health | Errors\n",
@@ -7015,15 +7017,15 @@ if (e) throw e.error;
 }
 return T;
 }, e.prototype.suspendProcess = function(e) {
-var t = Wr.suspendProcess(e);
+var t = Hr.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = Wr.resumeProcess(e);
+var t = Hr.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return Wr.resetStats ? (Wr.resetStats(), "Kernel statistics reset.") : "Kernel.resetStats is not implemented";
+return Hr.resetStats ? (Hr.resetStats(), "Kernel statistics reset.") : "Kernel.resetStats is not implemented";
 }, e.prototype.showProcessHealth = function() {
-var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S = Wr.getProcesses();
+var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S = Hr.getProcesses();
 if (0 === S.length) return "No processes registered with kernel.";
 var w = s([], i(S), !1).sort(function(e, t) {
 var r, o, n, a;
@@ -7046,13 +7048,13 @@ O && !O.done && (t = b.return) && t.call(b);
 if (e) throw e.error;
 }
 }
-var N = null !== (C = null === (T = Wr.getStatsSummary) || void 0 === T ? void 0 : T.call(Wr)) && void 0 !== C ? C : {
+var N = null !== (C = null === (T = Hr.getStatsSummary) || void 0 === T ? void 0 : T.call(Hr)) && void 0 !== C ? C : {
 avgHealthScore: 0,
 suspendedProcesses: 0
 };
 return (x += "\nAverage Health: ".concat(N.avgHealthScore.toFixed(1), "/100")) + "\nSuspended Processes: ".concat(N.suspendedProcesses);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = Wr.getProcesses().filter(function(e) {
+var e, t, r = Hr.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -7060,7 +7062,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Wr.resumeProcess(s.id) && o++;
+Hr.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -7075,7 +7077,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r, o = null === (r = qr.getStats) || void 0 === r ? void 0 : r.call(qr);
+var e, t, r, o = null === (r = jr.getStats) || void 0 === r ? void 0 : r.call(jr);
 if (!o) return "creepProcessManager.getStats is not implemented";
 var n = "=== Creep Process Stats ===\nTotal Creeps: ".concat(o.totalCreeps, "\nRegistered Processes: ").concat(o.registeredCreeps, "\n\nCreeps by Priority:");
 try {
@@ -7096,7 +7098,7 @@ if (e) throw e.error;
 }
 return n;
 }, e.prototype.showRoomStats = function() {
-var e, t, r, o = null === (r = jr.getStats) || void 0 === r ? void 0 : r.call(jr);
+var e, t, r, o = null === (r = zr.getStats) || void 0 === r ? void 0 : r.call(zr);
 if (!o) return "roomProcessManager.getStats is not implemented";
 var n = "=== Room Process Stats ===\nTotal Rooms: ".concat(o.totalRooms, "\nRegistered Processes: ").concat(o.registeredRooms, "\nOwned Rooms: ").concat(o.ownedRooms, "\n\nRooms by Priority:");
 try {
@@ -7117,7 +7119,7 @@ if (e) throw e.error;
 }
 return n;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o, n, c, u, l, m, d = Wr.getProcesses().filter(function(e) {
+var t, r, o, n, c, u, l, m, d = Hr.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (d = d.filter(function(t) {
@@ -7146,7 +7148,7 @@ if (t) throw t.error;
 }
 return p + "\nTotal: ".concat(d.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r, o, n, c, u, l, m = Wr.getProcesses().filter(function(e) {
+var e, t, r, o, n, c, u, l, m = Hr.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === m.length) return "No room processes registered.";
@@ -7172,67 +7174,67 @@ if (e) throw e.error;
 }
 }
 return d + "\nTotal: ".concat(m.length, " room processes");
-}, n([ Xr({
+}, n([ Zr({
 name: "showKernelStats",
 description: "Show kernel statistics including CPU usage and process info",
 usage: "showKernelStats()",
 examples: [ "showKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showKernelStats", null), n([ Xr({
+}) ], e.prototype, "showKernelStats", null), n([ Zr({
 name: "listProcesses",
 description: "List all registered kernel processes",
 usage: "listProcesses()",
 examples: [ "listProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "listProcesses", null), n([ Xr({
+}) ], e.prototype, "listProcesses", null), n([ Zr({
 name: "suspendProcess",
 description: "Suspend a kernel process by ID",
 usage: "suspendProcess(processId)",
 examples: [ "suspendProcess('empire:manager')", "suspendProcess('cluster:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "suspendProcess", null), n([ Xr({
+}) ], e.prototype, "suspendProcess", null), n([ Zr({
 name: "resumeProcess",
 description: "Resume a suspended kernel process",
 usage: "resumeProcess(processId)",
 examples: [ "resumeProcess('empire:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "resumeProcess", null), n([ Xr({
+}) ], e.prototype, "resumeProcess", null), n([ Zr({
 name: "resetKernelStats",
 description: "Reset all kernel process statistics",
 usage: "resetKernelStats()",
 examples: [ "resetKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "resetKernelStats", null), n([ Xr({
+}) ], e.prototype, "resetKernelStats", null), n([ Zr({
 name: "showProcessHealth",
 description: "Show health status of all processes with detailed metrics",
 usage: "showProcessHealth()",
 examples: [ "showProcessHealth()" ],
 category: "Kernel"
-}) ], e.prototype, "showProcessHealth", null), n([ Xr({
+}) ], e.prototype, "showProcessHealth", null), n([ Zr({
 name: "resumeAllProcesses",
 description: "Resume all suspended processes (use with caution)",
 usage: "resumeAllProcesses()",
 examples: [ "resumeAllProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "resumeAllProcesses", null), n([ Xr({
+}) ], e.prototype, "resumeAllProcesses", null), n([ Zr({
 name: "showCreepStats",
 description: "Show statistics about creep processes managed by the kernel",
 usage: "showCreepStats()",
 examples: [ "showCreepStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showCreepStats", null), n([ Xr({
+}) ], e.prototype, "showCreepStats", null), n([ Zr({
 name: "showRoomStats",
 description: "Show statistics about room processes managed by the kernel",
 usage: "showRoomStats()",
 examples: [ "showRoomStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showRoomStats", null), n([ Xr({
+}) ], e.prototype, "showRoomStats", null), n([ Zr({
 name: "listCreepProcesses",
 description: "List all creep processes with their details",
 usage: "listCreepProcesses(role?)",
 examples: [ "listCreepProcesses()", "listCreepProcesses('harvester')" ],
 category: "Kernel"
-}) ], e.prototype, "listCreepProcesses", null), n([ Xr({
+}) ], e.prototype, "listCreepProcesses", null), n([ Zr({
 name: "listRoomProcesses",
 description: "List all room processes with their details",
 usage: "listRoomProcesses()",
@@ -7242,16 +7244,16 @@ category: "Kernel"
 }(), function() {
 function e() {}
 e.prototype.listCommands = function() {
-return Qr.generateHelp();
+return Xr.generateHelp();
 }, e.prototype.commandHelp = function(e) {
-return Qr.generateCommandHelp(e);
-}, n([ Xr({
+return Xr.generateCommandHelp(e);
+}, n([ Zr({
 name: "listCommands",
 description: "List all available commands (alias for help)",
 usage: "listCommands()",
 examples: [ "listCommands()" ],
 category: "System"
-}) ], e.prototype, "listCommands", null), n([ Xr({
+}) ], e.prototype, "listCommands", null), n([ Zr({
 name: "commandHelp",
 description: "Get detailed help for a specific command",
 usage: "commandHelp(commandName)",
@@ -7260,13 +7262,13 @@ category: "System"
 }) ], e.prototype, "commandHelp", null);
 }();
 
-var Jr, $r = {
+var $r, eo = {
 maxPredictionTicks: 100,
 safetyMargin: .9,
 enableLogging: !1
-}, eo = function() {
+}, to = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, $r), e);
+void 0 === e && (e = {}), this.config = o(o({}, eo), e);
 }
 return e.prototype.findMyCreeps = function(e, t) {
 return e.find(FIND_MY_CREEPS).filter(t);
@@ -7428,24 +7430,24 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), to = new eo, ro = function() {
+}(), ro = new to, oo = function() {
 function e() {}
 return e.prototype.predictEnergy = function(e, t) {
 void 0 === t && (t = 50);
 var r = Game.rooms[e];
 return r ? r.controller && r.controller.my ? function(e, t) {
 return [ "=== Energy Prediction: ".concat(e, " ==="), "Current Energy: ".concat(t.current), "Predicted (".concat(t.ticks, " ticks): ").concat(Math.round(t.predicted)), "Net Flow: ".concat(t.netFlow.toFixed(2), " energy/tick"), "", "Income Breakdown (per tick):", "  Harvesters: ".concat(t.income.harvesters.toFixed(2)), "  Static Miners: ".concat(t.income.miners.toFixed(2)), "  Links: ".concat(t.income.links.toFixed(2)), "  Total: ".concat(t.income.total.toFixed(2)), "", "Consumption Breakdown (per tick):", "  Upgraders: ".concat(t.consumption.upgraders.toFixed(2)), "  Builders: ".concat(t.consumption.builders.toFixed(2)), "  Towers: ".concat(t.consumption.towers.toFixed(2)), "  Spawning: ".concat(t.consumption.spawning.toFixed(2)), "  Repairs: ".concat(t.consumption.repairs.toFixed(2)), "  Total: ".concat(t.consumption.total.toFixed(2)), "" ].join("\n");
-}(e, to.predictEnergyInTicks(r, t)) : "Room ".concat(e, " is not owned by you") : "Room ".concat(e, " is not visible");
+}(e, ro.predictEnergyInTicks(r, t)) : "Room ".concat(e, " is not owned by you") : "Room ".concat(e, " is not visible");
 }, e.prototype.showIncome = function(e) {
 var t = Game.rooms[e];
 return t ? function(e, t) {
 return [ "=== Energy Income: ".concat(e, " ==="), "Harvesters: ".concat(t.harvesters.toFixed(2), " energy/tick"), "Static Miners: ".concat(t.miners.toFixed(2), " energy/tick"), "Links: ".concat(t.links.toFixed(2), " energy/tick"), "Total: ".concat(t.total.toFixed(2), " energy/tick"), "" ].join("\n");
-}(e, to.calculateEnergyIncome(t)) : "Room ".concat(e, " is not visible");
+}(e, ro.calculateEnergyIncome(t)) : "Room ".concat(e, " is not visible");
 }, e.prototype.showConsumption = function(e) {
 var t = Game.rooms[e];
 return t ? function(e, t) {
 return [ "=== Energy Consumption: ".concat(e, " ==="), "Upgraders: ".concat(t.upgraders.toFixed(2), " energy/tick"), "Builders: ".concat(t.builders.toFixed(2), " energy/tick"), "Towers: ".concat(t.towers.toFixed(2), " energy/tick"), "Spawning: ".concat(t.spawning.toFixed(2), " energy/tick"), "Repairs: ".concat(t.repairs.toFixed(2), " energy/tick"), "Total: ".concat(t.total.toFixed(2), " energy/tick"), "" ].join("\n");
-}(e, to.calculateEnergyConsumption(t)) : "Room ".concat(e, " is not visible");
+}(e, ro.calculateEnergyConsumption(t)) : "Room ".concat(e, " is not visible");
 }, e.prototype.canAfford = function(e, t, r) {
 void 0 === r && (r = 50);
 var o, n = Game.rooms[e];
@@ -7453,14 +7455,14 @@ return n ? (o = {
 roomName: e,
 cost: t,
 ticks: r,
-canAfford: to.canAffordInTicks(n, t, r),
-predicted: to.predictEnergyInTicks(n, r).predicted,
-delay: to.getRecommendedSpawnDelay(n, t)
+canAfford: ro.canAffordInTicks(n, t, r),
+predicted: ro.predictEnergyInTicks(n, r).predicted,
+delay: ro.getRecommendedSpawnDelay(n, t)
 }).canAfford ? "✓ Room ".concat(o.roomName, " CAN afford ").concat(o.cost, " energy within ").concat(o.ticks, " ticks (predicted: ").concat(Math.round(o.predicted), ")") : o.delay >= 999 ? "✗ Room ".concat(o.roomName, " CANNOT afford ").concat(o.cost, " energy (negative energy flow)") : "✗ Room ".concat(o.roomName, " CANNOT afford ").concat(o.cost, " energy within ").concat(o.ticks, " ticks (would need ").concat(o.delay, " ticks)") : "Room ".concat(e, " is not visible");
 }, e.prototype.getSpawnDelay = function(e, t) {
 var r = Game.rooms[e];
 if (!r) return "Room ".concat(e, " is not visible");
-var o = to.getRecommendedSpawnDelay(r, t), n = r.energyAvailable, a = o > 0 && o < 999 ? to.predictEnergyInTicks(r, o) : void 0;
+var o = ro.getRecommendedSpawnDelay(r, t), n = r.energyAvailable, a = o > 0 && o < 999 ? ro.predictEnergyInTicks(r, o) : void 0;
 return function(e) {
 var t;
 return 0 === e.delay ? "✓ Room ".concat(e.roomName, " can spawn ").concat(e.cost, " energy body NOW (current: ").concat(e.current, ")") : e.delay >= 999 ? "✗ Room ".concat(e.roomName, " has negative energy flow, cannot spawn ").concat(e.cost, " energy body") : "Room ".concat(e.roomName, " needs to wait ").concat(e.delay, " ticks to spawn ").concat(e.cost, " energy body (current: ").concat(e.current, ", predicted: ").concat(Math.round(null !== (t = e.predicted) && void 0 !== t ? t : 0), ")");
@@ -7471,40 +7473,40 @@ delay: o,
 current: n,
 predicted: null == a ? void 0 : a.predicted
 });
-}, n([ Xr({
+}, n([ Zr({
 name: "economy.energy.predict",
 description: "Predict energy availability for a room in N ticks",
 usage: "economy.energy.predict(roomName, ticks)",
 examples: [ "economy.energy.predict('W1N1', 50)", "economy.energy.predict('E1S1', 100)" ],
 category: "Economy"
-}) ], e.prototype, "predictEnergy", null), n([ Xr({
+}) ], e.prototype, "predictEnergy", null), n([ Zr({
 name: "economy.energy.income",
 description: "Show energy income breakdown for a room",
 usage: "economy.energy.income(roomName)",
 examples: [ "economy.energy.income('W1N1')" ],
 category: "Economy"
-}) ], e.prototype, "showIncome", null), n([ Xr({
+}) ], e.prototype, "showIncome", null), n([ Zr({
 name: "economy.energy.consumption",
 description: "Show energy consumption breakdown for a room",
 usage: "economy.energy.consumption(roomName)",
 examples: [ "economy.energy.consumption('W1N1')" ],
 category: "Economy"
-}) ], e.prototype, "showConsumption", null), n([ Xr({
+}) ], e.prototype, "showConsumption", null), n([ Zr({
 name: "economy.energy.canAfford",
 description: "Check if a room can afford a certain energy cost within N ticks",
 usage: "economy.energy.canAfford(roomName, cost, ticks)",
 examples: [ "economy.energy.canAfford('W1N1', 1000, 50)", "economy.energy.canAfford('E1S1', 500, 25)" ],
 category: "Economy"
-}) ], e.prototype, "canAfford", null), n([ Xr({
+}) ], e.prototype, "canAfford", null), n([ Zr({
 name: "economy.energy.spawnDelay",
 description: "Get recommended spawn delay for a body cost",
 usage: "economy.energy.spawnDelay(roomName, cost)",
 examples: [ "economy.energy.spawnDelay('W1N1', 1000)", "economy.energy.spawnDelay('E1S1', 500)" ],
 category: "Economy"
 }) ], e.prototype, "getSpawnDelay", null), e;
-}(), oo = new ro, no = new Set([ ATTACK, RANGED_ATTACK, WORK, HEAL, CLAIM ]);
+}(), no = new oo, ao = new Set([ ATTACK, RANGED_ATTACK, WORK, HEAL, CLAIM ]);
 
-function ao(e) {
+function io(e) {
 var t, r, o, n = {
 meleeCount: 0,
 rangedCount: 0,
@@ -7517,7 +7519,7 @@ threatPartCount: 0
 try {
 for (var i = a(null !== (o = e.body) && void 0 !== o ? o : []), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.hits <= 0 || (void 0 !== c.boost && (n.boosted = !0), no.has(c.type) && (n.threatPartCount++,
+c.hits <= 0 || (void 0 !== c.boost && (n.boosted = !0), ao.has(c.type) && (n.threatPartCount++,
 c.type === ATTACK && n.meleeCount++, c.type === RANGED_ATTACK && n.rangedCount++,
 c.type === HEAL && n.healerCount++, c.type === WORK && n.dismantlerCount++, c.type === CLAIM && n.claimCount++));
 }
@@ -7535,29 +7537,29 @@ if (t) throw t.error;
 return n;
 }
 
-function io(e) {
-return void 0 === t && (t = {}), !z(e, t) && ao(e).threatPartCount > 0;
-var t;
-}
-
 function so(e) {
-return 0 === e.find(FIND_MY_SPAWNS).length || e.energyCapacityAvailable <= 0;
+return void 0 === t && (t = {}), !z(e, t) && io(e).threatPartCount > 0;
+var t;
 }
 
 function co(e) {
-var t, r, o, n = null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = X(e);
-return Boolean(null === (o = e.controller) || void 0 === o ? void 0 : o.my) && n <= 3 && so(e) && a.length > 0;
+return 0 === e.find(FIND_MY_SPAWNS).length || e.energyCapacityAvailable <= 0;
 }
 
 function uo(e) {
-var t;
-return Boolean(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && so(e) && X(e).length > 0;
+var t, r, o, n = null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Z(e);
+return Boolean(null === (o = e.controller) || void 0 === o ? void 0 : o.my) && n <= 3 && co(e) && a.length > 0;
 }
 
-function lo(e, t) {
-void 0 === t && (t = X(e));
+function lo(e) {
+var t;
+return Boolean(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && co(e) && Z(e).length > 0;
+}
+
+function mo(e, t) {
+void 0 === t && (t = Z(e));
 var r = function(e) {
-var t, r, o = e.filter(io);
+var t, r, o = e.filter(so);
 if (0 === o.length) return {
 guards: 0,
 rangers: 0
@@ -7565,7 +7567,7 @@ rangers: 0
 var n = 0, i = 0, s = 0, c = 0, u = 0, l = 0;
 try {
 for (var m = a(o), d = m.next(); !d.done; d = m.next()) {
-var p = ao(d.value);
+var p = io(d.value);
 n += p.meleeCount, i += p.rangedCount, s += p.healerCount, c += p.dismantlerCount,
 u += p.claimCount, p.boosted && l++;
 }
@@ -7589,27 +7591,27 @@ rangers: y
 };
 }(t);
 if (0 === r.guards && 0 === r.rangers) return !0;
-var o = yo(e);
+var o = vo(e);
 return o.guards >= r.guards && o.rangers >= r.rangers;
 }
 
-function mo(e) {
+function po(e) {
 var t, r, o, n, i = {
 guards: 0,
 rangers: 0,
 healers: 0,
 urgency: 1,
 reasons: []
-}, s = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 1, c = X(e);
+}, s = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 1, c = Z(e);
 if (0 === c.length) return i;
-var u = co(e);
-uo(e) && (i.guards = Math.max(1, i.guards), i.urgency = Math.max(i.urgency, 3),
+var u = uo(e);
+lo(e) && (i.guards = Math.max(1, i.guards), i.urgency = Math.max(i.urgency, 3),
 i.reasons.push("Hostile present with no local spawn capacity (RCL ".concat(s, ")"))),
 u && (i.guards = Math.max(1, i.guards), i.urgency = Math.max(i.urgency, 1.5), i.reasons.push("Hostile present in bootstrap defense gap (RCL ".concat(s, ")")));
 var l = 0, m = 0, d = 0, p = 0, f = 0, y = 0;
 try {
 for (var v = a(c), g = v.next(); !g.done; g = v.next()) {
-var h = ao(g.value);
+var h = io(g.value);
 l += h.meleeCount, m += h.rangedCount, d += h.healerCount, p += h.dismantlerCount,
 f += h.claimCount, h.boosted && y++;
 }
@@ -7645,22 +7647,22 @@ subsystem: "Defense"
 }), i;
 }
 
-function po(e, t) {
+function fo(e, t) {
 var r;
 return (null !== (r = e.body) && void 0 !== r ? r : []).some(function(e) {
 return e.hits > 0 && t.includes(e.type);
 });
 }
 
-function fo(e, t) {
+function yo(e, t) {
 var r = void 0 === t ? void 0 : new Set(t);
 return e.find(FIND_MY_CREEPS).filter(function(e) {
 var t, o = e.hits, n = null === (t = e.memory) || void 0 === t ? void 0 : t.role;
-return !0 !== e.spawning && !("number" == typeof o && o <= 0) && !(void 0 !== r && !r.has(null != n ? n : "")) && po(e, [ ATTACK, RANGED_ATTACK ]);
+return !0 !== e.spawning && !("number" == typeof o && o <= 0) && !(void 0 !== r && !r.has(null != n ? n : "")) && fo(e, [ ATTACK, RANGED_ATTACK ]);
 }).length;
 }
 
-function yo(e) {
+function vo(e) {
 var t = e.find(FIND_MY_CREEPS), r = function(e) {
 return !e.spawning;
 }, o = function(e) {
@@ -7668,24 +7670,24 @@ return e.memory.role;
 };
 return {
 guards: t.filter(function(t) {
-return r(t) && ("guard" === o(t) || "remoteGuard" === o(n = t) && n.memory.targetRoom === e.name) && po(t, [ ATTACK, RANGED_ATTACK ]);
+return r(t) && ("guard" === o(t) || "remoteGuard" === o(n = t) && n.memory.targetRoom === e.name) && fo(t, [ ATTACK, RANGED_ATTACK ]);
 var n;
 }).length,
 rangers: t.filter(function(e) {
-return r(e) && "ranger" === o(e) && po(e, [ RANGED_ATTACK ]);
+return r(e) && "ranger" === o(e) && fo(e, [ RANGED_ATTACK ]);
 }).length,
 healers: t.filter(function(e) {
-return !e.spawning && "healer" === e.memory.role && po(e, [ HEAL ]);
+return !e.spawning && "healer" === e.memory.role && fo(e, [ HEAL ]);
 }).length
 };
 }
 
-function vo(e, t) {
+function go(e, t) {
 var r, o, n = function(e) {
-return X(e).some(io);
-}(e), a = co(e), i = uo(e);
+return Z(e).some(so);
+}(e), a = uo(e), i = lo(e);
 if (t.danger < 2 && !n && !a && !i) return !1;
-var s = mo(e), c = yo(e), u = Math.max(0, s.guards - c.guards) + Math.max(0, s.rangers - c.rangers) + Math.max(0, s.healers - c.healers);
+var s = po(e), c = vo(e), u = Math.max(0, s.guards - c.guards) + Math.max(0, s.rangers - c.rangers) + Math.max(0, s.healers - c.healers);
 if (u <= 0) return !1;
 if (n) return !0;
 var l = e.find(FIND_MY_SPAWNS);
@@ -7700,9 +7702,9 @@ var m = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.l
 return t.danger >= 2 && (u >= 2 || m <= 3);
 }
 
-function go(e, t) {
-if (!vo(e, t)) return null;
-var r = mo(e), o = yo(e), n = {
+function ho(e, t) {
+if (!go(e, t)) return null;
+var r = po(e), o = vo(e), n = {
 roomName: e.name,
 guardsNeeded: Math.max(0, r.guards - o.guards),
 rangersNeeded: Math.max(0, r.rangers - o.rangers),
@@ -7716,38 +7718,38 @@ subsystem: "Defense"
 }), n;
 }
 
-var ho = ((Jr = {})[MOVE] = 50, Jr[WORK] = 100, Jr[CARRY] = 50, Jr[ATTACK] = 80,
-Jr[RANGED_ATTACK] = 150, Jr[HEAL] = 250, Jr[CLAIM] = 600, Jr[TOUGH] = 10, Jr);
+var Ro = (($r = {})[MOVE] = 50, $r[WORK] = 100, $r[CARRY] = 50, $r[ATTACK] = 80,
+$r[RANGED_ATTACK] = 150, $r[HEAL] = 250, $r[CLAIM] = 600, $r[TOUGH] = 10, $r);
 
-function Ro(e) {
+function Eo(e) {
 return "string" == typeof e ? e : e.type;
 }
 
-function Eo(e) {
+function To(e) {
 if ("string" != typeof e && void 0 !== e.boost) return String(e.boost);
 }
 
-function To(e) {
+function Co(e) {
 return "string" == typeof e || e.hits > 0;
 }
 
-function Co(e, t, r) {
+function So(e, t, r) {
 var o, n;
 if (!t) return 1;
 var a = globalThis.BOOSTS, i = null === (n = null === (o = null == a ? void 0 : a[e]) || void 0 === o ? void 0 : o[t]) || void 0 === n ? void 0 : n[r];
 return "number" == typeof i && i > 0 ? i : 1;
 }
 
-function So(e) {
+function wo(e) {
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (To(m)) {
+if (Co(m)) {
 c++;
-var d = Ro(m), p = Eo(m);
-d === ATTACK && (o += 30 * Co(d, p, "attack")), d === RANGED_ATTACK && (n += 10 * Co(d, p, "rangedAttack")),
-d === HEAL && (i += 12 * Co(d, p, "heal")), d === WORK && (s += 50 * Co(d, p, "dismantle"));
+var d = Eo(m), p = To(m);
+d === ATTACK && (o += 30 * So(d, p, "attack")), d === RANGED_ATTACK && (n += 10 * So(d, p, "rangedAttack")),
+d === HEAL && (i += 12 * So(d, p, "heal")), d === WORK && (s += 50 * So(d, p, "dismantle"));
 }
 }
 } catch (e) {
@@ -7771,7 +7773,7 @@ score: o + n + i + s + 2 * c
 };
 }
 
-function wo() {
+function xo() {
 return {
 partCount: 0,
 attack: 0,
@@ -7782,7 +7784,7 @@ score: 0
 };
 }
 
-function xo(e, t) {
+function bo(e, t) {
 return {
 partCount: e.partCount + t.partCount,
 attack: e.attack + t.attack,
@@ -7793,7 +7795,7 @@ score: e.score + t.score
 };
 }
 
-function bo(e, t) {
+function Oo(e, t) {
 return {
 partCount: e.partCount * t,
 attack: e.attack * t,
@@ -7804,7 +7806,7 @@ score: e.score * t
 };
 }
 
-function Oo(e) {
+function ko(e) {
 var t, r;
 if (0 === e.length) return null;
 var o = null, n = {
@@ -7817,7 +7819,7 @@ score: 0
 };
 try {
 for (var i = a(e), s = i.next(); !s.done; s = i.next()) {
-var c = So(s.value.body);
+var c = wo(s.value.body);
 n.partCount += c.partCount, n.attack += c.attack, n.ranged += c.ranged, n.heal += c.heal,
 n.dismantle += c.dismantle, n.score += c.score, (!o || c.score > o.score) && (o = c);
 }
@@ -7839,17 +7841,17 @@ total: n
 };
 }
 
-function ko(e) {
+function Mo(e) {
 var t = Game.rooms[e];
-return t ? Oo(X(t)) : null;
+return t ? ko(Z(t)) : null;
 }
 
-function Mo(e, t, r) {
+function Ao(e, t, r) {
 var o = function(e) {
 if (0 === e.length || e.length > 50 || !e.includes(MOVE)) return null;
 var t = function(e) {
 return e.reduce(function(e, t) {
-return e + ho[t];
+return e + Ro[t];
 }, 0);
 }(e);
 return {
@@ -7866,7 +7868,7 @@ return e.parts.join(",") === n;
 }
 }
 
-function Ao(e) {
+function Uo(e) {
 var t, r, o, n = [];
 try {
 for (var i = a([ TOUGH, WORK, ATTACK, RANGED_ATTACK, HEAL, MOVE ]), s = i.next(); !s.done; s = i.next()) for (var c = s.value, u = null !== (o = e[c]) && void 0 !== o ? o : 0, l = 0; l < u; l++) n.push(c);
@@ -7884,33 +7886,33 @@ if (t) throw t.error;
 return n;
 }
 
-function Uo(e, t) {
-var r = So(t.parts).score - So(e.parts).score;
+function _o(e, t) {
+var r = wo(t.parts).score - wo(e.parts).score;
 return 0 !== r ? r : t.cost - e.cost;
 }
 
-function _o(e) {
+function No(e) {
 return Boolean(e && (e.partCount >= 25 || e.score >= 250));
 }
 
-function No(e) {
-return Boolean(e && (_o(e.strongest) || _o(e.total)));
+function Po(e) {
+return Boolean(e && (No(e.strongest) || No(e.total)));
 }
 
-function Po(e, t, r) {
+function Io(e, t, r) {
 var o, n, a = function(e, t) {
 return "guard" === e ? function(e) {
-for (var t, r, o = [], n = 1; n <= 25; n++) Mo(o, Ao(((t = {})[ATTACK] = n, t[MOVE] = n,
-t)), e), Mo(o, Ao(((r = {})[TOUGH] = n, r[ATTACK] = n, r[MOVE] = n, r)), e);
+for (var t, r, o = [], n = 1; n <= 25; n++) Ao(o, Uo(((t = {})[ATTACK] = n, t[MOVE] = n,
+t)), e), Ao(o, Uo(((r = {})[TOUGH] = n, r[ATTACK] = n, r[MOVE] = n, r)), e);
 return o;
 }(t) : "ranger" === e ? function(e) {
-for (var t, r, o = [], n = 1; n <= 25; n++) Mo(o, Ao(((t = {})[RANGED_ATTACK] = n,
-t[MOVE] = n, t)), e), Mo(o, Ao(((r = {})[TOUGH] = Math.ceil(n / 2), r[RANGED_ATTACK] = n,
+for (var t, r, o = [], n = 1; n <= 25; n++) Ao(o, Uo(((t = {})[RANGED_ATTACK] = n,
+t[MOVE] = n, t)), e), Ao(o, Uo(((r = {})[TOUGH] = Math.ceil(n / 2), r[RANGED_ATTACK] = n,
 r[MOVE] = n, r)), e);
 return o;
 }(t) : function(e) {
-for (var t, r, o = [], n = 1; n <= 25; n++) Mo(o, Ao(((t = {})[HEAL] = n, t[MOVE] = n,
-t)), e), Mo(o, Ao(((r = {})[TOUGH] = Math.ceil(n / 2), r[HEAL] = n, r[MOVE] = n,
+for (var t, r, o = [], n = 1; n <= 25; n++) Ao(o, Uo(((t = {})[HEAL] = n, t[MOVE] = n,
+t)), e), Ao(o, Uo(((r = {})[TOUGH] = Math.ceil(n / 2), r[HEAL] = n, r[MOVE] = n,
 r)), e);
 return o;
 }(t);
@@ -7918,7 +7920,7 @@ return o;
 if (0 === a.length) return null;
 var c = null == r ? void 0 : r.strongest;
 if (c && c.score > 0) {
-var u = No(r) ? a.filter(function(t) {
+var u = Po(r) ? a.filter(function(t) {
 return function(e, t) {
 var r = t.filter(function(e) {
 return e === ATTACK || e === RANGED_ATTACK || e === HEAL || e === WORK;
@@ -7930,18 +7932,18 @@ if (0 === u.length) return null;
 var l = u.filter(function(e) {
 return function(e, t) {
 if (!t || t.score <= 0) return !0;
-var r = So(e);
+var r = wo(e);
 return r.partCount >= t.partCount && r.score >= t.score;
 }(e.parts, c);
 }).sort(function(e, t) {
-return e.cost - t.cost || Uo(e, t);
+return e.cost - t.cost || _o(e, t);
 });
-return l.length > 0 ? l[0] : null !== (o = s([], i(u), !1).sort(Uo)[0]) && void 0 !== o ? o : null;
+return l.length > 0 ? l[0] : null !== (o = s([], i(u), !1).sort(_o)[0]) && void 0 !== o ? o : null;
 }
-return null !== (n = s([], i(a), !1).sort(Uo)[0]) && void 0 !== n ? n : null;
+return null !== (n = s([], i(a), !1).sort(_o)[0]) && void 0 !== n ? n : null;
 }
 
-function Io(e, t, r) {
+function Go(e, t, r) {
 var o, n, i = function(e) {
 var t, r, o = {
 partCount: 0,
@@ -7955,7 +7957,7 @@ if (!e) return o;
 try {
 for (var n = a([ "guard", "ranger", "healer" ]), i = n.next(); !i.done; i = n.next()) {
 var s = e[i.value];
-s && (o = xo(o, s));
+s && (o = bo(o, s));
 }
 } catch (e) {
 t = {
@@ -7973,7 +7975,7 @@ return o;
 try {
 for (var s = a([ "guard", "ranger", "healer" ]), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t[u];
-l && e[u] > 0 && (i = xo(i, bo(l, e[u])));
+l && e[u] > 0 && (i = bo(i, Oo(l, e[u])));
 }
 } catch (e) {
 o = {
@@ -7989,7 +7991,7 @@ if (o) throw o.error;
 return i;
 }
 
-function Go(e, t, r, o) {
+function Lo(e, t, r, o) {
 if (!t || t.heal <= 0) return 0;
 var n = e.total.attack + e.total.ranged;
 if (!(o > 0 || e.total.heal > 0 || r >= 3) || n <= 0) return o;
@@ -7997,7 +7999,7 @@ var a = Math.ceil(.5 * n);
 return Math.max(1, o, Math.ceil(a / t.heal));
 }
 
-function Lo(e, t, r, o, n) {
+function Do(e, t, r, o, n) {
 var i, s, c;
 void 0 === r && (r = {}), void 0 === n && (n = 12);
 var u = {
@@ -8007,8 +8009,8 @@ healer: 0
 }, l = {}, m = {};
 try {
 for (var d = a([ "guard", "ranger", "healer" ]), p = d.next(); !p.done; p = d.next()) {
-var f = Po(C = p.value, e, t);
-f && (l[C] = f, m[C] = So(f.parts), u[C] = Math.max(0, Math.floor(null !== (c = r[C]) && void 0 !== c ? c : 0)));
+var f = Io(C = p.value, e, t);
+f && (l[C] = f, m[C] = wo(f.parts), u[C] = Math.max(0, Math.floor(null !== (c = r[C]) && void 0 !== c ? c : 0)));
 }
 } catch (e) {
 i = {
@@ -8024,7 +8026,7 @@ if (i) throw i.error;
 if (!t) return {
 counts: u,
 bodies: l,
-totalPower: Io(u, m, o),
+totalPower: Go(u, m, o),
 healerFloor: 0,
 targetScore: 0,
 capped: !1
@@ -8042,7 +8044,7 @@ return (null !== (n = null === (o = e[r]) || void 0 === o ? void 0 : o.score) &&
 return u.guard + u.ranger + u.healer;
 }, R = function(e) {
 return !!m[e] && (h() >= n ? (g = !0, !1) : (u[e]++, !0));
-}, E = Io(u, m, o);
+}, E = Go(u, m, o);
 if (0 === h() && E.score > y) return {
 counts: u,
 bodies: l,
@@ -8052,12 +8054,12 @@ targetScore: y,
 capped: !1
 };
 v && 0 === h() && R(v);
-for (var T = Go(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Go(t, m.healer, u.guard + u.ranger, u.healer);
-for (E = Io(u, m, o); E.score <= y; ) {
+for (var T = Lo(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Lo(t, m.healer, u.guard + u.ranger, u.healer);
+for (E = Go(u, m, o); E.score <= y; ) {
 var C;
 if (!R(C = null != v ? v : "healer")) break;
-for (T = Go(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Go(t, m.healer, u.guard + u.ranger, u.healer);
-E = Io(u, m, o);
+for (T = Lo(t, m.healer, u.guard + u.ranger, u.healer); u.healer < T && R("healer"); ) T = Lo(t, m.healer, u.guard + u.ranger, u.healer);
+E = Go(u, m, o);
 }
 return {
 counts: u,
@@ -8069,11 +8071,11 @@ capped: g
 };
 }
 
-function Do(e) {
+function Bo(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function Bo(e, t) {
+function Fo(e, t) {
 var r, o, n;
 void 0 === t && (t = {});
 var i = null === (n = t.scoreWorkPartThreats) || void 0 === n || n, s = 0, c = 0, u = 0, l = 0;
@@ -8127,8 +8129,8 @@ isDismantler: R
 };
 }
 
-function Fo(e) {
-var t, r, o = X(e), n = e.find(FIND_NUKES);
+function Wo(e) {
+var t, r, o = Z(e), n = e.find(FIND_NUKES);
 if (0 === o.length && 0 === n.length) return {
 roomName: e.name,
 dangerLevel: 0,
@@ -8152,7 +8154,7 @@ return "undefined" == typeof Memory || !1 !== (null === (e = Memory.defenseSetti
 }();
 try {
 for (var y = a(o), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Bo(g, {
+var g = v.value, h = Fo(g, {
 scoreWorkPartThreats: f
 });
 s += h.dps, c += g.hits, i += h.scoreContribution, h.isBoosted && u++, h.isHealer && l++,
@@ -8184,7 +8186,7 @@ return e + ((i = s / o.length) <= 5 ? 600 : i >= 20 ? 150 : 600 - 30 * (i - 5));
 }, 0), C = s > 1.5 * T, S = Math.min(100, Math.max(0, (s - T) / 10)), w = function(e, t, r) {
 if (Array.isArray(e)) {
 var o = e.reduce(function(e, t) {
-return e + Yo(t.body.filter(function(e) {
+return e + Vo(t.body.filter(function(e) {
 return e.hits > 0;
 }).map(function(e) {
 return e.type;
@@ -8193,12 +8195,12 @@ return e.type;
 return 300 * Math.ceil(o / 30);
 }
 if (void 0 === t || void 0 === r) {
-var n = zo("guard"), a = zo("ranger"), i = Qo(n), s = Qo(a), c = (i.avgDps + s.avgDps) / 2, u = (i.avgCost + s.avgCost) / 2;
+var n = Qo("guard"), a = Qo("ranger"), i = Xo(n), s = Xo(a), c = (i.avgDps + s.avgDps) / 2, u = (i.avgCost + s.avgCost) / 2;
 t = null != t ? t : c, r = null != r ? r : u;
 }
 return t <= 0 && (t = 300, r = 1300), Math.ceil(e / t) * r;
 }(s), x = Math.max(1, function(e) {
-return 0 === e || e < Wo ? 0 : e < Ho ? 1 : e < Ko ? 2 : 3;
+return 0 === e || e < Ho ? 0 : e < Ko ? 1 : e < Yo ? 2 : 3;
 }(i));
 return R = i < 100 ? "monitor" : i < 500 && !C ? "defend" : C && i < 1e3 ? "assist" : i > 1e3 || u > 3 ? "safemode" : "defend",
 n.length > 0 && (i += 500, R = "safemode", x = 3), {
@@ -8220,9 +8222,9 @@ recommendedResponse: R
 };
 }
 
-var Wo = 100, Ho = 500, Ko = 1e3;
+var Ho = 100, Ko = 500, Yo = 1e3;
 
-function Yo(e) {
+function Vo(e) {
 var t, r, o = 0;
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
@@ -8243,7 +8245,7 @@ if (t) throw t.error;
 return o;
 }
 
-function Vo(e) {
+function qo(e) {
 var t, r = ((t = {})[MOVE] = 50, t[WORK] = 100, t[CARRY] = 50, t[ATTACK] = 80, t[RANGED_ATTACK] = 150,
 t[HEAL] = 250, t[CLAIM] = 600, t[TOUGH] = 10, t);
 return e.reduce(function(e, t) {
@@ -8251,26 +8253,26 @@ return e + r[t];
 }, 0);
 }
 
-function qo(e) {
+function jo(e) {
 return {
 parts: e,
-cost: Vo(e),
-dps: Yo(e)
+cost: qo(e),
+dps: Vo(e)
 };
 }
 
-var jo = {
-guard: [ qo([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ]), qo([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), qo([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), qo([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ],
-ranger: [ qo([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ]), qo([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ]), qo([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), qo([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ]
+var zo = {
+guard: [ jo([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ]), jo([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), jo([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), jo([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ],
+ranger: [ jo([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ]), jo([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ]), jo([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]), jo([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ]) ]
 };
 
-function zo(e) {
-return s([], i(jo[e]), !1).sort(function(e, t) {
+function Qo(e) {
+return s([], i(zo[e]), !1).sort(function(e, t) {
 return e.cost - t.cost;
 });
 }
 
-function Qo(e) {
+function Xo(e) {
 if (0 === e.length) return {
 dpsPerEnergy: 300 / 1300,
 avgCost: 1300,
@@ -8288,23 +8290,23 @@ avgDps: n
 };
 }
 
-function Xo(e, t, r) {
-var o = $o(t) - $o(e);
+function Zo(e, t, r) {
+var o = en(t) - en(e);
 if (0 !== o) return o;
 if (!r) return 0;
-var n = Jo(e) - Jo(t);
-return 0 !== n ? n : Zo(e) - Zo(t);
-}
-
-function Zo(e) {
-return "number" == typeof e.hits ? e.hits : 1 / 0;
+var n = $o(e) - $o(t);
+return 0 !== n ? n : Jo(e) - Jo(t);
 }
 
 function Jo(e) {
-return "number" != typeof e.hits || "number" != typeof e.hitsMax || e.hitsMax <= 0 ? 1 : e.hits / e.hitsMax;
+return "number" == typeof e.hits ? e.hits : 1 / 0;
 }
 
 function $o(e) {
+return "number" != typeof e.hits || "number" != typeof e.hitsMax || e.hitsMax <= 0 ? 1 : e.hits / e.hitsMax;
+}
+
+function en(e) {
 var t = 0;
 return t += 100 * e.getActiveBodyparts(HEAL), t += 50 * e.getActiveBodyparts(RANGED_ATTACK),
 t += 40 * e.getActiveBodyparts(ATTACK), t += 60 * e.getActiveBodyparts(CLAIM), (t += 30 * e.getActiveBodyparts(WORK)) > 0 && e.body.some(function(e) {
@@ -8312,27 +8314,27 @@ return e.boost;
 }) && (t += 20), t;
 }
 
-function en(e) {
+function tn(e) {
 return e.hits < e.hitsMax;
 }
 
-function tn(e) {
+function rn(e) {
 return e.hits < .8 * e.hitsMax && e.structureType !== STRUCTURE_WALL && e.structureType !== STRUCTURE_RAMPART;
 }
 
-function rn(e) {
+function on(e) {
 return !e.isCombatPosture;
 }
 
-function on(e) {
+function nn(e) {
 var t, r = e.hostiles.length > 0 ? function(e, t) {
 var r, o;
 void 0 === t && (t = {});
 var n = !1 !== t.preferWoundedTargets, i = null;
 try {
-for (var s = a(e), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(X(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-(!i || Xo(u, i, n) < 0) && (i = u);
+(!i || Zo(u, i, n) < 0) && (i = u);
 }
 } catch (e) {
 r = {
@@ -8361,7 +8363,7 @@ var t = function(e) {
 return function(e) {
 return "siege" !== e.posture || !1 !== e.allowSiegeHealing;
 }(e) ? e.tower.pos.findClosestByRange(FIND_MY_CREEPS, {
-filter: en
+filter: tn
 }) : null;
 }(e);
 if (t) return {
@@ -8374,8 +8376,8 @@ return void 0 !== e.repairReserveEnergy ? Math.max(0, Math.min(TOWER_CAPACITY, e
 }(e);
 }(e)) return null;
 var r = function(e) {
-return rn(e) ? e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
-filter: tn
+return on(e) ? e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
+filter: rn
 }) : null;
 }(e);
 if (r) return {
@@ -8383,7 +8385,7 @@ type: "repair",
 target: r
 };
 var o = function(e) {
-return !rn(e) || e.hostiles.length > 0 ? null : e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
+return !on(e) || e.hostiles.length > 0 ? null : e.tower.pos.findClosestByRange(FIND_STRUCTURES, {
 filter: function(t) {
 return function(e, t) {
 return function(e) {
@@ -8402,7 +8404,7 @@ type: "idle"
 };
 }
 
-function nn(e, t) {
+function an(e, t) {
 var r, o, n = null !== (r = {
 1: 0,
 2: 3e5,
@@ -8423,7 +8425,7 @@ var a = null !== (o = {
 return Math.floor(n * a);
 }
 
-var an = [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_FACTORY, STRUCTURE_POWER_SPAWN, STRUCTURE_NUKER, STRUCTURE_OBSERVER ], sn = [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE ], cn = [ {
+var sn = [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_FACTORY, STRUCTURE_POWER_SPAWN, STRUCTURE_NUKER, STRUCTURE_OBSERVER ], cn = [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE ], un = [ {
 x: -2,
 y: 0
 }, {
@@ -8653,7 +8655,7 @@ x: 6,
 y: 4
 } ];
 
-function un(e) {
+function ln(e) {
 return [ {
 x: e.x - 1,
 y: e.y - 1
@@ -8681,7 +8683,7 @@ y: e.y + 1
 } ];
 }
 
-function ln(e, t, r) {
+function mn(e, t, r) {
 var o, n, i = [];
 try {
 for (var s = a(r), c = s.next(); !c.done; c = s.next()) for (var u = c.value, l = 1; l <= t; l++) switch (u) {
@@ -8726,7 +8728,7 @@ if (o) throw o.error;
 return i;
 }
 
-function mn(e, t) {
+function dn(e, t) {
 return e.filter(function(e) {
 return t.includes(e.structureType);
 }).map(function(e) {
@@ -8737,17 +8739,17 @@ y: e.y
 });
 }
 
-function dn(e, t) {
+function pn(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, Math.floor(e)) : t;
 }
 
-function pn() {
+function fn() {
 return "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES;
 }
 
-var fn = function() {
+var yn = function() {
 function e(e, t, r, o) {
-void 0 === r && (r = 10), void 0 === o && (o = pn()), this.initialRoomSiteCount = e,
+void 0 === r && (r = 10), void 0 === o && (o = fn()), this.initialRoomSiteCount = e,
 this.initialGlobalSiteCount = t, this.roomLimit = r, this.globalLimit = o, this.createdSites = 0,
 this.createdByStructureType = {};
 }
@@ -8788,7 +8790,7 @@ return null !== (t = this.createdByStructureType[e]) && void 0 !== t ? t : 0;
 return void 0 === e && (e = {}), !(this.remainingGlobalSites <= 0) && (!0 === e.bypassRoomLimit || this.remainingRoomSites > 0);
 }, e.prototype.capRequested = function(e, t) {
 void 0 === t && (t = {});
-var r = dn(e, 0);
+var r = pn(e, 0);
 if (r <= 0 || this.remainingGlobalSites <= 0) return 0;
 var o = !0 === t.bypassRoomLimit ? this.remainingGlobalSites : Math.min(this.remainingRoomSites, this.remainingGlobalSites);
 return Math.min(r, o);
@@ -8800,7 +8802,7 @@ return e !== OK ? 0 : (this.recordPlacement(t), 1);
 }, e;
 }();
 
-function yn(e, t, r) {
+function vn(e, t, r) {
 void 0 === r && (r = {});
 var o = function() {
 for (var o = [], n = 0; n < arguments.length; n++) o[n] = arguments[n];
@@ -8836,7 +8838,7 @@ return "function" == typeof n ? n.bind(e) : n;
 });
 }
 
-function vn(e) {
+function gn(e) {
 var t = Number.isFinite(e) ? e : 1;
 return {
 1: {
@@ -8933,15 +8935,15 @@ powerSpawn: 1
 }[Math.min(8, Math.max(1, Math.floor(t)))];
 }
 
-function gn(e, t) {
+function hn(e, t) {
 return "".concat(e, ",").concat(t);
 }
 
-function hn(e, t) {
+function Rn(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function Rn(e) {
+function En(e) {
 return e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_LINK;
@@ -8949,8 +8951,8 @@ return e.structureType === STRUCTURE_LINK;
 });
 }
 
-function En(e) {
-var t, r, o, n, i, s, c = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, u = null !== (i = vn(c)[STRUCTURE_LINK]) && void 0 !== i ? i : 0, l = [];
+function Tn(e) {
+var t, r, o, n, i, s, c = null !== (n = null === (o = e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, u = null !== (i = gn(c)[STRUCTURE_LINK]) && void 0 !== i ? i : 0, l = [];
 if (!(null === (s = e.controller) || void 0 === s ? void 0 : s.my) || c < 5 || u <= 0) return {
 roomName: e.name,
 rcl: c,
@@ -8962,7 +8964,7 @@ var t, r, o, n, i = new Set, s = e.find(FIND_STRUCTURES);
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-l.structureType !== STRUCTURE_LINK && i.add(gn(l.pos.x, l.pos.y));
+l.structureType !== STRUCTURE_LINK && i.add(hn(l.pos.x, l.pos.y));
 }
 } catch (e) {
 t = {
@@ -8978,7 +8980,7 @@ if (t) throw t.error;
 try {
 for (var m = a(e.find(FIND_MY_CONSTRUCTION_SITES)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-i.add(gn(p.pos.x, p.pos.y));
+i.add(hn(p.pos.x, p.pos.y));
 }
 } catch (e) {
 o = {
@@ -8997,14 +8999,14 @@ return function(a, i, s, c, u, l) {
 if (i && !(t.length >= r)) {
 var m = function(e, t, r, o, n, a, i) {
 for (var s = [], c = e.getTerrain(), u = t.x - o; u <= t.x + o; u += 1) for (var l = t.y - o; l <= t.y + o; l += 1) {
-var m = hn({
+var m = Rn({
 x: u,
 y: l
 }, t);
 if (!(m < r || m > o || u < 1 || u > 48 || l < 1 || l > 48 || c.get(u, l) === TERRAIN_MASK_WALL)) {
-var d = gn(u, l);
+var d = hn(u, l);
 if (!n.has(d) && !a.has(d)) {
-var p = i ? hn({
+var p = i ? Rn({
 x: u,
 y: l
 }, i) : 0;
@@ -9030,20 +9032,20 @@ roomName: e.name,
 role: a,
 targetId: i.id,
 priority: u
-}), n.add(gn(m.x, m.y)));
+}), n.add(hn(m.x, m.y)));
 }
 };
 }(e, l, u, m, d);
 v("controller", f, 2, 2, 400, null != p ? p : y);
 var g = null != p ? p : f, h = function(e, t) {
 return e.find(FIND_SOURCES).slice().sort(function(e, r) {
-return hn(r.pos, t.pos) - hn(e.pos, t.pos);
+return Rn(r.pos, t.pos) - Rn(e.pos, t.pos);
 });
 }(e, g), R = p && c >= 6 ? 1 : 0, E = y && c >= 8 ? 1 : 0, T = Math.max(0, u - l.length - R - E);
 try {
 for (var C = a(h.slice(0, T)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
-v("source", w, 1, 1, 300 + hn(w.pos, g.pos), null != p ? p : f);
+v("source", w, 1, 1, 300 + Rn(w.pos, g.pos), null != p ? p : f);
 }
 } catch (e) {
 t = {
@@ -9065,15 +9067,15 @@ placements: l
 };
 }
 
-function Tn(e, t) {
+function Cn(e, t) {
 var r;
 return null !== (r = function(e, t) {
 return function(e, t) {
-var r, o = gn(t.x, t.y);
+var r, o = hn(t.x, t.y);
 return null === (r = e.find(function(e) {
-return gn(e.x, e.y) === o;
+return hn(e.x, e.y) === o;
 })) || void 0 === r ? void 0 : r.role;
-}(En(e).placements, t);
+}(Tn(e).placements, t);
 }(e, t.pos)) && void 0 !== r ? r : function(e, t) {
 return e.controller && t.pos.getRangeTo(e.controller) <= 2 ? "controller" : e.storage && t.pos.getRangeTo(e.storage) <= 2 ? "storage" : e.find(FIND_MY_SPAWNS).some(function(e) {
 return t.pos.getRangeTo(e) <= 2;
@@ -9083,27 +9085,27 @@ return t.pos.getRangeTo(e) <= 2;
 }(e, t);
 }
 
-function Cn(e, t) {
+function Sn(e, t) {
 return "".concat(e, ",").concat(t);
 }
 
-function Sn(e, t) {
+function wn(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function wn(e, t) {
-var r = Cn(e.pos.x, e.pos.y);
-return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
-}
-
 function xn(e, t) {
-var r = Cn(e.pos.x, e.pos.y);
+var r = Sn(e.pos.x, e.pos.y);
 return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
 }
 
-function bn(e, t, r, o, n, a, i, s) {
+function bn(e, t) {
+var r = Sn(e.pos.x, e.pos.y);
+return !t.has(r) && e.structureType !== STRUCTURE_RAMPART;
+}
+
+function On(e, t, r, o, n, a, i, s) {
 if (!(r < 1 || r > 48 || o < 1 || o > 48)) {
-var c = Cn(r, o), u = a.has(c), l = i.has(c);
+var c = Sn(r, o), u = a.has(c), l = i.has(c);
 if (!u && !l) {
 if (t.getTerrain().get(r, o) === TERRAIN_MASK_WALL) return;
 if (s.has(c)) return;
@@ -9120,20 +9122,20 @@ distanceToHub: Math.max(Math.abs(r - n.x), Math.abs(o - n.y))
 }
 }
 
-function On(e, t) {
+function kn(e, t) {
 return 0 === t.length ? 0 : Math.min.apply(Math, s([], i(t.map(function(t) {
-return Sn(e, t);
+return wn(e, t);
 })), !1));
 }
 
-var kn = "spawn", Mn = "extension", An = "road", Un = "rampart", _n = "container", Nn = "tower", Pn = "storage", In = "link", Gn = "terminal", Ln = "extractor", Dn = "lab", Bn = "factory", Fn = "nuker", Wn = "observer", Hn = "powerSpawn", Kn = [ kn, Mn, Nn, Pn, In, Gn, Ln, Dn, Bn, Fn, Wn, Hn ];
+var Mn = "spawn", An = "extension", Un = "road", _n = "rampart", Nn = "container", Pn = "tower", In = "storage", Gn = "link", Ln = "terminal", Dn = "extractor", Bn = "lab", Fn = "factory", Wn = "nuker", Hn = "observer", Kn = "powerSpawn", Yn = [ Mn, An, Pn, In, Gn, Ln, Dn, Bn, Fn, Wn, Hn, Kn ];
 
-function Yn(e) {
+function Vn(e) {
 return Math.min(8, Math.max(1, Math.floor(Number.isFinite(e) ? e : 1)));
 }
 
-function Vn(e) {
-var t, r, o, n, i = Yn(e);
+function qn(e) {
+var t, r, o, n, i = Vn(e);
 if ("undefined" != typeof CONTROLLER_STRUCTURES) {
 var s = {};
 try {
@@ -9154,13 +9156,13 @@ if (t) throw t.error;
 }
 return s;
 }
-return vn(i);
+return gn(i);
 }
 
-function qn(e) {
-var t, r, o, n = Vn(e), i = {};
+function jn(e) {
+var t, r, o, n = qn(e), i = {};
 try {
-for (var s = a(Kn), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Yn), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = null !== (o = n[u]) && void 0 !== o ? o : 0;
 l > 0 && (i[u] = l);
 }
@@ -9178,10 +9180,10 @@ if (t) throw t.error;
 return i;
 }
 
-var jn = {
+var zn = {
 x: 0,
 y: 0
-}, zn = {
+}, Qn = {
 name: "seedNest",
 rcl: 1,
 type: "spread",
@@ -9191,8 +9193,8 @@ x: 25,
 y: 25
 },
 structures: [ {
-x: jn.x,
-y: jn.y,
+x: zn.x,
+y: zn.y,
 structureType: STRUCTURE_SPAWN
 }, {
 x: -2,
@@ -9215,12 +9217,12 @@ x: -2,
 y: -2,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s([], i(un(jn)), !1),
+roads: s([], i(ln(zn)), !1),
 ramparts: []
-}, Qn = {
+}, Xn = {
 x: 0,
 y: 0
-}, Xn = {
+}, Zn = {
 name: "foragingExpansion",
 rcl: 3,
 type: "spread",
@@ -9322,7 +9324,7 @@ x: -3,
 y: -3,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s(s(s(s([], i(un(Qn)), !1), [ {
+roads: s(s(s(s([], i(ln(Xn)), !1), [ {
 x: -2,
 y: -1
 }, {
@@ -9346,7 +9348,7 @@ y: 2
 }, {
 x: 1,
 y: 2
-} ], !1), i(ln(Qn, 3, [ "north", "south", "east", "west" ])), !1), [ {
+} ], !1), i(mn(Xn, 3, [ "north", "south", "east", "west" ])), !1), [ {
 x: 3,
 y: 3
 }, {
@@ -9357,10 +9359,10 @@ x: 3,
 y: 4
 } ], !1),
 ramparts: []
-}, Zn = {
+}, Jn = {
 x: 0,
 y: 0
-}, Jn = {
+}, $n = {
 name: "matureColony",
 rcl: 5,
 type: "spread",
@@ -9538,7 +9540,7 @@ x: 1,
 y: 5,
 structureType: STRUCTURE_LINK
 } ],
-roads: s(s(s([], i(un(Zn)), !1), [ {
+roads: s(s(s([], i(ln(Jn)), !1), [ {
 x: 3,
 y: -1
 }, {
@@ -9586,8 +9588,8 @@ y: 2
 }, {
 x: 1,
 y: 2
-} ], !1), i(ln(Zn, 3, [ "north", "south", "east", "west" ])), !1),
-ramparts: mn([ {
+} ], !1), i(mn(Jn, 3, [ "north", "south", "east", "west" ])), !1),
+ramparts: dn([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_SPAWN
@@ -9612,7 +9614,7 @@ x: 1,
 y: 5,
 structureType: STRUCTURE_LINK
 } ], [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_LINK ])
-}, $n = {
+}, ea = {
 name: "fortifiedHive",
 rcl: 7,
 type: "spread",
@@ -9762,13 +9764,13 @@ x: 3,
 y: -1,
 structureType: STRUCTURE_EXTENSION
 } ],
-roads: s(s(s(s([], i(un({
+roads: s(s(s(s([], i(ln({
 x: 0,
 y: 0
-})), !1), i(un({
+})), !1), i(ln({
 x: -5,
 y: -1
-})), !1), i(un({
+})), !1), i(ln({
 x: 5,
 y: -1
 })), !1), [ {
@@ -9808,7 +9810,7 @@ y: 2
 x: 1,
 y: 2
 } ], !1),
-ramparts: mn([ {
+ramparts: dn([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_SPAWN
@@ -9861,7 +9863,7 @@ x: -1,
 y: 5,
 structureType: STRUCTURE_POWER_SPAWN
 } ], [ STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL, STRUCTURE_TOWER, STRUCTURE_NUKER, STRUCTURE_POWER_SPAWN ])
-}, ea = {
+}, ta = {
 name: "compactBunker",
 rcl: 8,
 type: "bunker",
@@ -10294,7 +10296,7 @@ y: 3
 x: 3,
 y: 3
 } ],
-ramparts: s(s([], i(mn([ {
+ramparts: s(s([], i(dn([ {
 x: 0,
 y: 0,
 structureType: STRUCTURE_STORAGE
@@ -10407,7 +10409,7 @@ y: -2
 } ]), !1)
 };
 
-function ta(e, t, r) {
+function ra(e, t, r) {
 for (var o = e.getTerrain(), n = -1; n <= 1; n++) for (var a = -1; a <= 1; a++) {
 var i = t + n, s = r + a;
 if (i < 1 || i > 48 || s < 1 || s > 48) return !1;
@@ -10416,7 +10418,7 @@ if (o.get(i, s) === TERRAIN_MASK_WALL) return !1;
 return !0;
 }
 
-function ra(e, t, r) {
+function oa(e, t, r) {
 var o, n, i, s, c, u = e.getTerrain(), l = null !== (c = r.minSpaceRadius) && void 0 !== c ? c : 7, m = 0, d = 0;
 if (t.x < l || t.x > 49 - l || t.y < l || t.y > 49 - l) return {
 fits: !1,
@@ -10476,7 +10478,7 @@ totalTiles: d
 };
 }
 
-function oa(e, t) {
+function na(e, t) {
 var r, o, n, i, s, c = e.controller;
 if (!c) return null;
 var u = e.find(FIND_SOURCES), l = c.pos.x, m = c.pos.y;
@@ -10498,7 +10500,7 @@ for (var f = Math.round(l / (u.length + 1)), y = Math.round(m / (u.length + 1)),
 for (var R = -h; R <= h; R++) for (var E = -h; E <= h; E++) if (!(Math.abs(R) !== h && Math.abs(E) !== h && h > 0)) {
 var T = f + R, C = y + E;
 if (!(T < v || T > 49 - v || C < v || C > 49 - v)) {
-var S = new RoomPosition(T, C, e.name), w = ra(e, S, t);
+var S = new RoomPosition(T, C, e.name), w = oa(e, S, t);
 if (w.fits) {
 var x = 1e3, b = S.getRangeTo(c);
 b >= 4 && b <= 8 ? x += 100 : b < 4 ? x -= 50 : b > 12 && (x -= 30);
@@ -10540,8 +10542,8 @@ return t.score - e.score;
 return null;
 }
 
-function na(e, t) {
-var r, o = vn(t), n = {}, a = e.structures.filter(function(e) {
+function aa(e, t) {
+var r, o = gn(t), n = {}, a = e.structures.filter(function(e) {
 var t, r, a = e.structureType, i = null !== (t = o[a]) && void 0 !== t ? t : 0, s = null !== (r = n[a]) && void 0 !== r ? r : 0;
 return !(s >= i || (n[a] = s + 1, 0));
 }), c = null !== (r = o[STRUCTURE_EXTENSION]) && void 0 !== r ? r : 0;
@@ -10551,9 +10553,9 @@ return e.structureType === STRUCTURE_EXTENSION;
 }).length;
 if (r <= 0) return e;
 var o = function() {
-for (var e = [], t = 0; t < Math.min(80, cn.length); t++) e.push({
-x: cn[t].x,
-y: cn[t].y,
+for (var e = [], t = 0; t < Math.min(80, un.length); t++) e.push({
+x: un[t].x,
+y: un[t].y,
 structureType: STRUCTURE_EXTENSION
 });
 return e;
@@ -10566,7 +10568,7 @@ return s(s([], i(e), !1), i(a), !1);
 }(a, c)), a;
 }
 
-function aa(e) {
+function ia(e) {
 switch (e) {
 case STRUCTURE_SPAWN:
 return 100;
@@ -10594,18 +10596,18 @@ return 20;
 }
 }
 
-function ia(e, t, r) {
+function sa(e, t, r) {
 return !(t < 1 || t > 48 || r < 1 || r > 48) && e.getTerrain().get(t, r) !== TERRAIN_MASK_WALL;
 }
 
-function sa(e, t, r, o, n) {
-if (void 0 === n && (n = 6), ia(e, t, r) && !o.has("".concat(t, ",").concat(r))) return {
+function ca(e, t, r, o, n) {
+if (void 0 === n && (n = 6), sa(e, t, r) && !o.has("".concat(t, ",").concat(r))) return {
 x: t,
 y: r
 };
 for (var a = 1; a <= n; a++) for (var i = -a; i <= a; i++) for (var s = -a; s <= a; s++) if (Math.abs(i) === a || Math.abs(s) === a) {
 var c = t + i, u = r + s;
-if (ia(e, c, u) && !o.has("".concat(c, ",").concat(u))) return {
+if (sa(e, c, u) && !o.has("".concat(c, ",").concat(u))) return {
 x: c,
 y: u
 };
@@ -10613,13 +10615,13 @@ y: u
 return null;
 }
 
-var ca = {
+var ua = {
 recalculateInterval: 1e3,
 maxPathOps: 2e3,
 includeRemoteRoads: !0
-}, ua = new Map, la = new Map;
+}, la = new Map, ma = new Map;
 
-function ma(e) {
+function da(e) {
 var t, r, o, n, i = Game.rooms[e], s = new PathFinder.CostMatrix;
 if (!i) return s;
 var c = i.find(FIND_STRUCTURES);
@@ -10659,11 +10661,11 @@ if (o) throw o.error;
 return s;
 }
 
-function da(e) {
+function pa(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function pa(e) {
+function fa(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(r, 10),
@@ -10671,12 +10673,12 @@ y: parseInt(o, 10)
 };
 }
 
-function fa(e, t) {
+function ya(e, t) {
 var r, o, n;
 try {
 for (var i = a(t), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-e.has(c.roomName) || e.set(c.roomName, new Set), null === (n = e.get(c.roomName)) || void 0 === n || n.add(da(c));
+e.has(c.roomName) || e.set(c.roomName, new Set), null === (n = e.get(c.roomName)) || void 0 === n || n.add(pa(c));
 }
 } catch (e) {
 r = {
@@ -10691,7 +10693,7 @@ if (r) throw r.error;
 }
 }
 
-function ya(e, t, r, o) {
+function va(e, t, r, o) {
 return PathFinder.search(e, {
 pos: t,
 range: 0
@@ -10700,18 +10702,18 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return e === r && ma(e);
+return e === r && da(e);
 }
 });
 }
 
-function va(e, t, r) {
+function ga(e, t, r) {
 t.incomplete || function(e, t, r) {
 var o, n;
 try {
 for (var i = a(t), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.roomName === r && e.add(da(c));
+c.roomName === r && e.add(pa(c));
 }
 } catch (e) {
 o = {
@@ -10727,7 +10729,7 @@ if (o) throw o.error;
 }(e, t.path, r);
 }
 
-function ga(e, t, r, o, n) {
+function ha(e, t, r, o, n) {
 var i, s;
 try {
 for (var c = a(function(e, t, r, o) {
@@ -10739,7 +10741,7 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return e === r && ma(e);
+return e === r && da(e);
 }
 });
 if (!c.incomplete) try {
@@ -10764,7 +10766,7 @@ if (n) throw n.error;
 return s;
 }(t, r, o, n)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-e.add(da(l));
+e.add(pa(l));
 }
 } catch (e) {
 i = {
@@ -10779,20 +10781,20 @@ if (i) throw i.error;
 }
 }
 
-function ha(e, t, r) {
+function Ra(e, t, r) {
 var n, i, s, c, u, l, m;
 void 0 === r && (r = {});
-var d = o(o({}, ca), r), p = function(e, t, r) {
+var d = o(o({}, ua), r), p = function(e, t, r) {
 var o, n, a, i = null === (o = e.storage) || void 0 === o ? void 0 : o.pos, s = i ? "".concat(i.x, ",").concat(i.y) : "none", c = null !== (a = null === (n = e.controller) || void 0 === n ? void 0 : n.level) && void 0 !== a ? a : 0;
 return [ e.name, "anchor:".concat(t.x, ",").concat(t.y), "storage:".concat(s), "rcl:".concat(c), "ops:".concat(r.maxPathOps), "remote:".concat(r.includeRemoteRoads ? 1 : 0) ].join("|");
 }(e, t, d), f = function(e, t) {
-var r = ua.get(e);
+var r = la.get(e);
 if (r && Game.time - r.lastCalculated < t) return r;
 }(p, d.recalculateInterval);
 if (f) return f;
 var y = new Set, v = null !== (l = null === (u = e.controller) || void 0 === u ? void 0 : u.level) && void 0 !== l ? l : 0, g = e.find(FIND_SOURCES), h = e.controller, R = e.storage, E = e.find(FIND_MINERALS)[0], T = null !== (m = null == R ? void 0 : R.pos) && void 0 !== m ? m : t;
 try {
-for (var C = a(g), S = C.next(); !S.done; S = C.next()) ga(y, T, S.value.pos, e.name, d.maxPathOps);
+for (var C = a(g), S = C.next(); !S.done; S = C.next()) ha(y, T, S.value.pos, e.name, d.maxPathOps);
 } catch (e) {
 n = {
 error: e
@@ -10804,10 +10806,10 @@ S && !S.done && (i = C.return) && i.call(C);
 if (n) throw n.error;
 }
 }
-if (h && ga(y, T, h.pos, e.name, d.maxPathOps), E && v >= 6 && ga(y, T, E.pos, e.name, d.maxPathOps),
+if (h && ha(y, T, h.pos, e.name, d.maxPathOps), E && v >= 6 && ha(y, T, E.pos, e.name, d.maxPathOps),
 !R) {
 try {
-for (var w = a(g), x = w.next(); !x.done; x = w.next()) ga(y, t, x.value.pos, e.name, d.maxPathOps);
+for (var w = a(g), x = w.next(); !x.done; x = w.next()) ha(y, t, x.value.pos, e.name, d.maxPathOps);
 } catch (e) {
 s = {
 error: e
@@ -10819,7 +10821,7 @@ x && !x.done && (c = w.return) && c.call(w);
 if (s) throw s.error;
 }
 }
-h && ga(y, t, h.pos, e.name, d.maxPathOps);
+h && ha(y, t, h.pos, e.name, d.maxPathOps);
 }
 var b = {
 roomName: e.name,
@@ -10827,13 +10829,13 @@ positions: y,
 lastCalculated: Game.time
 };
 return function(e, t) {
-ua.set(e, t);
+la.set(e, t);
 }(p, b), U.debug("Calculated road network for ".concat(e.name, ": ").concat(y.size, " positions"), {
 subsystem: "RoadNetwork"
 }), b;
 }
 
-function Ra(e) {
+function Ea(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return null;
 var r = parseInt(t[2], 10), o = parseInt(t[4], 10);
@@ -10843,14 +10845,14 @@ y: "N" === t[3] ? o : -o - 1
 };
 }
 
-function Ea(e, t) {
-var r = Ra(e), o = Ra(t);
+function Ta(e, t) {
+var r = Ea(e), o = Ea(t);
 if (!r || !o) return null;
 var n = o.x - r.x, a = o.y - r.y;
 return Math.abs(n) + Math.abs(a) !== 1 ? null : 1 === n ? "right" : -1 === n ? "left" : 1 === a ? "top" : -1 === a ? "bottom" : null;
 }
 
-function Ta(e, t) {
+function Ca(e, t) {
 var r = [], o = Game.map.getRoomTerrain(e);
 switch (t) {
 case "top":
@@ -10871,7 +10873,7 @@ for (a = 0; a < 50; a++) o.get(49, a) !== TERRAIN_MASK_WALL && r.push(new RoomPo
 return r;
 }
 
-function Ca(e, t) {
+function Sa(e, t) {
 var r, o;
 if (0 === t.length) return null;
 var n = t[0], i = e.getRangeTo(n);
@@ -10894,11 +10896,11 @@ if (r) throw r.error;
 return n;
 }
 
-function Sa(e, t) {
+function wa(e, t) {
 return e.x <= t || e.x >= 49 - t || e.y <= t || e.y >= 49 - t;
 }
 
-function wa(e, t, r, o) {
+function xa(e, t, r, o) {
 var n = new RoomPosition(25, 25, r), a = PathFinder.search(t, {
 pos: n,
 range: 20
@@ -10907,16 +10909,16 @@ plainCost: 2,
 swampCost: 10,
 maxOps: o,
 roomCallback: function(e) {
-return ma(e);
+return da(e);
 }
 });
-a.incomplete || fa(e, a.path);
+a.incomplete || ya(e, a.path);
 }
 
-function xa(e, t, r) {
+function ba(e, t, r) {
 var n, i;
 void 0 === r && (r = {});
-var s = o(o({}, ca), r), c = new Map;
+var s = o(o({}, ua), r), c = new Map;
 if (!s.includeRemoteRoads) return c;
 var u = function(e) {
 var t, r = e.storage, o = e.find(FIND_MY_SPAWNS)[0];
@@ -10927,20 +10929,20 @@ try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 try {
-var p = Ea(e.name, d);
+var p = Ta(e.name, d);
 if (p) {
-var f = Ta(e.name, p);
+var f = Ca(e.name, p);
 if (0 === f.length) U.warn("No valid exit positions found in ".concat(e.name, " towards ").concat(d), {
 subsystem: "RoadNetwork"
 }); else {
-var y = Ca(u, f);
+var y = Sa(u, f);
 if (y) {
-var v = ya(u, y, e.name, s.maxPathOps);
-v.incomplete || fa(c, v.path);
+var v = va(u, y, e.name, s.maxPathOps);
+v.incomplete || ya(c, v.path);
 }
 }
 }
-wa(c, u, d, s.maxPathOps);
+xa(c, u, d, s.maxPathOps);
 } catch (e) {
 var g = e instanceof Error ? e.message : String(e);
 U.warn("Failed to calculate remote road to ".concat(d, ": ").concat(g), {
@@ -10962,9 +10964,9 @@ if (n) throw n.error;
 return c;
 }
 
-var ba = [ "top", "bottom", "left", "right" ];
+var Oa = [ "top", "bottom", "left", "right" ];
 
-function Oa(e, t, r, n) {
+function ka(e, t, r, n) {
 var c, u;
 void 0 === n && (n = []);
 var l = new Set(function(e, t, r, n) {
@@ -10975,9 +10977,9 @@ return "".concat(e.x, ",").concat(e.y);
 }).sort().join(";"), a = s([], i(o), !1).sort().join(",");
 return "".concat(e, "|").concat(t.x, ",").concat(t.y, "|").concat(n, "|").concat(a);
 }(e.name, t, r, n), u = function(e) {
-var t = la.get(e);
+var t = ma.get(e);
 if (t && function(e) {
-return Game.time - e.lastCalculated < ca.recalculateInterval;
+return Game.time - e.lastCalculated < ua.recalculateInterval;
 }(t)) return t.positions;
 }(c);
 if (u) return u;
@@ -10987,7 +10989,7 @@ var n, i, s = t.getTerrain();
 try {
 for (var c = a(o), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = r.x + l.x, d = r.y + l.y;
-m >= 1 && m <= 48 && d >= 1 && d <= 48 && s.get(m, d) !== TERRAIN_MASK_WALL && e.add(da({
+m >= 1 && m <= 48 && d >= 1 && d <= 48 && s.get(m, d) !== TERRAIN_MASK_WALL && e.add(pa({
 x: m,
 y: d
 }));
@@ -11004,7 +11006,7 @@ if (n) throw n.error;
 }
 }
 }(l, e, t, r), function(e, t, r) {
-var o, n, i = ha(t, r);
+var o, n, i = Ra(t, r);
 try {
 for (var s = a(i.positions), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
@@ -11027,19 +11029,19 @@ if (u) {
 var l = function(e, t, r) {
 var n, i;
 void 0 === r && (r = {});
-var s = o(o({}, ca), r), c = new Set;
+var s = o(o({}, ua), r), c = new Set;
 try {
-for (var u = a(ba), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Oa), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-var d = Ta(e.name, m);
+var d = Ca(e.name, m);
 if (0 === d.length) continue;
-var p = Ca(t, d);
+var p = Sa(t, d);
 if (!p) continue;
-var f = ya(t, p, e.name, s.maxPathOps);
+var f = va(t, p, e.name, s.maxPathOps);
 f.incomplete ? U.warn("Incomplete path when calculating exit road for ".concat(m, " in ").concat(e.name, " (target exit: ").concat(p.x, ",").concat(p.y, "). Path length: ").concat(f.path.length), {
 subsystem: "RoadNetwork"
-}) : va(c, f, e.name);
+}) : ga(c, f, e.name);
 } catch (t) {
 var y = t instanceof Error ? t.message : String(t);
 U.warn("Failed to calculate exit road for ".concat(m, " in ").concat(e.name, ": ").concat(y), {
@@ -11080,7 +11082,7 @@ if (r) throw r.error;
 }(l, e), function(e, t, r) {
 var o, n;
 if (0 !== r.length) {
-var i = xa(t, r).get(t.name);
+var i = ba(t, r).get(t.name);
 if (i) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
@@ -11099,7 +11101,7 @@ if (o) throw o.error;
 }
 }
 }(l, e, n), function(e, t) {
-la.set(e, t);
+ma.set(e, t);
 }(c, {
 roomName: e.name,
 positions: l,
@@ -11120,7 +11122,7 @@ return e.structureType === STRUCTURE_ROAD;
 try {
 for (var l = a(c), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-Sa(d.pos, t) && s.add(da(d.pos));
+wa(d.pos, t) && s.add(pa(d.pos));
 }
 } catch (e) {
 r = {
@@ -11136,7 +11138,7 @@ if (r) throw r.error;
 try {
 for (var p = a(u), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Sa(y.pos, t) && s.add(da(y.pos));
+wa(y.pos, t) && s.add(pa(y.pos));
 }
 } catch (e) {
 n = {
@@ -11170,9 +11172,9 @@ if (c) throw c.error;
 return l;
 }
 
-var ka = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], Ma = new Set(ka);
+var Ma = [ STRUCTURE_EXTENSION, STRUCTURE_ROAD ], Aa = new Set(Ma);
 
-var Aa = {
+var Ua = {
 id: "EXT10_DIAMOND",
 name: "EXT10 diamond extension pod",
 members: [ {
@@ -11208,7 +11210,7 @@ dy: 2
 } ].map(function(e, t) {
 return {
 id: "extension-".concat(t + 1),
-structureType: Mn,
+structureType: An,
 dx: e.dx,
 dy: e.dy,
 minRcl: 2,
@@ -11260,12 +11262,12 @@ minRcl: 2,
 priority: 50 - t
 };
 })
-}, Ua = {
+}, _a = {
 id: "HUB_CORE",
 name: "Storage-centered hub core",
 members: [ {
 id: "spawn-1",
-structureType: kn,
+structureType: Mn,
 dx: -2,
 dy: 0,
 minRcl: 1,
@@ -11276,7 +11278,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "storage",
-structureType: Pn,
+structureType: In,
 dx: 0,
 dy: 0,
 minRcl: 4,
@@ -11287,7 +11289,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "hub-link",
-structureType: In,
+structureType: Gn,
 dx: -1,
 dy: -1,
 minRcl: 5,
@@ -11298,7 +11300,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "terminal",
-structureType: Gn,
+structureType: Ln,
 dx: 0,
 dy: 1,
 minRcl: 6,
@@ -11309,7 +11311,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "factory",
-structureType: Bn,
+structureType: Fn,
 dx: 1,
 dy: 1,
 minRcl: 7,
@@ -11320,7 +11322,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "spawn-2",
-structureType: kn,
+structureType: Mn,
 dx: 2,
 dy: 0,
 minRcl: 7,
@@ -11331,7 +11333,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "spawn-3",
-structureType: kn,
+structureType: Mn,
 dx: 0,
 dy: -2,
 minRcl: 8,
@@ -11342,7 +11344,7 @@ fallback: "nearHub",
 rampart: !0
 }, {
 id: "tower-1",
-structureType: Nn,
+structureType: Pn,
 dx: -2,
 dy: -2,
 minRcl: 3,
@@ -11353,7 +11355,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-2",
-structureType: Nn,
+structureType: Pn,
 dx: 2,
 dy: -2,
 minRcl: 5,
@@ -11364,7 +11366,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-3",
-structureType: Nn,
+structureType: Pn,
 dx: -2,
 dy: 2,
 minRcl: 7,
@@ -11441,12 +11443,12 @@ dy: 0,
 minRcl: 1,
 priority: 97
 } ]
-}, _a = {
+}, Na = {
 id: "SOURCE_MINING",
 name: "Anchored source mining support",
 members: [ {
 id: "container",
-structureType: _n,
+structureType: Nn,
 dx: 0,
 dy: 0,
 minRcl: 2,
@@ -11456,7 +11458,7 @@ group: "source",
 fallback: "nearSource"
 }, {
 id: "source-link",
-structureType: In,
+structureType: Gn,
 dx: 1,
 dy: 0,
 minRcl: 5,
@@ -11473,12 +11475,12 @@ dy: 1,
 minRcl: 1,
 priority: 60
 } ]
-}, Na = {
+}, Pa = {
 id: "CONTROLLER_STAMP",
 name: "Controller upgrading support",
 members: [ {
 id: "controller-container",
-structureType: _n,
+structureType: Nn,
 dx: 0,
 dy: 0,
 minRcl: 2,
@@ -11488,7 +11490,7 @@ group: "controller",
 fallback: "nearController"
 }, {
 id: "controller-link",
-structureType: In,
+structureType: Gn,
 dx: 1,
 dy: 0,
 minRcl: 5,
@@ -11511,7 +11513,7 @@ dy: 1,
 minRcl: 1,
 priority: 54
 } ]
-}, Pa = {
+}, Ia = {
 id: "LAB3_TO_LAB10",
 name: "Expandable compact lab cluster",
 members: [ {
@@ -11567,7 +11569,7 @@ priority: 211
 } ].map(function(e, t) {
 return {
 id: "lab-".concat(t + 1),
-structureType: Dn,
+structureType: Bn,
 dx: e.dx,
 dy: e.dy,
 minRcl: e.minRcl,
@@ -11609,12 +11611,12 @@ dy: -1,
 minRcl: 6,
 priority: 86
 } ]
-}, Ia = {
+}, Ga = {
 id: "DEFENSE_TOWER_PAIR",
 name: "Late-game defended tower group",
 members: [ {
 id: "tower-4",
-structureType: Nn,
+structureType: Pn,
 dx: 0,
 dy: 0,
 minRcl: 8,
@@ -11625,7 +11627,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-5",
-structureType: Nn,
+structureType: Pn,
 dx: 1,
 dy: 0,
 minRcl: 8,
@@ -11636,7 +11638,7 @@ fallback: "defenseCoverage",
 rampart: !0
 }, {
 id: "tower-6",
-structureType: Nn,
+structureType: Pn,
 dx: 0,
 dy: 1,
 minRcl: 8,
@@ -11671,12 +11673,12 @@ dy: -1,
 minRcl: 8,
 priority: 77
 } ]
-}, Ga = {
+}, La = {
 id: "LATE_GAME_HEAVY",
 name: "Protected late-game heavy structures",
 members: [ {
 id: "power-spawn",
-structureType: Hn,
+structureType: Kn,
 dx: 0,
 dy: 0,
 minRcl: 8,
@@ -11687,7 +11689,7 @@ fallback: "nearStorage",
 rampart: !0
 }, {
 id: "nuker",
-structureType: Fn,
+structureType: Wn,
 dx: 2,
 dy: 0,
 minRcl: 8,
@@ -11698,7 +11700,7 @@ fallback: "protectedFlexible",
 rampart: !0
 }, {
 id: "observer",
-structureType: Wn,
+structureType: Hn,
 dx: -2,
 dy: 0,
 minRcl: 8,
@@ -11733,12 +11735,12 @@ dy: 0,
 minRcl: 8,
 priority: 67
 } ]
-}, La = {
+}, Da = {
 id: "MINERAL_STAMP",
 name: "Fixed mineral extractor support",
 members: [ {
 id: "extractor",
-structureType: Ln,
+structureType: Dn,
 dx: 0,
 dy: 0,
 minRcl: 6,
@@ -11748,7 +11750,7 @@ group: "mineral",
 fallback: "none"
 }, {
 id: "mineral-container",
-structureType: _n,
+structureType: Nn,
 dx: 1,
 dy: 0,
 minRcl: 6,
@@ -11766,11 +11768,11 @@ priority: 52
 } ]
 };
 
-function Da(e) {
+function Ba(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function Ba(e, t, r) {
+function Fa(e, t, r) {
 return t >= 1 && t <= 48 && r >= 1 && r <= 48 && !function(e, t, r) {
 var o = "undefined" == typeof TERRAIN_MASK_WALL ? 1 : TERRAIN_MASK_WALL;
 return 0 !== (function(e, t, r) {
@@ -11780,11 +11782,11 @@ return e.terrain instanceof Map ? null !== (o = e.terrain.get("".concat(t, ",").
 }(e, t, r);
 }
 
-function Fa(e) {
-return e === kn || e === Nn || e === Pn || e === Gn || e === Bn || e === In || e === Dn || e === Hn || e === Fn || e === Wn;
+function Wa(e) {
+return e === Mn || e === Pn || e === In || e === Ln || e === Fn || e === Gn || e === Bn || e === Kn || e === Wn || e === Hn;
 }
 
-function Wa(e, t, r) {
+function Ha(e, t, r) {
 var o, n, a, i;
 if (r.localAnchor) return r.localAnchor;
 switch (r.fallback) {
@@ -11802,14 +11804,14 @@ return t.anchor;
 }
 }
 
-function Ha(e, t, r, o) {
-return !!Ba(e, r, o) && !function(e) {
-return new Set(e.structures.map(Da));
+function Ka(e, t, r, o) {
+return !!Fa(e, r, o) && !function(e) {
+return new Set(e.structures.map(Ba));
 }(t).has("".concat(r, ",").concat(o));
 }
 
-function Ka(e, t, r, o, n) {
-var i = Wa(e, t, r), s = Math.max(Math.abs(i.x - o), Math.abs(i.y - n)), c = Math.max(Math.abs(t.anchor.x - o), Math.abs(t.anchor.y - n)), u = e.controller ? Math.max(Math.abs(e.controller.x - o), Math.abs(e.controller.y - n)) : 0, l = function(e, t, r) {
+function Ya(e, t, r, o, n) {
+var i = Ha(e, t, r), s = Math.max(Math.abs(i.x - o), Math.abs(i.y - n)), c = Math.max(Math.abs(t.anchor.x - o), Math.abs(t.anchor.y - n)), u = e.controller ? Math.max(Math.abs(e.controller.x - o), Math.abs(e.controller.y - n)) : 0, l = function(e, t, r) {
 var o, n;
 if (!e || 0 === e.length) return 0;
 var i = 1 / 0;
@@ -11850,9 +11852,9 @@ if (o) throw o.error;
 }
 return i;
 }(t, o, n), d = Math.min(o, n, 49 - o, 49 - n), p = 1e3 - 18 * s - 2 * c + m + 2 * Math.min(d, 10);
-return r.structureType === Nn && (p += 4 * Math.max(0, 14 - Math.min(c, u))), r.structureType === Mn && (p += m + 2 * Math.max(0, 16 - c)),
-r.structureType === In && (p += 4 * Math.max(0, 10 - Math.min(l, u, c))), r.structureType === Dn && (p += 8 * Math.max(0, 8 - c)),
-r.structureType === Ln && e.mineral && (p += e.mineral.x === o && e.mineral.y === n ? 1e4 : -1e4),
+return r.structureType === Pn && (p += 4 * Math.max(0, 14 - Math.min(c, u))), r.structureType === An && (p += m + 2 * Math.max(0, 16 - c)),
+r.structureType === Gn && (p += 4 * Math.max(0, 10 - Math.min(l, u, c))), r.structureType === Bn && (p += 8 * Math.max(0, 8 - c)),
+r.structureType === Dn && e.mineral && (p += e.mineral.x === o && e.mineral.y === n ? 1e4 : -1e4),
 {
 x: o,
 y: n,
@@ -11861,12 +11863,12 @@ reason: "fallback ".concat(r.fallback, " score ").concat(Math.round(p))
 };
 }
 
-function Ya(e, t, r, o) {
-if (void 0 === o && (o = "global"), r.structureType === Ln && e.mineral) return Ha(e, t, e.mineral.x, e.mineral.y) ? [ Ka(e, t, r, e.mineral.x, e.mineral.y) ] : [];
-for (var n = Wa(e, t, r), a = "local" === o ? 6 : 22, i = [], s = 0; s <= a; s++) {
+function Va(e, t, r, o) {
+if (void 0 === o && (o = "global"), r.structureType === Dn && e.mineral) return Ka(e, t, e.mineral.x, e.mineral.y) ? [ Ya(e, t, r, e.mineral.x, e.mineral.y) ] : [];
+for (var n = Ha(e, t, r), a = "local" === o ? 6 : 22, i = [], s = 0; s <= a; s++) {
 for (var c = -s; c <= s; c++) for (var u = -s; u <= s; u++) if (!(s > 0 && Math.abs(c) !== s && Math.abs(u) !== s)) {
 var l = n.x + c, m = n.y + u;
-Ha(e, t, l, m) && i.push(Ka(e, t, r, l, m));
+Ka(e, t, l, m) && i.push(Ya(e, t, r, l, m));
 }
 if ("local" === o && i.length > 0) break;
 }
@@ -11875,38 +11877,38 @@ return t.score - e.score;
 });
 }
 
-function Va(e) {
+function qa(e) {
 return e.length > 0 ? e[0] : null;
 }
 
-var qa = "stamp-v1";
+var ja = "stamp-v1";
 
-function ja(e) {
+function za(e) {
 return Math.max(9, Math.min(40, Math.round(e)));
 }
 
-function za(e) {
+function Qa(e) {
 return {
-x: ja(e.x),
-y: ja(e.y)
+x: za(e.x),
+y: za(e.y)
 };
 }
 
-function Qa(e, t) {
+function Xa(e, t) {
 return Math.max(Math.abs(e.x - t.x), Math.abs(e.y - t.y));
 }
 
-function Xa(e, t) {
+function Za(e, t) {
 var r;
 return null !== (r = e.counts[t]) && void 0 !== r ? r : 0;
 }
 
-function Za(e, t) {
-e.counts[t] = Xa(e, t) + 1;
+function Ja(e, t) {
+e.counts[t] = Za(e, t) + 1;
 }
 
-function Ja(e, t, r, o, n, a) {
-if (!(a > e.plan.rcl) && Ba(e.facts, t, r) && !e.occupied.has("".concat(t, ",").concat(r))) {
+function $a(e, t, r, o, n, a) {
+if (!(a > e.plan.rcl) && Fa(e.facts, t, r) && !e.occupied.has("".concat(t, ",").concat(r))) {
 var i = "".concat(t, ",").concat(r);
 e.roadKeys.has(i) || (e.plan.roads.push({
 x: t,
@@ -11918,13 +11920,13 @@ minRcl: a
 }
 }
 
-function $a(e, t, r) {
+function ei(e, t, r) {
 return void 0 === r && (r = !1), !!function(e, t, r, o) {
 var n, a = null !== (n = e.limits[t]) && void 0 !== n ? n : 0;
-return !(a <= 0 || Xa(e, t) >= a || !Ba(e.facts, r, o) || e.occupied.has("".concat(r, ",").concat(o)));
-}(e, t.structureType, t.x, t.y) && (e.plan.structures.push(t), e.occupied.add(Da(t)),
-Za(e, t.structureType), (r || Fa(t.structureType)) && function(e, t, r, o, n, a) {
-if (!(a > e.plan.rcl) && Ba(e.facts, t, r)) {
+return !(a <= 0 || Za(e, t) >= a || !Fa(e.facts, r, o) || e.occupied.has("".concat(r, ",").concat(o)));
+}(e, t.structureType, t.x, t.y) && (e.plan.structures.push(t), e.occupied.add(Ba(t)),
+Ja(e, t.structureType), (r || Wa(t.structureType)) && function(e, t, r, o, n, a) {
+if (!(a > e.plan.rcl) && Fa(e.facts, t, r)) {
 var i = "".concat(t, ",").concat(r);
 e.rampartKeys.has(i) || (e.plan.ramparts.push({
 x: t,
@@ -11937,12 +11939,12 @@ minRcl: a
 }(e, t.x, t.y, "".concat(t.source, ":rampart"), t.priority, t.minRcl), !0);
 }
 
-function ei(e, t, r) {
+function ti(e, t, r) {
 var o, n, i;
 try {
 for (var s = a(null != t ? t : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== An && u.structureType !== Un && Ba(e.facts, u.x, u.y)) {
+if (!((null !== (i = e.limits[u.structureType]) && void 0 !== i ? i : 0) <= 0) && u.structureType !== Un && u.structureType !== _n && Fa(e.facts, u.x, u.y)) {
 var l = "".concat(u.x, ",").concat(u.y);
 if (!e.occupied.has(l)) {
 var m = {
@@ -11954,7 +11956,7 @@ priority: 1e3,
 source: r,
 placedBy: "fixed"
 };
-e.plan.structures.push(m), e.occupied.add(l), Za(e, u.structureType);
+e.plan.structures.push(m), e.occupied.add(l), Ja(e, u.structureType);
 }
 }
 }
@@ -11971,7 +11973,7 @@ if (o) throw o.error;
 }
 }
 
-function ti(e, t, r, o) {
+function ri(e, t, r, o) {
 return {
 structureType: e.structureType,
 priority: e.priority,
@@ -11986,17 +11988,17 @@ minRcl: e.minRcl
 };
 }
 
-function ri(e, t) {
+function oi(e, t) {
 var r, o = null !== (r = e.limits[t.structureType]) && void 0 !== r ? r : 0;
-return o > 0 && Xa(e, t.structureType) < o;
+return o > 0 && Za(e, t.structureType) < o;
 }
 
-function oi(e, t, r, o) {
-return o.minRcl > e.plan.rcl || !ri(e, {
+function ni(e, t, r, o) {
+return o.minRcl > e.plan.rcl || !oi(e, {
 structureType: o.structureType,
 priority: o.priority,
 fallback: o.fallback
-}) || $a(e, {
+}) || ei(e, {
 x: r.x + o.dx,
 y: r.y + o.dy,
 structureType: o.structureType,
@@ -12007,13 +12009,13 @@ placedBy: "stamp"
 }, o.rampart);
 }
 
-function ni(e, t, r) {
+function ai(e, t, r) {
 var o, n, i, s, c = [], u = !0;
 e.plan.stamps.push(t.id);
 try {
 for (var l = a(t.roads), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-Ja(e, r.x + d.dx, r.y + d.dy, "".concat(t.id, ":").concat(d.id), d.priority, d.minRcl);
+$a(e, r.x + d.dx, r.y + d.dy, "".concat(t.id, ":").concat(d.id), d.priority, d.minRcl);
 }
 } catch (e) {
 o = {
@@ -12034,7 +12036,7 @@ return t.priority - e.priority;
 try {
 for (var f = a(p), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
-oi(e, t, r, v) || ((v.required || ri(e, ti(v, t.id, r, "stamp member blocked"))) && c.push(ti(v, t.id, r, "preferred stamp tile blocked")),
+ni(e, t, r, v) || ((v.required || oi(e, ri(v, t.id, r, "stamp member blocked"))) && c.push(ri(v, t.id, r, "preferred stamp tile blocked")),
 v.required && (u = !1));
 }
 } catch (e) {
@@ -12054,20 +12056,20 @@ missing: c
 };
 }
 
-function ai(e, t, r, o, n) {
+function ii(e, t, r, o, n) {
 for (var a = t.x, i = t.y, s = 0; (a !== r.x || i !== r.y) && s < 80 && (a < r.x ? a++ : a > r.x && a--,
-i < r.y ? i++ : i > r.y && i--, a !== r.x || i !== r.y); ) Ja(e, a, i, o, 40, n),
+i < r.y ? i++ : i > r.y && i--, a !== r.x || i !== r.y); ) $a(e, a, i, o, 40, n),
 s++;
 }
 
-function ii(e, t, r) {
+function si(e, t, r) {
 for (var o, n = null, a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) if (0 !== a || 0 !== i) {
 var s = {
 x: t.x + a,
 y: t.y + i
 };
-if (Ba(e.facts, s.x, s.y) && !e.occupied.has("".concat(s.x, ",").concat(s.y))) {
-var c = -Qa(s, r);
+if (Fa(e.facts, s.x, s.y) && !e.occupied.has("".concat(s.x, ",").concat(s.y))) {
+var c = -Xa(s, r);
 (!n || c > n.score) && (n = {
 point: s,
 score: c
@@ -12077,9 +12079,9 @@ score: c
 return null !== (o = null == n ? void 0 : n.point) && void 0 !== o ? o : null;
 }
 
-function si(e, t) {
-if (!ri(e, t)) return !0;
-var r = Va(Ya(e.facts, e.plan, t, "local")), o = null != r ? r : Va(Ya(e.facts, e.plan, t, "global"));
+function ci(e, t) {
+if (!oi(e, t)) return !0;
+var r = qa(Va(e.facts, e.plan, t, "local")), o = null != r ? r : qa(Va(e.facts, e.plan, t, "global"));
 if (!o) return !1;
 var n = function(e, t, r) {
 var o;
@@ -12093,11 +12095,11 @@ source: r,
 placedBy: "fallback"
 };
 }(o, t, t.sourceStamp ? "".concat(t.sourceStamp, ":fallback") : "fallback");
-return !!$a(e, n, Fa(t.structureType)) && (function(e, t) {
+return !!ei(e, n, Wa(t.structureType)) && (function(e, t) {
 var r, o;
 if (!function(e, t) {
 return e.roads.some(function(e) {
-return 1 === Qa(e, t);
+return 1 === Xa(e, t);
 });
 }(e.plan, t)) {
 var n = [ {
@@ -12125,12 +12127,12 @@ y: t.y + 1
 x: t.x + 1,
 y: t.y - 1
 } ].sort(function(t, r) {
-return Qa(t, e.plan.anchor) - Qa(r, e.plan.anchor);
+return Xa(t, e.plan.anchor) - Xa(r, e.plan.anchor);
 });
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (Ba(e.facts, c.x, c.y) && !e.occupied.has("".concat(c.x, ",").concat(c.y))) return void Ja(e, c.x, c.y, "fallback:road-access", 30, 1);
+if (Fa(e.facts, c.x, c.y) && !e.occupied.has("".concat(c.x, ",").concat(c.y))) return void $a(e, c.x, c.y, "fallback:road-access", 30, 1);
 }
 } catch (e) {
 r = {
@@ -12147,24 +12149,24 @@ if (r) throw r.error;
 }(e, n), !0);
 }
 
-function ci(e) {
+function ui(e) {
 switch (e) {
-case Mn:
+case An:
 return "nearRoad";
 
-case Nn:
+case Pn:
 return "defenseCoverage";
 
-case Pn:
-case Gn:
-case Bn:
-case Hn:
+case In:
+case Ln:
+case Fn:
+case Kn:
 return "nearStorage";
 
-case Dn:
+case Bn:
 return "labCluster";
 
-case Ln:
+case Dn:
 return "nearMineral";
 
 default:
@@ -12172,37 +12174,37 @@ return "protectedFlexible";
 }
 }
 
-function ui(e) {
+function li(e) {
 var t;
 return (null !== (t = function(e) {
 var t;
-return null !== (t = Vn(8)[e]) && void 0 !== t ? t : 0;
+return null !== (t = qn(8)[e]) && void 0 !== t ? t : 0;
 }(e)) && void 0 !== t ? t : 0) > 0;
 }
 
-function li(e) {
+function mi(e) {
 return "".concat(e.structureType, ":").concat(e.x, ",").concat(e.y);
 }
 
-function mi(e) {
+function di(e) {
 switch (e) {
-case kn:
-case _n:
+case Mn:
+case Nn:
 return "P0";
 
-case Pn:
-case Mn:
 case In:
+case An:
+case Gn:
 return "P1";
 
-case Nn:
-case Un:
+case Pn:
+case _n:
 return "P2";
 
-case Gn:
-case Dn:
 case Ln:
 case Bn:
+case Dn:
+case Fn:
 return "P3";
 
 default:
@@ -12210,7 +12212,7 @@ return "P4";
 }
 }
 
-function di(e) {
+function pi(e) {
 switch (e) {
 case "P0":
 return 500;
@@ -12229,7 +12231,7 @@ return 100;
 }
 }
 
-function pi(e, t) {
+function fi(e, t) {
 var r, o, n, i, s, c, u, l, m;
 void 0 === t && (t = {});
 var d = null !== (u = t.currentRcl) && void 0 !== u ? u : e.rcl, p = null !== (l = t.existingStructureKeys) && void 0 !== l ? l : new Set, f = null !== (m = t.existingSiteKeys) && void 0 !== m ? m : new Set, y = [];
@@ -12242,11 +12244,11 @@ x: h.x,
 y: h.y,
 structureType: h.structureType,
 minRcl: h.minRcl,
-priority: mi(h.structureType),
-score: di(mi(h.structureType)) + h.priority,
+priority: di(h.structureType),
+score: pi(di(h.structureType)) + h.priority,
 source: h.source
 };
-p.has(li(R)) || f.has(li(R)) || y.push(R);
+p.has(mi(R)) || f.has(mi(R)) || y.push(R);
 }
 }
 } catch (e) {
@@ -12266,12 +12268,12 @@ var C = T.value;
 C.minRcl > d || (R = {
 x: C.x,
 y: C.y,
-structureType: An,
+structureType: Un,
 minRcl: C.minRcl,
 priority: "P1",
 score: 360 + C.priority,
 source: C.source
-}, p.has(li(R)) || f.has(li(R)) || y.push(R));
+}, p.has(mi(R)) || f.has(mi(R)) || y.push(R));
 }
 } catch (e) {
 n = {
@@ -12290,12 +12292,12 @@ var x = w.value;
 x.minRcl > d || (R = {
 x: x.x,
 y: x.y,
-structureType: Un,
+structureType: _n,
 minRcl: x.minRcl,
 priority: "P2",
 score: 300 + x.priority,
 source: x.source
-}, p.has(li(R)) || f.has(li(R)) || y.push(R));
+}, p.has(mi(R)) || f.has(mi(R)) || y.push(R));
 }
 } catch (e) {
 s = {
@@ -12313,32 +12315,32 @@ return t.score - e.score || e.structureType.localeCompare(t.structureType);
 }), "number" == typeof t.maxItems ? y.slice(0, t.maxItems) : y;
 }
 
-var fi, yi = "defenseAssist";
+var yi, vi = "defenseAssist";
 
-function vi(e, t, r) {
+function gi(e, t, r) {
 return "defenseAssist:".concat(e, ":").concat(t, ":").concat(r);
 }
 
-function gi(e, t) {
+function hi(e, t) {
 Object.assign(e.memory, function(e) {
 var t, r, o = null !== (t = e.createdAt) && void 0 !== t ? t : e.now;
 return {
 assistTarget: e.targetRoom,
 targetRoom: e.targetRoom,
-task: yi,
-defenseSquadId: null !== (r = e.squadId) && void 0 !== r ? r : vi(e.homeRoom, e.targetRoom, o),
+task: vi,
+defenseSquadId: null !== (r = e.squadId) && void 0 !== r ? r : gi(e.homeRoom, e.targetRoom, o),
 defenseSquadSize: Math.max(1, e.squadSize),
 defenseSquadCreatedAt: o
 };
 }(t));
 }
 
-function hi(e) {
+function Ri(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === yi ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function Ri(e) {
+function Ei(e) {
 return !!function(e, t) {
 if ("retreat" === t.recommendedResponse || "safemode" === t.recommendedResponse) return !0;
 var r = e.room.find(FIND_MY_CREEPS, {
@@ -12366,7 +12368,7 @@ subsystem: "Defense",
 room: e.room.name,
 creep: e.name
 }), !0);
-}(e, Fo(e.room)) && (function(e) {
+}(e, Wo(e.room)) && (function(e) {
 var t, r, o, n, c = e.room.find(FIND_MY_SPAWNS)[0];
 if (c) {
 var u = e.moveTo(c, {
@@ -12421,7 +12423,7 @@ stroke: "#ff0000"
 }(e), !0);
 }
 
-function Ei(e) {
+function Ti(e) {
 var t;
 return (null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== t ? t : 0) >= 5100;
 }
@@ -12429,56 +12431,56 @@ return (null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENER
 !function(e) {
 e[e.NONE = 0] = "NONE", e[e.LOW = 1] = "LOW", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL";
-}(fi || (fi = {}));
+}(yi || (yi = {}));
 
-var Ti = function() {
+var Ci = function() {
 function e() {
 this.emergencyStates = new Map;
 }
 return e.prototype.assess = function(e, t) {
 var r, o, n = this.emergencyStates.get(e.name), a = this.calculateEmergencyLevel(e, t);
-if (a === fi.NONE && this.clearBoostPriority(e.name), a === fi.NONE && !n) return {
-level: fi.NONE,
+if (a === yi.NONE && this.clearBoostPriority(e.name), a === yi.NONE && !n) return {
+level: yi.NONE,
 startedAt: Game.time,
 assistanceRequested: !1,
 boostsAllocated: !1,
 lastEscalation: 0
 };
-var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : fi.NONE;
+var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : yi.NONE;
 return n ? (o = n).level = a : (o = {
 level: a,
 startedAt: Game.time,
 assistanceRequested: !1,
 boostsAllocated: !1,
 lastEscalation: 0
-}, this.emergencyStates.set(e.name, o)), a === fi.NONE ? (n && (U.info("Emergency resolved in ".concat(e.name), {
+}, this.emergencyStates.set(e.name, o)), a === yi.NONE ? (n && (U.info("Emergency resolved in ".concat(e.name), {
 subsystem: "Defense"
 }), this.emergencyStates.delete(e.name)), o) : (n && a > i && (U.warn("Emergency escalated in ".concat(e.name, ": Level ").concat(i, " → ").concat(a), {
 subsystem: "Defense"
 }), o.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, o), o);
 }, e.prototype.calculateEmergencyLevel = function(e, t) {
-var r = X(e), o = e.find(FIND_MY_STRUCTURES, {
+var r = Z(e), o = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
 }
 }), n = e.find(FIND_NUKES);
-if (0 === t.danger && 0 === r.length && 0 === o.length && 0 === n.length) return fi.NONE;
-var a = mo(e), i = yo(e), s = Fo(e);
-if (o.length > 0 || n.length > 0) return fi.CRITICAL;
+if (0 === t.danger && 0 === r.length && 0 === o.length && 0 === n.length) return yi.NONE;
+var a = po(e), i = vo(e), s = Wo(e);
+if (o.length > 0 || n.length > 0) return yi.CRITICAL;
 var c = r.filter(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && e.boost;
 });
 }), u = Math.max(0, a.guards - i.guards) + Math.max(0, a.rangers - i.rangers) + Math.max(0, a.healers - i.healers);
-return c.length > 0 && u >= 2 || r.length >= 5 && 0 === i.guards && 0 === i.rangers || s.dangerLevel >= 2 && u >= 2 ? fi.HIGH : (t.danger >= 2 || s.dangerLevel >= 2) && u >= 1 ? fi.MEDIUM : t.danger >= 1 || r.length > 0 ? fi.LOW : fi.NONE;
+return c.length > 0 && u >= 2 || r.length >= 5 && 0 === i.guards && 0 === i.rangers || s.dangerLevel >= 2 && u >= 2 ? yi.HIGH : (t.danger >= 2 || s.dangerLevel >= 2) && u >= 1 ? yi.MEDIUM : t.danger >= 1 || r.length > 0 ? yi.LOW : yi.NONE;
 }, e.prototype.executeEmergencyResponse = function(e, t, r) {
-r.level >= fi.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
-r.level >= fi.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
+r.level >= yi.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
+r.level >= yi.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
 r.boostsAllocated = !0), this.updateDefensePosture(e, t, r);
 }, e.prototype.requestDefenseAssistance = function(e, t) {
 var r;
-if (!vo(e, t)) return !1;
-var o = go(e, t);
+if (!go(e, t)) return !1;
+var o = ho(e, t);
 if (!o) return !1;
 var n = Memory, a = null !== (r = n.defenseRequests) && void 0 !== r ? r : [], c = a.find(function(t) {
 return t.roomName === e.name && Game.time - t.createdAt < 500;
@@ -12504,28 +12506,28 @@ subsystem: "Defense"
 });
 }, e.prototype.updateDefensePosture = function(e, t, r) {
 switch (r.level) {
-case fi.CRITICAL:
+case yi.CRITICAL:
 "evacuate" !== t.posture && (t.posture = "war", t.pheromones.war = 100, t.pheromones.defense = 100,
 U.warn("".concat(e.name, " posture: CRITICAL DEFENSE"), {
 subsystem: "Defense"
 }));
 break;
 
-case fi.HIGH:
+case yi.HIGH:
 "war" !== t.posture && "evacuate" !== t.posture && (t.posture = "defensive", t.pheromones.defense = 80,
 t.pheromones.war = 40, U.info("".concat(e.name, " posture: HIGH DEFENSE"), {
 subsystem: "Defense"
 }));
 break;
 
-case fi.MEDIUM:
+case yi.MEDIUM:
 "eco" !== t.posture && "expand" !== t.posture || (t.posture = "defensive", t.pheromones.defense = 60,
 U.info("".concat(e.name, " posture: MEDIUM DEFENSE"), {
 subsystem: "Defense"
 }));
 break;
 
-case fi.LOW:
+case yi.LOW:
 "eco" !== t.posture && "expand" !== t.posture || (t.pheromones.defense = 30, U.debug("".concat(e.name, ": LOW DEFENSE alert"), {
 subsystem: "Defense"
 }));
@@ -12544,13 +12546,13 @@ r.defenseRequests = o;
 return this.emergencyStates.get(e);
 }, e.prototype.hasEmergency = function(e) {
 var t = this.emergencyStates.get(e);
-return void 0 !== t && t.level > fi.NONE;
+return void 0 !== t && t.level > yi.NONE;
 }, e.prototype.getActiveEmergencies = function() {
 var e, t, r = [];
 try {
 for (var o = a(this.emergencyStates.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-u.level > fi.NONE && r.push({
+u.level > yi.NONE && r.push({
 roomName: c,
 state: u
 });
@@ -12570,27 +12572,27 @@ return r.sort(function(e, t) {
 return t.state.level - e.state.level;
 });
 }, e;
-}(), Ci = new Ti;
+}(), Si = new Ci;
 
-function Si(e) {
+function wi(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === HEAL || e.type === WORK || e.type === CLAIM);
 });
 }
 
-function wi(e, t) {
+function xi(e, t) {
 return e.body.filter(function(e) {
 return e.hits > 0 && e.type === t;
 }).length;
 }
 
-function xi(e) {
+function bi(e) {
 return !!e.body.some(function(e) {
 return e.hits > 0 && e.boost;
-}) || wi(e, WORK) >= 5 || wi(e, HEAL) >= 3;
+}) || xi(e, WORK) >= 5 || xi(e, HEAL) >= 3;
 }
 
-var bi = function() {
+var Oi = function() {
 function e() {}
 return e.prototype.checkSafeMode = function(e, t) {
 var r, o, n, a, i;
@@ -12608,7 +12610,7 @@ subsystem: "Defense"
 }, e.prototype.shouldTriggerSafeMode = function(e, t) {
 var r, o;
 if (t.danger < 2) return !1;
-var n = X(e), i = n.filter(Si), s = function() {
+var n = Z(e), i = n.filter(wi), s = function() {
 var e;
 return !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.safeModeDangerousHostilesOnly);
 }(), c = s ? i : n;
@@ -12638,25 +12640,25 @@ subsystem: "Defense"
 if (e.terminal && e.terminal.hits < .2 * e.terminal.hitsMax) return U.warn("Terminal critical: ".concat(e.terminal.hits, "/").concat(e.terminal.hitsMax), {
 subsystem: "Defense"
 }), !0;
-var p = fo(e, [ "guard", "ranger", "soldier" ]);
+var p = yo(e, [ "guard", "ranger", "soldier" ]);
 if (c.length > 3 * p) return U.warn("Overwhelmed: ".concat(c.length, " safe-mode-relevant hostiles vs ").concat(p, " defenders"), {
 subsystem: "Defense"
 }), !0;
-var f = c.filter(xi);
+var f = c.filter(bi);
 return f.length > 0 && p < 2 * f.length && (U.warn("High-impact siege hostiles detected: ".concat(f.length), {
 subsystem: "Defense"
 }), !0);
 }, e;
-}(), Oi = new bi, ki = new Set([ "nuke", "siege", "hostile_takeover", "manual" ]), Mi = {
+}(), ki = new Oi, Mi = new Set([ "nuke", "siege", "hostile_takeover", "manual" ]), Ai = {
 triggerDangerLevel: 3,
 nukeEvacuationLeadTime: 5e3,
 minStorageEnergy: 5e4,
 priorityResources: [ RESOURCE_ENERGY, RESOURCE_POWER, RESOURCE_GHODIUM, RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ACID, RESOURCE_CATALYZED_ZYNTHIUM_ACID, RESOURCE_OPS ],
 maxTransfersPerTick: 2
-}, Ai = function() {
+}, Ui = function() {
 function e(e) {
 void 0 === e && (e = {}), this.evacuations = new Map, this.lastTransferTick = 0,
-this.transfersThisTick = 0, this.config = o(o({}, Mi), e);
+this.transfersThisTick = 0, this.config = o(o({}, Ai), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o;
@@ -12713,7 +12715,7 @@ if (e) throw e.error;
 }, e.prototype.restorePersistedEvacuation = function(e) {
 var t = this.evacuations.get(e);
 if (t) return t;
-var r = Sr.getSwarmState(e), o = null == r ? void 0 : r.evacuationIntent;
+var r = wr.getSwarmState(e), o = null == r ? void 0 : r.evacuationIntent;
 if (o) if (this.isValidEvacuationIntent(o)) {
 if (!(o.complete && Game.time - o.startedAt > 1e3)) {
 var n = Game.rooms[e], a = n ? n.find(FIND_MY_CREEPS).filter(function(e) {
@@ -12740,9 +12742,9 @@ delete r.evacuationIntent;
 }, e.prototype.isValidEvacuationIntent = function(e) {
 if (!e || "object" != typeof e) return !1;
 var t = e;
-return ki.has(String(t.reason)) && "number" == typeof t.startedAt && Number.isFinite(t.startedAt) && "string" == typeof t.targetRoom && t.targetRoom.length > 0 && "number" == typeof t.progress && Number.isFinite(t.progress) && "boolean" == typeof t.complete && "number" == typeof t.updatedAt && Number.isFinite(t.updatedAt) && (void 0 === t.deadline || "number" == typeof t.deadline && Number.isFinite(t.deadline));
+return Mi.has(String(t.reason)) && "number" == typeof t.startedAt && Number.isFinite(t.startedAt) && "string" == typeof t.targetRoom && t.targetRoom.length > 0 && "number" == typeof t.progress && Number.isFinite(t.progress) && "boolean" == typeof t.complete && "number" == typeof t.updatedAt && Number.isFinite(t.updatedAt) && (void 0 === t.deadline || "number" == typeof t.deadline && Number.isFinite(t.deadline));
 }, e.prototype.persistEvacuation = function(e) {
-var t = Sr.getSwarmState(e.roomName);
+var t = wr.getSwarmState(e.roomName);
 if (t) {
 var r = {
 reason: e.reason,
@@ -12755,14 +12757,14 @@ updatedAt: Game.time
 void 0 !== e.deadline && (r.deadline = e.deadline), t.evacuationIntent = r;
 }
 }, e.prototype.clearPersistedEvacuationIntent = function(e) {
-var t = Sr.getSwarmState(e);
+var t = wr.getSwarmState(e);
 t && delete t.evacuationIntent;
 }, e.prototype.checkEvacuationTriggers = function() {
 var e, t, r, o;
 for (var n in Game.rooms) {
 var a = Game.rooms[n];
 if ((null === (e = a.controller) || void 0 === e ? void 0 : e.my) && !this.evacuations.has(n)) {
-var i = Sr.getSwarmState(n);
+var i = wr.getSwarmState(n);
 if (i) {
 var s = a.find(FIND_NUKES);
 if (s.length > 0) {
@@ -12780,7 +12782,7 @@ continue;
 }
 }
 if (i.danger >= this.config.triggerDangerLevel && "siege" === i.posture) {
-var l = X(a), m = fo(a);
+var l = Z(a), m = yo(a);
 if (l.length > 3 * m) {
 this.startEvacuation(n, "siege");
 continue;
@@ -12811,7 +12813,7 @@ complete: !1,
 deadline: r
 };
 this.evacuations.set(e, i), this.persistEvacuation(i);
-var s = Sr.getSwarmState(e);
+var s = wr.getSwarmState(e);
 return s && (s.posture = "evacuate"), U.warn("Starting evacuation of ".concat(e, " (").concat(t, "), target: ").concat(a) + (r ? ", deadline: ".concat(r - Game.time, " ticks") : ""), {
 subsystem: "Evacuation"
 }), !0;
@@ -12835,7 +12837,7 @@ n += 50;
 var i = t.storage.store.getFreeCapacity();
 n += 5 * Math.min(100, i / 5e4);
 }
-var s = X(t);
+var s = Z(t);
 return s.length > 0 && (n -= 20 * s.length), {
 room: t,
 score: n
@@ -12958,7 +12960,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var m = Sr.getSwarmState(e);
+var m = wr.getSwarmState(e);
 m && (m.posture = "eco"), U.info("Evacuation of ".concat(e, " cancelled"), {
 subsystem: "Evacuation"
 });
@@ -12973,15 +12975,15 @@ return void 0 !== t && !t.complete;
 return this.restorePersistedEvacuations(), Array.from(this.evacuations.values()).filter(function(e) {
 return !e.complete;
 });
-}, n([ Qe("cluster:evacuation", "Evacuation Manager", {
-priority: Pe.HIGH,
+}, n([ Xe("cluster:evacuation", "Evacuation Manager", {
+priority: Ie.HIGH,
 interval: 5,
 minBucket: 0,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Ui = new Ai;
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), _i = new Ui;
 
-function _i(e) {
+function Ni(e) {
 var t = Math.floor(e.bucketThresholds.lowMode / 2), r = {
 high: 1,
 medium: Math.max(1, Math.min(e.taskFrequencies.clusterLogic, e.taskFrequencies.pheromoneUpdate)),
@@ -13016,21 +13018,21 @@ maxPriorityBoost: 50
 };
 }
 
-var Ni, Pi = null, Ii = new Proxy({}, {
+var Pi, Ii = null, Gi = new Proxy({}, {
 get: function(e, t) {
-return Pi || (Pi = new Ke(_i(kr().cpu))), Pi[t];
+return Ii || (Ii = new Ye(Ni(Mr().cpu))), Ii[t];
 },
 set: function(e, t, r) {
-return Pi || (Pi = new Ke(_i(kr().cpu))), Pi[t] = r, !0;
+return Ii || (Ii = new Ye(Ni(Mr().cpu))), Ii[t] = r, !0;
 }
 });
 
-function Gi() {
+function Li() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-rt.apply(void 0, s([ Ii ], i(e), !1));
+ot.apply(void 0, s([ Gi ], i(e), !1));
 }
 
-var Li, Di, Bi = {
+var Di, Bi, Fi = {
 updateInterval: 200,
 minBucket: 0,
 minCreditsForPixels: 5e5,
@@ -13042,11 +13044,11 @@ targetPixelPrice: 2e3,
 maxPixelsPerTransaction: 10,
 purchaseCooldown: 1e3,
 minBaseMineralReserve: 1e4,
-criticalResourceThresholds: (Ni = {}, Ni[RESOURCE_GHODIUM] = 5e3, Ni),
+criticalResourceThresholds: (Pi = {}, Pi[RESOURCE_GHODIUM] = 5e3, Pi),
 enabled: !0
-}, Fi = function() {
+}, Wi = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Bi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Fi), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13222,15 +13224,15 @@ this.config.enabled = !1, U.info("Pixel buying disabled", {
 subsystem: "PixelBuying"
 });
 }, e;
-}(), Wi = {
+}(), Hi = {
 enabled: !0,
 fullBucketTicksRequired: 25,
 bucketMax: 1e4,
 cpuCostPerPixel: 1e4,
 minBucketAfterGeneration: 0
-}, Hi = function() {
+}, Ki = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, Wi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.config = o(o({}, Hi), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13292,7 +13294,7 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), Ki = function(e) {
+}(), Yi = function(e) {
 var t = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.map(function(e) {
@@ -13322,18 +13324,18 @@ for (var o = [], n = 1; n < arguments.length; n++) o[n - 1] = arguments[n];
 return console.log.apply(console, s([ "[".concat(e, "] ERROR:"), r ], i(t.apply(void 0, s([], i(o), !1))), !1));
 }
 };
-}("stats"), Yi = function(e) {
+}("stats"), Vi = function(e) {
 var t, r, o;
 return (null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.swarm) || (null === (o = Memory.swarm) || void 0 === o ? void 0 : o[e]) || {};
 };
 
 !function(e) {
 e.ACTIVE = "active", e.DECAY = "decay", e.INACTIVE = "inactive";
-}(Li || (Li = {})), function(e) {
+}(Di || (Di = {})), function(e) {
 e.PHEROMONES = "pheromones", e.PATHS = "paths", e.TARGETS = "targets", e.DEBUG = "debug";
-}(Di || (Di = {}));
+}(Bi || (Bi = {}));
 
-var Vi = new (function() {
+var qi = new (function() {
 function e() {
 this.metrics = {
 totalCalls: 0,
@@ -13381,7 +13383,7 @@ moveByPath: 0
 }, e;
 }());
 
-function qi(e, t) {
+function ji(e, t) {
 var r;
 void 0 === t && (t = {});
 var o = null === (r = t.includeCpuUsage) || void 0 === r || r, n = s([], i(e), !1).sort(function(e, t) {
@@ -13390,15 +13392,15 @@ return t.percentUsed - e.percentUsed;
 var r, n, a = "room:".concat(e.target), i = null === (r = t.processes) || void 0 === r ? void 0 : r[a], s = null !== (n = null == i ? void 0 : i.tickModulo) && void 0 !== n ? n : 1, c = s > 1 ? " [runs every ".concat(s, " ticks]") : "", u = "".concat((100 * e.percentUsed).toFixed(1), "%");
 return o ? "".concat(e.target, ": ").concat(u, " (").concat(e.cpuUsed.toFixed(3), "/").concat(e.budgetLimit.toFixed(3), " CPU)").concat(c) : "".concat(e.target, ": ").concat(u).concat(c);
 });
-return ji(n, e.length);
+return zi(n, e.length);
 }
 
-function ji(e, t) {
+function zi(e, t) {
 var r = t - e.length;
 return r > 0 && e.push("... ".concat(r, " more omitted")), e.join(", ");
 }
 
-var zi = {
+var Qi = {
 enabled: !0,
 smoothingFactor: .1,
 trackNativeCalls: !0,
@@ -13420,9 +13422,9 @@ enabled: !0,
 spikeThreshold: 2,
 minSamples: 10
 }
-}, Qi = 1e-9, Xi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
+}, Xi = 1e-9, Zi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
 
-function Zi() {
+function Ji() {
 return {
 tasks: 0,
 openTasks: 0,
@@ -13434,28 +13436,28 @@ remainingAmount: 0
 };
 }
 
-function Ji(e) {
+function $i(e) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, e) : 0;
 }
 
-function $i(e) {
+function es(e) {
 var t;
 return Object.values(null !== (t = e.reservations) && void 0 !== t ? t : {}).reduce(function(e, t) {
-return e + Ji(null == t ? void 0 : t.amount);
+return e + $i(null == t ? void 0 : t.amount);
 }, 0);
 }
 
-var es = function() {
+var ts = function() {
 function e(e) {
 void 0 === e && (e = {}), this.subsystemMeasurements = new Map, this.cpuDetailMeasurements = new Map,
 this.roomMeasurements = new Map, this.lastSegmentUpdate = 0, this.lastBudgetAlertLogTick = -1 / 0,
 this.lastAnomalyLogTick = -1 / 0, this.segmentRequested = !1, this.skippedProcessesThisTick = 0,
-this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, zi), e),
+this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Qi), e),
 this.currentSnapshot = this.createEmptySnapshot(), this.nativeCallsThisTick = this.createEmptyNativeCalls();
 }
 return e.prototype.initialize = function() {
 void 0 === RawMemory.segments[this.config.segmentId] && (RawMemory.setActiveSegments([ this.config.segmentId ]),
-this.segmentRequested = !0), this.installCpuProfilerGlobal(), Ki.info("Unified stats system initialized", {
+this.segmentRequested = !0), this.installCpuProfilerGlobal(), Yi.info("Unified stats system initialized", {
 subsystem: "Stats"
 });
 }, e.prototype.preserveRoomStats = function() {
@@ -13492,7 +13494,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-Vi.reset();
+qi.reset();
 }
 }, e.prototype.publishIdleTick = function() {
 this.startTick(), this.finalizeTick();
@@ -13528,19 +13530,19 @@ return "critical" === e.severity;
 }), C = R.alerts.filter(function(e) {
 return "warning" === e.severity;
 });
-T.length > 0 && Ki.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(qi(T, {
+T.length > 0 && Yi.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(ji(T, {
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
-}), C.length > 0 && Ki.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(qi(C, {
+}), C.length > 0 && Yi.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(ji(C, {
 includeCpuUsage: !1,
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
 }), this.lastBudgetAlertLogTick = Game.time;
 }
-E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Ki.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
-return ji(s([], i(e), !1).sort(function(e, t) {
+E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Yi.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
+return zi(s([], i(e), !1).sort(function(e, t) {
 return t.multiplier - e.multiplier;
 }).slice(0, 5).map(function(e) {
 return "".concat(e.target, " (").concat(e.type, "): ").concat(e.current.toFixed(3), " CPU (").concat(e.multiplier.toFixed(1), "x baseline)").concat(e.context ? " - ".concat(e.context) : "");
@@ -13640,7 +13642,7 @@ v.staleReservations = null !== (s = null === (i = y.stats) || void 0 === i ? voi
 v.blockedReservations = null !== (u = null === (c = y.stats) || void 0 === c ? void 0 : c.blockedReservations) && void 0 !== u ? u : 0;
 try {
 for (var g = a(Object.values(null !== (l = y.tasks) && void 0 !== l ? l : {})), h = g.next(); !h.done; h = g.next()) {
-var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : Zi(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = Ji(R.amount), w = $i(R), x = Math.max(0, S - w), b = Xi.has(E);
+var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : Ji(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = $i(R.amount), w = es(R), x = Math.max(0, S - w), b = Zi.has(E);
 v.tasks++, v.reservations += C, v.amount += S, v.reservedAmount += w, v.remainingAmount += x,
 T.tasks++, T.reservations += C, T.amount += S, T.reservedAmount += w, T.remainingAmount += x,
 "open" === R.status ? (v.openTasks++, T.openTasks++) : "assigned" === R.status && (v.assignedTasks++,
@@ -13864,9 +13866,9 @@ this.defenseAssistTelemetry.set(e, r), (null == o ? void 0 : o.defense) && (o.de
 }, e.prototype.recordRoom = function(e, t) {
 var r, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, k, M;
 if (this.config.enabled) {
-var A = Yi(e.name), U = Object.values(Game.creeps).filter(function(t) {
+var A = Vi(e.name), U = Object.values(Game.creeps).filter(function(t) {
 return t.room.name === e.name;
-}).length, _ = X(e), N = this.getRoomTaskBoardStats(e.name), P = this.getRemoteStats(e.name, A), I = this.getDefenseStats(e, _, A), G = this.defenseAssistTelemetry.get(e.name), L = this.getControllerDowngradeStats(e), D = this.currentSnapshot.rooms[e.name];
+}).length, _ = Z(e), N = this.getRoomTaskBoardStats(e.name), P = this.getRemoteStats(e.name, A), I = this.getDefenseStats(e, _, A), G = this.defenseAssistTelemetry.get(e.name), L = this.getControllerDowngradeStats(e), D = this.currentSnapshot.rooms[e.name];
 D || (D = {
 name: e.name,
 rcl: null !== (c = null === (s = e.controller) || void 0 === s ? void 0 : s.level) && void 0 !== c ? c : 0,
@@ -13972,7 +13974,7 @@ storageEnergy: W
 };
 }
 }, e.prototype.isWarRoom = function(e) {
-var t = Yi(e);
+var t = Vi(e);
 return !!t && ("war" === t.posture || "siege" === t.posture || t.danger >= 2);
 }, e.prototype.validateBudgets = function() {
 var e, t, r, o = {
@@ -13987,8 +13989,8 @@ try {
 for (var n = a(Object.entries(this.currentSnapshot.rooms)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
 o.roomsEvaluated++;
-var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Qi ? h : Math.abs(v - g) <= Qi ? g : v;
-v + Qi >= h ? (o.roomsOverBudget++, o.alerts.push({
+var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Xi ? h : Math.abs(v - g) <= Xi ? g : v;
+v + Xi >= h ? (o.roomsOverBudget++, o.alerts.push({
 severity: "critical",
 target: u,
 targetType: "room",
@@ -13996,7 +13998,7 @@ cpuUsed: y,
 budgetLimit: f,
 percentUsed: R,
 tick: Game.time
-})) : v + Qi >= g ? (o.alerts.push({
+})) : v + Xi >= g ? (o.alerts.push({
 severity: "warning",
 target: u,
 targetType: "room",
@@ -14030,7 +14032,7 @@ var v = null !== (n = this.roomMeasurements.get(f)) && void 0 !== n ? n : 0;
 if (!((x = y.profiler.avgCpu) < .01)) {
 var g = v / x;
 if (g >= this.config.anomalyDetection.spikeThreshold) {
-var h = Yi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
+var h = Vi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
 l.push({
 type: "spike",
 target: f,
@@ -14458,7 +14460,7 @@ evictions: 0
 }
 };
 }, e.prototype.finalizePathfindingStats = function() {
-this.currentSnapshot.pathfinding = Vi.getMetrics();
+this.currentSnapshot.pathfinding = qi.getMetrics();
 }, e.prototype.formatCpuDetailsForMemory = function() {
 var e, t, r, n, s = this.getCpuDetailsConfig(), c = {};
 try {
@@ -14856,24 +14858,24 @@ var o = JSON.parse(r);
 Array.isArray(o) && (t = o);
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Ki.error("Failed to parse stats segment: ".concat(n), {
+Yi.error("Failed to parse stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
 t.push(this.currentSnapshot), t.length > this.config.maxHistoryPoints && (t = t.slice(-this.config.maxHistoryPoints));
 var a = JSON.stringify(t);
 if (a.length > e) {
-for (Ki.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
+for (Yi.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
 subsystem: "Stats"
 }); a.length > e && t.length > 1; ) t.shift(), a = JSON.stringify(t);
-if (a.length > e) return void Ki.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
+if (a.length > e) return void Yi.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
 subsystem: "Stats"
 });
 }
 try {
 RawMemory.segments[this.config.segmentId] = a;
 } catch (e) {
-n = e instanceof Error ? e.message : String(e), Ki.error("Failed to save stats segment: ".concat(n), {
+n = e instanceof Error ? e.message : String(e), Yi.error("Failed to save stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
@@ -14890,17 +14892,17 @@ lastUpdate: 0
 }), e.stats.profiler;
 }, e.prototype.logSummary = function() {
 var e, t, r, o, n, i, s, c, u, l, m = this.currentSnapshot;
-Ki.info("=== Unified Stats Summary ==="), Ki.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
-Ki.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
+Yi.info("=== Unified Stats Summary ==="), Yi.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
+Yi.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
 var d = Object.values(m.subsystems).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (d.length > 0) {
-Ki.info("Top Subsystems:");
+Yi.info("Top Subsystems:");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Ki.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
+Yi.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
 }
 } catch (t) {
 e = {
@@ -14918,11 +14920,11 @@ var v = Object.values(m.roles).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (v.length > 0) {
-Ki.info("Top Roles:");
+Yi.info("Top Roles:");
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Ki.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
+Yi.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
 }
 } catch (e) {
 r = {
@@ -14940,11 +14942,11 @@ var E = Object.values(m.processes).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (E.length > 0) {
-Ki.info("Top Processes:");
+Yi.info("Top Processes:");
 try {
 for (var T = a(E), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-Ki.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
+Yi.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
 }
 } catch (e) {
 n = {
@@ -14962,11 +14964,11 @@ var w = Object.values(m.rooms).sort(function(e, t) {
 return t.profiler.avgCpu - e.profiler.avgCpu;
 }).slice(0, 5);
 if (w.length > 0) {
-Ki.info("Top Rooms by CPU:");
+Yi.info("Top Rooms by CPU:");
 try {
 for (var x = a(w), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Ki.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
+Yi.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
 }
 } catch (e) {
 s = {
@@ -14984,11 +14986,11 @@ var k = Object.values(m.creeps).sort(function(e, t) {
 return t.cpu - e.cpu;
 }).slice(0, 5);
 if (k.length > 0) {
-Ki.info("Top Creeps by CPU:");
+Yi.info("Top Creeps by CPU:");
 try {
 for (var M = a(k), A = M.next(); !A.done; A = M.next()) {
 var U = A.value;
-Ki.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
+Yi.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
 }
 } catch (e) {
 u = {
@@ -15002,7 +15004,7 @@ if (u) throw u.error;
 }
 }
 }
-this.config.trackNativeCalls && Ki.info("Native calls: ".concat(m.native.total, " total"));
+this.config.trackNativeCalls && Yi.info("Native calls: ".concat(m.native.total, " total"));
 }, e.prototype.postureToCode = function(e) {
 var t;
 return null !== (t = {
@@ -15048,16 +15050,16 @@ lastUpdate: 0
 return o({}, this.currentSnapshot);
 }, e.POSTURE_NAMES = [ "eco", "expand", "defensive", "war", "siege", "evacuate", "nukePrep" ],
 e;
-}(), ts = new es, rs = {
+}(), rs = new ts, os = {
 primarySegment: 90,
 backupSegment: 91,
 retentionPeriod: 1e4,
 updateInterval: 50,
 maxDataPoints: 1e3
-}, os = function() {
+}, ns = function() {
 function e(e) {
 void 0 === e && (e = {}), this.statsData = null, this.segmentRequested = !1, this.lastUpdate = 0,
-this.config = o(o({}, rs), e);
+this.config = o(o({}, os), e);
 }
 return e.prototype.initialize = function() {
 RawMemory.setActiveSegments([ this.config.primarySegment ]), this.segmentRequested = !0;
@@ -15068,12 +15070,12 @@ this.lastUpdate = Game.time);
 }, e.prototype.loadFromSegment = function() {
 var e = RawMemory.segments[this.config.primarySegment];
 if (e && 0 !== e.length) try {
-this.statsData = JSON.parse(e), Ki.debug("Loaded stats from segment", {
+this.statsData = JSON.parse(e), Yi.debug("Loaded stats from segment", {
 subsystem: "Stats"
 });
 } catch (e) {
 var t = e instanceof Error ? e.message : String(e);
-Ki.error("Failed to parse stats segment: ".concat(t), {
+Yi.error("Failed to parse stats segment: ".concat(t), {
 subsystem: "Stats"
 }), this.statsData = this.createDefaultStatsData();
 } else this.statsData = this.createDefaultStatsData();
@@ -15125,7 +15127,7 @@ c["".concat(p, ".energy.capacity")] = d.energyCapacity, c["".concat(p, ".storage
 c["".concat(p, ".terminal.energy")] = d.terminalEnergy, c["".concat(p, ".creeps")] = d.creepCount,
 c["".concat(p, ".controller.progress")] = d.controllerProgress, c["".concat(p, ".controller.progress_total")] = d.controllerProgressTotal,
 c["".concat(p, ".controller.progress_percent")] = d.controllerProgressTotal > 0 ? d.controllerProgress / d.controllerProgressTotal * 100 : 0;
-var f = Yi(d.roomName);
+var f = Vi(d.roomName);
 if (f) {
 if (c["".concat(p, ".brain.danger")] = f.danger, c["".concat(p, ".brain.posture_code")] = this.postureToCode(f.posture),
 c["".concat(p, ".brain.colony_level_code")] = this.colonyLevelToCode(f.colonyLevel),
@@ -15167,7 +15169,7 @@ if (t) throw t.error;
 }
 c["stats.system.tick"] = e.tick, c["stats.system.timestamp"] = Date.now();
 }, e.prototype.collectGlobalStats = function() {
-var e, t, r, o, n = Tt(), a = new Map;
+var e, t, r, o, n = Ct(), a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i];
 if (!s.spawning && (null === (e = s.room.controller) || void 0 === e ? void 0 : e.my)) {
@@ -15237,7 +15239,7 @@ try {
 this.statsData.lastUpdate = Game.time;
 var i = JSON.stringify(this.statsData);
 if (i.length > n) {
-for (Ki.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
+for (Yi.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
 subsystem: "Stats"
 }); i.length > n && this.statsData.history.length > 10; ) this.statsData.history.shift(),
 i = JSON.stringify(this.statsData);
@@ -15256,7 +15258,7 @@ if (e) throw e.error;
 }
 }
 if (i.length > n) {
-Ki.warn("Stats data still exceeds limit after trimming, clearing history", {
+Yi.warn("Stats data still exceeds limit after trimming, clearing history", {
 subsystem: "Stats"
 }), this.statsData.history = this.statsData.history.slice(-5);
 try {
@@ -15279,7 +15281,7 @@ i = JSON.stringify(this.statsData);
 RawMemory.segments[this.config.primarySegment] = i;
 } catch (e) {
 var p = e instanceof Error ? e.message : String(e);
-Ki.error("Failed to save stats segment: ".concat(p), {
+Yi.error("Failed to save stats segment: ".concat(p), {
 subsystem: "Stats"
 });
 }
@@ -15383,9 +15385,9 @@ fortifiedHive: 4,
 empireDominance: 5
 }[e]) && void 0 !== t ? t : 0;
 }, e;
-}(), ns = new os;
+}(), as = new ns;
 
-function as(e) {
+function is(e) {
 e._metrics || (e._metrics = {
 tasksCompleted: 0,
 energyTransferred: 0,
@@ -15398,15 +15400,15 @@ healingDone: 0
 });
 }
 
-function is(e) {
-return as(e), e._metrics;
+function ss(e) {
+return is(e), e._metrics;
 }
 
-function ss(e, t) {
-is(e).damageDealt += t;
+function cs(e, t) {
+ss(e).damageDealt += t;
 }
 
-var cs, us = {
+var us, ls = {
 minBucket: 0,
 minSourceLinkEnergy: 400,
 controllerLinkMaxEnergy: 700,
@@ -15418,16 +15420,16 @@ storageEnergyReserveForSpawnLink: 1e4
 !function(e) {
 e.SOURCE = "source", e.CONTROLLER = "controller", e.STORAGE = "storage", e.SPAWN = "spawn",
 e.UNKNOWN = "unknown";
-}(cs || (cs = {}));
+}(us || (us = {}));
 
-var ls, ms, ds = function() {
+var ms, ds, ps = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, us), e);
+void 0 === e && (e = {}), this.config = o(o({}, ls), e);
 }
 return e.prototype.run = function() {
 var e, t;
 if (!(Game.cpu.bucket < this.config.minBucket)) {
-var r = Tt().filter(function(e) {
+var r = Ct().filter(function(e) {
 var t, r;
 return (null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0) >= 5;
 });
@@ -15456,13 +15458,13 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (!(t.length < 2)) {
 var r = this.classifyLinks(e, t), o = r.filter(function(e) {
-return e.role === cs.SOURCE;
+return e.role === us.SOURCE;
 }), n = r.filter(function(e) {
-return e.role === cs.CONTROLLER;
+return e.role === us.CONTROLLER;
 }), a = r.filter(function(e) {
-return e.role === cs.STORAGE;
+return e.role === us.STORAGE;
 }), i = r.filter(function(e) {
-return e.role === cs.SPAWN;
+return e.role === us.SPAWN;
 });
 this.executeTransfers(e, o, n, a, i);
 }
@@ -15499,11 +15501,11 @@ try {
 for (var R = (l = void 0, a(f)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.link.store.getFreeCapacity(RESOURCE_ENERGY) < this.config.transferThreshold)) {
-if (T.role === cs.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
+if (T.role === us.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
 h = T;
 break;
 }
-if (T.role !== cs.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
+if (T.role !== us.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
 h = T;
 break;
 }
@@ -15583,25 +15585,25 @@ i.transferEnergy(m, l));
 var t = e.room, r = t.controller, o = t.storage, n = t.find(FIND_SOURCES), a = t.find(FIND_MY_SPAWNS);
 return this.classifyLinkRole(e, r, o, n, a);
 }, e.prototype.classifyLinkRole = function(e, t, r, o, n) {
-return t && e.pos.getRangeTo(t) <= 2 ? cs.CONTROLLER : o.some(function(t) {
+return t && e.pos.getRangeTo(t) <= 2 ? us.CONTROLLER : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 1;
-}) ? cs.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? cs.STORAGE : n.some(function(t) {
+}) ? us.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? us.STORAGE : n.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? cs.SPAWN : o.some(function(t) {
+}) ? us.SPAWN : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? cs.SOURCE : cs.UNKNOWN;
+}) ? us.SOURCE : us.UNKNOWN;
 }, e.prototype.getRolePriority = function(e) {
 switch (e) {
-case cs.CONTROLLER:
+case us.CONTROLLER:
 return 100;
 
-case cs.SPAWN:
+case us.SPAWN:
 return 75;
 
-case cs.STORAGE:
+case us.STORAGE:
 return 50;
 
-case cs.SOURCE:
+case us.SOURCE:
 return 10;
 
 default:
@@ -15617,34 +15619,34 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (r.length < 2) return !1;
 var o = this.classifyLinks(e, r), n = o.some(function(e) {
-return e.role === cs.SOURCE;
+return e.role === us.SOURCE;
 }), a = o.some(function(e) {
-return e.role === cs.CONTROLLER || e.role === cs.STORAGE;
+return e.role === us.CONTROLLER || e.role === us.STORAGE;
 });
 return n && a;
-}, n([ Qe("link:manager", "Link Manager", {
-priority: Pe.MEDIUM,
+}, n([ Xe("link:manager", "Link Manager", {
+priority: Ie.MEDIUM,
 interval: 5,
 minBucket: 0,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), ps = new ds;
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), fs = new ps;
 
-function fs(e) {
+function ys(e) {
 return "string" == typeof e.roomName && e.roomName.length > 0;
 }
 
-function ys(e) {
+function vs(e) {
 var t, r;
 return Math.max(0, null !== (r = null !== (t = e.remainingAmount) && void 0 !== t ? t : e.amount) && void 0 !== r ? r : 0);
 }
 
-function vs(e, t) {
+function gs(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var gs, hs, Rs, Es, Ts, Cs, Ss, ws, xs, bs, Os, ks = {
+var hs, Rs, Es, Ts, Cs, Ss, ws, xs, bs, Os, ks, Ms = {
 updateInterval: 100,
 priceUpdateInterval: 500,
 minBucket: 2e3,
@@ -15662,14 +15664,14 @@ highPriceMultiplier: 1.1,
 trendChangeThreshold: .05,
 buyOpportunityAdjustment: 1.02,
 sellOpportunityAdjustment: .98,
-sellThresholds: (ls = {}, ls[RESOURCE_ENERGY] = 5e5, ls[RESOURCE_HYDROGEN] = 2e4,
-ls[RESOURCE_OXYGEN] = 2e4, ls[RESOURCE_UTRIUM] = 2e4, ls[RESOURCE_LEMERGIUM] = 2e4,
-ls[RESOURCE_KEANIUM] = 2e4, ls[RESOURCE_ZYNTHIUM] = 2e4, ls[RESOURCE_CATALYST] = 2e4,
-ls),
-buyThresholds: (ms = {}, ms[RESOURCE_ENERGY] = 1e5, ms[RESOURCE_HYDROGEN] = 5e3,
-ms[RESOURCE_OXYGEN] = 5e3, ms[RESOURCE_UTRIUM] = 5e3, ms[RESOURCE_LEMERGIUM] = 5e3,
-ms[RESOURCE_KEANIUM] = 5e3, ms[RESOURCE_ZYNTHIUM] = 5e3, ms[RESOURCE_CATALYST] = 5e3,
+sellThresholds: (ms = {}, ms[RESOURCE_ENERGY] = 5e5, ms[RESOURCE_HYDROGEN] = 2e4,
+ms[RESOURCE_OXYGEN] = 2e4, ms[RESOURCE_UTRIUM] = 2e4, ms[RESOURCE_LEMERGIUM] = 2e4,
+ms[RESOURCE_KEANIUM] = 2e4, ms[RESOURCE_ZYNTHIUM] = 2e4, ms[RESOURCE_CATALYST] = 2e4,
 ms),
+buyThresholds: (ds = {}, ds[RESOURCE_ENERGY] = 1e5, ds[RESOURCE_HYDROGEN] = 5e3,
+ds[RESOURCE_OXYGEN] = 5e3, ds[RESOURCE_UTRIUM] = 5e3, ds[RESOURCE_LEMERGIUM] = 5e3,
+ds[RESOURCE_KEANIUM] = 5e3, ds[RESOURCE_ZYNTHIUM] = 5e3, ds[RESOURCE_CATALYST] = 5e3,
+ds),
 trackedResources: [ RESOURCE_ENERGY, RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_UTRIUM, RESOURCE_LEMERGIUM, RESOURCE_KEANIUM, RESOURCE_ZYNTHIUM, RESOURCE_CATALYST, RESOURCE_GHODIUM, RESOURCE_POWER ],
 criticalResources: [ RESOURCE_ENERGY, RESOURCE_GHODIUM ],
 emergencyBuyThreshold: 5e3,
@@ -15687,47 +15689,47 @@ minArbitrageMargin: .05,
 energyOverflowStorageEnter: 8e5,
 energyOverflowStorageExit: 5e5,
 minOverflowEnergySellAmount: 1e3
-}, Ms = function() {
+}, As = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedEmpireTick = -1, this.cachedEmpire = null,
 this.cachedTick = -1, this.cachedMarketOrders = new Map, this.cachedMarketOrderDealAmounts = new Map,
 this.cachedOwnedRooms = null, this.cachedOwnedTerminalRooms = null, this.cachedReadyOwnedTerminalRooms = null,
-this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, ks), e);
+this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, Ms), e);
 }
 return e.prototype.run = function() {
 var e = this;
 this.lastRun = Game.time, this.cachedEmpireTick = -1, this.cachedEmpire = null,
-vs("market.ensureMemory", function() {
+gs("market.ensureMemory", function() {
 return e.ensureMarketMemory();
-}), Game.time % this.config.priceUpdateInterval === 0 && vs("market.updatePriceTracking", function() {
+}), Game.time % this.config.priceUpdateInterval === 0 && gs("market.updatePriceTracking", function() {
 return e.updatePriceTracking();
-}), vs("market.updateOrderStats", function() {
+}), gs("market.updateOrderStats", function() {
 return e.updateOrderStats();
-}), vs("market.reconcilePendingArbitrage", function() {
+}), gs("market.reconcilePendingArbitrage", function() {
 return e.reconcilePendingArbitrage();
-}), vs("market.handleEmergencyBuying", function() {
+}), gs("market.handleEmergencyBuying", function() {
 return e.handleEmergencyBuying();
-}), vs("market.cancelOldOrders", function() {
+}), gs("market.cancelOldOrders", function() {
 return e.cancelOldOrders();
-}), vs("market.manageExistingOrders", function() {
+}), gs("market.manageExistingOrders", function() {
 return e.manageExistingOrders();
-}), this.canRunActiveTrading() && (vs("market.updateBuyOrders", function() {
+}), this.canRunActiveTrading() && (gs("market.updateBuyOrders", function() {
 return e.updateBuyOrders();
-}), vs("market.handleEnergyOverflowSales", function() {
+}), gs("market.handleEnergyOverflowSales", function() {
 return e.handleEnergyOverflowSales();
-}), vs("market.updateSellOrders", function() {
+}), gs("market.updateSellOrders", function() {
 return e.updateSellOrders();
-}), vs("market.checkArbitrageOpportunities", function() {
+}), gs("market.checkArbitrageOpportunities", function() {
 return e.checkArbitrageOpportunities();
-}), vs("market.executeDeal", function() {
+}), gs("market.executeDeal", function() {
 return e.executeDeal();
-}), Game.time % 200 == 0 && vs("market.balanceResourcesAcrossRooms", function() {
+}), Game.time % 200 == 0 && gs("market.balanceResourcesAcrossRooms", function() {
 return e.balanceResourcesAcrossRooms();
 }));
 }, e.prototype.canRunActiveTrading = function() {
 return Game.cpu.bucket >= this.config.activeTradingMinBucket;
 }, e.prototype.getEmpireMemory = function() {
-return this.cachedEmpireTick === Game.time && this.cachedEmpire || (this.cachedEmpire = Sr.getEmpire(),
+return this.cachedEmpireTick === Game.time && this.cachedEmpire || (this.cachedEmpire = wr.getEmpire(),
 this.cachedEmpireTick = Game.time), this.cachedEmpire;
 }, e.prototype.ensureTickCaches = function() {
 this.cachedTick !== Game.time && (this.cachedTick = Game.time, this.cachedMarketOrders.clear(),
@@ -15752,7 +15754,7 @@ remainingAmount: Math.max(0, e.remainingAmount - n)
 var r;
 t <= 0 || (this.ensureTickCaches(), this.cachedMarketOrderDealAmounts.set(e, (null !== (r = this.cachedMarketOrderDealAmounts.get(e)) && void 0 !== r ? r : 0) + t));
 }, e.prototype.getOwnedRooms = function() {
-return this.ensureTickCaches(), this.cachedOwnedRooms || (this.cachedOwnedRooms = Tt()),
+return this.ensureTickCaches(), this.cachedOwnedRooms || (this.cachedOwnedRooms = Ct()),
 this.cachedOwnedRooms;
 }, e.prototype.getOwnedTerminalRooms = function() {
 return this.ensureTickCaches(), this.cachedOwnedTerminalRooms || (this.cachedOwnedTerminalRooms = this.getOwnedRooms().filter(function(e) {
@@ -16138,8 +16140,8 @@ energyCreditValue: this.config.energyCreditValue,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}, u.orders.filter(fs).map(function(e) {
-var t = Math.min(u.requestedAmount, ys(e), u.maxDealAmount);
+}, u.orders.filter(ys).map(function(e) {
+var t = Math.min(u.requestedAmount, vs(e), u.maxDealAmount);
 if (!(t <= 0)) {
 var r = u.calcTransactionCost(t, u.sourceRoomName, e.roomName), o = e.price * t - r * u.energyCreditValue;
 return {
@@ -16358,8 +16360,8 @@ maxDealAmount: this.config.maxActiveBuyAmount,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}).orders.filter(fs).map(function(e) {
-var t = Math.min(ys(e), m.maxDealAmount, m.requestedAmount);
+}).orders.filter(ys).map(function(e) {
+var t = Math.min(vs(e), m.maxDealAmount, m.requestedAmount);
 if (!(t <= 0)) {
 var r = m.calcTransactionCost(t, e.roomName, m.destinationRoomName);
 return {
@@ -16622,13 +16624,13 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-}, n([ Xe("empire:market", "Market Manager", {
-priority: Pe.LOW,
+}, n([ Ze("empire:market", "Market Manager", {
+priority: Ie.LOW,
 interval: 100,
 minBucket: 2e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), As = new Ms, Us = function() {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), Us = new As, _s = function() {
 function e() {
 this.costCache = new Map, this.COST_CACHE_TTL = 100, this.MAX_HOPS = 3;
 }
@@ -16755,7 +16757,7 @@ if (e) throw e.error;
 var r = e.path.indexOf(t);
 return -1 === r || r === e.path.length - 1 ? null : e.path[r + 1] || null;
 }, e;
-}(), _s = new Us, Ns = {
+}(), Ns = new _s, Ps = {
 minBucket: 0,
 minStorageEnergy: 5e4,
 terminalEnergyTarget: 2e4,
@@ -16770,9 +16772,9 @@ emergencyDangerThreshold: 2,
 emergencyEnergyAmount: 2e4,
 energySurplusThreshold: 5e4,
 mineralSurplusThreshold: 5e3
-}, Ps = function() {
+}, Is = function() {
 function e(e) {
-void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, Ns), e);
+void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, Ps), e);
 }
 return e.prototype.requestTransfer = function(e, t, r, o, n) {
 if (void 0 === n && (n = 3), this.transferQueue.some(function(o) {
@@ -16794,10 +16796,10 @@ subsystem: "Terminal"
 }), !1);
 }, e.prototype.run = function() {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
-var e = Tt().filter(function(e) {
+var e = Ct().filter(function(e) {
 return e.terminal && e.terminal.my && e.terminal.isActive();
 });
-0 !== e.length && (_s.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
+0 !== e.length && (Ns.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
 e.length < 2 || (this.checkEmergencyTransfers(e), this.balanceEnergy(e), this.balanceMinerals(e),
 this.executeTransfers(e)));
 }
@@ -16809,7 +16811,7 @@ return !!(t && r && t.terminal && r.terminal);
 }, e.prototype.checkEmergencyTransfers = function(e) {
 var t, r, o, n, i = this, s = function(t) {
 if (!(null === (o = t.controller) || void 0 === o ? void 0 : o.my)) return "continue";
-var r = Sr.getSwarmState(t.name);
+var r = wr.getSwarmState(t.name);
 if (!r) return "continue";
 if (r.danger >= c.config.emergencyDangerThreshold) {
 var a = t.storage, s = t.terminal;
@@ -16825,7 +16827,7 @@ var l = u[0];
 if (!c.transferQueue.some(function(e) {
 return e.toRoom === t.name && e.resourceType === RESOURCE_ENERGY && e.isEmergency;
 })) {
-var m = _s.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
+var m = Ns.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
 m && (c.transferQueue.push({
 fromRoom: l.name,
 toRoom: t.name,
@@ -16880,7 +16882,7 @@ var r, o, n, i, s, c;
 U.info("Auto-clearing terminal ".concat(e.name, " (").concat((t.store.getUsedCapacity() / t.store.getCapacity() * 100).toFixed(1), "% full)"), {
 subsystem: "Terminal"
 });
-var u, l = Sr.getClusters();
+var u, l = wr.getClusters();
 for (var m in l) {
 var d = l[m];
 if (d.memberRooms.includes(e.name)) {
@@ -16916,7 +16918,7 @@ var w = C - S;
 if (u && u !== e.name) {
 var x = null === (c = Game.rooms[u]) || void 0 === c ? void 0 : c.terminal;
 if (x && x.store.getFreeCapacity() > w) {
-var b = _s.findOptimalRoute(e.name, u, w);
+var b = Ns.findOptimalRoute(e.name, u, w);
 if (b) {
 this.transferQueue.push({
 fromRoom: e.name,
@@ -16932,7 +16934,7 @@ continue;
 }
 }
 }
-Game.time % 10 == 0 && As.sellSurplusFromTerminal(e.name, T, w) && U.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
+Game.time % 10 == 0 && Us.sellSurplusFromTerminal(e.name, T, w) && U.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
 subsystem: "Terminal"
 });
 }
@@ -16977,7 +16979,7 @@ return r.fromRoom === t.room.name && r.toRoom === e.room.name && r.resourceType 
 })) return "continue";
 var r = Math.min(Math.floor((t.totalEnergy - u.config.energySendThreshold) / 2), u.config.energyRequestThreshold - e.totalEnergy, t.terminal.store.getUsedCapacity(RESOURCE_ENERGY));
 if (r < u.config.minTransferAmount) return "continue";
-var o = _s.findOptimalRoute(t.room.name, e.room.name, r);
+var o = Ns.findOptimalRoute(t.room.name, e.room.name, r);
 if (!o) return "continue";
 var n = o.cost / r;
 if (n > u.config.maxTransferCostRatio) return U.debug("Skipping terminal transfer from ".concat(t.room.name, " to ").concat(e.room.name, ": cost ratio ").concat(n.toFixed(2), " too high"), {
@@ -17112,7 +17114,7 @@ var a = r.terminal;
 if (a.cooldown > 0) return "continue";
 var i = t.toRoom;
 if (t.route && !t.route.isDirect) {
-var c = _s.getNextHop(t.route, t.fromRoom);
+var c = Ns.getNextHop(t.route, t.fromRoom);
 c && (i = c);
 }
 var u = null === (o = Game.rooms[i]) || void 0 === o ? void 0 : o.terminal;
@@ -17270,36 +17272,36 @@ S && !S.done && (u = C.return) && u.call(C);
 if (c) throw c.error;
 }
 }
-}, n([ Qe("terminal:manager", "Terminal Manager", {
-priority: Pe.MEDIUM,
+}, n([ Xe("terminal:manager", "Terminal Manager", {
+priority: Ie.MEDIUM,
 interval: 20,
 minBucket: 0,
 cpuBudget: .1
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Is = new Ps, Gs = {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), Gs = new Is, Ls = {
 minBucket: 0,
 minStorageEnergy: 8e4,
 inputBufferAmount: 2e3,
 outputBufferAmount: 5e3
-}, Ls = ((gs = {})[RESOURCE_UTRIUM_BAR] = ((hs = {})[RESOURCE_UTRIUM] = 500, hs[RESOURCE_ENERGY] = 200,
-hs), gs[RESOURCE_LEMERGIUM_BAR] = ((Rs = {})[RESOURCE_LEMERGIUM] = 500, Rs[RESOURCE_ENERGY] = 200,
-Rs), gs[RESOURCE_ZYNTHIUM_BAR] = ((Es = {})[RESOURCE_ZYNTHIUM] = 500, Es[RESOURCE_ENERGY] = 200,
-Es), gs[RESOURCE_KEANIUM_BAR] = ((Ts = {})[RESOURCE_KEANIUM] = 500, Ts[RESOURCE_ENERGY] = 200,
-Ts), gs[RESOURCE_GHODIUM_MELT] = ((Cs = {})[RESOURCE_GHODIUM] = 500, Cs[RESOURCE_ENERGY] = 200,
-Cs), gs[RESOURCE_OXIDANT] = ((Ss = {})[RESOURCE_OXYGEN] = 500, Ss[RESOURCE_ENERGY] = 200,
-Ss), gs[RESOURCE_REDUCTANT] = ((ws = {})[RESOURCE_HYDROGEN] = 500, ws[RESOURCE_ENERGY] = 200,
-ws), gs[RESOURCE_PURIFIER] = ((xs = {})[RESOURCE_CATALYST] = 500, xs[RESOURCE_ENERGY] = 200,
-xs), gs[RESOURCE_BATTERY] = ((bs = {})[RESOURCE_ENERGY] = 600, bs), gs), Ds = ((Os = {})[RESOURCE_BATTERY] = 10,
-Os[RESOURCE_UTRIUM_BAR] = 5, Os[RESOURCE_LEMERGIUM_BAR] = 5, Os[RESOURCE_ZYNTHIUM_BAR] = 5,
-Os[RESOURCE_KEANIUM_BAR] = 5, Os[RESOURCE_GHODIUM_MELT] = 4, Os[RESOURCE_OXIDANT] = 3,
-Os[RESOURCE_REDUCTANT] = 3, Os[RESOURCE_PURIFIER] = 3, Os), Bs = function() {
+}, Ds = ((hs = {})[RESOURCE_UTRIUM_BAR] = ((Rs = {})[RESOURCE_UTRIUM] = 500, Rs[RESOURCE_ENERGY] = 200,
+Rs), hs[RESOURCE_LEMERGIUM_BAR] = ((Es = {})[RESOURCE_LEMERGIUM] = 500, Es[RESOURCE_ENERGY] = 200,
+Es), hs[RESOURCE_ZYNTHIUM_BAR] = ((Ts = {})[RESOURCE_ZYNTHIUM] = 500, Ts[RESOURCE_ENERGY] = 200,
+Ts), hs[RESOURCE_KEANIUM_BAR] = ((Cs = {})[RESOURCE_KEANIUM] = 500, Cs[RESOURCE_ENERGY] = 200,
+Cs), hs[RESOURCE_GHODIUM_MELT] = ((Ss = {})[RESOURCE_GHODIUM] = 500, Ss[RESOURCE_ENERGY] = 200,
+Ss), hs[RESOURCE_OXIDANT] = ((ws = {})[RESOURCE_OXYGEN] = 500, ws[RESOURCE_ENERGY] = 200,
+ws), hs[RESOURCE_REDUCTANT] = ((xs = {})[RESOURCE_HYDROGEN] = 500, xs[RESOURCE_ENERGY] = 200,
+xs), hs[RESOURCE_PURIFIER] = ((bs = {})[RESOURCE_CATALYST] = 500, bs[RESOURCE_ENERGY] = 200,
+bs), hs[RESOURCE_BATTERY] = ((Os = {})[RESOURCE_ENERGY] = 600, Os), hs), Bs = ((ks = {})[RESOURCE_BATTERY] = 10,
+ks[RESOURCE_UTRIUM_BAR] = 5, ks[RESOURCE_LEMERGIUM_BAR] = 5, ks[RESOURCE_ZYNTHIUM_BAR] = 5,
+ks[RESOURCE_KEANIUM_BAR] = 5, ks[RESOURCE_GHODIUM_MELT] = 4, ks[RESOURCE_OXIDANT] = 3,
+ks[RESOURCE_REDUCTANT] = 3, ks[RESOURCE_PURIFIER] = 3, ks), Fs = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Gs), e);
+void 0 === e && (e = {}), this.config = o(o({}, Ls), e);
 }
 return e.prototype.run = function() {
 var e, t;
 if (!(Game.cpu.bucket < this.config.minBucket)) {
-var r = Tt().filter(function(e) {
+var r = Ct().filter(function(e) {
 return e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_FACTORY;
@@ -17336,7 +17338,7 @@ var s = e.storage;
 if (s && !(s.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.minStorageEnergy)) {
 var c = this.selectProduction(e, n, s);
 if (c) {
-var u = Ls[c];
+var u = Ds[c];
 if (u) {
 var l = !0;
 try {
@@ -17374,7 +17376,7 @@ subsystem: "Factory"
 }, e.prototype.selectProduction = function(e, t, r) {
 var o, n, s, c, u, l = [];
 try {
-for (var m = a(Object.entries(Ls)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Object.entries(Ds)), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1], v = f, g = !0, h = 0;
 try {
 for (var R = (s = void 0, a(Object.entries(y))), E = R.next(); !E.done; E = R.next()) {
@@ -17399,7 +17401,7 @@ if (s) throw s.error;
 if (g) {
 var b = t.store.getUsedCapacity(v) + r.store.getUsedCapacity(v);
 if (!(b > this.config.outputBufferAmount)) {
-var O = null !== (u = Ds[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
+var O = null !== (u = Bs[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
 l.push({
 commodity: v,
 priority: O,
@@ -17427,7 +17429,7 @@ var r, o, n = t.storage;
 if (!n) return [];
 var s = this.selectProduction(t, e, n);
 if (!s) return [];
-var c = Ls[s];
+var c = Ds[s];
 if (!c) return [];
 var u = [];
 try {
@@ -17453,7 +17455,7 @@ return u;
 }, e.prototype.hasOutputsToRemove = function(e) {
 var t, r;
 try {
-for (var o = a(Object.keys(Ls)), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Object.keys(Ds)), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 if (e.store.getUsedCapacity(i) > 0) return !0;
 }
@@ -17479,13 +17481,13 @@ return e.structureType === STRUCTURE_LAB;
 return t.filter(function(e) {
 return e.cooldown > 0;
 }).length < t.length / 2 || 0 === t.length;
-}, n([ Qe("factory:manager", "Factory Manager", {
-priority: Pe.LOW,
+}, n([ Xe("factory:manager", "Factory Manager", {
+priority: Ie.LOW,
 interval: 30,
 minBucket: 0,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), Fs = new Bs, Ws = {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), Ws = new Fs, Hs = {
 updateInterval: 500,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -17497,7 +17499,7 @@ opportunityConfidenceThreshold: .7
 !function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.supplyDemandCache = new Map, this.opportunities = [],
-this.config = o(o({}, Ws), e);
+this.config = o(o({}, Hs), e);
 }
 e.prototype.run = function() {
 var e, t, r = Game.cpu.getUsed();
@@ -17550,7 +17552,7 @@ tightness: 1 - Math.min(1, l / 1e6) * (1 - Math.min(1, 10 * m)),
 lastUpdate: Game.time
 };
 }, e.prototype.detectTradingOpportunities = function() {
-var e, t, r, o, n, i, s, c, u, l, m, d = Sr.getEmpire(), p = [];
+var e, t, r, o, n, i, s, c, u, l, m, d = wr.getEmpire(), p = [];
 try {
 for (var f = a(this.config.trackedResources), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = null === (n = d.market) || void 0 === n ? void 0 : n.resources[v];
@@ -17654,22 +17656,22 @@ return null !== (t = null == r ? void 0 : r.sentiment) && void 0 !== t ? t : 0;
 }, e.prototype.isMarketTight = function(e) {
 var t, r = this.supplyDemandCache.get(e);
 return (null !== (t = null == r ? void 0 : r.tightness) && void 0 !== t ? t : 0) > .7;
-}, n([ Xe("empire:marketTrends", "Market Trend Analyzer", {
-priority: Pe.LOW,
+}, n([ Ze("empire:marketTrends", "Market Trend Analyzer", {
+priority: Ie.LOW,
 interval: 500,
 minBucket: 2e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), e = n([ Je() ], e);
+}) ], e.prototype, "run", null), e = n([ $e() ], e);
 }();
 
-var Hs, Ks = 5e4;
+var Ks, Ys = 5e4;
 
-function Ys(e) {
+function Vs(e) {
 var t;
 return null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== t ? t : 0;
 }
 
-var Vs = {
+var qs = {
 updateInterval: 500,
 minGhodium: 5e3,
 minEnergy: 3e5,
@@ -17681,35 +17683,35 @@ donorRoomBuffer: 1e3,
 salvoSyncWindow: 10,
 roiThreshold: 2,
 counterNukeWarThreshold: 60
-}, qs = 1e7, js = 5e6, zs = ((Hs = {})[STRUCTURE_SPAWN] = 15e3, Hs[STRUCTURE_TOWER] = 5e3,
-Hs[STRUCTURE_STORAGE] = 3e4, Hs[STRUCTURE_TERMINAL] = 1e5, Hs[STRUCTURE_LAB] = 5e4,
-Hs[STRUCTURE_NUKER] = 1e5, Hs[STRUCTURE_POWER_SPAWN] = 1e5, Hs[STRUCTURE_OBSERVER] = 8e3,
-Hs[STRUCTURE_EXTENSION] = 3e3, Hs[STRUCTURE_LINK] = 5e3, Hs), Qs = new Map, Xs = -1, Zs = new WeakMap;
+}, js = 1e7, zs = 5e6, Qs = ((Ks = {})[STRUCTURE_SPAWN] = 15e3, Ks[STRUCTURE_TOWER] = 5e3,
+Ks[STRUCTURE_STORAGE] = 3e4, Ks[STRUCTURE_TERMINAL] = 1e5, Ks[STRUCTURE_LAB] = 5e4,
+Ks[STRUCTURE_NUKER] = 1e5, Ks[STRUCTURE_POWER_SPAWN] = 1e5, Ks[STRUCTURE_OBSERVER] = 8e3,
+Ks[STRUCTURE_EXTENSION] = 3e3, Ks[STRUCTURE_LINK] = 5e3, Ks), Xs = new Map, Zs = -1, Js = new WeakMap;
 
-function Js(e) {
+function $s(e) {
 var t = "undefined" != typeof Game && Number.isFinite(Game.time) ? Game.time : -1;
-t !== Xs && (Qs.clear(), Xs = t);
-var r = Qs.get(e.name);
+t !== Zs && (Xs.clear(), Zs = t);
+var r = Xs.get(e.name);
 if ((null == r ? void 0 : r.room) === e && r.tick === t) return r.nukes;
 var o = e.find(FIND_NUKES);
-return Qs.set(e.name, {
+return Xs.set(e.name, {
 room: e,
 tick: t,
 nukes: o
 }), o;
 }
 
-function $s(e, t, r, o) {
+function ec(e, t, r, o) {
 var n;
 if (!function(e, t) {
-var r = Zs.get(e);
+var r = Js.get(e);
 return (null == r ? void 0 : r.get(t)) === Game.time;
 }(e, t.name)) {
 !function(e, t) {
-var r = Zs.get(e);
-r || (r = new Map, Zs.set(e, r)), r.set(t, Game.time);
+var r = Js.get(e);
+r || (r = new Map, Js.set(e, r)), r.set(t, Game.time);
 }(e, t.name);
-var i = null != o ? o : Js(t);
+var i = null != o ? o : $s(t);
 if (i.length > 0) {
 var s = null !== (n = e.incomingNukes) && void 0 !== n ? n : e.incomingNukes = [];
 i.forEach(function(e, o) {
@@ -17739,7 +17741,7 @@ try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value.structure, l = Math.abs(u.pos.x - t.x), m = Math.abs(u.pos.y - t.y), d = Math.max(l, m);
 if (d <= 2) {
-var p = 0 === d ? qs : js;
+var p = 0 === d ? js : zs;
 u.hits <= p && n.push("".concat(u.structureType, "-").concat(u.pos.x, ",").concat(u.pos.y));
 }
 }
@@ -17772,13 +17774,13 @@ subsystem: "Nuke"
 }
 }
 
-function ec(e) {
+function tc(e) {
 return !!e.threatenedStructures && e.threatenedStructures.some(function(e) {
 return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
 });
 }
 
-function tc(e, t) {
+function rc(e, t) {
 var r = {
 empire: t
 };
@@ -17790,18 +17792,18 @@ return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 });
 }
 
-function rc(e, t) {
+function oc(e, t) {
 var r, o, n;
 if (!e) return !1;
 var a = null === (r = t.knownRooms) || void 0 === r ? void 0 : r[e], i = Game.rooms[e], s = null == i ? void 0 : i.controller, c = {
 empire: t
 };
 return j(e, c) || j(null == a ? void 0 : a.owner, c) || j(null == a ? void 0 : a.reserver, c) || j(null === (o = null == s ? void 0 : s.owner) || void 0 === o ? void 0 : o.username, c) || j(null === (n = null == s ? void 0 : s.reservation) || void 0 === n ? void 0 : n.username, c) || !!i && function(e, t) {
-return tc(e.find(FIND_CREEPS), t) || tc(e.find(FIND_POWER_CREEPS), t) || tc(e.find(FIND_STRUCTURES), t) || tc(e.find(FIND_CONSTRUCTION_SITES), t);
+return rc(e.find(FIND_CREEPS), t) || rc(e.find(FIND_POWER_CREEPS), t) || rc(e.find(FIND_STRUCTURES), t) || rc(e.find(FIND_CONSTRUCTION_SITES), t);
 }(i, t);
 }
 
-function oc(e, t, r) {
+function nc(e, t, r) {
 t.timeToLand < 5e3 ? (r.posture = "evacuate", U.warn("EVACUATION TRIGGERED for ".concat(e.name, ": Critical structures threatened by nuke!"), {
 subsystem: "Nuke"
 })) : ("war" !== r.posture && "evacuate" !== r.posture && (r.posture = "defensive"),
@@ -17810,7 +17812,7 @@ subsystem: "Nuke"
 })), r.pheromones.defense = 100;
 }
 
-function nc() {
+function ac() {
 var e, t = 0, r = 0;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
@@ -17820,14 +17822,14 @@ n.terminal && (t += n.terminal.store.getUsedCapacity(RESOURCE_ENERGY) || 0, r +=
 return t >= 6e5 && r >= 1e4;
 }
 
-function ac(e, t, r, o) {
+function ic(e, t, r, o) {
 var n = 0, a = [], c = t.knownRooms[e];
 if (!c) return {
 roomName: e,
 score: 0,
 reasons: [ "No intel" ]
 };
-if (rc(e, t)) return {
+if (oc(e, t)) return {
 roomName: e,
 score: 0,
 reasons: [ "Allied room" ]
@@ -17854,7 +17856,7 @@ return Game.map.getRoomLinearDistance(e, t.name);
 n -= 2 * d, a.push("".concat(d, " rooms away"));
 }
 t.warTargets.includes(e) && (n += 15, a.push("War target"));
-var p = new RoomPosition(25, 25, e), f = sc(e, p, t);
+var p = new RoomPosition(25, 25, e), f = cc(e, p, t);
 return f >= r.roiThreshold ? (n += Math.min(20, Math.floor(5 * f)), a.push("ROI: ".concat(f.toFixed(1), "x"))) : (n -= 20,
 a.push("Low ROI: ".concat(f.toFixed(1), "x"))), {
 roomName: e,
@@ -17863,7 +17865,7 @@ reasons: a
 };
 }
 
-function ic(e, t, r) {
+function sc(e, t, r) {
 var o, n, i = {
 estimatedDamage: 0,
 estimatedValue: 0,
@@ -17873,16 +17875,16 @@ if (!s) {
 var c = r.knownRooms[e];
 if (c) {
 var u = 5 * (c.towerCount || 0) + 10 * (c.spawnCount || 0) + 5;
-i.estimatedDamage = qs + js * u, i.estimatedValue = .01 * i.estimatedDamage;
+i.estimatedDamage = js + zs * u, i.estimatedValue = .01 * i.estimatedDamage;
 }
 return i;
 }
 var l = s.lookForAtArea(LOOK_STRUCTURES, Math.max(0, t.y - 2), Math.max(0, t.x - 2), Math.min(49, t.y + 2), Math.min(49, t.x + 2), !0);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
-var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? qs : js;
+var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? js : zs;
 p.hits <= v ? (i.estimatedDamage += p.hits, i.threatenedStructures.push("".concat(p.structureType, "-").concat(p.pos.x, ",").concat(p.pos.y)),
-i.estimatedValue += cc(p)) : i.estimatedDamage += v;
+i.estimatedValue += uc(p)) : i.estimatedDamage += v;
 }
 } catch (e) {
 o = {
@@ -17898,16 +17900,16 @@ if (o) throw o.error;
 return i;
 }
 
-function sc(e, t, r) {
-var o = ic(e, t, r);
+function cc(e, t, r) {
+var o = sc(e, t, r);
 return 0 === o.estimatedValue ? 0 : o.estimatedValue / 305e3;
 }
 
-function cc(e) {
-return zs[e.structureType] || 1e3;
+function uc(e) {
+return Qs[e.structureType] || 1e3;
 }
 
-function uc(e) {
+function lc(e) {
 if (e.nukesInFlight && (e.nukesInFlight = e.nukesInFlight.filter(function(e) {
 return e.impactTick > Game.time;
 })), e.incomingNukes) {
@@ -17922,7 +17924,7 @@ subsystem: "Nuke"
 }
 }
 
-function lc(e, t) {
+function mc(e, t) {
 var r, o, n;
 if (e.siegeSquadId) {
 try {
@@ -17950,7 +17952,7 @@ delete e.siegeSquadId;
 }
 }
 
-function mc(e, t, r) {
+function dc(e, t, r) {
 var o, n, i, s = null;
 try {
 for (var c = a(Object.values(t)), u = c.next(); !u.done; u = c.next()) {
@@ -18000,9 +18002,9 @@ subsystem: "Nuke"
 }), !0;
 }
 
-var dc = function() {
+var pc = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, Vs), e),
+void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, qs), e),
 this.getEmpire = t.getEmpire, this.getSwarmState = t.getSwarmState, this.getClusters = t.getClusters;
 }
 return e.prototype.run = function(e) {
@@ -18026,14 +18028,14 @@ for (var o in Game.rooms) {
 var n = Game.rooms[o];
 if (null === (r = n.controller) || void 0 === r ? void 0 : r.my) {
 var a = t(o);
-a && $s(e, n, a);
+a && ec(e, n, a);
 }
 }
 }(r, this.getSwarmState), this.handleEvacuations(r), this.recordCpu("defensiveObservationCpu", n),
 o) {
 var a = this.getCpuUsed();
 this.runOffensiveCoordination(r), this.recordCpu("offensiveCoordinationCpu", a);
-} else uc(r);
+} else lc(r);
 }, e.prototype.runOffensiveCoordination = function(e) {
 var t = this;
 !function(e, t, r, o) {
@@ -18043,7 +18045,7 @@ for (var c = a(e.incomingNukes), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.sourceRoom && !e.warTargets.includes(l.sourceRoom)) {
 var m = e.knownRooms[l.sourceRoom];
-if (m) if (rc(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
+if (m) if (oc(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
 subsystem: "Nuke"
 }); else if (!(m.controllerLevel < 8)) {
 var d = r(l.roomName);
@@ -18072,7 +18074,7 @@ u && !u.done && (i = c.return) && i.call(c);
 if (n) throw n.error;
 }
 }
-}(e, this.config, this.getSwarmState, nc), function(e, t, r, o) {
+}(e, this.config, this.getSwarmState, ac), function(e, t, r, o) {
 var n, a;
 if (e.objectives.warMode) for (var i in Game.rooms) {
 var s = Game.rooms[i];
@@ -18124,10 +18126,10 @@ if (e.nukeCandidates = [], e.objectives.warMode) {
 try {
 for (var i = a(e.warTargets), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (rc(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
+if (oc(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
 subsystem: "Nuke"
 }); else {
-var u = ac(c, e, t, r);
+var u = ic(c, e, t, r);
 u.score >= t.minScore && (e.nukeCandidates.push({
 roomName: c,
 score: u.score,
@@ -18171,11 +18173,11 @@ var d = r();
 try {
 for (var p = a(e.nukesInFlight), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (rc(y.targetRoom, e)) lc(y, d), U.warn("Skipping siege coordination for allied nuke target ".concat(y.targetRoom), {
+if (oc(y.targetRoom, e)) mc(y, d), U.warn("Skipping siege coordination for allied nuke target ".concat(y.targetRoom), {
 subsystem: "Nuke"
 }); else {
 var v = y.impactTick - Game.time;
-y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && mc(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
+y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && dc(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
 subsystem: "Nuke"
 });
 }
@@ -18204,7 +18206,7 @@ if (!r) return "continue";
 var o = null === (m = e.nukesInFlight) || void 0 === m ? void 0 : m.find(function(e) {
 return e.targetRoom === r;
 });
-if (rc(r, e)) return (null == o ? void 0 : o.siegeSquadId) === t.id && (delete o.siegeSquadId,
+if (oc(r, e)) return (null == o ? void 0 : o.siegeSquadId) === t.id && (delete o.siegeSquadId,
 t.state = "dissolving"), "continue";
 o && !o.siegeSquadId && (o.siegeSquadId = t.id, U.info("Linked siege squad ".concat(t.id, " with nuke on ").concat(r), {
 subsystem: "Nuke"
@@ -18314,14 +18316,14 @@ return e.structureType === STRUCTURE_NUKER;
 if (0 !== c.length) try {
 for (var m = a(e.nukeCandidates), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!p.launched) if (rc(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
+if (!p.launched) if (oc(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
 subsystem: "Nuke"
 }); else {
 try {
 for (var f = (n = void 0, a(c)), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (!(Game.map.getRoomLinearDistance(v.room.name, p.roomName) > 10)) {
-var g = new RoomPosition(25, 25, p.roomName), h = ic(p.roomName, g, e), R = sc(p.roomName, g, e);
+var g = new RoomPosition(25, 25, p.roomName), h = sc(p.roomName, g, e), R = cc(p.roomName, g, e);
 if (R < t.roiThreshold) U.warn("Skipping nuke launch on ".concat(p.roomName, ": ROI ").concat(R.toFixed(2), "x below threshold ").concat(t.roiThreshold, "x"), {
 subsystem: "Nuke"
 }); else {
@@ -18388,7 +18390,7 @@ if (r) throw r.error;
 }
 }
 }
-}(e, this.config), uc(e);
+}(e, this.config), lc(e);
 }, e.prototype.getCpuUsed = function() {
 var e;
 return "undefined" != typeof Game && "function" == typeof (null === (e = Game.cpu) || void 0 === e ? void 0 : e.getUsed) ? Game.cpu.getUsed() : void 0;
@@ -18405,11 +18407,11 @@ var t, r;
 if (e.incomingNukes) try {
 for (var o = a(e.incomingNukes), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-if (!i.evacuationTriggered && ec(i)) {
+if (!i.evacuationTriggered && tc(i)) {
 var s = Game.rooms[i.roomName];
 if (s) {
 var c = this.getSwarmState(i.roomName);
-c && (oc(s, i, c), i.evacuationTriggered = !0);
+c && (nc(s, i, c), i.evacuationTriggered = !0);
 }
 }
 }
@@ -18454,13 +18456,13 @@ subsystem: "Nuke"
 }) : U.debug("No donor room found for ".concat(r, " ").concat(t, " to ").concat(e), {
 subsystem: "Nuke"
 });
-}(e, t, r, this.config, Is);
+}(e, t, r, this.config, Gs);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e);
 }, e;
-}(), pc = [ {
+}(), fc = [ {
 carryParts: 4,
 capacity: 200,
 moveParts: 4,
@@ -18482,7 +18484,7 @@ moveParts: 24,
 cost: 2400
 } ];
 
-function fc(e, t, r, o, n) {
+function yc(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = {});
 var c = n.reserved, u = void 0 !== c && c, l = n.pathLength, m = n.terrainFactor, d = void 0 === m ? 1.2 : m, p = n.safetyBuffer, f = void 0 === p ? 1.2 : p, y = function(e, t) {
@@ -18505,9 +18507,9 @@ var r = 50 * e * t;
 return Math.ceil(2 * r);
 }(y, d), g = function(e, t) {
 return e * (t ? 3e3 : 1500) / 300;
-}(r, u), h = pc[0];
+}(r, u), h = fc[0];
 try {
-for (var R = a(pc), E = R.next(); !E.done; E = R.next()) {
+for (var R = a(fc), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.cost <= o)) break;
 h = T;
@@ -18536,7 +18538,7 @@ energyPerTick: g
 };
 }
 
-function yc(e) {
+function vc(e) {
 var t;
 return e ? null !== (t = {
 X: 15,
@@ -18549,12 +18551,12 @@ H: 8
 }[e]) && void 0 !== t ? t : 5 : 0;
 }
 
-function vc(e) {
-var t, r, o = Sr.getEmpire(), n = 0, i = Cc(e);
+function gc(e) {
+var t, r, o = wr.getEmpire(), n = 0, i = Sc(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-l && (l.owner && !Sc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
+l && (l.owner && !wc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
 l.towerCount && l.towerCount > 0 && (n += 5 * l.towerCount));
 }
 } catch (e) {
@@ -18571,14 +18573,14 @@ if (t) throw t.error;
 return n;
 }
 
-function gc(e) {
+function hc(e) {
 return "plains" === e ? 15 : "swamp" === e ? -10 : 0;
 }
 
-function hc(e) {
-var t, r, o = Cc(e);
+function Rc(e) {
+var t, r, o = Sc(e);
 try {
-for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (oe(i.value)) return !0;
+for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (ne(i.value)) return !0;
 } catch (e) {
 t = {
 error: e
@@ -18593,11 +18595,11 @@ if (t) throw t.error;
 return !1;
 }
 
-function Rc(e) {
-var t = Sr.getEmpire(), r = t.knownRooms[e];
+function Ec(e) {
+var t = wr.getEmpire(), r = t.knownRooms[e];
 if (null == r ? void 0 : r.hasPortal) return 20;
 var o = function(e, t) {
-if (!$(e)) return null;
+if (!ee(e)) return null;
 var r = null;
 for (var o in t) {
 var n = t[o];
@@ -18611,34 +18613,34 @@ return null === r || r > 3 ? null : r;
 return null === o ? 0 : o <= 1 ? 10 : o <= 2 ? 6 : o <= 3 ? 3 : 0;
 }
 
-function Ec(e, t) {
+function Tc(e, t) {
 var r = e < 0 ? "W" : "E", o = t < 0 ? "N" : "S", n = Math.abs(e) - (e < 0 ? 1 : 0), a = Math.abs(t) - (t < 0 ? 1 : 0);
 return "".concat(r).concat(n).concat(o).concat(a);
 }
 
-function Tc(e, t, r) {
+function Cc(e, t, r) {
 return 0 === t.length ? 0 : r <= 2 ? 25 : r <= 3 ? 15 : r <= 5 ? 5 : 0;
 }
 
-function Cc(e) {
-var t = $(e);
+function Sc(e) {
+var t = ee(e);
 if (!t) return [];
-for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(Ec(r + a, o + i));
+for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(Tc(r + a, o + i));
 return n;
 }
 
-function Sc(e) {
+function wc(e) {
 return j(e, {
-empire: Sr.getEmpire()
+empire: wr.getEmpire()
 });
 }
 
-function wc(e, t, r, o) {
+function xc(e, t, r, o) {
 var n, a = Game.map.getRoomLinearDistance(t, e);
 if (!Number.isFinite(a) || a <= 0) throw new Error("calculateRemoteProfitability: invalid distance ".concat(a, " between ").concat(t, " and ").concat(e));
 if (r.sources <= 0) throw new Error("calculateRemoteProfitability: intel.sources must be positive, got ".concat(r.sources, " for ").concat(e));
 if (void 0 !== r.threatLevel && null !== r.threatLevel && (r.threatLevel < 0 || r.threatLevel > 3)) throw new Error("calculateRemoteProfitability: intel.threatLevel must be in [0, 3], got ".concat(r.threatLevel, " for ").concat(e));
-var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = fc(t, e, r.sources, 800, {
+var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = yc(t, e, r.sources, 800, {
 reserved: m
 }), f = (650 * r.sources + p.haulerConfig.cost * p.recommendedHaulers) / 1500, y = 5e3 * r.sources + 50 * a * 300, v = y / 5e4, g = d * (null !== (n = [ 0, .1, .3, .6 ][r.threatLevel]) && void 0 !== n ? n : 0), h = d - f - v - g, R = f + v, E = R > 0 ? h / R : 0;
 return {
@@ -18662,9 +18664,9 @@ isProfitable: E > 2 && h > 0
 };
 }
 
-var xc = kr().cpu.bucketThresholds.highMode + 1e3, bc = {
+var bc = Mr().cpu.bucketThresholds.highMode + 1e3, Oc = {
 updateInterval: 500,
-minBucket: xc,
+minBucket: bc,
 maxRemoteDistance: 2,
 maxRemotesPerRoom: 5,
 minRemoteSources: 1,
@@ -18673,13 +18675,13 @@ minRclForClaiming: 1,
 minGclProgressForClaim: 0,
 clusterExpansionDistance: 5,
 minStableRoomPercentage: 0
-}, Oc = function() {
+}, kc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedUsername = "", this.usernameLastTick = 0,
-this.config = o(o({}, bc), e);
+this.config = o(o({}, Oc), e);
 }
 return e.prototype.run = function() {
-var e = Sr.getEmpire();
+var e = wr.getEmpire();
 this.lastRun = Game.time, this.monitorExpansionProgress(e), this.updateRemoteAssignments(e),
 this.assignRecoveryClaimers(e), this.assignConquestClaimers(e), this.isExpansionReady(e) && this.assignClaimerTargets(e),
 this.assignReserverTargets();
@@ -18690,7 +18692,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = Sr.getSwarmState(d.name);
+var d = m.value, p = wr.getSwarmState(d.name);
 if (p && !((null !== (s = null === (i = d.controller) || void 0 === i ? void 0 : i.level) && void 0 !== s ? s : 0) < this.config.minRclForRemotes)) {
 var f = null !== (c = p.remoteAssignments) && void 0 !== c ? c : [], y = this.validateRemoteAssignments(f, e, d.name), v = this.calculateRemoteCapacity(d, p);
 if (y.length < v) {
@@ -18758,7 +18760,7 @@ s > o.config.maxRemoteDistance && (U.info("Removing remote ".concat(e, " - too f
 subsystem: "Expansion"
 }), a = "unreachable");
 }
-return !a || (Ii.emit("remote.lost", {
+return !a || (Gi.emit("remote.lost", {
 homeRoom: r,
 remoteRoom: e,
 reason: a,
@@ -18771,7 +18773,7 @@ for (var i in t.knownRooms) if (!r.includes(i) && !this.isRemoteAssignedElsewher
 var s = t.knownRooms[i], c = Game.map.getRoomLinearDistance(e, i);
 if ((s.scouted || !(c > 1)) && !s.owner && !(s.reserver && s.reserver !== a || s.isHighway || s.isSK || s.threatLevel >= 2 || c < 1 || c > this.config.maxRemoteDistance)) if (s.scouted) {
 if (!(s.sources < this.config.minRemoteSources)) {
-var u = wc(i, e, s);
+var u = xc(i, e, s);
 if (u.isProfitable) {
 var l = this.scoreRemoteCandidate(s, c);
 n.push({
@@ -18803,10 +18805,10 @@ return r += 50 * e.sources, r -= 20 * t, r -= 30 * e.threatLevel, "plains" === e
 r;
 }, e.prototype.scoreClaimCandidate = function(e, t, r) {
 var o = 0;
-return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += yc(e.mineralType),
-o -= 5 * t, o -= vc(e.name), o -= 15 * e.threatLevel, o += gc(e.terrain), hc(e.name) && (o += 10),
-o += Rc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
-o + Tc(e.name, r, t);
+return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += vc(e.mineralType),
+o -= 5 * t, o -= gc(e.name), o -= 15 * e.threatLevel, o += hc(e.terrain), Rc(e.name) && (o += 10),
+o += Ec(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
+o + Cc(e.name, r, t);
 }, e.prototype.isRemoteAssignedElsewhere = function(e, t) {
 var r, o, n, i = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -18816,7 +18818,7 @@ try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
 if (u.name !== t) {
-var l = Sr.getSwarmState(u.name);
+var l = wr.getSwarmState(u.name);
 if (null === (n = null == l ? void 0 : l.remoteAssignments) || void 0 === n ? void 0 : n.includes(e)) return !0;
 }
 }
@@ -18836,7 +18838,7 @@ return !1;
 var r = Game.rooms[e];
 if (r) {
 var o = r.controller;
-return !(!o || o.my || o.owner || o.reservation || X(r).length > 0);
+return !(!o || o.my || o.owner || o.reservation || Z(r).length > 0);
 }
 var n = t.knownRooms[e], a = this.getMyUsername();
 return !n || (!n.owner || n.owner === a) && (!n.reserver || n.reserver === a) && n.threatLevel <= 0;
@@ -19000,7 +19002,7 @@ if (r) throw r.error;
 }
 }
 if (c) {
-var f = Sr.getSwarmState(c.name);
+var f = wr.getSwarmState(c.name);
 f && "defensive" !== f.posture && "evacuate" !== f.posture && f.danger < 2 && "expand" !== f.posture && (f.posture = "expand",
 U.info("Set ".concat(c.name, " to expand posture for claiming ").concat(e, " (distance: ").concat(u, ")"), {
 subsystem: "Expansion"
@@ -19015,7 +19017,7 @@ var c = s.value, u = c.memory;
 if ("claimer" === u.role && !u.targetRoom) {
 var l = u.homeRoom;
 if (l) {
-var m = Sr.getSwarmState(l);
+var m = wr.getSwarmState(l);
 if (null === (n = null == m ? void 0 : m.remoteAssignments) || void 0 === n ? void 0 : n.length) try {
 for (var d = (r = void 0, a(m.remoteAssignments)), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
@@ -19079,7 +19081,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 if (0 === r.length) return !1;
 var o = r.some(function(e) {
-var t, r = Sr.getSwarmState(e.name);
+var t, r = wr.getSwarmState(e.name);
 return (null !== (t = null == r ? void 0 : r.danger) && void 0 !== t ? t : 0) >= 2 || "war" === (null == r ? void 0 : r.posture) || "siege" === (null == r ? void 0 : r.posture);
 });
 if (o) return !1;
@@ -19152,15 +19154,15 @@ e.length > 0 && (this.cachedUsername = e[0].owner.username), this.usernameLastTi
 return this.cachedUsername;
 }, e.prototype.performSafetyAnalysis = function(e, t) {
 var r, o, n = [], i = function(e) {
-var t = [], r = $(e);
+var t = [], r = ee(e);
 if (!r) return [];
-for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(Ec(o + a, n + i));
+for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(Tc(o + a, n + i));
 return t;
 }(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t.knownRooms[u];
-l && (l.owner && !Sc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
+l && (l.owner && !wc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
 l.towerCount && l.towerCount > 0 && n.push("".concat(l.towerCount, " towers in ").concat(u)),
 l.spawnCount && l.spawnCount > 0 && n.push("".concat(l.spawnCount, " spawns in ").concat(u)),
 l.threatLevel >= 2 && n.push("Threat level ".concat(l.threatLevel, " in ").concat(u)));
@@ -19177,11 +19179,11 @@ if (r) throw r.error;
 }
 }
 return function(e) {
-var t, r, o = Sr.getEmpire(), n = Cc(e), i = new Set;
+var t, r, o = wr.getEmpire(), n = Sc(e), i = new Set;
 try {
 for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-(null == l ? void 0 : l.owner) && !Sc(l.owner) && i.add(l.owner);
+(null == l ? void 0 : l.owner) && !wc(l.owner) && i.add(l.owner);
 }
 } catch (e) {
 t = {
@@ -19278,7 +19280,7 @@ return e.roomName === t;
 });
 -1 !== r && e.claimQueue.splice(r, 1);
 }, e.prototype.addRemoteRoom = function(e, t) {
-var r = Sr.getSwarmState(e);
+var r = wr.getSwarmState(e);
 return r ? (r.remoteAssignments || (r.remoteAssignments = []), r.remoteAssignments.includes(t) ? (U.warn("Remote ".concat(t, " already assigned to ").concat(e), {
 subsystem: "Expansion"
 }), !1) : (r.remoteAssignments.push(t), U.info("Manually added remote ".concat(t, " to ").concat(e), {
@@ -19287,22 +19289,22 @@ subsystem: "Expansion"
 subsystem: "Expansion"
 }), !1);
 }, e.prototype.removeRemoteRoom = function(e, t) {
-var r = Sr.getSwarmState(e);
+var r = wr.getSwarmState(e);
 if (!(null == r ? void 0 : r.remoteAssignments)) return !1;
 var o = r.remoteAssignments.indexOf(t);
 return -1 !== o && (r.remoteAssignments.splice(o, 1), U.info("Manually removed remote ".concat(t, " from ").concat(e), {
 subsystem: "Expansion"
 }), !0);
-}, n([ Qe("expansion:manager", "Expansion Manager", {
-priority: Pe.LOW,
+}, n([ Xe("expansion:manager", "Expansion Manager", {
+priority: Ie.LOW,
 interval: 500,
-minBucket: xc,
+minBucket: bc,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), kc = new Oc, Mc = function() {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), Mc = new kc, Ac = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r, o, n, i, s, c, u, l, m = Sr.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c, u, l, m = wr.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }), p = Game.gcl.progressTotal, f = (100 * (p > 0 ? Game.gcl.progress / p : 0)).toFixed(1), y = Game.gcl.level - d.length, v = y > 0, g = m.objectives.expansionPaused, h = m.claimQueue.length, R = m.claimQueue.filter(function(e) {
@@ -19387,68 +19389,68 @@ C += "  RCL ".concat(I, ": ").concat(L, " (").concat(G, ")\n");
 }
 return C;
 }, e.prototype.pause = function() {
-return Sr.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use expansion.resume() to re-enable.";
+return wr.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use expansion.resume() to re-enable.";
 }, e.prototype.resume = function() {
-return Sr.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
+return wr.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
 }, e.prototype.addRemote = function(e, t) {
-return kc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
+return Mc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
 }, e.prototype.removeRemote = function(e, t) {
-return kc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
+return Mc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
 }, e.prototype.clearQueue = function() {
-var e = Sr.getEmpire(), t = e.claimQueue.length;
+var e = wr.getEmpire(), t = e.claimQueue.length;
 return e.claimQueue = [], "Cleared ".concat(t, " candidates from claim queue. Queue will repopulate on next empire tick.");
-}, n([ Xr({
+}, n([ Zr({
 name: "expansion.status",
 description: "Show expansion system status, GCL progress, and claim queue",
 usage: "expansion.status()",
 examples: [ "expansion.status()" ],
 category: "Empire"
-}) ], e.prototype, "status", null), n([ Xr({
+}) ], e.prototype, "status", null), n([ Zr({
 name: "expansion.pause",
 description: "Pause autonomous expansion",
 usage: "expansion.pause()",
 examples: [ "expansion.pause()" ],
 category: "Empire"
-}) ], e.prototype, "pause", null), n([ Xr({
+}) ], e.prototype, "pause", null), n([ Zr({
 name: "expansion.resume",
 description: "Resume autonomous expansion",
 usage: "expansion.resume()",
 examples: [ "expansion.resume()" ],
 category: "Empire"
-}) ], e.prototype, "resume", null), n([ Xr({
+}) ], e.prototype, "resume", null), n([ Zr({
 name: "expansion.addRemote",
 description: "Manually add a remote room assignment",
 usage: "expansion.addRemote(homeRoom, remoteRoom)",
 examples: [ "expansion.addRemote('W1N1', 'W2N1')" ],
 category: "Empire"
-}) ], e.prototype, "addRemote", null), n([ Xr({
+}) ], e.prototype, "addRemote", null), n([ Zr({
 name: "expansion.removeRemote",
 description: "Manually remove a remote room assignment",
 usage: "expansion.removeRemote(homeRoom, remoteRoom)",
 examples: [ "expansion.removeRemote('W1N1', 'W2N1')" ],
 category: "Empire"
-}) ], e.prototype, "removeRemote", null), n([ Xr({
+}) ], e.prototype, "removeRemote", null), n([ Zr({
 name: "expansion.clearQueue",
 description: "Clear the expansion claim queue",
 usage: "expansion.clearQueue()",
 examples: [ "expansion.clearQueue()" ],
 category: "Empire"
 }) ], e.prototype, "clearQueue", null), e;
-}(), Ac = new Mc;
+}(), Uc = new Ac;
 
-function Uc(e) {
+function _c(e) {
 return function(e) {
 return "string" == typeof e && e.trimStart().startsWith("{");
 }(e) ? e.trim() : null;
 }
 
-function _c(e) {
+function Nc(e) {
 var t;
 if (!e.controller) return null;
 var r = e.controller;
 if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
 var o = function(e) {
-var t = Uc(e);
+var t = _c(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19466,12 +19468,12 @@ availableQuests: [ o.id ]
 };
 }
 
-function Nc() {
+function Pc() {
 var e;
 return (null === (e = Memory.tooangel) || void 0 === e ? void 0 : e.npcRooms) || {};
 }
 
-function Pc(e) {
+function Ic(e) {
 var t = Memory;
 t.tooangel || (t.tooangel = {}), t.tooangel.npcRooms || (t.tooangel.npcRooms = {});
 var r = t.tooangel.npcRooms[e.roomName];
@@ -19482,7 +19484,7 @@ e.availableQuests = Array.from(o);
 t.tooangel.npcRooms[e.roomName] = e;
 }
 
-function Ic() {
+function Gc() {
 var e = Memory;
 return e.tooangel || (e.tooangel = {
 enabled: !0,
@@ -19504,14 +19506,14 @@ Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionI
 e.tooangel;
 }
 
-var Gc = [ "applied", "active" ];
+var Lc = [ "applied", "active" ];
 
-function Lc(e) {
+function Dc(e) {
 var t, r;
 return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
 }
 
-function Dc(e, t) {
+function Bc(e, t) {
 return !!function(e, t) {
 if (e.sender) return "TooAngel" === e.sender.username;
 var r = function(e) {
@@ -19519,7 +19521,7 @@ var t, r, o = new Set(Object.keys(e.npcRooms || {}));
 try {
 for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Gc.includes(s.status) && s.originRoom && o.add(s.originRoom);
+Lc.includes(s.status) && s.originRoom && o.add(s.originRoom);
 }
 } catch (e) {
 t = {
@@ -19533,25 +19535,25 @@ if (t) throw t.error;
 }
 }
 return o;
-}(Ic());
+}(Gc());
 return !!r.has(e.from) && (void 0 === t || r.has(t));
 }(e, t) && !function(e) {
-return Ic().recentTransactionIds.includes(Lc(e));
+return Gc().recentTransactionIds.includes(Dc(e));
 }(e) && (function(e) {
-var t = Ic(), r = Lc(e);
+var t = Gc(), r = Dc(e);
 t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
 }(e), !0);
 }
 
-var Bc = {
+var Fc = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function Fc(e) {
-var t = Uc(e);
+function Wc(e) {
+var t = _c(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19562,24 +19564,24 @@ subsystem: "TooAngel"
 return null;
 }
 
-function Wc() {
-return Ic().activeQuests || {};
+function Hc() {
+return Gc().activeQuests || {};
 }
 
-function Hc() {
-var e = Wc();
+function Kc() {
+var e = Hc();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < Bc.MAX_ACTIVE_QUESTS;
+}).length < Fc.MAX_ACTIVE_QUESTS;
 }
 
-function Kc(e) {
-return Bc.SUPPORTED_TYPES.includes(e);
+function Yc(e) {
+return Fc.SUPPORTED_TYPES.includes(e);
 }
 
-function Yc(e, t, r) {
+function Vc(e, t, r) {
 var o, n;
-if (!Hc()) return U.debug("Cannot accept more quests (at max capacity)", {
+if (!Kc()) return U.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19596,17 +19598,17 @@ if (!n || !n.terminal || !n.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < Bc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Bc.MIN_APPLICATION_ENERGY), {
+if (l < Fc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Fc.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, Bc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, Fc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (U.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
-}), Ic().activeQuests[e] = {
+}), Gc().activeQuests[e] = {
 id: e,
 type: "buildcs",
 status: "applied",
@@ -19619,8 +19621,8 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Vc(e) {
-var t = Ic(), r = t.activeQuests[e.id];
+function qc(e) {
+var t = Gc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (U.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
 }), r.status = "completed") : (U.warn("Quest ".concat(e.id, " failed"), {
@@ -19630,13 +19632,13 @@ subsystem: "TooAngel"
 });
 }
 
-function qc() {
+function jc() {
 var e;
-return (null === (e = Ic().reputation) || void 0 === e ? void 0 : e.value) || 0;
+return (null === (e = Gc().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function jc(e) {
-var t = Uc(e);
+function zc(e) {
+var t = _c(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19645,8 +19647,8 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function zc(e) {
-var t, r, o, n = Ic(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
+function Qc(e) {
+var t, r, o, n = Gc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return U.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
 }), !1;
@@ -19661,7 +19663,7 @@ if (!o || !o.terminal || !o.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var c = function(e) {
-var t = Nc(), r = null, o = 1 / 0;
+var t = Pc(), r = null, o = 1 / 0;
 for (var n in t) {
 var a = Game.map.getRoomLinearDistance(e, n);
 a < o && (o = a, r = t[n]);
@@ -19685,7 +19687,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Qc(e) {
+function Xc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19775,7 +19777,7 @@ l.notifyComplete && (U.info("Quest ".concat(e.id, " (buildcs) completed! All con
 subsystem: "TooAngel"
 }), function(e, t) {
 var r, o, n = function(e) {
-return Wc()[e] || null;
+return Hc()[e] || null;
 }(e);
 if (!n) return U.warn("Cannot notify completion for unknown quest: ".concat(e), {
 subsystem: "TooAngel"
@@ -19827,7 +19829,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Xc, Zc, Jc = kr().cpu.bucketThresholds.highMode + 1e3, $c = Jc, eu = /^tooangel_error_\d+$/, tu = function() {
+var Zc, Jc, $c = Mr().cpu.bucketThresholds.highMode + 1e3, eu = $c, tu = /^tooangel_error_\d+$/, ru = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19845,19 +19847,19 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, U.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < $c)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < eu)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Ic();
+var r = Gc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = jc(i.description);
-null !== s && Dc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
+var s = zc(i.description);
+null !== s && Bc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19884,7 +19886,7 @@ if (e) throw e.error;
 }(), function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Ic();
+var r = Gc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
@@ -19892,12 +19894,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = Fc(i.description);
-if (s && Dc(i, s.origin)) {
+var s = Wc(i.description);
+if (s && Bc(i, s.origin)) {
 if (U.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-Vc(s);
+qc(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19911,7 +19913,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Kc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
+}, Yc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19948,15 +19950,15 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (U.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Qc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Xc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
 }(), function() {
-var e = Ic().activeQuests || {};
+var e = Gc().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - Bc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - Fc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19968,9 +19970,9 @@ var e = String(t);
 (function(e) {
 !function() {
 var e = Memory;
-for (var t in e) eu.test(t) && delete e[t];
+for (var t in e) tu.test(t) && delete e[t];
 }();
-var t = Ic(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
+var t = Gc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
 return t.errorThrottle = {
 lastErrorTick: i ? Game.time : o,
 count: i ? 1 : n + 1,
@@ -19984,7 +19986,7 @@ subsystem: "TooAngel"
 var e, t, r = function() {
 var e = [];
 for (var t in Game.rooms) {
-var r = _c(Game.rooms[t]);
+var r = Nc(Game.rooms[t]);
 r && (U.info("Detected TooAngel NPC room: ".concat(t), {
 subsystem: "TooAngel"
 }), e.push(r));
@@ -19992,7 +19994,7 @@ subsystem: "TooAngel"
 return e;
 }();
 try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) Pc(n.value);
+for (var o = a(r), n = o.next(); !n.done; n = o.next()) Ic(n.value);
 } catch (t) {
 e = {
 error: t
@@ -20008,12 +20010,12 @@ r.length > 0 && U.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-zc();
+Qc();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (Hc()) {
-var r = Nc(), o = Wc();
+if (Kc()) {
+var r = Pc(), o = Hc();
 for (var n in r) {
 var i = r[n];
 try {
@@ -20021,7 +20023,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return U.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void Yc(u, n);
+}), void Vc(u, n);
 }
 } catch (t) {
 e = {
@@ -20038,11 +20040,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return qc();
+return jc();
 }, e.prototype.getActiveQuests = function() {
-return Wc();
+return Hc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return Yc(e, t, r);
+return Vc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -20056,30 +20058,30 @@ var i = t[a], s = i.deadline - Game.time;
 n.push("  ".concat(a, ": ").concat(i.type, " in ").concat(i.targetRoom, " (").concat(i.status, ", ").concat(s, " ticks left)"));
 }
 return n.join("\n");
-}, n([ Xe("empire:tooangel", "TooAngel Manager", {
-priority: Pe.LOW,
+}, n([ Ze("empire:tooangel", "TooAngel Manager", {
+priority: Ie.LOW,
 interval: 100,
-minBucket: Jc
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), ru = new tu, ou = {
+minBucket: $c
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), ou = new ru, nu = {
 status: function() {
-return ru.getStatus();
+return ou.getStatus();
 },
 enable: function() {
-return ru.enable(), "TooAngel integration enabled";
+return ou.enable(), "TooAngel integration enabled";
 },
 disable: function() {
-return ru.disable(), "TooAngel integration disabled";
+return ou.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = qc();
+var e = jc();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return zc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return Qc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
-var e, t = Wc(), r = [ "Active Quests:" ];
+var e, t = Hc(), r = [ "Active Quests:" ];
 if (0 === Object.keys(t).length) r.push("  No active quests"); else for (var o in t) {
 var n = t[o], a = n.deadline - Game.time, i = (null === (e = n.assignedCreeps) || void 0 === e ? void 0 : e.length) || 0;
 r.push("  ".concat(o, ":")), r.push("    Type: ".concat(n.type)), r.push("    Target: ".concat(n.targetRoom)),
@@ -20089,7 +20091,7 @@ r.push("    Assigned creeps: ".concat(i));
 return r.join("\n");
 },
 npcs: function() {
-var e = Nc(), t = [ "TooAngel NPC Rooms:" ];
+var e = Pc(), t = [ "TooAngel NPC Rooms:" ];
 if (0 === Object.keys(e).length) t.push("  No NPC rooms discovered"); else for (var r in e) {
 var o = e[r];
 t.push("  ".concat(r, ":")), t.push("    Has terminal: ".concat(o.hasTerminal)),
@@ -20098,12 +20100,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return Yc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return Vc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, nu = function() {
+}, au = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -20125,20 +20127,20 @@ if (r) throw r.error;
 }
 }
 return "".concat(s.join("\n"), "\n");
-}(er.checkMemoryUsage(), er);
+}(tr.checkMemoryUsage(), tr);
 }, e.prototype.analyze = function(e) {
 return void 0 === e && (e = 10), t = {
 topN: e,
-consumers: er.getLargestConsumers(e),
-recommendations: vr.getRecommendations()
-}, r = er, o = [ "Top ".concat(t.topN, " Memory Consumers:") ], t.consumers.forEach(function(e, t) {
+consumers: tr.getLargestConsumers(e),
+recommendations: gr.getRecommendations()
+}, r = tr, o = [ "Top ".concat(t.topN, " Memory Consumers:") ], t.consumers.forEach(function(e, t) {
 o.push("".concat(t + 1, ". ").concat(e.type, ":").concat(e.name, " - ").concat(r.formatBytes(e.size)));
 }), t.recommendations.length > 0 ? o.push.apply(o, s([ "", "Recommendations:" ], i(t.recommendations.map(function(e) {
 return "- ".concat(e);
 })), !1)) : o.push("", "No recommendations at this time."), "".concat(o.join("\n"), "\n");
 var t, r, o;
 }, e.prototype.prune = function() {
-return e = vr.pruneAll(), t = er, [ "Memory Pruning Complete:", "  Dead creeps removed:        ".concat(e.deadCreeps), "  Event log entries removed:  ".concat(e.eventLogs), "  Stale intel removed:        ".concat(e.staleIntel), "  Market history removed:     ".concat(e.marketHistory), "  Total bytes saved:          ".concat(t.formatBytes(e.bytesSaved)), "" ].join("\n");
+return e = gr.pruneAll(), t = tr, [ "Memory Pruning Complete:", "  Dead creeps removed:        ".concat(e.deadCreeps), "  Event log entries removed:  ".concat(e.eventLogs), "  Stale intel removed:        ".concat(e.staleIntel), "  Market history removed:     ".concat(e.marketHistory), "  Total bytes saved:          ".concat(t.formatBytes(e.bytesSaved)), "" ].join("\n");
 var e, t;
 }, e.prototype.segments = function() {
 return function(e, t) {
@@ -20171,12 +20173,12 @@ if (r) throw r.error;
 }
 return "".concat(n.join("\n"), "\n");
 }({
-activeSegments: or.getActiveSegments(),
-allocation: tr,
+activeSegments: nr.getActiveSegments(),
+allocation: rr,
 segmentSize: function(e) {
-return or.getSegmentSize(e);
+return nr.getSegmentSize(e);
 }
-}, er);
+}, tr);
 }, e.prototype.compress = function(e) {
 var t, r, o = e.split("."), n = Memory;
 try {
@@ -20197,98 +20199,98 @@ if (t) throw t.error;
 }
 }
 if (!n) return "No data at path: ".concat(e);
-var u = pr.getCompressionStats(n), l = "Compression Test for: ".concat(e, "\n");
-return l += "  Original size:    ".concat(er.formatBytes(u.originalSize), "\n"),
-l += "  Compressed size:  ".concat(er.formatBytes(u.compressedSize), "\n"), l += "  Bytes saved:      ".concat(er.formatBytes(u.bytesSaved), "\n"),
+var u = fr.getCompressionStats(n), l = "Compression Test for: ".concat(e, "\n");
+return l += "  Original size:    ".concat(tr.formatBytes(u.originalSize), "\n"),
+l += "  Compressed size:  ".concat(tr.formatBytes(u.compressedSize), "\n"), l += "  Bytes saved:      ".concat(tr.formatBytes(u.bytesSaved), "\n"),
 (l += "  Compression ratio: ".concat((100 * u.ratio).toFixed(1), "%\n")) + "  Worth compressing: ".concat(u.ratio < .9 ? "YES" : "NO", "\n");
 }, e.prototype.migrations = function() {
 return e = {
-currentVersion: Rr.getCurrentVersion(),
-latestVersion: Rr.getLatestVersion(),
-pending: Rr.getPendingMigrations()
+currentVersion: Er.getCurrentVersion(),
+latestVersion: Er.getLatestVersion(),
+pending: Er.getPendingMigrations()
 }, t = [ "Memory Migration Status:", "  Current version: ".concat(e.currentVersion), "  Latest version:  ".concat(e.latestVersion), "  Status: ".concat(e.pending.length > 0 ? "PENDING" : "UP TO DATE"), "" ],
 e.pending.length > 0 && t.push.apply(t, s(s([ "Pending Migrations:" ], i(e.pending.map(function(e) {
 return "  v".concat(e.version, ": ").concat(e.description);
 })), !1), [ "", "Migrations will run automatically on next tick." ], !1)), "".concat(t.join("\n"), "\n");
 var e, t;
 }, e.prototype.migrate = function() {
-var e = Rr.getCurrentVersion();
-Rr.runMigrations();
-var t = Rr.getCurrentVersion();
+var e = Er.getCurrentVersion();
+Er.runMigrations();
+var t = Er.getCurrentVersion();
 return t > e ? "Migrated from v".concat(e, " to v").concat(t) : "No migrations needed (current: v".concat(t, ")");
 }, e.prototype.reset = function(e) {
 if ("CONFIRM" !== e) return "WARNING: This will clear ALL memory!\nTo confirm, use: memory.reset('CONFIRM')";
 var t = Memory;
 for (var r in t) delete t[r];
 for (var o = 0; o < 100; o++) RawMemory.segments[o] = "";
-return Sr.initialize(), "Memory reset complete. All data cleared (main memory + 100 segments).";
-}, n([ Xr({
+return wr.initialize(), "Memory reset complete. All data cleared (main memory + 100 segments).";
+}, n([ Zr({
 name: "memory.status",
 description: "Show current memory usage and status",
 usage: "memory.status()",
 examples: [ "memory.status()" ],
 category: "Memory"
-}) ], e.prototype, "status", null), n([ Xr({
+}) ], e.prototype, "status", null), n([ Zr({
 name: "memory.analyze",
 description: "Analyze memory usage and show largest consumers",
 usage: "memory.analyze([topN])",
 examples: [ "memory.analyze()", "memory.analyze(20)" ],
 category: "Memory"
-}) ], e.prototype, "analyze", null), n([ Xr({
+}) ], e.prototype, "analyze", null), n([ Zr({
 name: "memory.prune",
 description: "Manually trigger memory pruning to clean stale data",
 usage: "memory.prune()",
 examples: [ "memory.prune()" ],
 category: "Memory"
-}) ], e.prototype, "prune", null), n([ Xr({
+}) ], e.prototype, "prune", null), n([ Zr({
 name: "memory.segments",
 description: "Show memory segment allocation and usage",
 usage: "memory.segments()",
 examples: [ "memory.segments()" ],
 category: "Memory"
-}) ], e.prototype, "segments", null), n([ Xr({
+}) ], e.prototype, "segments", null), n([ Zr({
 name: "memory.compress",
 description: "Test compression on a memory path",
 usage: "memory.compress(path)",
 examples: [ "memory.compress('empire.knownRooms')" ],
 category: "Memory"
-}) ], e.prototype, "compress", null), n([ Xr({
+}) ], e.prototype, "compress", null), n([ Zr({
 name: "memory.migrations",
 description: "Show migration status and pending migrations",
 usage: "memory.migrations()",
 examples: [ "memory.migrations()" ],
 category: "Memory"
-}) ], e.prototype, "migrations", null), n([ Xr({
+}) ], e.prototype, "migrations", null), n([ Zr({
 name: "memory.migrate",
 description: "Manually trigger memory migrations",
 usage: "memory.migrate()",
 examples: [ "memory.migrate()" ],
 category: "Memory"
-}) ], e.prototype, "migrate", null), n([ Xr({
+}) ], e.prototype, "migrate", null), n([ Zr({
 name: "memory.reset",
 description: "Clear all memory (DANGEROUS - requires confirmation)",
 usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), au = new nu, iu = {
+}(), iu = new au, su = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, su = function() {
+}, cu = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, iu), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, su), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
 this.updateOperations(), this.evaluateOpportunities(), Game.time % 100 == 0 && this.operations.size > 0 && this.logStatus();
 }, e.prototype.scanForPowerBanks = function() {
-var e, t, r = Sr.getEmpire(), o = function(o) {
+var e, t, r = wr.getEmpire(), o = function(o) {
 var i, s, c = Game.rooms[o];
-if (!oe(o)) return "continue";
+if (!ne(o)) return "continue";
 var u = c.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_POWER_BANK;
@@ -20426,7 +20428,7 @@ var e, t, r = this;
 if (!(Array.from(this.operations.values()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).length >= this.config.maxConcurrentOps)) {
-var o = Sr.getEmpire(), n = Object.values(Game.rooms).filter(function(e) {
+var o = wr.getEmpire(), n = Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.controller.level >= 7;
 });
@@ -20638,22 +20640,22 @@ n && !n.done && (t = o.return) && t.call(o);
 if (e) throw e.error;
 }
 }
-}, n([ Xe("empire:powerBank", "Power Bank Harvesting", {
-priority: Pe.LOW,
+}, n([ Ze("empire:powerBank", "Power Bank Harvesting", {
+priority: Ie.LOW,
 interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), cu = new su, uu = {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), uu = new cu, lu = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, lu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], mu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], du = function() {
+}, mu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], du = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], pu = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, uu), e);
+this.config = o(o({}, lu), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20782,7 +20784,7 @@ i && (a = i.name);
 var s = n.map(function(e) {
 return {
 room: e,
-swarm: Sr.getSwarmState(e.name)
+swarm: wr.getSwarmState(e.name)
 };
 }).filter(function(e) {
 return null !== e.swarm;
@@ -20807,7 +20809,7 @@ return l.homeRoom = a, l.role = o, U.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? lu : mu).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? mu : du).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20945,217 +20947,217 @@ U.info("Power System: GPL ".concat(this.gplState.currentLevel, " ") + "(".concat
 subsystem: "PowerCreep"
 });
 }
-}, n([ Xe("empire:powerCreep", "Power Creep Management", {
-priority: Pe.LOW,
+}, n([ Ze("empire:powerCreep", "Power Creep Management", {
+priority: Ie.LOW,
 interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), pu = new du, fu = {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), fu = new pu, yu = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, yu = ((Xc = {})[RESOURCE_HYDROXIDE] = {
+}, vu = ((Zc = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Xc[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Zc[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Xc[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Zc[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Xc[RESOURCE_GHODIUM] = {
+}, Zc[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Xc[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Zc[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Xc[RESOURCE_UTRIUM_OXIDE] = {
+}, Zc[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Xc[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Zc[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Xc[RESOURCE_KEANIUM_OXIDE] = {
+}, Zc[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Xc[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Zc[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Xc[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Zc[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Xc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Zc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Xc[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Zc[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Xc[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Zc[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Xc[RESOURCE_GHODIUM_OXIDE] = {
+}, Zc[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Xc[RESOURCE_UTRIUM_ACID] = {
+}, Zc[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Zc[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_KEANIUM_ACID] = {
+}, Zc[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Zc[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_LEMERGIUM_ACID] = {
+}, Zc[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Zc[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_ZYNTHIUM_ACID] = {
+}, Zc[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Zc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_GHODIUM_ACID] = {
+}, Zc[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Zc[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Xc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Xc), vu = ((Zc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Zc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Zc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Zc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Zc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Zc[RESOURCE_GHODIUM] = 5e3, Zc[RESOURCE_HYDROXIDE] = 5e3, Zc);
+}, Zc), gu = ((Jc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Jc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Jc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Jc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Jc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Jc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Jc[RESOURCE_GHODIUM] = 5e3, Jc[RESOURCE_HYDROXIDE] = 5e3, Jc);
 
-function gu(e, t) {
-var r, o, n, a = null !== (r = vu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function hu(e, t) {
+var r, o, n, a = null !== (r = gu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function hu(e) {
+function Ru(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var Ru = function() {
+var Eu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : fu;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : yu;
 }
 return e.prototype.getReaction = function(e) {
-return yu[e];
+return vu[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = yu[e];
+var c = vu[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -21177,11 +21179,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = hu(t);
+var d = Ru(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (yu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < gu(y, t)) {
+if (vu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < hu(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -21240,12 +21242,12 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = hu(t);
+var h = Ru(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = yu[T];
+var T = E.value, C = vu[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = gu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = hu(T, t), x = w - S;
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), k = {};
 try {
@@ -21361,7 +21363,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), Eu = [ {
+}(), Tu = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21379,13 +21381,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function Tu(e) {
-return Eu.find(function(t) {
+function Cu(e) {
+return Tu.find(function(t) {
 return t.role === e;
 });
 }
 
-function Cu(e, t) {
+function Su(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21402,29 +21404,29 @@ return;
 }
 }
 
-function Su(e, t) {
+function wu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function wu(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : bu(e, t) && bu(e, r) ? "output" : "boost";
-}
-
-function xu(e, t) {
-return t.filter(function(t) {
-return e.id !== t.id && bu(e, t);
-}).length;
+function xu(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : Ou(e, t) && Ou(e, r) ? "output" : "boost";
 }
 
 function bu(e, t) {
+return t.filter(function(t) {
+return e.id !== t.id && Ou(e, t);
+}).length;
+}
+
+function Ou(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var Ou, ku = function() {
+var ku, Mu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : fu;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : yu;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21540,7 +21542,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Cu(s.role, o);
+var s = i.value, c = Su(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21562,13 +21564,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, xu(t, e) ];
+return [ t.id, bu(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && bu(e, s) && bu(e, c);
+return t !== a && t !== i && Ou(e, s) && Ou(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21581,19 +21583,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(Su)[0];
+return n.sort(wu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: wu(e, t.input1, t.input2)
+role: xu(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, xu(r, e));
+return Math.max(t, bu(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21737,17 +21739,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), Mu = function() {
+}(), Au = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = Tu(o.role);
+var n = Cu(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = Tu(n.role);
+var r, o, n = e.memory, i = Cu(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21825,7 +21827,7 @@ return 0 === c.length && (n.boosted = !0, U.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = Tu(t);
+var r, o, n = Cu(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21856,7 +21858,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = Tu(t);
+var r, o, n = Cu(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21890,7 +21892,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ Tu("soldier"), Tu("ranger"), Tu("healer"), Tu("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ Cu("soldier"), Cu("ranger"), Cu("healer"), Cu("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21947,7 +21949,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = Tu(e);
+var r = Cu(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21957,7 +21959,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = Tu(e);
+var n = Cu(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21991,7 +21993,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), Au = new Mu, Uu = {
+}(), Uu = new Au, _u = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -22004,10 +22006,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, _u = function() {
+}, Nu = function() {
 function e() {
-this.manager = new ku({
-logger: Uu
+this.manager = new Mu({
+logger: _u
 });
 }
 return e.prototype.initialize = function(e) {
@@ -22062,14 +22064,14 @@ var r = Memory.rooms[e];
 if (r) {
 r.labConfig = t;
 var o = "memory:room:".concat(e, ":labConfig");
-Zt.set(o, t, Ht);
+Jt.set(o, t, Kt);
 }
 }
 }, e.prototype.loadFromMemory = function(e) {
-var t = "memory:room:".concat(e, ":labConfig"), r = Zt.get(t);
+var t = "memory:room:".concat(e, ":labConfig"), r = Jt.get(t);
 if (!r) {
 var o = Memory.rooms[e], n = null == o ? void 0 : o.labConfig;
-n && (Zt.set(t, n, Ht), r = n);
+n && (Jt.set(t, n, Kt), r = n);
 }
 r && this.manager.importConfig(r);
 }, e.prototype.getConfiguredRooms = function() {
@@ -22077,14 +22079,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), Nu = new _u, Pu = function() {
+}(), Pu = new Nu, Iu = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = Nu.getConfig(e);
+var s = Pu.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = Nu.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = Pu.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -22096,7 +22098,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = Nu.getBoostLabs(e), f = function(e) {
+var p = Pu.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -22127,9 +22129,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = Nu.getConfig(e);
+var c = Pu.getConfig(e);
 if (!c) return [];
-var u = [], l = Nu.getOutputLabs(e);
+var u = [], l = Pu.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -22154,7 +22156,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = Nu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = Pu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -22190,15 +22192,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = Nu.getConfig(e);
+var r, o, n, i, s = Pu.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = Nu.getInputLabs(e), u = c.input1, l = c.input2;
+var c = Pu.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = Nu.getOutputLabs(e);
+var m = Pu.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -22220,23 +22222,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-Nu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
+Pu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = Nu.setActiveReaction(e, t, r, o);
+var n = Pu.setActiveReaction(e, t, r, o);
 return n && U.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return Nu.runReactions(e);
+return Pu.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return Nu.getBoostLabs(e).length > 0;
+return Pu.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = Nu.getConfig(e);
+var r, o, n, i, s, c = Pu.getConfig(e);
 if (!c) return null;
-var u = Nu.getBoostLabs(e);
+var u = Pu.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -22340,17 +22342,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = Nu.getConfig(e);
+var t = Pu.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-Nu.loadFromMemory(e), Nu.initialize(e);
+Pu.loadFromMemory(e), Pu.initialize(e);
 }, e.prototype.save = function(e) {
-Nu.saveToMemory(e);
+Pu.saveToMemory(e);
 }, e;
-}(), Iu = new Pu, Gu = function() {
+}(), Gu = new Iu, Lu = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = Nu.getConfig(e);
+var t, r, o, n, i, s, c, u, l = Pu.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22373,7 +22375,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = Iu.getLabResourceNeeds(e);
+var h = Gu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22393,7 +22395,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = Iu.getLabOverflow(e);
+var C = Gu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22415,13 +22417,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return Iu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return Gu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return Iu.clearReactions(e), "Cleared active reactions in ".concat(e);
+return Gu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = Au.areBoostLabsReady(n, t), s = Au.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = Uu.areBoostLabsReady(n, t), s = Uu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22442,32 +22444,32 @@ if (r) throw r.error;
 }
 } else c += "\nAll boosts ready!";
 return c;
-}, n([ Xr({
+}, n([ Zr({
 name: "labs.status",
 description: "Get lab status for a room",
 usage: "labs.status(roomName)",
 examples: [ "labs.status('E1S1')" ],
 category: "Labs"
-}) ], e.prototype, "status", null), n([ Xr({
+}) ], e.prototype, "status", null), n([ Zr({
 name: "labs.setReaction",
 description: "Set active reaction for a room",
 usage: "labs.setReaction(roomName, input1, input2, output)",
 examples: [ "labs.setReaction('E1S1', RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_HYDROXIDE)" ],
 category: "Labs"
-}) ], e.prototype, "setReaction", null), n([ Xr({
+}) ], e.prototype, "setReaction", null), n([ Zr({
 name: "labs.clear",
 description: "Clear active reaction for a room",
 usage: "labs.clear(roomName)",
 examples: [ "labs.clear('E1S1')" ],
 category: "Labs"
-}) ], e.prototype, "clear", null), n([ Xr({
+}) ], e.prototype, "clear", null), n([ Zr({
 name: "labs.boost",
 description: "Check boost lab readiness for a role",
 usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), Lu = function() {
+}(), Du = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22505,29 +22507,29 @@ return s;
 }, e.prototype.profit = function() {
 var e = "=== Market Profit ===\n";
 return (e += "Credits: ".concat(Game.market.credits.toLocaleString(), "\n")) + "\nNote: Detailed profit tracking requires memory access\n";
-}, n([ Xr({
+}, n([ Zr({
 name: "market.data",
 description: "Get market data for a resource",
 usage: "market.data(resource)",
 examples: [ "market.data(RESOURCE_ENERGY)", "market.data(RESOURCE_GHODIUM)" ],
 category: "Market"
-}) ], e.prototype, "data", null), n([ Xr({
+}) ], e.prototype, "data", null), n([ Zr({
 name: "market.orders",
 description: "List your active market orders",
 usage: "market.orders()",
 examples: [ "market.orders()" ],
 category: "Market"
-}) ], e.prototype, "orders", null), n([ Xr({
+}) ], e.prototype, "orders", null), n([ Zr({
 name: "market.profit",
 description: "Show market trading profit statistics",
 usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), Du = function() {
+}(), Bu = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = pu.getGPLState();
+var e = fu.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22536,7 +22538,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = pu.getAssignments();
+var e, t, r = fu.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22558,7 +22560,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = cu.getActiveOperations();
+var e, t, r = uu.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22583,7 +22585,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return pu.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return fu.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22614,74 +22616,74 @@ if (!POWER_INFO[t]) return "Invalid power: ".concat(t);
 if (r.level >= Game.gpl.level) return "Power creep is already at max level (".concat(r.level, "/").concat(Game.gpl.level, ")");
 var o = r.upgrade(t);
 return o === OK ? "Upgraded ".concat(e, " to level ").concat(r.level, " with ").concat(t) : "Failed to upgrade: ".concat(o);
-}, n([ Xr({
+}, n([ Zr({
 name: "power.gpl",
 description: "Show GPL (Global Power Level) status",
 usage: "power.gpl()",
 examples: [ "power.gpl()" ],
 category: "Power"
-}) ], e.prototype, "gpl", null), n([ Xr({
+}) ], e.prototype, "gpl", null), n([ Zr({
 name: "power.creeps",
 description: "List power creeps and their assignments",
 usage: "power.creeps()",
 examples: [ "power.creeps()" ],
 category: "Power"
-}) ], e.prototype, "creeps", null), n([ Xr({
+}) ], e.prototype, "creeps", null), n([ Zr({
 name: "power.operations",
 description: "List active power bank operations",
 usage: "power.operations()",
 examples: [ "power.operations()" ],
 category: "Power"
-}) ], e.prototype, "operations", null), n([ Xr({
+}) ], e.prototype, "operations", null), n([ Zr({
 name: "power.assign",
 description: "Reassign a power creep to a different room",
 usage: "power.assign(powerCreepName, roomName)",
 examples: [ "power.assign('operator_eco', 'E2S2')" ],
 category: "Power"
-}) ], e.prototype, "assign", null), n([ Xr({
+}) ], e.prototype, "assign", null), n([ Zr({
 name: "power.create",
 description: "Manually create a new power creep (automatic creation is also enabled)",
 usage: "power.create(name, className)",
 examples: [ "power.create('operator_eco', POWER_CLASS.OPERATOR)", "power.create('my_operator', 'operator')" ],
 category: "Power"
-}) ], e.prototype, "create", null), n([ Xr({
+}) ], e.prototype, "create", null), n([ Zr({
 name: "power.spawn",
 description: "Manually spawn a power creep at a power spawn",
 usage: "power.spawn(powerCreepName, roomName?)",
 examples: [ "power.spawn('operator_eco')", "power.spawn('operator_eco', 'E2S2')" ],
 category: "Power"
-}) ], e.prototype, "spawn", null), n([ Xr({
+}) ], e.prototype, "spawn", null), n([ Zr({
 name: "power.upgrade",
 description: "Manually upgrade a power creep with a specific power",
 usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), Bu = new Gu, Fu = new Lu, Wu = new Du;
+}(), Fu = new Lu, Wu = new Du, Hu = new Bu;
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(Ou || (Ou = {}));
+}(ku || (ku = {}));
 
-var Hu = {
-level: Ou.INFO,
+var Ku = {
+level: ku.INFO,
 cpuLogging: !1,
 enableBatching: !0,
 maxBatchSize: 50,
 debugSampleRate: 1,
 maxEntriesPerSubsystemPerTick: 0,
 maxEntriesPerTick: 0
-}, Ku = o({}, Hu), Yu = [], Vu = {
+}, Yu = o({}, Ku), Vu = [], qu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
 debugSampleCounter: 0
 };
 
-function qu() {
+function ju() {
 var e = "undefined" != typeof Game && "number" == typeof Game.time ? Game.time : 0;
-Vu.tick !== e && (Vu = {
+qu.tick !== e && (qu = {
 tick: e,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22689,47 +22691,47 @@ debugSampleCounter: 0
 });
 }
 
-function ju(e, t) {
+function zu(e, t) {
 return !!function(e) {
-if (e !== Ou.DEBUG) return !0;
-qu();
-var t, r = (t = Ku.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
+if (e !== ku.DEBUG) return !0;
+ju();
+var t, r = (t = Yu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
 if (r >= 1) return !0;
 if (r <= 0) return !1;
-Vu.debugSampleCounter += 1;
+qu.debugSampleCounter += 1;
 var o = Math.max(1, Math.ceil(1 / r));
-return Vu.debugSampleCounter % o === 0;
+return qu.debugSampleCounter % o === 0;
 }(e) && function(e) {
-var t, r, o = zu(Ku.maxEntriesPerTick), n = zu(Ku.maxEntriesPerSubsystemPerTick);
+var t, r, o = Qu(Yu.maxEntriesPerTick), n = Qu(Yu.maxEntriesPerSubsystemPerTick);
 if (0 === o && 0 === n) return !0;
-if (qu(), o > 0 && Vu.totalCount >= o) return !1;
+if (ju(), o > 0 && qu.totalCount >= o) return !1;
 if (n > 0) {
 var a = null != e ? e : "global";
-if ((null !== (t = Vu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
+if ((null !== (t = qu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
 }
-Vu.totalCount += 1;
+qu.totalCount += 1;
 var i = null != e ? e : "global";
-return Vu.perSubsystemCounts.set(i, (null !== (r = Vu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
+return qu.perSubsystemCounts.set(i, (null !== (r = qu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
 !0;
 }(null == t ? void 0 : t.subsystem);
 }
 
-function zu(e) {
+function Qu(e) {
 return Number.isFinite(e) && e > 0 ? Math.floor(e) : 0;
 }
 
-function Qu(e) {
-Yu.length > 0 && Ju();
-var t = Ku;
-Ku = o(o(o({}, Hu), e), {
+function Xu(e) {
+Vu.length > 0 && $u();
+var t = Yu;
+Yu = o(o(o({}, Ku), e), {
 level: "level" in e ? e.level : t.level,
 cpuLogging: "cpuLogging" in e ? e.cpuLogging : t.cpuLogging,
 enableBatching: "enableBatching" in e ? e.enableBatching : t.enableBatching,
 maxBatchSize: "maxBatchSize" in e ? e.maxBatchSize : t.maxBatchSize,
 debugSampleRate: "debugSampleRate" in e ? e.debugSampleRate : t.debugSampleRate,
-maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Hu.maxEntriesPerSubsystemPerTick,
-maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Hu.maxEntriesPerTick
-}), Yu = [], Vu = {
+maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Ku.maxEntriesPerSubsystemPerTick,
+maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Ku.maxEntriesPerTick
+}), Vu = [], qu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22737,21 +22739,21 @@ debugSampleCounter: 0
 };
 }
 
-function Xu() {
-return o({}, Ku);
+function Zu() {
+return o({}, Yu);
 }
 
-function Zu(e) {
-Ku.enableBatching ? (Yu.push(e), Yu.length >= Ku.maxBatchSize && Ju()) : console.log(e);
+function Ju(e) {
+Yu.enableBatching ? (Vu.push(e), Vu.length >= Yu.maxBatchSize && $u()) : console.log(e);
 }
 
-function Ju() {
-0 !== Yu.length && (console.log(Yu.join("\n")), Yu = []);
+function $u() {
+0 !== Vu.length && (console.log(Vu.join("\n")), Vu = []);
 }
 
-var $u = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
+var el = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
 
-function el(e) {
+function tl(e) {
 return JSON.stringify(e, (t = new WeakSet, function(e, r) {
 return "bigint" == typeof r ? r.toString() : "object" != typeof r || null === r ? r : t.has(r) ? "[Circular]" : (t.add(r),
 r);
@@ -22759,7 +22761,7 @@ r);
 var t;
 }
 
-function tl(e, t, r, o) {
+function rl(e, t, r, o) {
 void 0 === o && (o = "log");
 var n = {
 type: o,
@@ -22770,35 +22772,35 @@ shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (r.shard && (n.shard = r.shard), r.subsystem && (n.subsystem = r.subsystem),
 r.room && (n.room = r.room), r.creep && (n.creep = r.creep), r.processId && (n.processId = r.processId),
-r.meta)) for (var a in r.meta) $u.has(a) || (n[a] = r.meta[a]);
-return el(n);
-}
-
-function rl(e, t) {
-Ku.level <= Ou.DEBUG && ju(Ou.DEBUG, t) && Zu(tl("DEBUG", e, t));
+r.meta)) for (var a in r.meta) el.has(a) || (n[a] = r.meta[a]);
+return tl(n);
 }
 
 function ol(e, t) {
-Ku.level <= Ou.INFO && ju(Ou.INFO, t) && Zu(tl("INFO", e, t));
+Yu.level <= ku.DEBUG && zu(ku.DEBUG, t) && Ju(rl("DEBUG", e, t));
 }
 
 function nl(e, t) {
-Ku.level <= Ou.WARN && ju(Ou.WARN, t) && Zu(tl("WARN", e, t));
+Yu.level <= ku.INFO && zu(ku.INFO, t) && Ju(rl("INFO", e, t));
 }
 
 function al(e, t) {
-Ku.level <= Ou.ERROR && ju(Ou.ERROR, t) && Zu(tl("ERROR", e, t));
+Yu.level <= ku.WARN && zu(ku.WARN, t) && Ju(rl("WARN", e, t));
 }
 
-function il(e, t, r) {
-if (!Ku.cpuLogging) return t();
+function il(e, t) {
+Yu.level <= ku.ERROR && zu(ku.ERROR, t) && Ju(rl("ERROR", e, t));
+}
+
+function sl(e, t, r) {
+if (!Yu.cpuLogging) return t();
 var o = Game.cpu.getUsed(), n = t(), a = Game.cpu.getUsed() - o;
-return rl("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
+return ol("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 }
 
-var sl = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
+var cl = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function cl(e, t, r, o) {
+function ul(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -22807,21 +22809,13 @@ tick: "undefined" != typeof Game ? Game.time : 0,
 shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (n.unit = r), o && (o.shard && (n.shard = o.shard), o.subsystem && (n.subsystem = o.subsystem),
-o.room && (n.room = o.room), o.meta)) for (var a in o.meta) sl.has(a) || (n[a] = o.meta[a]);
-ju(Ou.INFO, o) && Zu(el(n));
+o.room && (n.room = o.room), o.meta)) for (var a in o.meta) cl.has(a) || (n[a] = o.meta[a]);
+zu(ku.INFO, o) && Ju(tl(n));
 }
 
-function ul(e) {
+function ll(e) {
 return {
 debug: function(t, r) {
-rl(t, "string" == typeof r ? {
-subsystem: e,
-room: r
-} : o({
-subsystem: e
-}, r));
-},
-info: function(t, r) {
 ol(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22829,7 +22823,7 @@ room: r
 subsystem: e
 }, r));
 },
-warn: function(t, r) {
+info: function(t, r) {
 nl(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22837,7 +22831,7 @@ room: r
 subsystem: e
 }, r));
 },
-error: function(t, r) {
+warn: function(t, r) {
 al(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22845,8 +22839,16 @@ room: r
 subsystem: e
 }, r));
 },
+error: function(t, r) {
+il(t, "string" == typeof r ? {
+subsystem: e,
+room: r
+} : o({
+subsystem: e
+}, r));
+},
 stat: function(t, r, n, a) {
-cl(t, r, n, "string" == typeof a ? {
+ul(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -22854,7 +22856,7 @@ subsystem: e
 }, a));
 },
 measureCpu: function(t, r, n) {
-return il(t, r, "string" == typeof n ? {
+return sl(t, r, "string" == typeof n ? {
 subsystem: e,
 room: n
 } : o({
@@ -22864,36 +22866,36 @@ subsystem: e
 };
 }
 
-var ll, ml = {
-debug: rl,
-info: ol,
-warn: nl,
-error: al,
-stat: cl,
-measureCpu: il,
-configure: Qu,
-getConfig: Xu,
-createLogger: ul,
-flush: Ju
-}, dl = function() {
+var ml, dl = {
+debug: ol,
+info: nl,
+warn: al,
+error: il,
+stat: ul,
+measureCpu: sl,
+configure: Xu,
+getConfig: Zu,
+createLogger: ll,
+flush: $u
+}, pl = function() {
 function e() {}
 return e.prototype.showConfig = function() {
-var e = kr(), t = Xu();
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(Ou[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
-}, n([ Xr({
+var e = Mr(), t = Zu();
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(ku[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+}, n([ Zr({
 name: "showConfig",
 description: "Show current bot configuration",
 usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), pl = new Map, fl = ((ll = {})[STRUCTURE_SPAWN] = 100, ll[STRUCTURE_TOWER] = 95,
-ll[STRUCTURE_STORAGE] = 90, ll[STRUCTURE_EXTENSION] = 80, ll[STRUCTURE_TERMINAL] = 75,
-ll[STRUCTURE_LINK] = 70, ll[STRUCTURE_CONTAINER] = 65, ll[STRUCTURE_RAMPART] = 55,
-ll[STRUCTURE_WALL] = 50, ll[STRUCTURE_ROAD] = 30, ll);
+}(), fl = new Map, yl = ((ml = {})[STRUCTURE_SPAWN] = 100, ml[STRUCTURE_TOWER] = 95,
+ml[STRUCTURE_STORAGE] = 90, ml[STRUCTURE_EXTENSION] = 80, ml[STRUCTURE_TERMINAL] = 75,
+ml[STRUCTURE_LINK] = 70, ml[STRUCTURE_CONTAINER] = 65, ml[STRUCTURE_RAMPART] = 55,
+ml[STRUCTURE_WALL] = 50, ml[STRUCTURE_ROAD] = 30, ml);
 
-function yl(e) {
-var t, r, o, n, i, s = pl.get(e.name);
+function vl(e) {
+var t, r, o, n, i, s = fl.get(e.name);
 if (s && s.tick === Game.time) return s;
 var c = e.find(FIND_MY_STRUCTURES), u = {
 tick: Game.time,
@@ -22918,66 +22920,66 @@ m && !m.done && (r = l.return) && r.call(l);
 if (t) throw t.error;
 }
 }
-return pl.set(e.name, u), u;
+return fl.set(e.name, u), u;
 }
 
-function vl(e) {
+function gl(e) {
 return !e.hasStorage && e.builtTowerCount > 0;
 }
 
-function gl(e, t) {
+function hl(e, t) {
 var r;
 return function(e, t) {
 if (!t || e.structureType !== STRUCTURE_EXTENSION) return !1;
-var r = yl(t);
-return r.controllerLevel >= 4 && vl(r) && r.energyCapacityAvailable < 650;
+var r = vl(t);
+return r.controllerLevel >= 4 && gl(r) && r.energyCapacityAvailable < 650;
 }(e, t) ? 98 : function(e, t) {
 if (!t || e.structureType !== STRUCTURE_STORAGE) return !1;
-var r = yl(t);
-return r.controllerLevel >= 4 && vl(r);
-}(e, t) ? 97 : null !== (r = fl[e.structureType]) && void 0 !== r ? r : 50;
+var r = vl(t);
+return r.controllerLevel >= 4 && gl(r);
+}(e, t) ? 97 : null !== (r = yl[e.structureType]) && void 0 !== r ? r : 50;
 }
 
-var hl = M("CreepContext"), Rl = new Map;
+var Rl = M("CreepContext"), El = new Map;
 
-function El(e) {
+function Tl(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function Tl(e) {
-return void 0 === e._containers && (El(e), e._containers = e.allStructures.filter(function(e) {
+function Cl(e) {
+return void 0 === e._containers && (Tl(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 }
 
-function Cl(e) {
+function Sl(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(t, r) {
 return function(e, t, r) {
-return gl(t, r) - gl(e, r);
+return hl(t, r) - hl(e, r);
 }(t, r, e.room);
 })), e._prioritizedSites;
 }
 
-function Sl(e) {
-return void 0 === e._repairTargets && (El(e), e._repairTargets = e.allStructures.filter(function(e) {
+function wl(e) {
+return void 0 === e._repairTargets && (Tl(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function wl(e) {
+function xl(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = Rl.get(e.name);
+var t = El.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
 room: e,
-hostiles: X(e),
+hostiles: Z(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return Rl.set(e.name, r), r;
+return El.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, hl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Rl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -23042,10 +23044,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return Cl(i).length;
+return Sl(i).length;
 },
 get damagedStructureCount() {
-return Sl(i).length;
+return wl(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -23056,7 +23058,7 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return Tl(i);
+return Cl(i);
 },
 get sourceContainers() {
 return function(e) {
@@ -23064,7 +23066,7 @@ if (void 0 === e._sourceContainers) {
 var t = function(e) {
 return void 0 === e._sources && (e._sources = e.room.find(FIND_SOURCES)), e._sources;
 }(e);
-0 === t.length ? e._sourceContainers = [] : e._sourceContainers = Tl(e).filter(function(e) {
+0 === t.length ? e._sourceContainers = [] : e._sourceContainers = Cl(e).filter(function(e) {
 return t.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
@@ -23074,7 +23076,7 @@ return e._sourceContainers;
 }(i);
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (El(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (Tl(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -23103,10 +23105,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return Cl(i);
+return Sl(i);
 },
 get repairTargets() {
-return Sl(i);
+return wl(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -23126,7 +23128,7 @@ e._tombstones;
 var e;
 },
 get mineralContainers() {
-return void 0 === (e = i)._mineralContainers && (El(e), e._mineralContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._mineralContainers && (Tl(e), e._mineralContainers = e.allStructures.filter(function(e) {
 if (e.structureType !== STRUCTURE_CONTAINER) return !1;
 var t = e;
 return Object.keys(t.store).some(function(e) {
@@ -23138,12 +23140,12 @@ var e;
 };
 }
 
-var xl, bl = {}, Ol = function() {
-if (xl) return bl;
-xl = 1, Object.defineProperty(bl, "__esModule", {
+var bl, Ol = {}, kl = function() {
+if (bl) return Ol;
+bl = 1, Object.defineProperty(Ol, "__esModule", {
 value: !0
 });
-var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== nr ? nr : "undefined" != typeof self ? self : {}, t = function(e) {
+var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== ar ? ar : "undefined" != typeof self ? self : {}, t = function(e) {
 return e && e.Math === Math && e;
 }, r = t("object" == typeof globalThis && globalThis) || t("object" == typeof window && window) || t("object" == typeof self && self) || t("object" == typeof e && e) || t("object" == typeof e && e) || function() {
 return this;
@@ -23326,7 +23328,7 @@ return jt(e);
 });
 var zt, Qt, Xt, Zt = qt.inspectSource, Jt = B, $t = r.WeakMap, er = Jt($t) && /native code/.test(String($t)), tr = We, rr = Ae("keys"), or = function(e) {
 return rr[e] || (rr[e] = tr(e));
-}, ar = {}, ir = er, sr = r, cr = Dt, ur = Ge, lr = ke, mr = or, dr = ar, pr = "Object already initialized", fr = sr.TypeError, yr = sr.WeakMap;
+}, nr = {}, ir = er, sr = r, cr = Dt, ur = Ge, lr = ke, mr = or, dr = nr, pr = "Object already initialized", fr = sr.TypeError, yr = sr.WeakMap;
 if (ir || lr.state) {
 var vr = lr.state || (lr.state = new yr);
 vr.get = vr.get, vr.has = vr.has, vr.set = vr.set, zt = function(e, t) {
@@ -23395,7 +23397,7 @@ return r < 0 ? jr(r + t, 0) : zr(r, t);
 }(r, n); n > a; a++) if (a in o && o[a] === t) return a || 0;
 return -1;
 }
-}, to = Ge, ro = L, oo = eo.indexOf, no = ar, ao = T([].push), io = function(e, t) {
+}, to = Ge, ro = L, oo = eo.indexOf, no = nr, ao = T([].push), io = function(e, t) {
 var r, o = ro(e), n = 0, a = [];
 for (r in o) !to(no, r) && to(o, r) && ao(a, r);
 for (;t.length > n; ) to(o, r = t[n++]) && (~oo(a, r) || ao(a, r));
@@ -23523,7 +23525,7 @@ Kn(e);
 for (var r, o = Yn(t), n = Vn(t), a = n.length, i = 0; a > i; ) Hn.f(e, r = n[i++], o[r]);
 return e;
 };
-var qn, jn = Y("document", "documentElement"), zn = wt, Qn = Gn, Xn = so, Zn = ar, Jn = jn, $n = st, ea = "prototype", ta = "script", ra = or("IE_PROTO"), oa = function() {}, na = function(e) {
+var qn, jn = Y("document", "documentElement"), zn = wt, Qn = Gn, Xn = so, Zn = nr, Jn = jn, $n = st, ea = "prototype", ta = "script", ra = or("IE_PROTO"), oa = function() {}, na = function(e) {
 return "<" + ta + ">" + e + "</" + ta + ">";
 }, aa = function(e) {
 e.write(na("")), e.close();
@@ -24817,14 +24819,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, As = "_rsi";
-return bl.CachingStrategies = vi, bl.CoordListSerializer = fi, bl.CoordSerializer = pi,
-bl.Keys = ji, bl.MoveTargetListSerializer = li, bl.MoveTargetSerializer = ui, bl.NumberSerializer = Oa,
-bl.PositionListSerializer = di, bl.PositionSerializer = mi, bl.adjacentWalkablePositions = xi,
-bl.blockSquare = function(e) {
+return Ol.CachingStrategies = vi, Ol.CoordListSerializer = fi, Ol.CoordSerializer = pi,
+Ol.Keys = ji, Ol.MoveTargetListSerializer = li, Ol.MoveTargetSerializer = ui, Ol.NumberSerializer = Oa,
+Ol.PositionListSerializer = di, Ol.PositionSerializer = mi, Ol.adjacentWalkablePositions = xi,
+Ol.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, bl.cachePath = ys, bl.cachedPathKey = ps, bl.calculateAdjacencyMatrix = Ti, bl.calculateAdjacentPositions = Ci,
-bl.calculateNearbyPositions = Si, bl.calculatePositionsAtRange = wi, bl.cleanAllCaches = yi,
-bl.clearCachedPath = ks, bl.compressPath = e => {
+}, Ol.cachePath = ys, Ol.cachedPathKey = ps, Ol.calculateAdjacencyMatrix = Ti, Ol.calculateAdjacentPositions = Ci,
+Ol.calculateNearbyPositions = Si, Ol.calculatePositionsAtRange = wi, Ol.cleanAllCaches = yi,
+Ol.clearCachedPath = ks, Ol.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24833,19 +24835,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, bl.config = Ta, bl.decompressPath = e => {
+}, Ol.config = Ta, Ol.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, bl.fastRoomPosition = Ga, bl.fixEdgePosition = Ei, bl.follow = function(e, t) {
+}, Ol.fastRoomPosition = Ga, Ol.fixEdgePosition = Ei, Ol.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, bl.followPath = hs, bl.fromGlobalPosition = ti, bl.generatePath = ts, bl.getCachedPath = vs,
-bl.getMoveIntents = ns, bl.getRangeTo = ri, bl.globalPosition = ei, bl.isExit = hi,
-bl.isPositionWalkable = bi, bl.move = ds, bl.moveByPath = function(e, t, r) {
+}, Ol.followPath = hs, Ol.fromGlobalPosition = ti, Ol.generatePath = ts, Ol.getCachedPath = vs,
+Ol.getMoveIntents = ns, Ol.getRangeTo = ri, Ol.globalPosition = ei, Ol.isExit = hi,
+Ol.isPositionWalkable = bi, Ol.move = ds, Ol.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, As));
@@ -24874,9 +24876,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = Mi(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : Ms(e, d, r)) : ERR_NO_PATH;
-}, bl.moveTo = Ms, bl.normalizeTargets = Ri, bl.offsetRoomPosition = Da, bl.packCoord = qa,
-bl.packCoordList = za, bl.packPos = Ya, bl.packPosList = Xa, bl.packRoomName = ii,
-bl.packRoomNames = ni, bl.posAtDirection = oi, bl.preTick = function() {
+}, Ol.moveTo = Ms, Ol.normalizeTargets = Ri, Ol.offsetRoomPosition = Da, Ol.packCoord = qa,
+Ol.packCoordList = za, Ol.packPos = Ya, Ol.packPosList = Xa, Ol.packRoomName = ii,
+Ol.packRoomNames = ni, Ol.posAtDirection = oi, Ol.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) Ui(e), Fi(e);
 !function() {
@@ -24888,34 +24890,34 @@ n.expires && n.expires < Game.time ? (null === (e = Bi.get(n.room1)) || void 0 =
 null === (t = Bi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, bl.reconcileTraffic = function(e) {
+}, Ol.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 _a.with(Oa).set(cs, Game.time);
-}, bl.reconciledRecently = us, bl.resetCachedPath = gs, bl.roomNameFromCoords = $a,
-bl.roomNameToCoords = Ja, bl.sameRoomPosition = La, bl.unpackCoord = ja, bl.unpackCoordList = Qa,
-bl.unpackPos = Va, bl.unpackPosList = Za, bl.unpackRoomName = si, bl.unpackRoomNames = ai,
-bl;
+}, Ol.reconciledRecently = us, Ol.resetCachedPath = gs, Ol.roomNameFromCoords = $a,
+Ol.roomNameToCoords = Ja, Ol.sameRoomPosition = La, Ol.unpackCoord = ja, Ol.unpackCoordList = Qa,
+Ol.unpackPos = Va, Ol.unpackPosList = Za, Ol.unpackRoomName = si, Ol.unpackRoomNames = ai,
+Ol;
 }();
 
-function kl(e) {
+function Ml(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var Ml, Al = 5e5;
+var Al, Ul = 5e5;
 
-function Ul(e) {
+function _l(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Al;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Ul;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Al), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Ul), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24927,21 +24929,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(Ml || (Ml = {}));
+}(Al || (Al = {}));
 
-var _l = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Nl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Pl = new Set([ "build", "repair", "upgrade" ]), Il = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Nl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Pl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Il = new Set([ "build", "repair", "upgrade" ]), Gl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function Gl(e, t) {
+function Ll(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function Ll() {
+function Dl() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function Dl() {
+function Bl() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24956,8 +24958,8 @@ rooms: {}
 };
 }
 
-function Bl(e) {
-var t = Dl();
+function Fl(e) {
+var t = Bl();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24976,42 +24978,42 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Fl(e, t, r) {
+function Wl(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Wl(e) {
+function Hl(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function Hl(e) {
-return Nl.includes(e);
-}
-
 function Kl(e) {
-return Pl.has(e);
+return Pl.includes(e);
 }
 
 function Yl(e) {
-return e.store.getUsedCapacity(RESOURCE_ENERGY);
+return Il.has(e);
 }
 
 function Vl(e) {
+return e.store.getUsedCapacity(RESOURCE_ENERGY);
+}
+
+function ql(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function ql(e, t, r) {
-if (void 0 === r && (r = {}), "harvest" === t.type) return Vl(e);
-var o = Yl(e);
-return r.reserveEmptyEnergyDelivery && Hl(t.type) ? Vl(e) : Math.max(1, o);
+function jl(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return ql(e);
+var o = Vl(e);
+return r.reserveEmptyEnergyDelivery && Kl(t.type) ? ql(e) : Math.max(1, o);
 }
 
-function jl(e, t) {
+function zl(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function zl(e, t, r) {
+function Ql(e, t, r) {
 if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -25019,12 +25021,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return Yl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && Vl(e.creep) > 0;
+return Vl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && ql(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return Yl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return Vl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -25043,7 +25045,7 @@ return !1;
 }
 }
 
-function Ql(e, t) {
+function Xl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -25060,7 +25062,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Xl(e) {
+function Zl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -25068,36 +25070,36 @@ roomName: e.roomName
 };
 }
 
-function Zl(e, t, r, o, n) {
+function Jl(e, t, r, o, n) {
 return {
-id: Fl(e, t, r.id),
+id: Wl(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Xl(r.pos),
+targetPos: Zl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: _l,
+allowedRoles: Nl,
 expiresTick: Game.time + 50
 };
 }
 
-function Jl(e, t) {
+function $l(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = Ll()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = Dl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < p)) {
 t.lastGeneratedTick = Game.time;
-var f = Gl("taskBoard.findMyStructures", function() {
+var f = Ll("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Ql(t, Zl(e.name, "refillTower", h, g, Ml.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Ql(t, Zl(e.name, "refillExtension", h, g, Ml.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Ql(t, Zl(e.name, "refillSpawn", h, g, Ml.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Xl(t, Jl(e.name, "refillTower", h, g, Al.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Xl(t, Jl(e.name, "refillExtension", h, g, Al.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Xl(t, Jl(e.name, "refillSpawn", h, g, Al.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -25110,29 +25112,29 @@ v && !v.done && (o = y.return) && o.call(y);
 if (r) throw r.error;
 }
 }
-var R = Ul(e);
-R && Ql(t, Zl(e.name, "fillTerminalEnergy", R.terminal, R.amount, Ml.NORMAL));
+var R = _l(e);
+R && Xl(t, Jl(e.name, "fillTerminalEnergy", R.terminal, R.amount, Al.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
-var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ks ? Ml.NORMAL : Ml.LOW, S = Math.min(E, 1e3);
-Ql(t, Zl(e.name, "storeEnergy", e.storage, S, C));
+var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ys ? Al.NORMAL : Al.LOW, S = Math.min(E, 1e3);
+Xl(t, Jl(e.name, "storeEnergy", e.storage, S, C));
 }
-var w = Gl("taskBoard.findHostiles", function() {
-return X(e);
+var w = Ll("taskBoard.findHostiles", function() {
+return Z(e);
 });
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Ql(t, {
-id: Fl(e.name, "defend", O.id),
+Xl(t, {
+id: Wl(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
-priority: Ml.CRITICAL,
+priority: Al.CRITICAL,
 targetId: O.id,
-targetPos: Xl(O.pos),
+targetPos: Zl(O.pos),
 amount: O.hits,
 maxAssignments: 3,
-allowedRoles: Il,
+allowedRoles: Gl,
 expiresTick: Game.time + 50
 });
 }
@@ -25147,7 +25149,7 @@ b && !b.done && (i = x.return) && i.call(x);
 if (n) throw n.error;
 }
 }
-var k = Gl("taskBoard.findInjuredAllies", function() {
+var k = Ll("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -25157,13 +25159,13 @@ return e.hits < e.hitsMax;
 try {
 for (var M = a(k.slice(0, 5)), A = M.next(); !A.done; A = M.next()) {
 var U = A.value;
-Ql(t, {
-id: Fl(e.name, "heal", U.id),
+Xl(t, {
+id: Wl(e.name, "heal", U.id),
 roomName: e.name,
 type: "heal",
-priority: Ml.HIGH,
+priority: Al.HIGH,
 targetId: U.id,
-targetPos: Xl(U.pos),
+targetPos: Zl(U.pos),
 amount: U.hitsMax - U.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -25184,17 +25186,17 @@ if (s) throw s.error;
 }
 }
 
-function $l(e) {
+function em(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function em(e) {
+function tm(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && z(e));
 }
 
-function tm(e) {
+function rm(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -25206,7 +25208,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? Ul(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? _l(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -25219,11 +25221,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !em(t);
+return !tm(t);
 }
 }
 
-function rm(e, t) {
+function om(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -25245,7 +25247,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function om(e, t) {
+function nm(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -25253,7 +25255,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (Kl(m.type)) rm(e, m); else {
+if (Yl(m.type)) om(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -25270,7 +25272,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-$l(m), Game.time > m.expiresTick || !tm(m) ? rm(e, m) : (Wl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Hl(m.type)) && (m.status = "assigned");
+em(m), Game.time > m.expiresTick || !rm(m) ? om(e, m) : (Hl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Kl(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -25288,7 +25290,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function nm(e, t, r) {
+function am(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -25296,15 +25298,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-$l(t);
+em(t);
 }
 }
 
-function am(e, t) {
+function im(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function im(e, t, r) {
+function sm(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -25318,37 +25320,37 @@ return e.reservations[t];
 }(e, t.creep.name, t.memory.assignedTaskId);
 s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId;
 var c = null;
-if (s && am(s, r) && tm(s) && zl(t, s, r)) {
+if (s && im(s, r) && rm(s) && Ql(t, s, r)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Ml.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Al.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var u = sm(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Ml.CRITICAL);
+var u = cm(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Al.CRITICAL);
 if (!u || l < m || !d) return s;
-c = u, nm(0, s, t.creep.name), e.stats.preemptions++;
-} else if (s && (c = sm(e, t, r), nm(0, s, t.creep.name), e.stats.preemptions++,
+c = u, am(0, s, t.creep.name), e.stats.preemptions++;
+} else if (s && (c = cm(e, t, r), am(0, s, t.creep.name), e.stats.preemptions++,
 !c)) return null;
-if (null != c || (c = sm(e, t, r)), !c) return null;
-var p = ql(t.creep, c, r);
+if (null != c || (c = cm(e, t, r)), !c) return null;
+var p = jl(t.creep, c, r);
 if (p <= 0) return null;
-var f = Math.min(Math.max(1, Wl(c)), p);
+var f = Math.min(Math.max(1, Hl(c)), p);
 return t.memory.assignedTaskId = c.id, c.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, c.updatedTick = Game.time, $l(c), e.stats.assigned++, c;
+}, c.updatedTick = Game.time, em(c), e.stats.assigned++, c;
 }
 
-function sm(e, t, r) {
+function cm(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (am(l, r) && zl(t, l, r) && tm(l) && !(Wl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Hl(l.type))) {
-var m = cm(t.creep, l), d = 1e3 * l.priority - m;
+if (im(l, r) && Ql(t, l, r) && rm(l) && !(Hl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Kl(l.type))) {
+var m = um(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -25366,7 +25368,7 @@ if (o) throw o.error;
 return i;
 }
 
-function cm(e, t) {
+function um(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -25374,7 +25376,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function um(e, t) {
+function lm(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -25388,7 +25390,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: jl(e, t.creep.name)
+amount: zl(e, t.creep.name)
 };
 
 case "build":
@@ -25417,7 +25419,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (em(t)) return null;
+if (tm(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -25436,83 +25438,83 @@ return null;
 }
 }
 
-var lm = function() {
+var mm = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== Dl().enabled;
+return !1 !== Bl().enabled;
 }, e.prototype.setEnabled = function(e) {
-Dl().enabled = e;
+Bl().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !Ll()) return null;
-var r = Bl(e.room.name);
-Gl("taskBoard.cleanup", function() {
-return om(r);
-}), Gl("taskBoard.generate", function() {
-return Jl(e.room, r);
+if (!this.isEnabled() || !Dl()) return null;
+var r = Fl(e.room.name);
+Ll("taskBoard.cleanup", function() {
+return nm(r);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, r);
 });
-var o = im(r, e, {
+var o = sm(r, e, {
 allowedTypes: t
 });
-return o ? um(o, e) : null;
+return o ? lm(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !Ll()) return null;
-var t = Bl(e.room.name);
-Gl("taskBoard.cleanup", function() {
-return om(t);
-}), Gl("taskBoard.generate", function() {
-return Jl(e.room, t);
+if (!this.isEnabled() || !Dl()) return null;
+var t = Fl(e.room.name);
+Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, t);
 });
-var r = im(t, e, {
+var r = sm(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: Ml.NORMAL,
+preemptPriority: Al.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = um(r, e);
+var o = lm(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.reserveDeliveryWork = function(e) {
-if (!this.isEnabled() || !Ll()) return !1;
-var t = Bl(e.room.name);
-return Gl("taskBoard.cleanup", function() {
-return om(t);
-}), Gl("taskBoard.generate", function() {
-return Jl(e.room, t);
-}), Boolean(im(t, e, {
+if (!this.isEnabled() || !Dl()) return !1;
+var t = Fl(e.room.name);
+return Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, t);
+}), Boolean(sm(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: Ml.NORMAL,
+preemptPriority: Al.NORMAL,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.reserveCriticalDeliveryWork = function(e) {
-if (!this.isEnabled() || !Ll()) return !1;
-var t = Bl(e.room.name);
-return Gl("taskBoard.cleanup", function() {
-return om(t);
-}), Gl("taskBoard.generate", function() {
-return Jl(e.room, t);
-}), Boolean(im(t, e, {
+if (!this.isEnabled() || !Dl()) return !1;
+var t = Fl(e.room.name);
+return Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, t);
+}), Boolean(sm(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower" ],
-preemptPriority: Ml.HIGH,
+preemptPriority: Al.HIGH,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = Ll();
+var r, o = Dl();
 if (!this.isEnabled() || !o) return !1;
-var n = Bl(e);
-Gl("taskBoard.cleanup", function() {
-return om(n);
+var n = Fl(e);
+Ll("taskBoard.cleanup", function() {
+return nm(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && Gl("taskBoard.generate", function() {
-return Jl(a, n);
+return a && Ll("taskBoard.generate", function() {
+return $l(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && tm(e);
+return t.includes(e.type) && rm(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && Ll()) {
+if (this.isEnabled() && Dl()) {
 !function(e) {
-var t, r, o, n, s = Dl();
+var t, r, o, n, s = Bl();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -25533,20 +25535,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = Bl(e.name);
-Gl("taskBoard.cleanup", function() {
-return om(t);
-}), Gl("taskBoard.generate", function() {
-return Jl(e, t);
+var t = Fl(e.name);
+Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = Dl(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = Bl(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) nm(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) am(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -25573,37 +25575,37 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = Dl(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && Hl(c.type) && tm(c))) return delete e.memory.assignedTaskId,
+var a = Bl(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && Kl(c.type) && rm(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = jl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = zl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-$l(c), u.amount);
+em(c), u.amount);
 }, e.prototype.refreshAssignedDeliveryReservation = function(e) {
 var t, r = e.memory.assignedTaskId;
 if (!r) return !1;
-var o = Dl(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
-if (!(a && i && s && Hl(i.type) && tm(i))) return delete e.memory.assignedTaskId,
+var o = Bl(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && Kl(i.type) && rm(i))) return delete e.memory.assignedTaskId,
 !1;
-var c = ql(e.creep, i, {
+var c = jl(e.creep, i, {
 reserveEmptyEnergyDelivery: !0
 });
-return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Wl(i) + s.amount), c),
-s.expiresTick = Game.time + 15, i.updatedTick = Game.time, $l(i), !0);
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Hl(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, em(i), !0);
 }, e.prototype.clear = function(e) {
-var t = Dl();
+var t = Bl();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = Ll();
+var t, r = Dl();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = Bl(e);
-Gl("taskBoard.cleanup", function() {
-return om(n, !0);
-}), Gl("taskBoard.generate", function() {
-return Jl(o, n);
+var n = Fl(e);
+Ll("taskBoard.cleanup", function() {
+return nm(n, !0);
+}), Ll("taskBoard.generate", function() {
+return $l(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25628,10 +25630,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = Ll(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = Dl(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = Bl(e);
-om(i, !0), Jl(n, i);
+var i = Fl(e);
+nm(i, !0), $l(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25653,8 +25655,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = Bl(e);
-om(s, !0);
+var t, r, o, n, i, s = Fl(e);
+nm(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25689,15 +25691,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), mm = new lm;
+}(), dm = new mm;
 
-function dm(e) {
+function pm(e) {
 return e === ERR_NO_PATH;
 }
 
-function pm(e) {
+function fm(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && dm(e.moveResult),
+clearState: void 0 !== e.moveResult && pm(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25708,11 +25710,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var fm, ym = M("ActionExecutor");
+var ym, vm = M("ActionExecutor");
 
-function vm(e, t, r) {
+function gm(e, t, r) {
 var o;
-return !!z(r) && (ym.warn("Refusing harmful action against known ally target", {
+return !!z(r) && (vm.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25720,37 +25722,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (Ol.clearCachedPath(e.creep), ht(e.creep)),
-mm.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (kl.clearCachedPath(e.creep), Rt(e.creep)),
+dm.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function gm(e, t, r) {
+function hm(e, t, r) {
 var o, n;
-if (!t || !t.type) return ym.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return vm.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && ym.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-ym.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && vm.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+vm.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25774,7 +25776,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = Rm(e, function() {
+i = Em(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25788,92 +25790,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (vm(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (vm(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Rm(e, function() {
+Em(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (vm(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Rm(e, function() {
+Em(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-Rm(e, function() {
+Em(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), dm(Ol.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), pm(kl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (vm(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Rm(e, function() {
+i = Em(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-dm(Ol.moveTo(e, a.target)) && (i = !0);
+pm(kl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-dm(Ol.moveTo(e, {
+pm(kl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25882,11 +25884,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-dm(hm(e, a.target, a.routeType)) && (i = !0);
+pm(Rm(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), dm(hm(e, {
+c = new RoomPosition(25, 25, a.roomName), pm(Rm(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25901,44 +25903,44 @@ pos: e,
 range: 10
 };
 });
-dm(Ol.moveTo(e, u, {
+pm(kl.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (Ol.isExit(e.pos)) {
+if (kl.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-Ol.moveTo(e, l, {
+kl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || dm(Ol.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || pm(kl.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-dm(Ol.moveTo(e, a.target, {
+pm(kl.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (Ol.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), Ol.moveTo(e, l, {
+if (kl.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), kl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = kl(m.name);
+var d = Ml(m.name);
 if (d && !e.pos.isEqualTo(d) && function(e) {
 return "scout" !== e.role;
 }({
 role: r.memory.role
 })) {
-dm(Ol.moveTo(e, d, {
+pm(kl.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25947,7 +25949,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && Ol.moveTo(e, {
+p && kl.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25955,8 +25957,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, Ol.clearCachedPath(e), ht(e), mm.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || mm.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, kl.clearCachedPath(e), Rt(e), dm.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || dm.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25964,27 +25966,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function hm(e, t, r, o) {
-if (!fm) return Ol.moveTo(e, t, o);
+function Rm(e, t, r, o) {
+if (!ym) return kl.moveTo(e, t, o);
 try {
-return fm(e, t, r, o);
+return ym(e, t, r, o);
 } catch (n) {
-return ym.warn("Remote movement handler failed; falling back to default movement", {
+return vm.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), Ol.moveTo(e, t, o);
+}), kl.moveTo(e, t, o);
 }
 }
 
-function Rm(e, t, r, o, n, a) {
+function Em(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = Ol.moveTo(e, r);
-return s !== OK && ym.info("Movement attempt returned non-OK result", {
+var s = kl.moveTo(e, r);
+return s !== OK && vm.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25992,49 +25994,49 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), pm({
+}), fm({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = pm({
+var c = fm({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
 var n, a, i, s, c, u, l, m = e.memory;
-switch (as(m), t) {
+switch (is(m), t) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
 var d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length;
-l = 2 * d, is(m).energyHarvested += l;
+l = 2 * d, ss(m).energyHarvested += l;
 break;
 
 case "transfer":
 var p = null !== (n = null == o ? void 0 : o.resourceType) && void 0 !== n ? n : RESOURCE_ENERGY, f = Math.min(null !== (a = null == o ? void 0 : o.amount) && void 0 !== a ? a : e.store.getUsedCapacity(p), e.store.getUsedCapacity(p), null !== (s = null === (i = r.store) || void 0 === i ? void 0 : i.getFreeCapacity(p)) && void 0 !== s ? s : 1 / 0);
 f > 0 && function(e, t) {
-is(e).energyTransferred += t;
+ss(e).energyTransferred += t;
 }(m, f);
 break;
 
 case "build":
 c = m, u = 5 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
-}).length), is(c).buildProgress += u;
+}).length), ss(c).buildProgress += u;
 break;
 
 case "repair":
 !function(e, t) {
-is(e).repairProgress += t;
+ss(e).repairProgress += t;
 }(m, 100 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length));
 break;
 
 case "attack":
-ss(m, g = 30 * e.body.filter(function(e) {
+cs(m, g = 30 * e.body.filter(function(e) {
 return e.type === ATTACK && e.hits > 0;
 }).length);
 break;
@@ -26043,7 +26045,7 @@ case "rangedAttack":
 var y = e.body.filter(function(e) {
 return e.type === RANGED_ATTACK && e.hits > 0;
 }).length, v = e.pos.getRangeTo(r), g = 0;
-v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), ss(m, g);
+v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), cs(m, g);
 break;
 
 case "heal":
@@ -26052,18 +26054,18 @@ var h = e.body.filter(function(e) {
 return e.type === HEAL && e.hits > 0;
 }).length;
 !function(e, t) {
-is(e).healingDone += t;
+ss(e).healingDone += t;
 }(m, "heal" === t ? 12 * h : 4 * h);
 break;
 
 case "upgrade":
 !function(e, t) {
-is(e).upgradeProgress += t;
+ss(e).upgradeProgress += t;
 }(m, d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (ym.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (vm.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -26074,13 +26076,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Em, Tm = M("StateMachine");
+var Tm, Cm = M("StateMachine");
 
-function Cm(e) {
+function Sm(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function Sm(e, t, r) {
+function wm(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -26102,12 +26104,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== Cm(e.amount) ? {
+}, void 0 !== Sm(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), Tm.info(r, {
+}(t), Cm.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26115,13 +26117,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : Tm.info("Behavior returned idle action", {
+})) : Cm.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (Tm.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (Cm.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26132,11 +26134,11 @@ type: "idle"
 });
 }
 
-function wm(e, t, r) {
+function xm(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, Sm(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, wm(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -26216,7 +26218,7 @@ return !0;
 default:
 return !1;
 }
-}(a, e)) Tm.info("State completed, evaluating new action", {
+}(a, e)) Cm.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26266,7 +26268,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = Cm(e.data.amount);
+var c = Sm(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -26349,12 +26351,12 @@ return null;
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(c) && mm.refreshAssignedDeliveryReservation(e), c;
-var u = e.memory.assignedTaskId, l = mm.refreshCreepReservation(e, c);
+}(c) && dm.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = dm.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-Tm.info("Task-board delivery reservation missing, re-evaluating behavior", {
+Cm.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26364,7 +26366,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-Tm.info("State reconstruction failed, re-evaluating behavior", {
+Cm.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26372,7 +26374,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (Tm.info("State invalid, re-evaluating behavior", {
+} else a && (Cm.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -26381,33 +26383,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return Sm(e, t(e), "Committed new state action");
+return wm(e, t(e), "Committed new state action");
 }
 
-(Em = {})[FIND_SOURCES] = 5e3, Em[FIND_MINERALS] = 5e3, Em[FIND_DEPOSITS] = 100,
-Em[FIND_STRUCTURES] = 50, Em[FIND_MY_STRUCTURES] = 50, Em[FIND_HOSTILE_STRUCTURES] = 20,
-Em[FIND_MY_SPAWNS] = 100, Em[FIND_MY_CONSTRUCTION_SITES] = 20, Em[FIND_CONSTRUCTION_SITES] = 20,
-Em[FIND_CREEPS] = 5, Em[FIND_MY_CREEPS] = 5, Em[FIND_HOSTILE_CREEPS] = 3, Em[FIND_DROPPED_RESOURCES] = 5,
-Em[FIND_TOMBSTONES] = 10, Em[FIND_RUINS] = 10, Em[FIND_FLAGS] = 50, Em[FIND_NUKES] = 20,
-Em[FIND_POWER_CREEPS] = 10, Em[FIND_MY_POWER_CREEPS] = 10;
+(Tm = {})[FIND_SOURCES] = 5e3, Tm[FIND_MINERALS] = 5e3, Tm[FIND_DEPOSITS] = 100,
+Tm[FIND_STRUCTURES] = 50, Tm[FIND_MY_STRUCTURES] = 50, Tm[FIND_HOSTILE_STRUCTURES] = 20,
+Tm[FIND_MY_SPAWNS] = 100, Tm[FIND_MY_CONSTRUCTION_SITES] = 20, Tm[FIND_CONSTRUCTION_SITES] = 20,
+Tm[FIND_CREEPS] = 5, Tm[FIND_MY_CREEPS] = 5, Tm[FIND_HOSTILE_CREEPS] = 3, Tm[FIND_DROPPED_RESOURCES] = 5,
+Tm[FIND_TOMBSTONES] = 10, Tm[FIND_RUINS] = 10, Tm[FIND_FLAGS] = 50, Tm[FIND_NUKES] = 20,
+Tm[FIND_POWER_CREEPS] = 10, Tm[FIND_MY_POWER_CREEPS] = 10;
 
-var xm, bm, Om = {}, km = {}, Mm = {}, Am = {};
-
-function Um() {
-if (xm) return Am;
-xm = 1;
-const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Am.encode = function(t) {
-if (0 <= t && t < e.length) return e[t];
-throw new TypeError("Must be between 0 and 63: " + t);
-}, Am;
-}
+var bm, Om, km = {}, Mm = {}, Am = {}, Um = {};
 
 function _m() {
-if (bm) return Mm;
+if (bm) return Um;
 bm = 1;
-const e = Um();
-return Mm.encode = function(t) {
+const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
+return Um.encode = function(t) {
+if (0 <= t && t < e.length) return e[t];
+throw new TypeError("Must be between 0 and 63: " + t);
+}, Um;
+}
+
+function Nm() {
+if (Om) return Am;
+Om = 1;
+const e = _m();
+return Am.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -26415,23 +26417,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Mm;
+}, Am;
 }
 
-var Nm, Pm, Im, Gm = {}, Lm = ar(Object.freeze({
+var Pm, Im, Gm, Lm = {}, Dm = ir(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Dm() {
-return Pm ? Nm : (Pm = 1, Nm = "function" == typeof URL ? URL : Lm.URL);
+function Bm() {
+return Im ? Pm : (Im = 1, Pm = "function" == typeof URL ? URL : Dm.URL);
 }
 
-function Bm() {
-if (Im) return Gm;
-Im = 1;
-const e = Dm();
-Gm.getArg = function(e, t, r) {
+function Fm() {
+if (Gm) return Lm;
+Gm = 1;
+const e = Bm();
+Lm.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -26451,16 +26453,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Gm.toSetString = t ? r : function(e) {
+Lm.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Gm.fromSetString = t ? r : function(e) {
+}, Lm.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Gm.compareByGeneratedPositionsInflated = function(e, t) {
+}, Lm.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Gm.parseSourceMapInput = function(e) {
+}, Lm.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -26514,7 +26516,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Gm.normalize = f, Gm.join = y, Gm.relative = function(t, r) {
+return Lm.normalize = f, Lm.join = y, Lm.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -26526,18 +26528,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Gm.computeSourceURL = function(e, t, r) {
+}, Lm.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Gm;
+}, Lm;
 }
 
-var Fm, Wm = {};
+var Wm, Hm = {};
 
-function Hm() {
-if (Fm) return Wm;
-Fm = 1;
+function Km() {
+if (Wm) return Hm;
+Wm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -26570,19 +26572,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Wm.ArraySet = e, Wm;
+return Hm.ArraySet = e, Hm;
 }
 
-var Km, Ym, Vm = {};
+var Ym, Vm, qm = {};
 
-function qm() {
-if (Ym) return km;
+function jm() {
+if (Vm) return Mm;
+Vm = 1;
+const e = Nm(), t = Fm(), r = Km().ArraySet, o = function() {
+if (Ym) return qm;
 Ym = 1;
-const e = _m(), t = Bm(), r = Hm().ArraySet, o = function() {
-if (Km) return Vm;
-Km = 1;
-const e = Bm();
-return Vm.MappingList = class {
+const e = Fm();
+return qm.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -26602,7 +26604,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, Vm;
+}, qm;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26731,13 +26733,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, km.SourceMapGenerator = n, km;
+return n.prototype._version = 3, Mm.SourceMapGenerator = n, Mm;
 }
 
-var jm, zm = {}, Qm = {};
+var zm, Qm = {}, Xm = {};
 
-function Xm() {
-return jm || (jm = 1, function(e) {
+function Zm() {
+return zm || (zm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26749,36 +26751,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(Qm)), Qm;
+}(Xm)), Xm;
 }
 
-var Zm, Jm, $m, ed, td = {
+var Jm, $m, ed, td, rd = {
 exports: {}
 };
 
-function rd() {
-if (Zm) return td.exports;
-Zm = 1;
+function od() {
+if (Jm) return rd.exports;
+Jm = 1;
 let e = null;
-return td.exports = function() {
+return rd.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, td.exports.initialize = t => {
+}, rd.exports.initialize = t => {
 e = t;
-}, td.exports;
+}, rd.exports;
 }
 
-function od() {
-if ($m) return Jm;
-$m = 1;
-const e = rd();
+function nd() {
+if (ed) return $m;
+ed = 1;
+const e = od();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return Jm = function() {
+return $m = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26845,28 +26847,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, Jm;
+}, $m;
 }
 
-var nd, ad, id, sd, cd = {};
+var ad, id, sd, cd, ud = {};
 
-function ud(e, t, r) {
+function ld(e, t, r) {
 return e - t >= r;
 }
 
-function ld(e, t) {
+function md(e, t) {
 return e.priority - t.priority;
 }
 
-function md(e, t, r, o) {
+function dd(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function dd(e, t, r, o) {
+function pd(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function pd(e) {
+function fd(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26884,12 +26886,12 @@ if (t) throw t.error;
 return o;
 }
 
-ad || (ad = 1, Om.SourceMapGenerator = qm().SourceMapGenerator, Om.SourceMapConsumer = function() {
-if (ed) return zm;
-ed = 1;
-const e = Bm(), t = Xm(), r = Hm().ArraySet;
-_m();
-const o = rd(), n = od(), a = Symbol("smcInternal");
+id || (id = 1, km.SourceMapGenerator = jm().SourceMapGenerator, km.SourceMapConsumer = function() {
+if (td) return Qm;
+td = 1;
+const e = Fm(), t = Zm(), r = Km().ArraySet;
+Nm();
+const o = od(), n = nd(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26926,7 +26928,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, zm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, Qm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -27116,7 +27118,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, zm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, Qm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -27225,11 +27227,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return zm.IndexedSourceMapConsumer = c, zm;
-}().SourceMapConsumer, Om.SourceNode = function() {
-if (nd) return cd;
-nd = 1;
-const e = qm().SourceMapGenerator, t = Bm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return Qm.IndexedSourceMapConsumer = c, Qm;
+}().SourceMapConsumer, km.SourceNode = function() {
+if (ad) return ud;
+ad = 1;
+const e = jm().SourceMapGenerator, t = Fm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -27368,27 +27370,27 @@ map: o
 };
 }
 }
-return cd.SourceNode = n, cd;
+return ud.SourceNode = n, ud;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(sd || (sd = {}));
+}(cd || (cd = {}));
 
-var fd, yd = [ sd.CRITICAL, sd.HIGH, sd.MEDIUM, sd.LOW ], vd = {
-bucketThresholds: (id = {}, id[sd.CRITICAL] = 0, id[sd.HIGH] = 2e3, id[sd.MEDIUM] = 5e3,
-id[sd.LOW] = 8e3, id),
+var yd, vd = [ cd.CRITICAL, cd.HIGH, cd.MEDIUM, cd.LOW ], gd = {
+bucketThresholds: (sd = {}, sd[cd.CRITICAL] = 0, sd[cd.HIGH] = 2e3, sd[cd.MEDIUM] = 5e3,
+sd[cd.LOW] = 8e3, sd),
 defaultMaxCpu: 5,
 logExecution: !1
-}, gd = function() {
+}, hd = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: pd(yd),
+tasksByPriority: fd(vd),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, vd), e);
+}, this.config = o(o({}, gd), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -27402,13 +27404,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(ld), l = 0;
+var u = Array.from(this.tasks.values()).sort(md), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (ud(Game.time, p.lastRun, p.interval)) if (md(p.priority, s, this.config.bucketThresholds, sd.CRITICAL)) this.stats.skippedThisTick++; else {
+if (ld(Game.time, p.lastRun, p.interval)) if (dd(p.priority, s, this.config.bucketThresholds, cd.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (dd(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (pd(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -27456,7 +27458,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = pd(yd);
+var t, r, o = fd(vd);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -27473,22 +27475,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), hd = ((fd = global)._computationScheduler || (fd._computationScheduler = new gd),
-fd._computationScheduler), Rd = new Map;
+}(), Rd = ((yd = global)._computationScheduler || (yd._computationScheduler = new hd),
+yd._computationScheduler), Ed = new Map;
 
-function Ed(e) {
-var t = Rd.get(e);
+function Td(e) {
+var t = Ed.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Rd.set(e, t)), t;
+}, Ed.set(e, t)), t;
 }
 
-function Td(e, t, r) {
+function Cd(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return Cd(e, t[0], r), t[0];
-var i = Ed(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Sd(e, t[0], r), t[0];
+var i = Td(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -27505,32 +27507,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && Cd(e, s, r), s;
+return s && Sd(e, s, r), s;
 }
 
-function Cd(e, t, r) {
-var o = Ed(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Sd(e, t, r) {
+var o = Td(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var Sd = {
+var wd = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function wd(e, t, r) {
+function xd(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(Sd[t], ";") : "";
+var o = t ? "color: ".concat(wd[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function xd(e) {
+function bd(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var bd = {
+var Od = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -27544,7 +27546,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(xd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(bd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -27561,44 +27563,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(xd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(bd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function Od() {
+function kd() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Ad() + Ud() + '<div class="module-help">'.concat(e.map(kd).join(""), "</div>");
+return Ud() + _d() + '<div class="module-help">'.concat(e.map(Md).join(""), "</div>");
 }
 
-var kd = function(e) {
-var t = e.api.map(Md).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(wd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(wd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Md = function(e) {
+var Md = function(e) {
+var t = e.api.map(Ad).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(xd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(xd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Ad = function(e) {
 var t = [];
-e.describe && t.push(wd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(wd(e.name, "blue"), ": ").concat(wd(e.desc, "green"));
+e.describe && t.push(xd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(xd(e.name, "blue"), ": ").concat(xd(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return wd(e.name, "blue");
-}).join(", ") : "", o = wd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return xd(e.name, "blue");
+}).join(", ") : "", o = xd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(wd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Ad = function() {
-return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(xd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
 }, Ud = function() {
+return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
+}, _d = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, _d = M("EnergyCollection"), Nd = [ "refillSpawn", "refillExtension", "refillTower" ], Pd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, Nd = M("EnergyCollection"), Pd = [ "refillSpawn", "refillExtension", "refillTower" ], Id = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function Id(e) {
+function Gd(e) {
 if (e.droppedResources.length > 0) {
-var t = gt(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return _d.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+var t = ht(e.creep, e.droppedResources, "energy_drop", 5);
+if (t) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27608,15 +27610,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Td(e.creep, r, "energy_container");
-if (o) return _d.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Cd(e.creep, r, "energy_container");
+if (o) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (_d.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return _d.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27627,57 +27629,57 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ks && Pd.has(e.memory.role);
-}(e, n)) return _d.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ys && Id.has(e.memory.role);
+}(e, n)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
 };
 }
-var a = pt(e.room).filter(function(e) {
+var a = ft(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = Td(e.creep, a, "energy_source");
-if (s) return _d.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = Cd(e.creep, a, "energy_source");
+if (s) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (_d.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return _d.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return _d.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Gd(e) {
-var t = mm.getAssignedAction(e, Nd);
+function Ld(e) {
+var t = dm.getAssignedAction(e, Pd);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Ld(e) {
-return mm.hasActiveTask(e.room.name, Nd);
-}
-
-function Dd(e, t) {
-return function(e) {
-return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(t) && mm.reserveCriticalDeliveryWork(e), t;
+function Dd(e) {
+return dm.hasActiveTask(e.room.name, Pd);
 }
 
 function Bd(e, t) {
+return function(e) {
+return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
+}(t) && dm.reserveCriticalDeliveryWork(e), t;
+}
+
+function Fd(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (r.length > 0 && (n = gt(e.creep, r, "".concat(t, "_spawn"), 5))) return {
+if (r.length > 0 && (n = ht(e.creep, r, "".concat(t, "_spawn"), 5))) return {
 type: "transfer",
 target: n,
 resourceType: RESOURCE_ENERGY
@@ -27685,7 +27687,7 @@ resourceType: RESOURCE_ENERGY
 var o = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_EXTENSION && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (o.length > 0 && (n = gt(e.creep, o, "".concat(t, "_ext"), 5))) return {
+if (o.length > 0 && (n = ht(e.creep, o, "".concat(t, "_ext"), 5))) return {
 type: "transfer",
 target: n,
 resourceType: RESOURCE_ENERGY
@@ -27693,18 +27695,18 @@ resourceType: RESOURCE_ENERGY
 var n, a = e.towers.filter(function(e) {
 return e.store.getFreeCapacity(RESOURCE_ENERGY) >= 100;
 });
-return a.length > 0 && (n = gt(e.creep, a, "".concat(t, "_tower"), 10)) ? {
+return a.length > 0 && (n = ht(e.creep, a, "".concat(t, "_tower"), 10)) ? {
 type: "transfer",
 target: n,
 resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Fd(e) {
-var t = mm.getAssignedDeliveryAction(e);
+function Wd(e) {
+var t = dm.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Ld(e)) {
-var r = Bd(e, "deliver");
+if (!Dd(e)) {
+var r = Fd(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27716,7 +27718,7 @@ var o = e.depositContainers.filter(function(e) {
 return e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
 if (o.length > 0) {
-var n = gt(e.creep, o, "deliver_cont", 10);
+var n = ht(e.creep, o, "deliver_cont", 10);
 if (n) return {
 type: "transfer",
 target: n,
@@ -27726,9 +27728,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Wd = /^[WE]\d+[NS]\d+$/;
+var Hd = /^[WE]\d+[NS]\d+$/;
 
-function Hd(e) {
+function Kd(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27738,28 +27740,28 @@ routeType: "hauler"
 } : null;
 }
 
-function Kd(e) {
-return Wd.test(e);
-}
-
 function Yd(e) {
-var t, r = e.memory, o = r.questAction, n = r.questTarget;
-if ("build" !== o) return null;
-if (!n || !Kd(n)) return Hd(e);
-var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
-return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
-type: "remoteMoveToRoom",
-roomName: e.homeRoom,
-routeType: "hauler"
-} : null : Hd(e) : null;
+return Hd.test(e);
 }
 
 function Vd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = Yd(e);
+if (!n || !Yd(n)) return Kd(e);
+var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
+return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
+type: "remoteMoveToRoom",
+roomName: e.homeRoom,
+routeType: "hauler"
+} : null : Kd(e) : null;
+}
+
+function qd(e) {
+var t, r = e.memory, o = r.questAction, n = r.questTarget;
+if ("build" !== o) return null;
+var a = Vd(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !Kd(n)) return null;
+if (!n || !Yd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27772,20 +27774,20 @@ target: null != s ? s : i[0]
 };
 }
 
-function qd(e) {
+function jd(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
 t ? e.memory.working = !1 : r && (e.memory.working = !0);
 var n = e.memory.working;
-return o !== n && Rt(e.creep), n;
+return o !== n && Et(e.creep), n;
 }
 
-function jd(e) {
-e.memory.working = !1, Rt(e.creep);
+function zd(e) {
+e.memory.working = !1, Et(e.creep);
 }
 
-var zd = function() {
+var Qd = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27880,20 +27882,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), Qd = new zd, Xd = M("LarvaWorkerBehavior");
+}(), Xd = new Qd, Zd = M("LarvaWorkerBehavior");
 
-function Zd(e) {
-var t = qd(e), r = Yd(e);
+function Jd(e) {
+var t = jd(e), r = Vd(e);
 if (r) return r;
 if (t) {
-Xd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = Vd(e);
+Zd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = qd(e);
 if (o) return o;
-var n = Fd(e);
-if (n) return Xd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = Wd(e);
+if (n) return Zd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = Qd.getSwarmState(e.room.name);
+var t, r = Xd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27910,7 +27912,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Xd.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Zd.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27919,54 +27921,54 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Xd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Zd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Xd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-jd(e);
+Zd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+zd(e);
 }
-return Dd(e, Id(e));
+return Bd(e, Gd(e));
 }
 
-function Jd(e) {
+function $d(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-var $d = new Map;
+var ep = new Map;
 
-function ep(e) {
+function tp(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var tp = M("HarvesterBehavior"), rp = M("HaulerBehavior"), op = Ks, np = [ "refillSpawn", "refillExtension" ];
+var rp = M("HarvesterBehavior"), op = M("HaulerBehavior"), np = Ys, ap = [ "refillSpawn", "refillExtension" ];
 
-function ap(e, t) {
-return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && mm.reserveDeliveryWork(e),
-"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && mm.reserveDeliveryWork(e),
+function ip(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && dm.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && dm.reserveDeliveryWork(e),
 t;
 }
 
-function ip(e, t, r) {
+function sp(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return Cd(e, c, r), c;
+if (c) return Sd(e, c, r), c;
 }
-var u = Td(e, t, r);
+var u = Cd(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function sp(e) {
+function cp(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27980,9 +27982,9 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-function cp(e) {
+function up(e) {
 if (e.creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
-var t = Fd(e);
+var t = Wd(e);
 if (t) return t;
 }
 var r, o = (r = e.creep, Object.keys(r.store).find(function(e) {
@@ -28000,7 +28002,7 @@ resourceType: o
 } : null;
 }
 
-var up = {
+var lp = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -28010,16 +28012,16 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, lp = up, mp = function(e) {
-return lp.getLabResourceNeeds(e);
+}, mp = lp, dp = function(e) {
+return mp.getLabResourceNeeds(e);
 };
 
-function dp(e) {
+function pp(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
 var n = null !== (r = e.memory.working) && void 0 !== r && r;
-return o !== n && (Rt(e.creep), delete e.memory.targetId), n;
+return o !== n && (Et(e.creep), delete e.memory.targetId), n;
 }(e);
 return t ? function(e) {
 if (e.memory.targetId) {
@@ -28036,7 +28038,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = mp(e.room.name);
+var n = dp(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -28064,7 +28066,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, lp.getLabOverflow(r));
+var t, r, o = (r = e.room.name, mp.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -28079,7 +28081,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = mp(e.room.name);
+var i = dp(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -28098,8 +28100,8 @@ type: "idle"
 }(e);
 }
 
-var pp = {
-larvaWorker: Zd,
+var fp = {
+larvaWorker: Jd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -28110,13 +28112,13 @@ type: "remoteMoveToRoom",
 roomName: r,
 routeType: "hauler"
 };
-var o = e.hostiles.filter(io);
-if (o.length > 0 && !lo(e.room, o)) return {
+var o = e.hostiles.filter(so);
+if (o.length > 0 && !mo(e.room, o)) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (qd(e)) {
+if (jd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28135,7 +28137,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Id(e);
+return Gd(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -28172,10 +28174,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(Jd)) return {
+if (e.hostiles.some($d)) return {
 type: "idle"
 };
-if (qd(e)) {
+if (jd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28194,10 +28196,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Id(e);
+return Gd(e);
 },
 harvester: function(e) {
-var t, r = (t = ep(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = tp(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -28246,8 +28248,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), tp.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return tp.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), rp.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return rp.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -28275,7 +28277,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return tp.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return rp.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -28296,12 +28298,12 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (tp.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (rp.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (tp.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (rp.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
@@ -28314,8 +28316,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-var r = qd(e), o = "defenseRefuel" === e.memory.task;
-if (rp.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var r = jd(e), o = "defenseRefuel" === e.memory.task;
+if (op.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -28328,13 +28330,13 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = mm.getAssignedAction(e, np);
+var t = dm.getAssignedAction(e, ap);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (mm.hasActiveTask(e.room.name, np)) return null;
+if (dm.hasActiveTask(e.room.name, ap)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (r.length > 0 && (o = gt(e.creep, r, "defense_refuel_spawn", 3))) return {
+if (r.length > 0 && (o = ht(e.creep, r, "defense_refuel_spawn", 3))) return {
 type: "transfer",
 target: o,
 resourceType: RESOURCE_ENERGY
@@ -28342,7 +28344,7 @@ resourceType: RESOURCE_ENERGY
 var o, n = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_EXTENSION && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-return n.length > 0 && (o = gt(e.creep, n, "defense_refuel_ext", 3)) ? {
+return n.length > 0 && (o = ht(e.creep, n, "defense_refuel_ext", 3)) ? {
 type: "transfer",
 target: o,
 resourceType: RESOURCE_ENERGY
@@ -28350,17 +28352,17 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = mm.getAssignedDeliveryAction(e);
+var c = dm.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Ld(e)) {
-var u = Bd(e, "hauler");
+if (!Dd(e)) {
+var u = Fd(e, "hauler");
 if (u) return u;
 }
 var l = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Ul(e.room);
-return r < 2e4 && o > op && n > 0 || Boolean(a) ? {
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = _l(e.room);
+return r < 2e4 && o > np && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28381,17 +28383,17 @@ resourceType: RESOURCE_ENERGY
 var m, d = e.depositContainers.filter(function(e) {
 return e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
-if (d.length > 0 && (m = gt(e.creep, d, "hauler_cont", 15))) return {
+if (d.length > 0 && (m = ht(e.creep, d, "hauler_cont", 15))) return {
 type: "transfer",
 target: m,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return rp.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return op.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-rp.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-jd(e);
+op.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+zd(e);
 }
 if (o) {
 var p = function(e) {
@@ -28399,7 +28401,7 @@ var t = e.sourceContainers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (t.length > 0) {
-var r = ip(e.creep, t, "energy_container");
+var r = sp(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -28412,7 +28414,7 @@ target: o,
 resourceType: RESOURCE_ENERGY
 };
 }
-return Ei(e.terminal) ? {
+return Ti(e.terminal) ? {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28420,7 +28422,7 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (p) return p;
 }
-if (e.droppedResources.length > 0 && (m = gt(e.creep, e.droppedResources, "hauler_drop", 5))) return ap(e, {
+if (e.droppedResources.length > 0 && (m = ht(e.creep, e.droppedResources, "hauler_drop", 5))) return ip(e, {
 type: "pickup",
 target: m
 });
@@ -28428,9 +28430,9 @@ var f = e.tombstones.filter(function(e) {
 return e.store.getUsedCapacity() > 0;
 });
 if (f.length > 0) {
-var y = gt(e.creep, f, "hauler_tomb", 10);
+var y = ht(e.creep, f, "hauler_tomb", 10);
 if (y) {
-if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return ap(e, {
+if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return ip(e, {
 type: "withdraw",
 target: y,
 resourceType: RESOURCE_ENERGY
@@ -28449,24 +28451,24 @@ var g = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (g.length > 0) {
-var h = ip(e.creep, g, "energy_container");
-if (h) return rp.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-ap(e, {
+var h = sp(e.creep, g, "energy_container");
+if (h) return op.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+ip(e, {
 type: "withdraw",
 target: h,
 resourceType: RESOURCE_ENERGY
 });
-rp.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
+op.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
 var R = e.creep.pos.findClosestByRange(g);
-if (R) return rp.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
-ap(e, {
+if (R) return op.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
+ip(e, {
 type: "withdraw",
 target: R,
 resourceType: RESOURCE_ENERGY
 });
 }
 if (e.mineralContainers.length > 0) {
-var E = ip(e.creep, e.mineralContainers, "mineral_container");
+var E = sp(e.creep, e.mineralContainers, "mineral_container");
 if (E) {
 if (T = Object.keys(E.store).find(function(e) {
 return e !== RESOURCE_ENERGY && E.store.getUsedCapacity(e) > 0;
@@ -28476,11 +28478,11 @@ target: E,
 resourceType: T
 };
 } else {
-rp.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+op.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var T, C = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (C && (T = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
-}))) return rp.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
+}))) return op.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
 {
 type: "withdraw",
 target: C,
@@ -28494,7 +28496,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > op || Ul(e.room)) return {
+if (o < 2e4 && n > np || _l(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28525,53 +28527,53 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return S ? ap(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (rp.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-ap(e, {
+return S ? ip(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (op.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+ip(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-})) : (rp.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (op.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 });
 },
 builder: function(e) {
-var t = qd(e), r = Yd(e);
+var t = jd(e), r = Vd(e);
 if (r) return r;
 if (t) {
-var o = Vd(e);
+var o = qd(e);
 if (o) return o;
-var n = Gd(e);
+var n = Ld(e);
 if (n) return n;
-if (!Ld(e)) {
-var a = Bd(e, "builder");
+if (!Dd(e)) {
+var a = Fd(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = ep(e), r = function(e) {
-var t = $d.get(e.name);
+var t = tp(e), r = function(e) {
+var t = ep.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(t, r) {
-return Math.max(t, gl(r, e));
+return Math.max(t, hl(r, e));
 }, Number.NEGATIVE_INFINITY), n = {
 tick: Game.time,
 sites: r,
 highestPriority: o
 };
-return $d.set(e.name, n), n;
+return ep.set(e.name, n), n;
 }(e.room);
 if (0 === r.sites.length) return delete t.targetId, null;
 if (t.targetId) {
 var o = Game.getObjectById(t.targetId);
 if (o && function(e, t) {
 return e.pos.roomName === t.name;
-}(o, e.room) && gl(o, e.room) >= r.highestPriority) return o;
+}(o, e.room) && hl(o, e.room) >= r.highestPriority) return o;
 delete t.targetId;
 }
 var n = function(e, t) {
 var r, o, n = t.sites.filter(function(r) {
-return gl(r, e.room) === t.highestPriority;
+return hl(r, e.room) === t.highestPriority;
 });
 return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
 }(e, r);
@@ -28590,15 +28592,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Dd(e, Id(e));
+return Bd(e, Gd(e));
 },
 upgrader: function(e) {
-if (qd(e)) {
-if (sp(e)) {
-var t = Gd(e);
+if (jd(e)) {
+if (cp(e)) {
+var t = Ld(e);
 if (t) return t;
-if (!Ld(e)) {
-var r = Bd(e, "upgrader");
+if (!Dd(e)) {
+var r = Fd(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28609,8 +28611,8 @@ target: e.room.controller
 type: "idle"
 };
 }
-var o = sp(e), n = function(t) {
-return o ? Dd(e, t) : t;
+var o = cp(e), n = function(t) {
+return o ? Bd(e, t) : t;
 }, a = e.room.controller;
 if (a) {
 var i = a.pos.findInRange(FIND_MY_STRUCTURES, 2, {
@@ -28640,12 +28642,12 @@ ids: l.map(function(e) {
 return e.id;
 }),
 tick: Game.time
-}), l.length > 0 && (m = gt(e.creep, l, "upgrader_nearby", 30))) return n({
+}), l.length > 0 && (m = ht(e.creep, l, "upgrader_nearby", 30))) return n({
 type: "withdraw",
 target: m,
 resourceType: RESOURCE_ENERGY
 });
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Ks) return n({
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Ys) return n({
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28653,16 +28655,16 @@ resourceType: RESOURCE_ENERGY
 var m, d = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
-if (d.length > 0 && (m = gt(e.creep, d, "upgrader_cont", 30))) return n({
+if (d.length > 0 && (m = ht(e.creep, d, "upgrader_cont", 30))) return n({
 type: "withdraw",
 target: m,
 resourceType: RESOURCE_ENERGY
 });
-var p = pt(e.room).filter(function(e) {
+var p = ft(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (p.length > 0) {
-var f = gt(e.creep, p, "upgrader_source", 30);
+var f = ht(e.creep, p, "upgrader_source", 30);
 if (f) return n({
 type: "harvest",
 target: f
@@ -28673,7 +28675,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (qd(e)) {
+if (jd(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28697,7 +28699,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Fd(e) || (e.storage ? {
+} : Wd(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28716,15 +28718,15 @@ return e.pos.getRangeTo(t) <= 2;
 })[0];
 }
 }(e.room);
-return r ? Dd(e, {
+return r ? Bd(e, {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
-}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Dd(e, {
+}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Bd(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Dd(e, {
+}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Bd(e, {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28733,7 +28735,7 @@ type: "idle"
 };
 },
 mineralHarvester: function(e) {
-var t, r = dt(e.room, FIND_MINERALS)[0];
+var t, r = pt(e.room, FIND_MINERALS)[0];
 if (!r) return {
 type: "idle"
 };
@@ -28774,7 +28776,7 @@ target: r
 depositHarvester: function(e) {
 var t;
 if (!e.memory.targetId) {
-var r = dt(e.room, FIND_DEPOSITS);
+var r = pt(e.room, FIND_DEPOSITS);
 if (r.length > 0) {
 var o = r.reduce(function(e, t) {
 return e.cooldown < t.cooldown ? e : t;
@@ -28817,15 +28819,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : dp(e);
+} : pp(e);
 },
-labSupply: dp,
+labSupply: pp,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (qd(e)) {
+if (jd(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28915,7 +28917,7 @@ routeType: "harvester"
 };
 var o = e.assignedSource;
 if (o || (o = function(e) {
-var t, r, o, n, i, s = pt(e.room);
+var t, r, o, n, i, s = ft(e.room);
 if (0 === s.length) return null;
 if (e.memory.sourceId) {
 var c = s.find(function(t) {
@@ -29005,11 +29007,11 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t, r = qd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
+var t, r = jd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
 if (!o || o === n) return {
 type: "idle"
 };
-if (a && e.room.name === n && (t = cp(e))) return t;
+if (a && e.room.name === n && (t = up(e))) return t;
 if (e.nearbyEnemies && e.hostiles.length > 0) {
 var i = e.hostiles.filter(function(t) {
 return e.creep.pos.getRangeTo(t) <= 5 && (t.getActiveBodyparts(ATTACK) > 0 || t.getActiveBodyparts(RANGED_ATTACK) > 0);
@@ -29029,7 +29031,7 @@ if (r || a && e.room.name === n) return e.room.name !== n ? {
 type: "remoteMoveToRoom",
 roomName: n,
 routeType: "hauler"
-} : (t = cp(e)) || (a && e.room.name === n ? (jd(e), {
+} : (t = up(e)) || (a && e.room.name === n ? (zd(e), {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
@@ -29044,7 +29046,7 @@ routeType: "hauler"
 var s = .3 * e.creep.store.getCapacity(RESOURCE_ENERGY), c = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) >= s;
 });
-if (c.length > 0 && (u = gt(e.creep, c, "remoteHauler_remoteCont", 10))) return {
+if (c.length > 0 && (u = ht(e.creep, c, "remoteHauler_remoteCont", 10))) return {
 type: "withdraw",
 target: u,
 resourceType: RESOURCE_ENERGY
@@ -29052,10 +29054,10 @@ resourceType: RESOURCE_ENERGY
 var u, l = e.droppedResources.filter(function(e) {
 return e.resourceType === RESOURCE_ENERGY && e.amount > 50;
 });
-return l.length > 0 && (u = gt(e.creep, l, "remoteHauler_remoteDrop", 3)) ? {
+return l.length > 0 && (u = ht(e.creep, l, "remoteHauler_remoteDrop", 3)) ? {
 type: "pickup",
 target: u
-} : 0 === c.length && e.containers.length > 0 && (u = gt(e.creep, e.containers, "remoteHauler_waitCont", 20)) && e.creep.pos.getRangeTo(u) > 2 ? {
+} : 0 === c.length && e.containers.length > 0 && (u = ht(e.creep, e.containers, "remoteHauler_waitCont", 20)) && e.creep.pos.getRangeTo(u) > 2 ? {
 type: "remoteMoveTo",
 target: u,
 routeType: "hauler"
@@ -29084,17 +29086,17 @@ type: "transfer",
 target: i.storage,
 resourceType: a
 };
-if ((s = dt(i, FIND_STRUCTURES, {
+if ((s = pt(i, FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_CONTAINER && e.store.getFreeCapacity(a) > 0;
 },
 filterKey: "container_".concat(a)
-})).length > 0 && (c = gt(e.creep, s, "interRoomCarrier_targetCont", 10))) return {
+})).length > 0 && (c = ht(e.creep, s, "interRoomCarrier_targetCont", 10))) return {
 type: "transfer",
 target: c,
 resourceType: a
 };
-var u = ft(i, STRUCTURE_SPAWN);
+var u = yt(i, STRUCTURE_SPAWN);
 return u.length > 0 ? e.creep.pos.isNearTo(u[0]) ? {
 type: "drop",
 resourceType: a
@@ -29112,12 +29114,12 @@ roomName: o
 type: "withdraw",
 target: i.storage,
 resourceType: a
-} : (s = dt(i, FIND_STRUCTURES, {
+} : (s = pt(i, FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_CONTAINER && e.store.getUsedCapacity(a) > 0;
 },
 filterKey: "container_".concat(a)
-})).length > 0 && (c = gt(e.creep, s, "interRoomCarrier_sourceCont", 10)) ? {
+})).length > 0 && (c = ht(e.creep, s, "interRoomCarrier_sourceCont", 10)) ? {
 type: "withdraw",
 target: c,
 resourceType: a
@@ -29130,16 +29132,16 @@ roomName: o
 }
 };
 
-function fp(e) {
+function yp(e) {
 var t;
-return (null !== (t = pp[e.memory.role]) && void 0 !== t ? t : Zd)(e);
+return (null !== (t = fp[e.memory.role]) && void 0 !== t ? t : Jd)(e);
 }
 
-var yp = new Set([ "build", "repair", "upgrade" ]);
+var vp = new Set([ "build", "repair", "upgrade" ]);
 
-function vp(e, t) {
+function gp(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && Kd(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && Yd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -29148,12 +29150,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Vd(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : qd(e);
 }(e, t);
-return r || (yp.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || sp(e) ? Gd(e) : null : null);
+return r || (vp.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || cp(e) ? Ld(e) : null : null);
 }
 
-var gp = "patrol", hp = [ {
+var hp = "patrol", Rp = [ {
 x: 10,
 y: 5
 }, {
@@ -29189,7 +29191,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], Rp = [ {
+} ], Ep = [ {
 x: 10,
 y: 10
 }, {
@@ -29206,7 +29208,7 @@ x: 25,
 y: 25
 } ];
 
-function Ep(e) {
+function Tp(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -29214,7 +29216,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function Tp(e) {
+function Cp(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -29224,9 +29226,9 @@ roomName: e.roomName
 });
 }
 
-function Cp(e) {
-var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Re.get(e.name, {
-namespace: gp
+function Sp(e) {
+var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Ee.get(e.name, {
+namespace: hp
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -29246,25 +29248,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(hp), !1), i(Rp), !1);
-}(t).map(Ep).filter(function(e) {
+}(e)), !1), i(Rp), !1), i(Ep), !1);
+}(t).map(Tp).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
-return Re.set(e.name, {
-waypoints: Tp(n),
+return Ee.set(e.name, {
+waypoints: Cp(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: gp,
+namespace: hp,
 ttl: 1e3
 }), n;
 }
 
-function Sp(e, t) {
+function wp(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -29274,89 +29276,89 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var wp = M("MilitaryBehaviors");
+var xp = M("MilitaryBehaviors");
 
-function xp(e) {
+function bp(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
-delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === yi && (delete e.task,
+delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === vi && (delete e.task,
 delete e.targetRoom);
 }
 
-function bp(e, t) {
+function Op(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function Op(e) {
-return No(ko(e));
-}
-
 function kp(e) {
-return e.creep.room.name === e.homeRoom && X(e.room).length > 0;
+return Po(Mo(e));
 }
 
 function Mp(e) {
+return e.creep.room.name === e.homeRoom && Z(e.room).length > 0;
+}
+
+function Ap(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Ap(e, t) {
+function Up(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Up(e) {
-return Ap(e, "guard") + Ap(e, "ranger") + Ap(e, "healer");
+function _p(e) {
+return Up(e, "guard") + Up(e, "ranger") + Up(e, "healer");
 }
 
-function _p(e, t, r) {
+function Np(e, t, r) {
 var o = e.memory;
-return hi(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
+return Ri(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function Np(e, t) {
+function Pp(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return _p(r, e, t);
+return Np(r, e, t);
 });
 }
 
-function Pp(e) {
+function Ip(e) {
 return "number" == typeof e.createdAt && Number.isFinite(e.createdAt) ? e.createdAt : Game.time;
 }
 
-function Ip(e, t, r) {
-return Ap(e, t) > function(e, t) {
+function Gp(e, t, r) {
+return Up(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
-return !r.spawning && o.role === t && hi(o) === e;
+return !r.spawning && o.role === t && Ri(o) === e;
 }).length;
-}(e.roomName, t) || Up(e) > 0 && Op(e.roomName) && function(e, t) {
-return Np(e, t).length;
+}(e.roomName, t) || _p(e) > 0 && kp(e.roomName) && function(e, t) {
+return Pp(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Gp(e, t) {
+function Lp(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
-if (t.task && t.task !== yi) return null;
-if (kp(e)) return null;
+if (t.task && t.task !== vi) return null;
+if (Mp(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Mp).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ap).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== X(l).length && Ip(u, t.role, e.homeRoom)) {
-var m = Pp(u);
-return gi(e.creep, {
+if (l && 0 !== Z(l).length && Gp(u, t.role, e.homeRoom)) {
+var m = Ip(u);
+return hi(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
 createdAt: m,
-squadId: vi(e.homeRoom, u.roomName, m),
-squadSize: Op(u.roomName) ? Math.max(5, Up(u)) : Math.max(1, Up(u))
+squadId: gi(e.homeRoom, u.roomName, m),
+squadSize: kp(u.roomName) ? Math.max(5, _p(u)) : Math.max(1, _p(u))
 }), u.roomName;
 }
 }
@@ -29374,7 +29376,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Lp(e) {
+function Dp(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -29382,19 +29384,19 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Dp(e, t) {
+function Bp(e, t) {
 if (!function(e) {
-return Boolean(hi(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
+return Boolean(Ri(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
 if (e.creep.room.name !== e.homeRoom) return null;
-var r = hi(t);
+var r = Ri(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = ko(r), n = No(o), a = n ? Np(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
-var r = hi(e);
+var o = Mo(r), n = Po(o), a = n ? Pp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var r = Ri(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && _p(e, r, o);
+return e.memory.defenseSquadId === t && Np(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -29408,9 +29410,9 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return Np(e, t).reduce(function(e, t) {
+return Pp(e, t).reduce(function(e, t) {
 var r, o;
-return r = e, o = So(t.body.filter(function(e) {
+return r = e, o = wo(t.body.filter(function(e) {
 return e.hits > 0;
 })), {
 partCount: r.partCount + o.partCount,
@@ -29430,16 +29432,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return bp(t, "parity-ready"), null;
-if (c >= u) return bp(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Op(t, "parity-ready"), null;
+if (c >= u) return Op(t, "squad-quorum"), null;
 if (l) {
-if (!n) return bp(t, "expired-staging"), null;
+if (!n) return Op(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Lp(e) - Lp(t);
+var r = Dp(e) - Dp(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -29447,20 +29449,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return bp(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Op(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return bp(t, "squad-quorum"), null;
-if (l) return bp(t, "expired-staging"), null;
+if (c >= u) return Op(t, "squad-quorum"), null;
+if (l) return Op(t, "expired-staging"), null;
 }
-var m = kl(e.room.name);
+var m = Ml(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function Bp(e) {
+function Fp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -29492,21 +29494,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Fp(e, t) {
+function Wp(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Wp(e, t) {
+function Hp(e, t) {
 if (!e.swarmState) return null;
-var r = kl(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (wp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = Ml(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (xp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Hp(e) {
+function Kp(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -29530,7 +29532,7 @@ if (t) throw t.error;
 }
 }
 
-function Kp(e) {
+function Yp(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -29538,38 +29540,38 @@ return Boolean(e);
 });
 }
 
-function Yp(e) {
+function Vp(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Vp(e) {
+function qp(e) {
 var t, r = e.creep.memory;
-if (Ri(e.creep)) return {
+if (Ei(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Hp(e.memory.squadId);
-if (o) return qp(e, o);
+var o = Kp(e.memory.squadId);
+if (o) return jp(e, o);
 }
-var n = null !== (t = Gp(e, r)) && void 0 !== t ? t : hi(r);
-if (n && !kp(e)) {
-var a = Dp(e, r);
+var n = null !== (t = Lp(e, r)) && void 0 !== t ? t : Ri(r);
+if (n && !Mp(e)) {
+var a = Bp(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
 var i = function(e) {
-var t, r, o = Z(e.room).filter(function(e) {
+var t, r, o = J(e.room).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Bp(e);
+var s = Fp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Fp(e.creep, RANGED_ATTACK), l = Fp(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -29581,7 +29583,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Fp(e.creep, RANGED_ATTACK), l = Fp(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29592,7 +29594,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (xp(r), e.creep.room.name !== e.homeRoom) return {
+} else if (bp(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29601,8 +29603,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Bp(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Fp(e.creep, RANGED_ATTACK), l = Fp(e.creep, ATTACK),
+var m = Fp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -29613,7 +29615,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = Cp(e.room), p = Sp(e.creep, d);
+var d = Sp(e.room), p = wp(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -29627,7 +29629,7 @@ type: "idle"
 };
 }
 
-function qp(e, t) {
+function jp(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -29635,7 +29637,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Yp(t);
+var n = Vp(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -29643,7 +29645,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Kp(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Yp(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29666,7 +29668,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Kp(e).filter(function(t) {
+var t, r, o = Yp(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29695,7 +29697,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Kp(t).filter(function(t) {
+var r = Yp(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29711,7 +29713,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Kp(t).sort(function(e, t) {
+var a = Yp(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29748,7 +29750,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Kp(t).filter(function(e) {
+var l = Yp(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29765,7 +29767,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Kp(e).find(function(e) {
+return null !== (t = Yp(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29776,7 +29778,7 @@ target: m
 type: "idle"
 };
 }
-var d = Bp(e);
+var d = Fp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29788,10 +29790,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Fp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Fp(e.creep, ATTACK) && p <= 1 ? {
+} : Wp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29799,7 +29801,7 @@ type: "moveTo",
 target: d
 };
 }
-var f = Z(e.room).filter(function(e) {
+var f = J(e.room).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 }), y = null !== (o = e.creep.pos.findClosestByRange(f.filter(function(e) {
 return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAWN;
@@ -29807,10 +29809,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Fp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Fp(e.creep, ATTACK) && p <= 1 ? {
+} : Wp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29826,7 +29828,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Yp(t)
+target: Vp(t)
 };
 
 case "dissolving":
@@ -29844,8 +29846,8 @@ type: "idle"
 }
 }
 
-var jp = {
-guard: Vp,
+var zp = {
+guard: qp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29854,8 +29856,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = Cp(e.room);
-return (o = Sp(e.creep, r)) ? {
+var r = Sp(e.room);
+return (o = wp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29867,12 +29869,12 @@ type: "remoteMoveToRoom",
 roomName: t.targetRoom,
 routeType: "guard"
 };
-var o, n = X(e.room).filter(io);
+var o, n = Z(e.room).filter(so);
 if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = Cp(e.room), (o = Sp(e.creep, r)) ? {
+} : (r = Sp(e.room), (o = wp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29886,11 +29888,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Fp(e, HEAL);
+return Wp(e, HEAL);
 }), t.filter(function(e) {
-return Fp(e, RANGED_ATTACK);
+return Wp(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Fp(e, ATTACK);
+return Wp(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29911,7 +29913,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Fp(e.creep, RANGED_ATTACK), u = Fp(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Wp(e.creep, RANGED_ATTACK), u = Wp(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29942,19 +29944,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Hp(e.memory.squadId);
-if (o) return qp(e, o);
+var o = Kp(e.memory.squadId);
+if (o) return jp(e, o);
 }
-var n = null !== (t = Gp(e, r)) && void 0 !== t ? t : hi(r);
-if (n && !kp(e)) {
-var a = Dp(e, r);
+var n = null !== (t = Lp(e, r)) && void 0 !== t ? t : Ri(r);
+if (n && !Mp(e)) {
+var a = Bp(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === X(i).length) return xp(r), {
+if (0 === Z(i).length) return bp(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -29962,7 +29964,7 @@ type: "moveToRoom",
 roomName: n
 };
 }
-if (r.targetRoom && r.task !== yi && !r.assistTarget) {
+if (r.targetRoom && r.task !== vi && !r.assistTarget) {
 if (e.room.name !== r.targetRoom) return {
 type: "moveToRoom",
 roomName: r.targetRoom
@@ -30022,7 +30024,7 @@ var r, o = e.room.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax && function(e, t) {
 var r = e.memory;
-return "healer" !== r.role && "military" === r.family && (!t || hi(r) === t);
+return "healer" !== r.role && "military" === r.family && (!t || Ri(r) === t);
 }(e, t);
 }
 });
@@ -30042,13 +30044,13 @@ return "military" === t.family && "healer" !== t.role;
 }
 });
 if (p.length > 0) {
-var f = gt(e.creep, p, "healer_follow", 5);
+var f = ht(e.creep, p, "healer_follow", 5);
 if (f) return {
 type: "moveTo",
 target: f
 };
 }
-var y = Cp(e.room), v = Sp(e.creep, y);
+var y = Sp(e.room), v = wp(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -30059,8 +30061,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Hp(e.memory.squadId);
-if (r) return qp(e, r);
+var r = Kp(e.memory.squadId);
+if (r) return jp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30082,9 +30084,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Bp(e);
+var a = Fp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Fp(e.creep, RANGED_ATTACK), c = Fp(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Wp(e.creep, RANGED_ATTACK), c = Wp(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -30096,14 +30098,14 @@ type: "moveTo",
 target: a
 };
 }
-var u = e.creep.pos.findClosestByRange(Z(e.room).filter(function(e) {
+var u = e.creep.pos.findClosestByRange(J(e.room).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 }));
 if (u) return {
 type: "attack",
 target: u
 };
-var l = Cp(e.room), m = Sp(e.creep, l);
+var l = Sp(e.room), m = wp(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -30112,7 +30114,7 @@ var d = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 if (d.length > 0) {
-var p = gt(e.creep, d, "soldier_spawn", 20);
+var p = ht(e.creep, d, "soldier_spawn", 20);
 if (p && e.creep.pos.getRangeTo(p) > 5) return {
 type: "moveTo",
 target: p
@@ -30125,8 +30127,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Hp(e.memory.squadId);
-if (r) return qp(e, r);
+var r = Kp(e.memory.squadId);
+if (r) return jp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30148,7 +30150,7 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Z(e.room), c = e.creep.pos.findClosestByRange(a.filter(function(e) {
+var a = J(e.room), c = e.creep.pos.findClosestByRange(a.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 }));
 if (c) return {
@@ -30174,7 +30176,7 @@ return Boolean(a && j(a) || i && j(i));
 return e.structureType === STRUCTURE_RAMPART && e.hits < 1e5;
 })), !1);
 if (l.length > 0) {
-var m = gt(e.creep, l, "siege_wall", 10);
+var m = ht(e.creep, l, "siege_wall", 10);
 if (m) return {
 type: "dismantle",
 target: m
@@ -30187,9 +30189,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Wp(e, "siegeUnit");
+var p = Hp(e, "siegeUnit");
 if (p) return p;
-var f = Cp(e.room), y = Sp(e.creep, f);
+var f = Sp(e.room), y = wp(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -30200,8 +30202,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Hp(e.memory.squadId);
-if (r) return qp(e, r);
+var r = Kp(e.memory.squadId);
+if (r) return jp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -30218,7 +30220,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Wp(e, "harasser (no target)") || {
+if (!t) return Hp(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -30260,9 +30262,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Wp(e, "harasser (no targets)");
+var c = Hp(e, "harasser (no targets)");
 if (c) return c;
-var u = Cp(e.room), l = Sp(e.creep, u);
+var u = Sp(e.room), l = wp(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -30272,12 +30274,12 @@ type: "idle"
 },
 ranger: function(e) {
 var t, r, o = e.creep.memory;
-if (Ri(e.creep)) return {
+if (Ei(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Hp(e.memory.squadId))) return qp(e, a);
+if (e.memory.squadId && (a = Kp(e.memory.squadId))) return jp(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (hi(o) && xp(o), e.room.name !== e.homeRoom) return {
+if (Ri(o) && bp(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -30291,26 +30293,26 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Gp(e, o)) && void 0 !== t ? t : hi(o);
-if (i && !kp(e)) {
-var s = Dp(e, o);
+var a, i = null !== (t = Lp(e, o)) && void 0 !== t ? t : Ri(o);
+if (i && !Mp(e)) {
+var s = Bp(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
 type: "moveToRoom",
 roomName: i
 };
-var u = X(c), l = Z(c).filter(function(e) {
+var u = Z(c), l = J(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return xp(o), {
+if (0 === u.length && 0 === l.length) return bp(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Bp(e);
+var m = Fp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -30330,8 +30332,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Hp(e.memory.squadId))) return qp(e, a);
-var p, f = Bp(e);
+if (e.memory.squadId && (a = Kp(e.memory.squadId))) return jp(e, a);
+var p, f = Fp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -30342,7 +30344,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = Cp(e.room), v = Sp(e.creep, y);
+var y = Sp(e.room), v = wp(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -30351,7 +30353,7 @@ var g = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 if (g.length > 0) {
-var h = gt(e.creep, g, "harasser_home_spawn", 20);
+var h = ht(e.creep, g, "harasser_home_spawn", 20);
 if (h && e.creep.pos.getRangeTo(h) > 10) return {
 type: "moveTo",
 target: h
@@ -30363,21 +30365,21 @@ type: "idle"
 }
 };
 
-function zp(e) {
+function Qp(e) {
 var t;
-return mm.getAssignedAction(e) || (null !== (t = jp[e.memory.role]) && void 0 !== t ? t : Vp)(e);
+return dm.getAssignedAction(e) || (null !== (t = zp[e.memory.role]) && void 0 !== t ? t : qp)(e);
 }
 
-var Qp = M("PowerExecutor");
+var Xp = M("PowerExecutor");
 
-function Xp(e, t) {
+function Zp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Zp(e) {
+function Jp(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -30386,7 +30388,7 @@ if (e.room.name !== t) return {
 type: "moveToRoom",
 roomName: t
 };
-var r = dt(e.room, FIND_STRUCTURES, {
+var r = pt(e.room, FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_POWER_BANK;
 },
@@ -30397,7 +30399,7 @@ type: "moveToRoom",
 roomName: e.homeRoom
 };
 if (e.creep.hits < .5 * e.creep.hitsMax) {
-var o = dt(e.room, FIND_MY_CREEPS, {
+var o = pt(e.room, FIND_MY_CREEPS, {
 filter: function(e) {
 return "healer" === e.memory.role && e.memory.targetRoom === t;
 },
@@ -30419,8 +30421,8 @@ type: "idle"
 };
 }
 
-var Jp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), $p = {
-powerHarvester: Zp,
+var $p = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), ef = {
+powerHarvester: Jp,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -30430,7 +30432,7 @@ roomName: e.homeRoom
 };
 var r = Game.rooms[e.homeRoom];
 if (r) {
-var o = ft(r, STRUCTURE_POWER_SPAWN)[0];
+var o = yt(r, STRUCTURE_POWER_SPAWN)[0];
 if (o && o.store.getFreeCapacity(RESOURCE_POWER) > 0) return {
 type: "transfer",
 target: o,
@@ -30453,17 +30455,17 @@ if (e.room.name !== t) return {
 type: "moveToRoom",
 roomName: t
 };
-var n, a, i = (n = e.room, a = RESOURCE_POWER, a ? dt(n, FIND_DROPPED_RESOURCES, {
+var n, a, i = (n = e.room, a = RESOURCE_POWER, a ? pt(n, FIND_DROPPED_RESOURCES, {
 filter: function(e) {
 return e.resourceType === a;
 },
 filterKey: a
-}) : dt(n, FIND_DROPPED_RESOURCES))[0];
+}) : pt(n, FIND_DROPPED_RESOURCES))[0];
 if (i) return {
 type: "pickup",
 target: i
 };
-var s = dt(e.room, FIND_RUINS, {
+var s = pt(e.room, FIND_RUINS, {
 filter: function(e) {
 return e.store.getUsedCapacity(RESOURCE_POWER) > 0;
 },
@@ -30474,7 +30476,7 @@ type: "withdraw",
 target: s,
 resourceType: RESOURCE_POWER
 };
-var c = dt(e.room, FIND_STRUCTURES, {
+var c = pt(e.room, FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_POWER_BANK;
 },
@@ -30492,65 +30494,65 @@ roomName: e.homeRoom
 }
 };
 
-function ef(e) {
+function tf(e) {
 var t;
-return (null !== (t = $p[e.memory.role]) && void 0 !== t ? t : Zp)(e);
+return (null !== (t = ef[e.memory.role]) && void 0 !== t ? t : Jp)(e);
 }
 
-function tf(e) {
+function rf(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var rf = {
+var of = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, of = {
+}, nf = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, nf = {
+}, af = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, af = {
+}, sf = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, sf = {
+}, cf = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, cf = {
+}, uf = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, uf = {
+}, lf = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, lf = {
+}, mf = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function mf(e) {
+function df(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function df(e) {
+function pf(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -30558,7 +30560,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function pf(e) {
+function ff(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -30566,12 +30568,12 @@ y: parseInt(n, 10)
 };
 }
 
-function ff(e) {
+function yf(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = yf(s);
+o[s.n] = vf(s);
 }
 } catch (e) {
 t = {
@@ -30587,23 +30589,23 @@ if (t) throw t.error;
 return o;
 }
 
-function yf(e) {
+function vf(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = of[e.r]) && void 0 !== t ? t : "core",
-health: vf(e.h),
+role: null !== (t = nf[e.r]) && void 0 !== t ? t : "core",
+health: gf(e.h),
 activeTasks: e.t,
-portals: e.p.map(gf),
+portals: e.p.map(hf),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(hf)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Rf)
 };
 }
 
-function vf(e) {
+function gf(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = af[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = sf[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -30616,11 +30618,11 @@ lastUpdate: e.u
 };
 }
 
-function gf(e) {
+function hf(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: df(e.sp),
+sourcePos: pf(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -30630,7 +30632,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function hf(e) {
+function Rf(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -30639,7 +30641,7 @@ bucketLevel: e.b
 };
 }
 
-function Rf(e) {
+function Ef(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30649,12 +30651,12 @@ isAlly: 1 === e.a
 };
 }
 
-function Ef(e) {
+function Tf(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Tf(u);
+i[u.n] = Cf(u);
 }
 } catch (e) {
 t = {
@@ -30677,13 +30679,13 @@ updatedAt: e.u
 };
 }
 
-function Tf(e) {
+function Cf(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: pf(e.pp),
+portalPos: ff(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30694,46 +30696,46 @@ lastUpdate: e.u
 };
 }
 
-function Cf(e) {
+function Sf(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = cf[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = uf[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = lf[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = mf[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function Sf(e, t) {
+function wf(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
-}
-
-function wf(e) {
-var t;
-return {
-c: null !== (t = nf[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: Sf(e.cpuUsage, 2),
-b: e.bucketLevel,
-e: Math.round(e.economyIndex),
-w: Math.round(e.warIndex),
-m: Math.round(e.commodityIndex),
-rc: e.roomCount,
-rl: Sf(e.avgRCL, 1),
-cc: e.creepCount,
-u: e.lastUpdate
-};
 }
 
 function xf(e) {
 var t;
 return {
+c: null !== (t = af[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: wf(e.cpuUsage, 2),
+b: e.bucketLevel,
+e: Math.round(e.economyIndex),
+w: Math.round(e.warIndex),
+m: Math.round(e.commodityIndex),
+rc: e.roomCount,
+rl: wf(e.avgRCL, 1),
+cc: e.creepCount,
+u: e.lastUpdate
+};
+}
+
+function bf(e) {
+var t;
+return {
 sr: e.sourceRoom,
-sp: mf(e.sourcePos),
+sp: df(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30742,27 +30744,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function bf(e) {
+function Of(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: Sf(e.cpuUsed, 2),
+u: wf(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function Of(e) {
+function kf(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(kf)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Mf)
 };
 }
 
-function kf(e) {
+function Mf(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30772,23 +30774,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Mf(e) {
+function Af(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = sf[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = cf[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = uf[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = lf[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Af(e) {
+function Uf(e) {
 return {
 name: e,
 role: "core",
@@ -30811,7 +30813,7 @@ cpuLimit: 0
 };
 }
 
-function Uf(e) {
+function _f(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30821,16 +30823,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = rf[t.role]) && void 0 !== r ? r : t.role[0],
-h: wf(t.health),
+r: null !== (r = of[t.role]) && void 0 !== r ? r : t.role[0],
+h: xf(t.health),
 t: t.activeTasks,
-p: t.portals.map(xf),
+p: t.portals.map(bf),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(bf)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Of)
 };
 }(t[0], t[1]);
 }),
-g: Of(e.globalTargets),
+g: kf(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30844,7 +30846,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? mf(t.portalPos) : void 0,
+pp: t.portalPos ? df(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30856,21 +30858,21 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Mf),
+k: e.tasks.map(Af),
 ls: e.lastSync
 };
 var t;
-}(e), r = tf(JSON.stringify(t));
+}(e), r = rf(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function _f(e) {
+function Nf(e) {
 try {
-var t = JSON.parse(e), r = tf(JSON.stringify(t.d));
-return t.c !== r ? (_e.warn("InterShardMemory checksum mismatch", {
+var t = JSON.parse(e), r = rf(JSON.stringify(t.d));
+return t.c !== r ? (Ne.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
 expected: r,
@@ -30878,30 +30880,30 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: ff(a.s),
+shards: yf(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(Rf)), n),
-footprintOperation: a.o ? Ef(a.o) : void 0,
-tasks: a.k.map(Cf),
+o.en && (n.enemies = o.en.map(Ef)), n),
+footprintOperation: a.o ? Tf(a.o) : void 0,
+tasks: a.k.map(Sf),
 lastSync: a.ls,
 checksum: i
 });
 } catch (e) {
-return _e.error("Failed to deserialize InterShardMemory: ".concat(String(e)), {
+return Ne.error("Failed to deserialize InterShardMemory: ".concat(String(e)), {
 subsystem: "InterShard"
 }), null;
 }
 var o, n, a, i;
 }
 
-var Nf, Pf, If = 102400, Gf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var Pf, If, Gf = 102400, Lf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function Lf(e, t, r) {
+function Df(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = Wf(t), s = function(e, t, r) {
+var i = Hf(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30914,11 +30916,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(Ff(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Gf), c = null !== (a = Wf(Uf(s))) && void 0 !== a ? a : {};
+}(Wf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Lf), c = null !== (a = Hf(_f(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function Df(e) {
+function Bf(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30934,69 +30936,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = Ff(r, Wf(r))) && void 0 !== t ? t : e;
+return r && null !== (t = Wf(r, Hf(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function Bf(e, t) {
+function Ff(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(Lf(e, r, t)), !0;
+return InterShardMemory.setLocal(Df(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function Ff(e, t) {
+function Wf(e, t) {
 return t && function(e) {
-return Hf(e.d) && "number" == typeof e.c;
-}(t) ? _f(e) : null;
+return Kf(e.d) && "number" == typeof e.c;
+}(t) ? Nf(e) : null;
 }
 
-function Wf(e) {
+function Hf(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return Hf(t) ? t : null;
+return Kf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function Hf(e) {
+function Kf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Nf || (Nf = {})), function(e) {
+}(Pf || (Pf = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(Pf || (Pf = {}));
+}(If || (If = {}));
 
-var Kf = null != _e ? _e : {
+var Yf = null != Ne ? Ne : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Yf = {
+}, Vf = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Vf = {
+}, qf = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, qf = function() {
+}, jf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Yf), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Vf), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -31013,19 +31015,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = _f(r);
-o && (this.interShardMemory = o, Kf.debug("Loaded InterShardMemory", {
+var o = Nf(r);
+o && (this.interShardMemory = o, Yf.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Kf.error("Failed to load InterShardMemory: ".concat(n), {
+Yf.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Af(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Uf(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -31110,7 +31112,7 @@ f = l.length > 0 ? f / l.length : 0;
 var R = 0;
 try {
 for (var E = a(l), T = E.next(); !T.done; T = E.next()) {
-var C = X(T.value).length;
+var C = Z(T.value).length;
 R += Math.min(100, 10 * C);
 }
 } catch (e) {
@@ -31186,25 +31188,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Kf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Yf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Kf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Yf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Kf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Yf.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Kf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Yf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -31237,7 +31239,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Kf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Yf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31267,12 +31269,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Kf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Yf.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Kf.info("War ended, transitioning to ".concat(i), {
+Yf.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Kf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Yf.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -31298,7 +31300,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Vf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = qf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -31350,13 +31352,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Kf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Yf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Kf.debug("Could not set shard limits: ".concat(S), {
+Yf.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -31364,27 +31366,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Kf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Yf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = Lf(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = Df(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > If) {
-Kf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(If), {
+if (r.length > Gf) {
+Yf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(Gf), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = Lf(this.interShardMemory, t, {
+var o = Df(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > If ? (Kf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(If), {
+return o.length > Gf ? (Yf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(Gf), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Kf.error("Failed to sync InterShardMemory: ".concat(n), {
+Yf.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -31422,7 +31424,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Af(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Uf(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -31440,40 +31442,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Kf.info("Repaired InterShardMemory structure", {
+Yf.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Kf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Yf.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = _f(r);
-if (!o) return void Kf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Nf(r);
+if (!o) return void Yf.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Kf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Yf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Kf.warn("InterShardMemory verification failed: ".concat(a), {
+Yf.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Kf.info("Attempting InterShardMemory recovery", {
+Yf.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = _f(r);
-if (o) return this.interShardMemory = o, void Kf.info("Recovered InterShardMemory from storage", {
+var o = Nf(r);
+if (o) return this.interShardMemory = o, void Yf.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -31488,12 +31490,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Af(n), Kf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Uf(n), Yf.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Kf.error("InterShardMemory recovery failed: ".concat(a), {
+Yf.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31503,7 +31505,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Kf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Yf.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -31519,7 +31521,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Kf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Yf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -31535,7 +31537,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Kf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Yf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -31550,7 +31552,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Kf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Yf.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -31569,7 +31571,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Kf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Yf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -31615,11 +31617,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Kf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Yf.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = Uf(this.interShardMemory).length, o = r / If * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = _f(this.interShardMemory).length, o = r / Gf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -31646,11 +31648,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Kf.info("Forcing InterShardMemory sync with validation", {
+Yf.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = Uf(this.interShardMemory).length, n = Uf(o(o({}, this.interShardMemory), {
+var e, t, r = _f(this.interShardMemory).length, n = _f(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31674,8 +31676,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: If,
-percent: Math.round(r / If * 1e4) / 100,
+limit: Gf,
+percent: Math.round(r / Gf * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31683,10 +31685,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Nf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Pf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), jf = new qf, zf = {
+}(), zf = new jf, Qf = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31697,11 +31699,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: Pf.LOW,
-NORMAL: Pf.NORMAL,
-HIGH: Pf.HIGH
+LOW: If.LOW,
+NORMAL: If.NORMAL,
+HIGH: If.HIGH
 }
-}, Qf = function() {
+}, Xf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31711,7 +31713,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = jf.getActiveTransferTasks();
+var n = zf.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31738,7 +31740,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = jf.getOptimalPortalRoute(e.targetShard);
+var t = zf.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31755,13 +31757,13 @@ status: "queued",
 assignedCreeps: [],
 transferred: 0
 };
-this.memory.requests[e.id] = o, _e.info("Created transfer request: ".concat(e.resourceAmount, " ").concat(e.resourceType, " from ").concat(r, " to ").concat(e.targetShard, "/").concat(e.targetRoom), {
+this.memory.requests[e.id] = o, Ne.info("Created transfer request: ".concat(e.resourceAmount, " ").concat(e.resourceType, " from ").concat(r, " to ").concat(e.targetShard, "/").concat(e.targetRoom), {
 subsystem: "CrossShardTransfer"
 });
-} else _e.warn("No room with sufficient ".concat(e.resourceType, " for transfer"), {
+} else Ne.warn("No room with sufficient ".concat(e.resourceType, " for transfer"), {
 subsystem: "CrossShardTransfer"
 });
-} else _e.warn("No portal found to ".concat(e.targetShard, ", cannot create transfer request"), {
+} else Ne.warn("No portal found to ".concat(e.targetShard, ", cannot create transfer request"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31806,7 +31808,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-jf.updateTaskProgress(e.taskId, t);
+zf.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31815,26 +31817,26 @@ return void 0 !== e;
 }), n = o.reduce(function(e, t) {
 return e + t.carryCapacity;
 }, 0);
-if (n >= r) return e.status = "gathering", void _e.info("Transfer request ".concat(e.taskId, " moving to gathering phase"), {
+if (n >= r) return e.status = "gathering", void Ne.info("Transfer request ".concat(e.taskId, " moving to gathering phase"), {
 subsystem: "CrossShardTransfer"
 });
 var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = zf.optimizeBody({
+i = Qf.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
 } catch (e) {
-return void _e.error("Failed to optimize body for crossShardCarrier: ".concat(String(e)), {
+return void Ne.error("Failed to optimize body for crossShardCarrier: ".concat(String(e)), {
 subsystem: "CrossShardTransfer"
 });
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = zf.spawnPriorities.LOW;
-e.priority >= 80 ? d = zf.spawnPriorities.HIGH : e.priority >= 50 && (d = zf.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Qf.spawnPriorities.LOW;
+e.priority >= 80 ? d = Qf.spawnPriorities.HIGH : e.priority >= 50 && (d = Qf.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31852,14 +31854,14 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-zf.spawnQueue.addRequest(y), _e.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Qf.spawnQueue.addRequest(y), Ne.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
-_e.debug("Transfer request ".concat(e.taskId, " needs ").concat(s, " carry capacity, requested ").concat(m, " carriers"), {
+Ne.debug("Transfer request ".concat(e.taskId, " needs ").concat(s, " carry capacity, requested ").concat(m, " carriers"), {
 subsystem: "CrossShardTransfer"
 });
-} else _e.warn("Source room ".concat(e.sourceRoom, " not available for spawning carriers"), {
+} else Ne.warn("Source room ".concat(e.sourceRoom, " not available for spawning carriers"), {
 subsystem: "CrossShardTransfer"
 });
 }, e.prototype.handleGatheringRequest = function(e) {
@@ -31870,7 +31872,7 @@ return void 0 !== e;
 });
 0 !== t.length ? t.every(function(t) {
 return t.store.getUsedCapacity(e.resourceType) > 0;
-}) && (e.status = "moving", _e.info("Transfer request ".concat(e.taskId, " moving to portal"), {
+}) && (e.status = "moving", Ne.info("Transfer request ".concat(e.taskId, " moving to portal"), {
 subsystem: "CrossShardTransfer"
 })) : e.status = "queued";
 }, e.prototype.handleMovingRequest = function(e) {
@@ -31879,10 +31881,10 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void jf.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void zf.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
-}).length > 0 && (e.status = "transferring", _e.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
+}).length > 0 && (e.status = "transferring", Ne.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.handleTransferringRequest = function(e) {
@@ -31891,8 +31893,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, jf.updateTaskProgress(e.taskId, 100, "complete"),
-jf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), _e.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, zf.updateTaskProgress(e.taskId, 100, "complete"),
+zf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ne.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31908,7 +31910,7 @@ if (r && r.assignedCreeps.includes(e)) return r;
 return null;
 }, e.prototype.assignCreep = function(e, t) {
 var r = this.memory.requests[e];
-r && !r.assignedCreeps.includes(t) && (r.assignedCreeps.push(t), _e.info("Assigned creep ".concat(t, " to transfer request ").concat(e), {
+r && !r.assignedCreeps.includes(t) && (r.assignedCreeps.push(t), Ne.info("Assigned creep ".concat(t, " to transfer request ").concat(e), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.getActiveRequests = function() {
@@ -31922,12 +31924,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Xf = new Qf;
+}(), Zf = new Xf;
 
-function Zf(e, t, r) {
+function Jf(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Df({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Bf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31942,13 +31944,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Bf(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Ff(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function Jf(e) {
+function $f(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31979,15 +31981,15 @@ range: 0
 type: "idle"
 };
 }(e, i);
-if (Zf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Jf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
-if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || X(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Zf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || Z(n).length > 0))) return i.targetRoom = e.room.name,
+"interShardScout" === e.memory.role ? (Jf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Zf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Jf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -32004,34 +32006,34 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Zf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Jf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Zf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Jf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function $f(e) {
+function ey(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function ey(e, t) {
+function ty(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
-var p = X(e);
+var p = Z(e);
 return l.threatLevel = p.length > 5 ? 3 : p.length > 2 ? 2 : p.length > 0 ? 1 : 0,
 void (e.controller && (l.controllerLevel = null !== (o = e.controller.level) && void 0 !== o ? o : 0,
 (null === (n = e.controller.owner) || void 0 === n ? void 0 : n.username) && (l.owner = e.controller.owner.username),
 (null === (a = e.controller.reservation) || void 0 === a ? void 0 : a.username) && (l.reserver = e.controller.reservation.username)));
 }
-for (var f = e.find(FIND_SOURCES), y = e.find(FIND_MINERALS)[0], v = e.controller, g = X(e), h = e.getTerrain(), R = 0, E = 0, T = 5; T < 50; T += 10) for (var C = 5; C < 50; C += 10) {
+for (var f = e.find(FIND_SOURCES), y = e.find(FIND_MINERALS)[0], v = e.controller, g = Z(e), h = e.getTerrain(), R = 0, E = 0, T = 5; T < 50; T += 10) for (var C = 5; C < 50; C += 10) {
 var S = h.get(T, C);
 S === TERRAIN_MASK_SWAMP ? R++ : 0 === S && E++;
 }
@@ -32055,12 +32057,12 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function ty(e, t) {
+function ry(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function ry(e) {
+function oy(e) {
 var t = Game.map.describeExits(e), r = t ? Object.values(t) : [], o = function(e) {
 var t = function(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
@@ -32071,20 +32073,20 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ ty(t.x, t.y - 1), ty(t.x + 1, t.y), ty(t.x, t.y + 1), ty(t.x - 1, t.y) ] : [];
+return t ? [ ry(t.x, t.y - 1), ry(t.x + 1, t.y), ry(t.x, t.y + 1), ry(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }
 
-function oy(e) {
-var t = Qd.getEmpire();
-if (Ol.isExit(e.creep.pos)) return $f(e.room.name);
+function ny(e) {
+var t = Xd.getEmpire();
+if (kl.isExit(e.creep.pos)) return ey(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (o && !function(e, t) {
-return t === e || ry(e).includes(t);
+return t === e || oy(e).includes(t);
 }(e.room.name, o) && (delete e.memory.targetRoom, o = void 0), !o) {
 if (o = function(e, t, r) {
-var o, n, i, s, c = t.knownRooms, u = ry(e);
+var o, n, i, s, c = t.knownRooms, u = oy(e);
 if (0 !== u.length) {
 var l = [];
 try {
@@ -32144,13 +32146,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (ey(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (ty(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (ey(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (ty(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -32160,19 +32162,19 @@ type: "idle"
 };
 }
 
-function ny(e) {
+function ay(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function ay(e) {
-return e.hostiles.some(ny);
-}
-
 function iy(e) {
-return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+return e.hostiles.some(ay);
 }
 
 function sy(e) {
+return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
+}
+
+function cy(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32183,7 +32185,7 @@ type: "transfer",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
 };
-var t = gt(e.creep, e.spawnStructures.filter(function(e) {
+var t = ht(e.creep, e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 }), "remoteWorker_spawn", 5);
 return t ? {
@@ -32195,8 +32197,8 @@ type: "idle"
 };
 }
 
-var cy = {
-scout: oy,
+var uy = {
+scout: ny,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -32220,7 +32222,7 @@ var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 if (r.length > 0) {
-var o = gt(e.creep, r, "claimer_spawn", 20);
+var o = ht(e.creep, r, "claimer_spawn", 20);
 if (o) return {
 type: "moveTo",
 target: o
@@ -32230,7 +32232,7 @@ return {
 type: "idle"
 };
 }
-if (Ol.isExit(e.creep.pos)) return $f(e.room.name);
+if (kl.isExit(e.creep.pos)) return ey(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -32252,8 +32254,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Jf,
-interShardScout: Jf,
+interShardClaimer: $f,
+interShardScout: $f,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -32261,7 +32263,7 @@ var o = e.repairTargets.filter(function(e) {
 return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_STORAGE) && e.hits < .5 * e.hitsMax;
 });
 if (o.length > 0) {
-var n = gt(e.creep, o, "engineer_critical", 5);
+var n = ht(e.creep, o, "engineer_critical", 5);
 if (n) return {
 type: "repair",
 target: n
@@ -32271,7 +32273,7 @@ var a = e.repairTargets.filter(function(e) {
 return (e.structureType === STRUCTURE_ROAD || e.structureType === STRUCTURE_CONTAINER) && e.hits < .75 * e.hitsMax;
 });
 if (a.length > 0) {
-var i = gt(e.creep, a, "engineer_infra", 5);
+var i = ht(e.creep, a, "engineer_infra", 5);
 if (i) return {
 type: "repair",
 target: i
@@ -32281,7 +32283,7 @@ var s = null !== (r = null === (t = e.swarmState) || void 0 === t ? void 0 : t.d
 return e.structureType === STRUCTURE_RAMPART && e.hits < c;
 });
 if (u.length > 0) {
-var l = gt(e.creep, u, "engineer_rampart", 5);
+var l = ht(e.creep, u, "engineer_rampart", 5);
 if (l) return {
 type: "repair",
 target: l
@@ -32291,7 +32293,7 @@ var m = e.repairTargets.filter(function(e) {
 return e.structureType === STRUCTURE_WALL && e.hits < c;
 });
 if (m.length > 0) {
-var d = gt(e.creep, m, "engineer_wall", 5);
+var d = ht(e.creep, m, "engineer_wall", 5);
 if (d) return {
 type: "repair",
 target: d
@@ -32313,7 +32315,7 @@ var p = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (p.length > 0) {
-var f = gt(e.creep, p, "engineer_cont", 15);
+var f = ht(e.creep, p, "engineer_cont", 15);
 if (f) return {
 type: "withdraw",
 target: f,
@@ -32329,8 +32331,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return sy(e);
-if (ay(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return cy(e);
+if (iy(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32347,14 +32349,14 @@ routeType: "hauler"
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), !e.memory.working) return null !== (t = function(e) {
 var t = e.droppedResources.filter(function(e) {
 return e.resourceType === RESOURCE_ENERGY && e.amount > 0;
-}), r = gt(e.creep, t, "remoteWorker_dropped", 5);
+}), r = ht(e.creep, t, "remoteWorker_dropped", 5);
 if (r) return {
 type: "pickup",
 target: r
 };
 var o = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 0;
-}), n = gt(e.creep, o, "remoteWorker_container", 10);
+}), n = ht(e.creep, o, "remoteWorker_container", 10);
 if (n) return {
 type: "withdraw",
 target: n,
@@ -32371,7 +32373,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return iy(t) - iy(e);
+return sy(t) - sy(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -32391,7 +32393,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : sy(e);
+} : cy(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -32480,9 +32482,9 @@ type: "idle"
 }
 };
 
-function uy(e, t) {
+function ly(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : ay(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : iy(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -32490,30 +32492,30 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function ly(e) {
-var t;
-return (null !== (t = cy[e.memory.role]) && void 0 !== t ? t : oy)(e);
-}
-
 function my(e) {
-var t = wl(e);
-gm(e, wm(t, fp, {
-interrupt: vp
-}), t);
+var t;
+return (null !== (t = uy[e.memory.role]) && void 0 !== t ? t : ny)(e);
 }
 
 function dy(e) {
-var t = wl(e);
-gm(e, wm(t, ly, {
-interrupt: uy
+var t = xl(e);
+hm(e, xm(t, yp, {
+interrupt: gp
 }), t);
 }
 
 function py(e) {
+var t = xl(e);
+hm(e, xm(t, my, {
+interrupt: ly
+}), t);
+}
+
+function fy(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
-var n = e.room, i = null !== (o = e.memory.homeRoom) && void 0 !== o ? o : n.name, s = ft(n, STRUCTURE_LAB), c = ft(n, STRUCTURE_SPAWN), u = ft(n, STRUCTURE_EXTENSION), l = ft(n, STRUCTURE_FACTORY)[0], m = ft(n, STRUCTURE_POWER_SPAWN)[0], d = [];
+var n = e.room, i = null !== (o = e.memory.homeRoom) && void 0 !== o ? o : n.name, s = yt(n, STRUCTURE_LAB), c = yt(n, STRUCTURE_SPAWN), u = yt(n, STRUCTURE_EXTENSION), l = yt(n, STRUCTURE_FACTORY)[0], m = yt(n, STRUCTURE_POWER_SPAWN)[0], d = [];
 try {
 for (var p = a(Object.keys(e.powers)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value, v = e.powers[y];
@@ -32550,8 +32552,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Jp.has(i) && z(s))) {
-Qp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && $p.has(i) && z(s))) {
+Xp.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -32562,16 +32564,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && Ol.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && kl.moveTo(e, t.target);
 break;
 
 case "moveTo":
-Ol.moveTo(e, t.target);
+kl.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-Ol.moveTo(e, {
+kl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -32580,11 +32582,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && Ol.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && kl.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && Ol.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && kl.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -32593,7 +32595,7 @@ if (void 0 !== e.powerCreep.ticksToLive && e.powerCreep.ticksToLive < 1e3 && e.p
 type: "renewSelf",
 spawn: e.powerSpawn
 };
-var o = e.availablePowers, n = X(e.room), c = Z(e.room);
+var o = e.availablePowers, n = Z(e.room), c = J(e.room);
 if (e.room.controller && !e.room.controller.isPowerEnabled) return {
 type: "enableRoom"
 };
@@ -32602,7 +32604,7 @@ type: "usePower",
 power: PWR_GENERATE_OPS
 };
 if (o.includes(PWR_SHIELD) && e.ops >= 10 && n.length > 0) {
-var u = dt(e.room, FIND_MY_CREEPS, {
+var u = pt(e.room, FIND_MY_CREEPS, {
 filter: function(e) {
 return "military" === e.memory.family && e.hits < .7 * e.hitsMax;
 },
@@ -32616,7 +32618,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Xp(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Zp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -32626,7 +32628,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Xp(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -32635,9 +32637,9 @@ target: m
 };
 }
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
-var d = dt(e.room, FIND_MY_STRUCTURES, {
+var d = pt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Xp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32676,7 +32678,7 @@ y && !y.done && (r = f.return) && r.call(f);
 if (t) throw t.error;
 }
 }
-var h = dt(e.room, FIND_STRUCTURES, {
+var h = pt(e.room, FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_RAMPART && e.hits < 5e5;
 },
@@ -32690,7 +32692,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Xp(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Zp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32732,7 +32734,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Xp(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Zp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32742,15 +32744,15 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Xp(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Zp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
 };
-if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && X(e.room).length > 0) {
-var o = dt(e.room, FIND_MY_STRUCTURES, {
+if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && Z(e.room).length > 0) {
+var o = pt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Xp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32762,7 +32764,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Xp(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Zp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32770,18 +32772,18 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Xp(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Zp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Xp(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Zp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
 };
 if (t.includes(PWR_REGEN_SOURCE) && e.ops >= 100) {
-var a = dt(e.room, FIND_SOURCES, {
+var a = pt(e.room, FIND_SOURCES, {
 filter: function(e) {
 return 0 === e.energy && e.ticksToRegeneration > 100;
 },
@@ -32809,58 +32811,58 @@ roomName: e.homeRoom
 }(t));
 }
 
-function fy(e) {
+function yy(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var yy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), vy = -1, gy = Object.create(null);
+var vy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), gy = -1, hy = Object.create(null);
 
-function hy(e) {
+function Ry(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var Ry = {
-harvester: Pe.CRITICAL,
-queenCarrier: Pe.CRITICAL,
-hauler: Pe.HIGH,
-guard: Pe.HIGH,
-healer: Pe.HIGH,
-soldier: Pe.HIGH,
-ranger: Pe.HIGH,
-siegeUnit: Pe.HIGH,
-harasser: Pe.HIGH,
-powerQueen: Pe.HIGH,
-powerWarrior: Pe.HIGH,
-larvaWorker: Pe.HIGH,
-pioneer: Pe.HIGH,
-interShardPioneer: Pe.HIGH,
-interShardClaimer: Pe.HIGH,
-interShardScout: Pe.HIGH,
-builder: Pe.MEDIUM,
-upgrader: Pe.MEDIUM,
-interRoomCarrier: Pe.MEDIUM,
-scout: Pe.MEDIUM,
-claimer: Pe.MEDIUM,
-engineer: Pe.MEDIUM,
-remoteHarvester: Pe.MEDIUM,
-powerHarvester: Pe.MEDIUM,
-powerCarrier: Pe.MEDIUM,
-remoteHauler: Pe.LOW,
-remoteWorker: Pe.LOW,
-linkManager: Pe.LOW,
-terminalManager: Pe.LOW,
-mineralHarvester: Pe.LOW,
-labTech: Pe.IDLE,
-factoryWorker: Pe.IDLE
+var Ey = {
+harvester: Ie.CRITICAL,
+queenCarrier: Ie.CRITICAL,
+hauler: Ie.HIGH,
+guard: Ie.HIGH,
+healer: Ie.HIGH,
+soldier: Ie.HIGH,
+ranger: Ie.HIGH,
+siegeUnit: Ie.HIGH,
+harasser: Ie.HIGH,
+powerQueen: Ie.HIGH,
+powerWarrior: Ie.HIGH,
+larvaWorker: Ie.HIGH,
+pioneer: Ie.HIGH,
+interShardPioneer: Ie.HIGH,
+interShardClaimer: Ie.HIGH,
+interShardScout: Ie.HIGH,
+builder: Ie.MEDIUM,
+upgrader: Ie.MEDIUM,
+interRoomCarrier: Ie.MEDIUM,
+scout: Ie.MEDIUM,
+claimer: Ie.MEDIUM,
+engineer: Ie.MEDIUM,
+remoteHarvester: Ie.MEDIUM,
+powerHarvester: Ie.MEDIUM,
+powerCarrier: Ie.MEDIUM,
+remoteHauler: Ie.LOW,
+remoteWorker: Ie.LOW,
+linkManager: Ie.LOW,
+terminalManager: Ie.LOW,
+mineralHarvester: Ie.LOW,
+labTech: Ie.IDLE,
+factoryWorker: Ie.IDLE
 };
 
-function Ey(e) {
+function Ty(e) {
 var t;
-return null !== (t = Ry[e]) && void 0 !== t ? t : Pe.MEDIUM;
+return null !== (t = Ey[e]) && void 0 !== t ? t : Ie.MEDIUM;
 }
 
-function Ty(e) {
+function Cy(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32876,30 +32878,30 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && hy(o) === e && t++;
+o && Ry(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (vy !== Game.time && (vy = Game.time, gy = function() {
+}(e) : null !== (r = (gy !== Game.time && (gy = Game.time, hy = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = hy(o);
+var n = Ry(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), gy)[e]) && void 0 !== r ? r : 0;
+}()), hy)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
-useCache: !0 !== kr().cpu.disableCreepBootstrapCountCache
+useCache: !0 !== Mr().cpu.disableCreepBootstrapCountCache
 });
-if (o && Game.time % 50 == 0 && ml.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
+if (o && Game.time % 50 == 0 && dl.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
 subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!yy.has(t.role)) return !1;
+if (!vy.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32909,7 +32911,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !fy(r)) return !1;
+if (!r || !yy(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32923,7 +32925,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !fy(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !yy(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32931,7 +32933,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !fy(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !yy(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32939,7 +32941,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !fy(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !yy(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32947,7 +32949,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && fy(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && yy(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32963,7 +32965,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !fy(r)) return !1;
+if (!r || !yy(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32998,41 +33000,41 @@ var t;
 return null !== (t = e.memory.family) && void 0 !== t ? t : "economy";
 }(e), i = t.role;
 try {
-ts.measureSubsystem("role:".concat(i), function() {
+rs.measureSubsystem("role:".concat(i), function() {
 switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = wl(e);
-gm(e, wm(t, fp, {
-interrupt: vp
+var t = xl(e);
+hm(e, xm(t, yp, {
+interrupt: gp
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = wl(e);
-gm(e, wm(t, zp), t);
+var t = xl(e);
+hm(e, xm(t, Qp), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = wl(e);
-gm(e, wm(t, ly), t);
+var t = xl(e);
+hm(e, xm(t, my), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = wl(e);
-gm(e, wm(t, ef), t);
+var t = xl(e);
+hm(e, xm(t, tf), t);
 }(e);
 }
 });
 } catch (t) {
-ml.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
+dl.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
 subsystem: "CreepProcessManager",
 creep: e.name,
 meta: {
@@ -33048,7 +33050,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var Cy = function() {
+var Sy = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -33077,7 +33079,7 @@ if (e) throw e.error;
 }
 }
 var d = s < 5;
-(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && ml.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
+(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && dl.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
 subsystem: "CreepProcessManager",
 meta: {
 activeCreeps: r.size,
@@ -33089,8 +33091,8 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Ey(r), n = "creep:".concat(e.name);
-Ii.registerProcess({
+var t = e.memory, r = t.role, o = Ty(r), n = "creep:".concat(e.name);
+Gi.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
 priority: o,
@@ -33105,32 +33107,32 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Ty(t);
+t && !t.spawning && Cy(t);
 }
-}), this.registeredCreeps.add(e.name), ml.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
+}), this.registeredCreeps.add(e.name), dl.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.unregisterCreepProcess = function(e) {
 var t = "creep:".concat(e);
-Ii.unregisterProcess(t), this.registeredCreeps.delete(e), ml.info("Unregistered creep process: ".concat(e), {
+Gi.unregisterProcess(t), this.registeredCreeps.delete(e), dl.info("Unregistered creep process: ".concat(e), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.getMinBucketForRole = function(e, t) {
-var r, o, n = kr().cpu.bucketThresholds, a = n.lowMode, i = n.highMode, s = e.memory;
+var r, o, n = Mr().cpu.bucketThresholds, a = n.lowMode, i = n.highMode, s = e.memory;
 if ("upgrader" === s.role) {
 var c = null !== (r = Game.rooms[s.homeRoom]) && void 0 !== r ? r : e.room;
 if ((null === (o = null == c ? void 0 : c.controller) || void 0 === o ? void 0 : o.my) && c.controller.level <= 2) return 0;
 }
-return t >= Pe.HIGH ? 0 : t === Pe.MEDIUM || t === Pe.LOW ? a : t === Pe.IDLE ? i : 0;
+return t >= Ie.HIGH ? 0 : t === Ie.MEDIUM || t === Ie.LOW ? a : t === Ie.IDLE ? i : 0;
 }, e.prototype.getCpuBudgetForPriority = function(e) {
-return e >= Pe.CRITICAL ? .012 : e >= Pe.HIGH ? .01 : e >= Pe.MEDIUM ? .008 : .006;
+return e >= Ie.CRITICAL ? .012 : e >= Ie.HIGH ? .01 : e >= Ie.MEDIUM ? .008 : .006;
 }, e.prototype.getStats = function() {
 var e, t, r, o, n = {};
 try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Ey(u.memory.role), m = null !== (r = Pe[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = Ty(u.memory.role), m = null !== (r = Ie[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -33155,20 +33157,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), Sy = new Cy;
-
-function wy(e) {
-var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, xy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
-}
+}(), wy = new Sy;
 
 function xy(e) {
+var t, r, o;
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, by(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+}
+
+function by(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function by(e) {
+function Oy(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -33181,14 +33183,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function Oy(e, t) {
+function ky(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var ky = {
+var My = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -33216,11 +33218,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function My(e, t) {
+function Ay(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function Ay(e) {
+function Uy(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -33230,9 +33232,9 @@ tick: Game.time
 }, a;
 }
 
-var Uy = [ "defense", "war", "expand", "siege" ];
+var _y = [ "defense", "war", "expand", "siege" ];
 
-function _y(e) {
+function Ny(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -33245,11 +33247,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function Ny(e, t, r) {
-t >= 2 && (e.pheromones.war = My(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = My(e.pheromones.siege + 20, r));
+function Py(e, t, r) {
+t >= 2 && (e.pheromones.war = Ay(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ay(e.pheromones.siege + 20, r));
 }
 
-var Py = function() {
+var Iy = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -33264,27 +33266,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), Iy = function() {
+}(), Gy = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, ky), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, My), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new Py(10),
-energySpawning: new Py(10),
-energyConstruction: new Py(10),
-energyRepair: new Py(10),
-energyTower: new Py(10),
-controllerProgress: new Py(10),
-hostileCount: new Py(5),
-damageReceived: new Py(5),
-idleWorkers: new Py(10),
+energyHarvested: new Iy(10),
+energySpawning: new Iy(10),
+energyConstruction: new Iy(10),
+energyRepair: new Iy(10),
+energyTower: new Iy(10),
+controllerProgress: new Iy(10),
+hostileCount: new Iy(5),
+damageReceived: new Iy(5),
+idleWorkers: new Iy(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = Ay(e);
+var o = Uy(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -33311,7 +33313,7 @@ var o = e.controller.progress - t.lastControllerProgress;
 o > 0 && o < 1e5 && t.controllerProgress.add(o), t.lastControllerProgress = e.controller.progress;
 }
 }(e, r);
-var n = X(e);
+var n = Z(e);
 r.hostileCount.add(n.length), r.damageReceived.add(function(e) {
 var t, r, o, n, i = 0;
 try {
@@ -33357,7 +33359,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = My(e[s] * c, t);
+e[s] = Ay(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -33373,43 +33375,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = Ay(t);
+var o = Uy(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = My(e.harvest + n / 3e3 * 10, r);
+e.harvest = Ay(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = My(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = Ay(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = My(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = Ay(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = My(e.defense + 10 * o, r));
+o > 0 && (e.defense = Ay(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = My(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = My(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = Ay(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ay(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = My(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = Ay(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = My(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = Ay(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = My(e.pheromones.defense + 5 * t, o), Ny(e, r, o),
+e.danger = r, e.pheromones.defense = Ay(e.pheromones.defense + 5 * t, o), Py(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -33417,7 +33419,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = My(t / 10, o), Ny(e, r, o);
+e.danger = r, e.pheromones.defense = Ay(t / 10, o), Py(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -33430,8 +33432,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = My(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = My(f + y, o);
+var p = Ay(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = Ay(f + y, o);
 }
 }
 }
@@ -33450,18 +33452,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = My(e.pheromones.defense + 5, r), e.pheromones.build = My(e.pheromones.build + 10, r),
+e.pheromones.defense = Ay(e.pheromones.defense + 5, r), e.pheromones.build = Ay(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = My(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ay(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = My(e.pheromones.siege + 50, t), e.pheromones.defense = My(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = Ay(e.pheromones.siege + 50, t), e.pheromones.defense = Ay(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = My(e.pheromones.expand - 10, t), e.pheromones.defense = My(e.pheromones.defense + 5, t);
+e.pheromones.expand = Ay(e.pheromones.expand - 10, t), e.pheromones.defense = Ay(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -33471,10 +33473,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(_y(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(Ny(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Uy)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(_y)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -33528,7 +33530,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = My(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = Ay(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -33563,7 +33565,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), Gy = new Iy, Ly = {
+}(), Ly = new Gy, Dy = {
 seedNest: {
 rcl: 1
 },
@@ -33604,7 +33606,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, Dy = {
+}, By = {
 eco: {
 economy: .75,
 military: .05,
@@ -33647,7 +33649,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, By = {
+}, Fy = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33704,15 +33706,15 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Fy = function() {
+}, Wy = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Ly.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Ly.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Ly.fortifiedHive.rcl ? "fortifiedHive" : s >= Ly.matureColony.rcl ? "matureColony" : s >= Ly.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Dy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Dy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Dy.fortifiedHive.rcl ? "fortifiedHive" : s >= Dy.matureColony.rcl ? "matureColony" : s >= Dy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
-var t, r, o, n = Re.get(e.name, {
+var t, r, o, n = Ee.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
 ttl: this.structureCacheTtl
 });
@@ -33734,7 +33736,7 @@ u && !u.done && (r = c.return) && r.call(c);
 if (t) throw t.error;
 }
 }
-return Re.set(e.name, i, {
+return Ee.set(e.name, i, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
 ttl: this.structureCacheTtl
 }), i;
@@ -33745,7 +33747,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Ly[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Dy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33758,7 +33760,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Wy = function() {
+}(), Hy = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33771,7 +33773,7 @@ var n = e.posture, a = null != r ? r : e.role;
 return U.info("Posture change: ".concat(n, " -> ").concat(o), {
 room: a,
 subsystem: "Posture"
-}), e.posture = o, Ii.emit("posture.change", {
+}), e.posture = o, Gi.emit("posture.change", {
 roomName: a,
 oldPosture: n,
 newPosture: o,
@@ -33780,9 +33782,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return Dy[e];
-}, e.prototype.getResourcePriorities = function(e) {
 return By[e];
+}, e.prototype.getResourcePriorities = function(e) {
+return Fy[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33792,17 +33794,17 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Hy = new Fy, Ky = new Wy;
+}(), Ky = new Wy, Yy = new Hy;
 
-function Yy(e) {
+function Vy(e) {
 return !j(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Vy(e, t, r) {
+function qy(e, t, r) {
 if (!e) return null;
-var o = Sr.getEmpire();
+var o = wr.getEmpire();
 if (j(e, {
 empire: o
 })) return null;
@@ -33839,17 +33841,17 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function qy() {
+function jy() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var jy = new Map, zy = function() {
+var zy = new Map, Qy = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
-var o = X(e), n = Js(e), a = this.getDefensePostureIntent(e, t, r, o, n);
-this.executeDefensePostureIntent(e, t, o, a), $s(Sr.getEmpire(), e, t, n);
+var o = Z(e), n = $s(e), a = this.getDefensePostureIntent(e, t, r, o, n);
+this.executeDefensePostureIntent(e, t, o, a), ec(wr.getEmpire(), e, t, n);
 }, e.prototype.getDefensePostureIntent = function(e, t, r, o, n) {
-return void 0 === o && (o = X(e)), void 0 === n && (n = Js(e)), function(e, t) {
+return void 0 === o && (o = Z(e)), void 0 === n && (n = $s(e)), function(e, t) {
 var r = e.currentStructures.spawns.length + e.currentStructures.towers.length, o = e.previousStructures;
 o && o.lastTick < e.time && (e.currentStructures.spawns.length < o.spawns.length && t.kernelEvents.push({
 type: "structure.destroyed",
@@ -33980,7 +33982,7 @@ if (r) throw r.error;
 }(c, u), u;
 var c, u;
 }, e.prototype.getDefensePostureSnapshot = function(e, t, r, o, n) {
-var a, i = t.clusterId ? Sr.getCluster(t.clusterId) : null, s = o.length > 0 ? Fo(e) : void 0;
+var a, i = t.clusterId ? wr.getCluster(t.clusterId) : null, s = o.length > 0 ? Wo(e) : void 0;
 return {
 roomName: e.name,
 time: Game.time,
@@ -33989,7 +33991,7 @@ nukeDetected: null !== (a = t.nukeDetected) && void 0 !== a && a,
 nukeScanPerformed: !0,
 clusterId: t.clusterId,
 clusterMemberRooms: null == i ? void 0 : i.memberRooms,
-previousStructures: jy.get(e.name),
+previousStructures: zy.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -34019,7 +34021,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && jy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && zy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -34028,7 +34030,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Yy(u) && o.add(u.owner.username);
+Vy(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -34042,7 +34044,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Vy(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) qy(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -34058,7 +34060,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? Gy.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Gy.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Gy.onNukeDetected(t);
+"danger" === y.type ? Ly.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Ly.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Ly.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -34074,7 +34076,7 @@ if (n) throw n.error;
 try {
 for (var v = a(o.roomEvents), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
-Sr.addRoomEvent(h.roomName, h.type, h.message);
+wr.addRoomEvent(h.roomName, h.type, h.message);
 }
 } catch (e) {
 u = {
@@ -34108,26 +34110,26 @@ case "hostile.detected":
 case "hostile.cleared":
 case "structure.destroyed":
 case "nuke.detected":
-Ii.emit(e.type, e.payload);
+Gi.emit(e.type, e.payload);
 }
 }, e.prototype.runTowerControl = function(e, t, r) {
 var o, n, i, s;
 if (0 !== r.length) {
-var c = X(e), u = null !== (s = null === (i = e.controller) || void 0 === i ? void 0 : i.level) && void 0 !== s ? s : 1, l = function(e) {
+var c = Z(e), u = null !== (s = null === (i = e.controller) || void 0 === i ? void 0 : i.level) && void 0 !== s ? s : 1, l = function(e) {
 var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = qy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = jy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = qy()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = jy()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
 if (!(O.store.getUsedCapacity(RESOURCE_ENERGY) < 10)) {
-var k = on({
+var k = nn({
 tower: O,
 hostiles: f,
 posture: y,
@@ -34164,8 +34166,8 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Ky.isCombatPosture(t.posture),
-wallRepairTarget: nn(u, t.danger),
+isCombatPosture: Yy.isCombatPosture(t.posture),
+wallRepairTarget: an(u, t.danger),
 bucket: Game.cpu.bucket
 });
 try {
@@ -34188,27 +34190,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Qy = new zy, Xy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Xy = new Qy, Zy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Zy() {
+function Jy() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Jy(e, t, r, o) {
+function $y(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Zy()
+selectedAt: Jy()
 });
 }
 
-function $y(e) {
+function ev(e) {
 return e >= 2 && e <= 3;
 }
 
-function ev(e, t, r) {
+function tv(e, t, r) {
 var o, n = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -34221,7 +34223,7 @@ return e.structureType === t;
 return n.length + a.length + (null !== (o = null == r ? void 0 : r.getPlacedCount(t)) && void 0 !== o ? o : 0);
 }
 
-function tv(e, t) {
+function rv(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -34235,23 +34237,23 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var rv = function() {
+var ov = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return $y(e) ? 5 : 10;
+return ev(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
 var p = r, f = null !== (l = null === (u = e.controller) || void 0 === u ? void 0 : u.level) && void 0 !== l ? l : 1, y = function(e, t) {
 void 0 === t && (t = {});
-var r = dn(t.roomSiteCount, e.find(FIND_MY_CONSTRUCTION_SITES).length), o = dn(t.globalSiteCount, function(e) {
+var r = pn(t.roomSiteCount, e.find(FIND_MY_CONSTRUCTION_SITES).length), o = pn(t.globalSiteCount, function(e) {
 var t;
 return "undefined" == typeof Game ? e : Object.keys(null !== (t = Game.constructionSites) && void 0 !== t ? t : {}).length;
-}(r)), n = dn(t.roomLimit, 10), a = dn(t.globalLimit, pn());
-return new fn(r, o, n, a);
+}(r)), n = pn(t.roomLimit, 10), a = pn(t.globalLimit, fn());
+return new yn(r, o, n, a);
 }(e, {
 roomSiteCount: p.length
-}), v = yn(e, y), g = yn(e, y, {
+}), v = vn(e, y), g = vn(e, y, {
 bypassRoomLimit: !0
 }), h = n[0], R = null == h || h.pos;
 if (h) {
@@ -34267,17 +34269,17 @@ void 0 === r && (r = {});
 var c = function(e, t, r) {
 var n;
 void 0 === r && (r = {});
-var a = Yn(null != t ? t : e.rcl), c = function(e) {
+var a = Vn(null != t ? t : e.rcl), c = function(e) {
 var t, r, o;
-if (e.anchor) return za(e.anchor);
+if (e.anchor) return Qa(e.anchor);
 var n = null === (t = e.existingStructures) || void 0 === t ? void 0 : t.find(function(e) {
-return e.structureType === Pn;
+return e.structureType === In;
 });
-if (n) return za(n);
+if (n) return Qa(n);
 var a = null === (r = e.existingStructures) || void 0 === r ? void 0 : r.find(function(e) {
-return e.structureType === kn;
+return e.structureType === Mn;
 });
-if (a) return za({
+if (a) return Qa({
 x: a.x + 2,
 y: a.y
 });
@@ -34295,7 +34297,7 @@ y: e.y + t.y
 x: 0,
 y: 0
 });
-return za({
+return Qa({
 x: u.x / c.length,
 y: u.y / c.length
 });
@@ -34312,7 +34314,7 @@ ramparts: [],
 unplaced: [],
 errors: [],
 stamps: [],
-version: qa
+version: ja
 };
 return {
 facts: o(o({}, e), {
@@ -34320,21 +34322,21 @@ rcl: a
 }),
 plan: u,
 counts: {},
-limits: Vn(a),
-targets: qn(a),
+limits: qn(a),
+targets: jn(a),
 occupied: new Set,
 roadKeys: new Set,
 rampartKeys: new Set
 };
 }(e, t, r);
-ei(c, c.facts.existingStructures, "existing-structure"), ei(c, c.facts.existingConstructionSites, "existing-site");
+ti(c, c.facts.existingStructures, "existing-structure"), ti(c, c.facts.existingConstructionSites, "existing-site");
 var u = [];
 u.push.apply(u, s([], i(function(e) {
 var t, r, o, n = [];
 try {
 for (var c = a(null !== (o = e.facts.sources) && void 0 !== o ? o : []), u = c.next(); !u.done; u = c.next()) {
-var l = ii(e, u.value, e.plan.anchor);
-l && (ni(e, _a, l), ai(e, e.plan.anchor, l, "SOURCE_MINING:path", 1));
+var l = si(e, u.value, e.plan.anchor);
+l && (ai(e, Na, l), ii(e, e.plan.anchor, l, "SOURCE_MINING:path", 1));
 }
 } catch (e) {
 t = {
@@ -34348,17 +34350,17 @@ if (t) throw t.error;
 }
 }
 if (e.facts.controller) {
-var m = ii(e, e.facts.controller, e.plan.anchor);
+var m = si(e, e.facts.controller, e.plan.anchor);
 if (m) {
-var d = ni(e, Na, m);
-n.push.apply(n, s([], i(d.missing), !1)), ai(e, e.plan.anchor, m, "CONTROLLER_STAMP:path", 1);
+var d = ai(e, Pa, m);
+n.push.apply(n, s([], i(d.missing), !1)), ii(e, e.plan.anchor, m, "CONTROLLER_STAMP:path", 1);
 }
 }
-return e.facts.mineral && e.plan.rcl >= 6 && (d = ni(e, La, e.facts.mineral), n.push.apply(n, s([], i(d.missing), !1)),
-ai(e, e.plan.anchor, e.facts.mineral, "MINERAL_STAMP:path", 6)), n;
+return e.facts.mineral && e.plan.rcl >= 6 && (d = ai(e, Da, e.facts.mineral), n.push.apply(n, s([], i(d.missing), !1)),
+ii(e, e.plan.anchor, e.facts.mineral, "MINERAL_STAMP:path", 6)), n;
 }(c)), !1)), u.push.apply(u, s([], i(function(e) {
 var t, r, o, n = [];
-n.push.apply(n, s([], i(ni(e, Ua, e.plan.anchor).missing), !1));
+n.push.apply(n, s([], i(ai(e, _a, e.plan.anchor).missing), !1));
 try {
 for (var c = a([ {
 x: (o = e.plan.anchor).x - 6,
@@ -34379,7 +34381,7 @@ y: o.y - 6
 x: o.x + 6,
 y: o.y + 6
 } ]), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = ni(e, Aa, l);
+var l = u.value, m = ai(e, Ua, l);
 n.push.apply(n, s([], i(m.missing), !1));
 }
 } catch (e) {
@@ -34393,13 +34395,13 @@ u && !u.done && (r = c.return) && r.call(c);
 if (t) throw t.error;
 }
 }
-return n.push.apply(n, s([], i(ni(e, Pa, {
+return n.push.apply(n, s([], i(ai(e, Ia, {
 x: e.plan.anchor.x + 4,
 y: e.plan.anchor.y + 1
-}).missing), !1)), n.push.apply(n, s([], i(ni(e, Ia, {
+}).missing), !1)), n.push.apply(n, s([], i(ai(e, Ga, {
 x: e.plan.anchor.x + 4,
 y: e.plan.anchor.y - 3
-}).missing), !1)), n.push.apply(n, s([], i(ni(e, Ga, {
+}).missing), !1)), n.push.apply(n, s([], i(ai(e, La, {
 x: e.plan.anchor.x,
 y: e.plan.anchor.y + 4
 }).missing), !1)), n;
@@ -34408,7 +34410,7 @@ var r, o, n, c, u, l = s([], i(t), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 try {
-for (var m = a(l), d = m.next(); !d.done; d = m.next()) ri(e, g = d.value) && si(e, g);
+for (var m = a(l), d = m.next(); !d.done; d = m.next()) oi(e, g = d.value) && ci(e, g);
 } catch (e) {
 r = {
 error: e
@@ -34421,14 +34423,14 @@ if (r) throw r.error;
 }
 }
 try {
-for (var p = a(Kn), f = p.next(); !f.done; f = p.next()) for (var y = f.value, v = null !== (u = e.targets[y]) && void 0 !== u ? u : 0; Xa(e, y) < v; ) {
+for (var p = a(Yn), f = p.next(); !f.done; f = p.next()) for (var y = f.value, v = null !== (u = e.targets[y]) && void 0 !== u ? u : 0; Za(e, y) < v; ) {
 var g;
-if (!si(e, g = {
+if (!ci(e, g = {
 structureType: y,
 priority: 100,
-fallback: ci(y),
+fallback: ui(y),
 reason: "target count not met by preferred stamps",
-localAnchor: y === Ln ? e.facts.mineral : e.plan.anchor,
+localAnchor: y === Dn ? e.facts.mineral : e.plan.anchor,
 minRcl: e.plan.rcl
 })) {
 e.plan.unplaced.push(g), e.plan.errors.push({
@@ -34453,12 +34455,12 @@ if (n) throw n.error;
 }
 }(c, u);
 var l = function(e, t) {
-var r, o, n, i, s, c, u, l, m, d, p, f = Vn(t.rcl), y = qn(t.rcl), v = {}, g = [], h = new Set;
+var r, o, n, i, s, c, u, l, m, d, p, f = qn(t.rcl), y = jn(t.rcl), v = {}, g = [], h = new Set;
 try {
 for (var R = a(t.structures), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 v[T.structureType] = (null !== (u = v[T.structureType]) && void 0 !== u ? u : 0) + 1,
-Ba(e, T.x, T.y) || g.push({
+Fa(e, T.x, T.y) || g.push({
 type: "TERRAIN_WALL",
 structureType: T.structureType,
 x: T.x,
@@ -34550,7 +34552,7 @@ var l = e.getTerrain(), m = [], d = [];
 try {
 for (var p = a(e.find(FIND_STRUCTURES)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-ui(y.structureType) && m.push({
+li(y.structureType) && m.push({
 x: y.pos.x,
 y: y.pos.y,
 structureType: y.structureType
@@ -34619,7 +34621,7 @@ y: E.y
 } : {});
 R = new RoomPosition(T.anchor.x, T.anchor.y, e.name);
 var C, S = (C = T, {
-name: "".concat(qa, "-rcl-").concat(C.rcl),
+name: "".concat(ja, "-rcl-").concat(C.rcl),
 rcl: C.rcl,
 anchor: {
 x: C.anchor.x,
@@ -34647,10 +34649,10 @@ y: e.y - C.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Jy(t, R, S.name, f);
+$y(t, R, S.name, f);
 var w = f >= 3 && (t.danger >= 1 || function(e, t, r) {
-var o = tv(STRUCTURE_TOWER, t);
-return o > 0 && ev(e, STRUCTURE_TOWER, r) < o;
+var o = rv(STRUCTURE_TOWER, t);
+return o > 0 && tv(e, STRUCTURE_TOWER, r) < o;
 }(e, f, y));
 if (w) {
 var x = y.capRequested(t.danger >= 2 ? 3 : 1, {
@@ -34661,7 +34663,7 @@ var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = tv(STRUCTURE_TOWER, g), R = ev(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = rv(STRUCTURE_TOWER, g), R = tv(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -34694,7 +34696,7 @@ b && !b.done && (s = x.return) && s.call(x);
 if (i) throw i.error;
 }
 }
-var k = pi(t, {
+var k = fi(t, {
 existingStructureKeys: E,
 existingSiteKeys: T,
 currentRcl: g
@@ -34755,22 +34757,22 @@ var b = y.capRequested(2);
 b > 0 && function(e, t) {
 var r, o;
 void 0 === t && (t = 1);
-var n = En(e);
+var n = Tn(e);
 if (0 === n.placements.length || t <= 0) return 0;
-var c = e.find(FIND_MY_CONSTRUCTION_SITES), u = Rn(e), l = c.filter(function(e) {
+var c = e.find(FIND_MY_CONSTRUCTION_SITES), u = En(e), l = c.filter(function(e) {
 return e.structureType === STRUCTURE_LINK;
 }), m = u.length + l.length, d = 0, p = function(e, t) {
 return new Set(s(s([], i(e.map(function(e) {
-return gn(e.pos.x, e.pos.y);
+return hn(e.pos.x, e.pos.y);
 })), !1), i(t.map(function(e) {
-return gn(e.pos.x, e.pos.y);
+return hn(e.pos.x, e.pos.y);
 })), !1));
 }(u, l);
 try {
 for (var f = a(n.placements), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (d >= t || m >= n.linkLimit) break;
-var g = gn(v.x, v.y);
+var g = hn(v.x, v.y);
 p.has(g) || e.createConstructionSite(v.x, v.y, STRUCTURE_LINK) === OK && (d += 1,
 m += 1, p.add(g));
 }
@@ -34797,7 +34799,7 @@ if (n.length >= 10) return 0;
 var c = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f = function(e) {
 var t, r, o;
-return null !== (o = vn(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
+return null !== (o = gn(null !== (r = null === (t = e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0)[STRUCTURE_LAB]) && void 0 !== o ? o : 0;
 }(e);
 if (f < 3) return null;
 var y = e.find(FIND_MY_STRUCTURES, {
@@ -34807,16 +34809,16 @@ return e.structureType === STRUCTURE_LAB;
 }), v = e.find(FIND_MY_CONSTRUCTION_SITES), g = v.filter(function(e) {
 return e.structureType === STRUCTURE_LAB;
 }), h = new Set(y.map(function(e) {
-return Cn(e.pos.x, e.pos.y);
+return Sn(e.pos.x, e.pos.y);
 })), R = new Set(g.map(function(e) {
-return Cn(e.pos.x, e.pos.y);
+return Sn(e.pos.x, e.pos.y);
 })), E = new Set(s(s([], i(h), !1), i(R), !1));
 if (E.size > f) return null;
 var T = e.find(FIND_STRUCTURES), C = new Set;
 try {
 for (var S = a(T), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-wn(x, h) && C.add(Cn(x.pos.x, x.pos.y));
+xn(x, h) && C.add(Sn(x.pos.x, x.pos.y));
 }
 } catch (e) {
 t = {
@@ -34832,7 +34834,7 @@ if (t) throw t.error;
 try {
 for (var b = a(v), O = b.next(); !O.done; O = b.next()) {
 var k = O.value;
-xn(k, R) && C.add(Cn(k.pos.x, k.pos.y));
+bn(k, R) && C.add(Sn(k.pos.x, k.pos.y));
 }
 } catch (e) {
 o = {
@@ -34877,7 +34879,7 @@ y: e.find(FIND_MY_SPAWNS)[0].pos.y
 return void 0 !== e;
 });
 try {
-for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) bn(A, e, P.x + I, P.y + G, M, h, R, C);
+for (var _ = a(U), N = _.next(); !N.done; N = _.next()) for (var P = N.value, I = -6; I <= 6; I++) for (var G = -6; G <= 6; G++) On(A, e, P.x + I, P.y + G, M, h, R, C);
 } catch (e) {
 c = {
 error: e
@@ -34913,7 +34915,7 @@ return void 0 !== e;
 }), o = s([], i(e.values()), !1).filter(function(e) {
 return !t.has(e.key);
 }).sort(function(e, t) {
-var o = On(e, r) - On(t, r);
+var o = kn(e, r) - kn(t, r);
 return 0 !== o ? o : e.existingLab !== t.existingLab ? e.existingLab ? -1 : 1 : e.existingSite !== t.existingSite ? e.existingSite ? -1 : 1 : e.distanceToHub - t.distanceToHub;
 });
 return s(s([], i(r), !1), i(o), !1).slice(0, 80);
@@ -34924,7 +34926,7 @@ var t, r, o = function(t) {
 var r, o, n, c;
 if (e.key === t.key) return "continue";
 var u = F.filter(function(r) {
-return r.key === e.key || r.key === t.key || Sn(r, e) <= 2 && Sn(r, t) <= 2;
+return r.key === e.key || r.key === t.key || wn(r, e) <= 2 && wn(r, t) <= 2;
 });
 if (u.length < f) return "continue";
 if (s([], i(E), !1).some(function(e) {
@@ -34980,7 +34982,7 @@ return e.existingLab;
 return e.existingSite;
 }).length - e.reduce(function(e, t) {
 return e + t.distanceToHub;
-}, 0) - 5 * Sn(t, r);
+}, 0) - 5 * wn(t, r);
 }(T, e, t);
 (!H || C > H.score) && (H = {
 positions: T,
@@ -35060,11 +35062,11 @@ if (r) throw r.error;
 }(v, O);
 }
 var k = function(e, t, r) {
-var o, n, i, s = qn(t);
+var o, n, i, s = jn(t);
 try {
 for (var c = a(Object.keys(s)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = null !== (i = s[l]) && void 0 !== i ? i : 0;
-if (!(m <= 0) && ev(e, l, r) < m) return !0;
+if (!(m <= 0) && tv(e, l, r) < m) return !0;
 }
 } catch (e) {
 o = {
@@ -35080,8 +35082,8 @@ if (o) throw o.error;
 return !1;
 }(e, f, y);
 if (y.canPlace() || k) {
-if (!Ky.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Zy());
+if (!Yy.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Jy());
 }(t, R)) {
 var M = function(e, t, r, o, n) {
 var i, s;
@@ -35089,7 +35091,7 @@ void 0 === n && (n = []);
 var c = function(e, t, r, o) {
 var n, i, s, c, u, l, m, d, p, f;
 void 0 === o && (o = []);
-var y = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 1, v = na(r, y), g = e.getTerrain(), h = [], R = new Map;
+var y = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 1, v = aa(r, y), g = e.getTerrain(), h = [], R = new Map;
 try {
 for (var E = a(v), T = E.next(); !T.done; T = E.next()) {
 var C = T.value, S = t.x + C.x, w = t.y + C.y;
@@ -35109,7 +35111,7 @@ T && !T.done && (i = E.return) && i.call(E);
 if (n) throw n.error;
 }
 }
-var b = Oa(e, t, r.roads, o);
+var b = ka(e, t, r.roads, o);
 if (R.set(STRUCTURE_ROAD, b), y >= 6) {
 var O = e.find(FIND_MINERALS);
 if (O.length > 0) {
@@ -35119,14 +35121,14 @@ M.add("".concat(k.pos.x, ",").concat(k.pos.y)), R.set(STRUCTURE_EXTRACTOR, M);
 }
 var A = function(e) {
 var t, r, o = function(e) {
-return new Set(En(e).placements.map(function(e) {
-return gn(e.x, e.y);
+return new Set(Tn(e).placements.map(function(e) {
+return hn(e.x, e.y);
 }));
 }(e);
 try {
-for (var n = a(Rn(e)), i = n.next(); !i.done; i = n.next()) {
+for (var n = a(En(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Tn(e, s) && o.add(gn(s.pos.x, s.pos.y));
+Cn(e, s) && o.add(hn(s.pos.x, s.pos.y));
 }
 } catch (e) {
 t = {
@@ -35160,7 +35162,7 @@ R.set(STRUCTURE_LINK, U);
 }
 var P = e.find(FIND_STRUCTURES, {
 filter: function(e) {
-return Ma.has(e.structureType) && (!0 === e.my || e.structureType === STRUCTURE_ROAD);
+return Aa.has(e.structureType) && (!0 === e.my || e.structureType === STRUCTURE_ROAD);
 }
 });
 try {
@@ -35213,7 +35215,7 @@ return u;
 }(e, R, S, 1, t.remoteAssignments);
 if (M > 0) {
 var A = 1 === M ? "structure" : "structures";
-Sr.addRoomEvent(e.name, "structureDestroyed", "".concat(M, " misplaced ").concat(A, " destroyed for blueprint compliance"));
+wr.addRoomEvent(e.name, "structureDestroyed", "".concat(M, " misplaced ").concat(A, " destroyed for blueprint compliance"));
 }
 }
 var _ = function(e) {
@@ -35238,7 +35240,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Xy.has(e.structureType);
+return Zy.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -35247,7 +35249,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var P = $y(f) ? 2 : 3, I = y.capRequested(P);
+var P = ev(f) ? 2 : 3, I = y.capRequested(P);
 I > 0 && (N = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -35257,7 +35259,7 @@ wallsRemoved: 0
 var y = function(e, t, r, o) {
 var n, c, u, l;
 void 0 === o && (o = []);
-var m = Oa(e, t, r, o), d = function(e) {
+var m = ka(e, t, r, o), d = function(e) {
 var t, r, o, n, c, u, l, m = Game.map.getRoomTerrain(e), d = [], p = [], f = new Set, y = function(e, t, r) {
 if (!(e < 1 || e > 48 || t < 1 || t > 48) && m.get(e, t) !== TERRAIN_MASK_WALL) {
 var o = "".concat(e, ",").concat(t);
@@ -35581,9 +35583,9 @@ return {
 sitesPlaced: h,
 wallsRemoved: R
 };
-}(v, R, S.roads, f, I, t.remoteAssignments)), N.wallsRemoved > 0 && Sr.addRoomEvent(e.name, "wallRemoved", "".concat(N.wallsRemoved, " wall(s) removed to allow road passage"));
+}(v, R, S.roads, f, I, t.remoteAssignments)), N.wallsRemoved > 0 && wr.addRoomEvent(e.name, "wallRemoved", "".concat(N.wallsRemoved, " wall(s) removed to allow road passage"));
 }
-var G = k ? yn(e, y, {
+var G = k ? vn(e, y, {
 bypassRoomLimit: !0
 }) : v, L = y.capRequested(3, {
 bypassRoomLimit: k
@@ -35631,7 +35633,7 @@ return {
 structures: i,
 sites: s
 };
-}(e), p = pi(t, {
+}(e), p = fi(t, {
 existingStructureKeys: d.structures,
 existingSiteKeys: d.sites,
 currentRcl: null !== (s = null === (i = e.controller) || void 0 === i ? void 0 : i.level) && void 0 !== s ? s : t.rcl
@@ -35663,19 +35665,19 @@ var o, n;
 void 0 === r && (r = 3);
 var i = e.find(FIND_MY_CONSTRUCTION_SITES);
 if (i.length >= 10) return 0;
-var s = ha(e, t), c = e.getTerrain(), u = function(e) {
+var s = Ra(e, t), c = e.getTerrain(), u = function(e) {
 var t = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
 }
 });
 return new Set(t.map(function(e) {
-return da(e.pos);
+return pa(e.pos);
 }));
 }(e), l = new Set(i.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
 }).map(function(e) {
-return da(e.pos);
+return pa(e.pos);
 })), m = 0;
 try {
 for (var d = a(s.positions), p = d.next(); !p.done; p = d.next()) {
@@ -35683,7 +35685,7 @@ var f = p.value;
 if (m >= r) break;
 if (i.length + m >= 10) break;
 if (!u.has(f) && !l.has(f)) {
-var y = pa(f), v = y.x, g = y.y;
+var y = fa(f), v = y.x, g = y.y;
 c.get(v, g) !== TERRAIN_MASK_WALL && e.createConstructionSite(v, g, STRUCTURE_ROAD) === OK && m++;
 }
 }
@@ -35715,7 +35717,7 @@ protected: 0
 };
 if (t < 2) return u;
 var l = function(e, t) {
-var r = e.find(FIND_MY_STRUCTURES), o = t < 4 ? sn : an;
+var r = e.find(FIND_MY_STRUCTURES), o = t < 4 ? cn : sn;
 return r.filter(function(e) {
 return o.includes(e.structureType);
 });
@@ -35727,7 +35729,7 @@ var d = Math.min(o, 10 - m.length), p = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_RAMPART;
 }
-}), f = nn(t, r), y = [], v = function(t) {
+}), f = an(t, r), y = [], v = function(t) {
 var o = t.pos, n = o.x, a = o.y;
 if (function(e, t, r) {
 return e.lookForAt(LOOK_STRUCTURES, t, r).some(function(e) {
@@ -35791,7 +35793,7 @@ if (s) throw s.error;
 return (u.placed > 0 || y.length > 0) && U.info("Rampart automation for ".concat(e.name, ": ") + "".concat(u.protected, "/").concat(u.totalCritical, " protected, ") + "".concat(u.placed, " placed, ") + "".concat(y.length - u.placed, " pending"), {
 subsystem: "Defense"
 }), u;
-}(v, f, t.danger, y.capRequested(F))).placed > 0 && Sr.addRoomEvent(e.name, "rampartPlaced", "".concat(B.placed, " rampart(s) placed on critical structures"));
+}(v, f, t.danger, y.capRequested(F))).placed > 0 && wr.addRoomEvent(e.name, "rampartPlaced", "".concat(B.placed, " rampart(s) placed on critical structures"));
 }
 t.metrics.constructionSites = y.roomSiteCount;
 } else t.metrics.constructionSites = y.roomSiteCount;
@@ -35803,38 +35805,38 @@ return e.structureType === STRUCTURE_SPAWN;
 if (!0 === (null === (m = e.controller) || void 0 === m ? void 0 : m.my) && !W) {
 var H = function(e, t) {
 if (t >= 8) {
-var r = oa(e, ea);
+var r = na(e, ta);
 if (r) return {
-blueprint: ea,
+blueprint: ta,
 anchor: r
 };
-if (o = oa(e, $n)) return {
-blueprint: $n,
+if (o = na(e, ea)) return {
+blueprint: ea,
 anchor: o
 };
 }
 var o;
-if (t >= 7 && (o = oa(e, $n))) return {
-blueprint: $n,
+if (t >= 7 && (o = na(e, ea))) return {
+blueprint: ea,
 anchor: o
 };
 if (t >= 5) {
-var n = oa(e, Jn);
+var n = na(e, $n);
 if (n) return {
-blueprint: Jn,
+blueprint: $n,
 anchor: n
 };
 }
 if (t >= 3) {
-var c = oa(e, Xn);
+var c = na(e, Zn);
 if (c) return {
-blueprint: Xn,
+blueprint: Zn,
 anchor: c
 };
 }
-var u = oa(e, zn);
+var u = na(e, Qn);
 if (u) return {
-blueprint: zn,
+blueprint: Qn,
 anchor: u
 };
 var l = function(e) {
@@ -35859,7 +35861,7 @@ if (t) throw t.error;
 }
 for (var d = Math.round(s / (n.length + 1)), p = Math.round(c / (n.length + 1)), f = 0; f < 15; f++) for (var y = -f; y <= f; y++) for (var v = -f; v <= f; v++) if (Math.abs(y) === f || Math.abs(v) === f) {
 var g = d + y, h = p + v;
-if (!(g < 3 || g > 46 || h < 3 || h > 46) && ta(e, g, h)) {
+if (!(g < 3 || g > 46 || h < 3 || h > 46) && ra(e, g, h)) {
 if (Math.max(Math.abs(g - o.pos.x), Math.abs(h - o.pos.y)) > 20) continue;
 if (i.get(g, h) === TERRAIN_MASK_WALL) continue;
 return new RoomPosition(g, h, e.name);
@@ -35870,14 +35872,14 @@ return null;
 if (l) {
 var m = function(e, t, r) {
 var o, n, c = function(e) {
-return e >= 7 ? $n : e >= 5 ? Jn : e >= 3 ? Xn : zn;
-}(t), u = s([], i(na(c, t)), !1).sort(function(e, t) {
-var r = aa(t.structureType) - aa(e.structureType);
+return e >= 7 ? ea : e >= 5 ? $n : e >= 3 ? Zn : Qn;
+}(t), u = s([], i(aa(c, t)), !1).sort(function(e, t) {
+var r = ia(t.structureType) - ia(e.structureType);
 return 0 !== r ? r : t.structureType.localeCompare(e.structureType);
 }), l = new Set, m = [];
 try {
 for (var d = a(u), p = d.next(); !p.done; p = d.next()) {
-var f = p.value, y = r.x + f.x, v = r.y + f.y, g = sa(e, y, v, l);
+var f = p.value, y = r.x + f.x, v = r.y + f.y, g = ca(e, y, v, l);
 if (g) {
 var h = g.x - r.x, R = g.y - r.y;
 m.push({
@@ -35905,7 +35907,7 @@ y: e.y
 };
 }).filter(function(t) {
 var o = r.x + t.x, n = r.y + t.y;
-return ia(e, o, n) && !l.has("".concat(o, ",").concat(n));
+return sa(e, o, n) && !l.has("".concat(o, ",").concat(n));
 });
 return {
 name: "adaptive-".concat(c.name, "-rcl-").concat(Math.max(1, Math.min(8, Math.floor(t)))),
@@ -35927,7 +35929,7 @@ return e.structureType === STRUCTURE_SPAWN;
 blueprint: m,
 anchor: l
 } : {
-blueprint: zn,
+blueprint: Qn,
 anchor: l
 };
 }
@@ -35936,16 +35938,16 @@ return null;
 if (H && y.canPlace({
 bypassRoomLimit: !0
 })) {
-Jy(t, H.anchor, H.blueprint.name, f);
+$y(t, H.anchor, H.blueprint.name, f);
 var K = e.createConstructionSite(H.anchor.x, H.anchor.y, STRUCTURE_SPAWN);
 y.recordResult(K, STRUCTURE_SPAWN);
 }
 }
 }
 }, e;
-}(), ov = new rv;
+}(), nv = new ov;
 
-function nv(e) {
+function av(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35967,7 +35969,7 @@ siege: e.pheromones.siege
 };
 }
 
-var av = {
+var iv = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35980,10 +35982,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, iv = new (function() {
+}, sv = new (function() {
 function e() {
-this.manager = new Ru({
-logger: av
+this.manager = new Eu({
+logger: iv
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35993,23 +35995,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = nv(t);
+var r = av(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = nv(t);
+var r = av(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), sv = {
-labManager: Iu,
-boostManager: Au,
-chemistryPlanner: iv,
-labConfigManager: Nu,
-logger: ml
-}, cv = function() {
+}()), cv = {
+labManager: Gu,
+boostManager: Uu,
+chemistryPlanner: sv,
+labConfigManager: Pu,
+logger: dl
+}, uv = function() {
 function e(e) {
-void 0 === e && (e = sv), this.deps = e;
+void 0 === e && (e = cv), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -36048,9 +36050,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), uv = new cv, lv = function() {
+}(), lv = new uv, mv = function() {
 function e(e) {
-void 0 === e && (e = uv), this.labWorkflow = e;
+void 0 === e && (e = lv), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -36073,30 +36075,30 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), mv = new lv, dv = {
+}(), dv = new mv, pv = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, pv = new Map;
+}, fv = new Map;
 
-function fv(e) {
+function yv(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function yv(e) {
+function vv(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var vv = function() {
+var gv = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, dv), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, pv), t);
 }
 return e.prototype.run = function(e) {
-var t, r, o, n = ts.startRoom(this.roomName);
+var t, r, o, n = rs.startRoom(this.roomName);
 try {
 var i = Game.rooms[this.roomName];
 if (!i || !(null === (t = i.controller) || void 0 === t ? void 0 : t.my)) return;
@@ -36104,22 +36106,22 @@ var s = Game.cpu.bucket < 6e3;
 s || function(e) {
 var t, r, o;
 if (null === (o = e.controller) || void 0 === o ? void 0 : o.my) {
-e.storage && Re.set(e.storage.id, e.storage, {
-namespace: it,
+e.storage && Ee.set(e.storage.id, e.storage, {
+namespace: st,
 ttl: 10
-}), e.terminal && Re.set(e.terminal.id, e.terminal, {
-namespace: it,
+}), e.terminal && Ee.set(e.terminal.id, e.terminal, {
+namespace: st,
 ttl: 10
-}), e.controller && Re.set(e.controller.id, e.controller, {
-namespace: it,
+}), e.controller && Ee.set(e.controller.id, e.controller, {
+namespace: st,
 ttl: 10
 });
 var n = e.find(FIND_SOURCES);
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-Re.set(c.id, c, {
-namespace: it,
+Ee.set(c.id, c, {
+namespace: st,
 ttl: 5
 });
 }
@@ -36136,8 +36138,8 @@ if (t) throw t.error;
 }
 }
 }(i);
-var c = Sr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = pv.get(e.name);
+var c = wr.getOrInitSwarmState(this.roomName), u = function(e) {
+var t = fv.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -36159,51 +36161,51 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return pv.set(e.name, o), o;
+return fv.set(e.name, o), o;
 }(i);
-this.config.enablePheromones && !s && Game.time % 5 == 0 && Gy.updateMetrics(i, c),
-Qy.updateThreatAssessment(i, c, {
+this.config.enablePheromones && !s && Game.time % 5 == 0 && Ly.updateMetrics(i, c),
+Xy.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Ci.assess(i, c), Oi.checkSafeMode(i, c), this.config.enableEvolution && (Hy.updateEvolutionStage(c, i, e),
-s || Hy.updateMissingStructures(c, i)), Ky.updatePosture(c), this.config.enablePheromones && !s && Gy.updatePheromones(c, i),
-this.config.enableTowers && Qy.runTowerControl(i, c, u.towers);
+}), Si.assess(i, c), ki.checkSafeMode(i, c), this.config.enableEvolution && (Ky.updateEvolutionStage(c, i, e),
+s || Ky.updateMissingStructures(c, i)), Yy.updatePosture(c), this.config.enablePheromones && !s && Ly.updatePheromones(c, i),
+this.config.enableTowers && Xy.runTowerControl(i, c, u.towers);
 var l = 0 === u.spawns.length || c.danger >= 2;
 if (this.config.enableConstruction && (!s || l)) {
-var m = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, d = ov.getConstructionInterval(m), p = Ky.allowsBuilding(c.posture), f = !p && c.danger >= 2 || s && l;
+var m = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, d = nv.getConstructionInterval(m), p = Yy.allowsBuilding(c.posture), f = !p && c.danger >= 2 || s && l;
 (p || f) && function(e, t, r) {
-var o = fv(r), n = yv(e);
+var o = yv(r), n = vv(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, d) && (ov.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, d) && (nv.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: f
 }), function(e, t, r) {
-var o = fv(r), n = yv(e);
+var o = yv(r), n = vv(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, d));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && mv.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && dv.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
 var y = Game.cpu.getUsed() - n;
-ts.recordRoom(i, y);
+rs.recordRoom(i, y);
 } finally {
-ts.endRoom(this.roomName, n);
+rs.endRoom(this.roomName, n);
 }
 }, e;
-}(), gv = function() {
+}(), hv = function() {
 function e() {
 this.nodes = new Map;
 }
 return e.prototype.run = function() {
-var e, t, r, o, n, s, c, u = Tt(), l = u.length;
+var e, t, r, o, n, s, c, u = Ct(), l = u.length;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-this.nodes.has(p.name) || this.nodes.set(p.name, new vv(p.name));
+this.nodes.has(p.name) || this.nodes.set(p.name, new gv(p.name));
 }
 } catch (t) {
 e = {
@@ -36239,7 +36241,7 @@ try {
 R.run(l);
 } catch (e) {
 var E = e instanceof Error ? e.message : String(e), T = e instanceof Error && e.stack ? e.stack : void 0;
-ml.error("Error in room ".concat(R.roomName, ": ").concat(E), {
+dl.error("Error in room ".concat(R.roomName, ": ").concat(E), {
 subsystem: "RoomManager",
 room: R.roomName,
 meta: {
@@ -36266,59 +36268,59 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new vv(e.name));
-var r = Tt().length;
+this.nodes.has(e.name) || this.nodes.set(e.name, new gv(e.name));
+var r = Ct().length;
 this.nodes.get(e.name).run(r);
 }
 }, e;
-}(), hv = new gv, Rv = new Map;
+}(), Rv = new hv, Ev = new Map;
 
-function Ev(e) {
+function Tv(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return !1;
 if (function(e) {
 var t, r, o = null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.swarm;
 if (null == o ? void 0 : o.nukeDetected) return !0;
-var n = Sr.getSwarmState(e);
+var n = wr.getSwarmState(e);
 if (null == n ? void 0 : n.nukeDetected) return !0;
-var a = Sr.getEmpire().incomingNukes;
+var a = wr.getEmpire().incomingNukes;
 return Array.isArray(a) && a.some(function(t) {
 return t.roomName === e && Number.isFinite(t.impactTick) && t.impactTick > Game.time;
 });
 }(e.name)) return !0;
-var r = Rv.get(e.name), o = Game.cpu.bucket < kr().cpu.bucketThresholds.lowMode ? 50 : 5;
+var r = Ev.get(e.name), o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode ? 50 : 5;
 if (r && Game.time - r.checkedAt < o) return r.active;
 var n = e.find(FIND_NUKES).length > 0;
-return Rv.set(e.name, {
+return Ev.set(e.name, {
 checkedAt: Game.time,
 active: n
 }), n;
 }
 
-function Tv(e, t) {
+function Cv(e, t) {
 var r, o = (null === (r = e.controller) || void 0 === r ? void 0 : r.my) ? " (owned)" : "", n = t ? " [nuke response]" : "";
 return "Room ".concat(e.name).concat(o).concat(n);
 }
 
-function Cv(e, t) {
+function Sv(e, t) {
 var r, o, n;
-if (t.nukeThreat || t.hostiles.length > 0) return Pe.CRITICAL;
-if (null === (r = e.controller) || void 0 === r ? void 0 : r.my) return Pe.HIGH;
+if (t.nukeThreat || t.hostiles.length > 0) return Ie.CRITICAL;
+if (null === (r = e.controller) || void 0 === r ? void 0 : r.my) return Ie.HIGH;
 var a = function() {
 var e, t, r, o = null !== (e = Game.spawns) && void 0 !== e ? e : {}, n = Object.values(o)[0];
 return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "";
 }();
-return a && (null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.reservation) || void 0 === n ? void 0 : n.username) === a ? Pe.MEDIUM : Pe.LOW;
+return a && (null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.reservation) || void 0 === n ? void 0 : n.username) === a ? Ie.MEDIUM : Ie.LOW;
 }
 
-function Sv(e, t) {
+function wv(e, t) {
 var r;
 if (!(null === (r = e.controller) || void 0 === r ? void 0 : r.my)) return .02;
 var o = e.controller.level;
 return t.nukeThreat || t.hostiles.length > 0 ? .12 : o <= 3 ? .04 : o <= 6 ? .06 : .08;
 }
 
-var wv, xv = function() {
+var xv, bv = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -36328,20 +36330,20 @@ var t = this.roomIndices.get(e);
 return void 0 === t && (t = this.nextRoomIndex++, this.roomIndices.set(e, t)), t;
 }, e.prototype.getRoomProcessDescriptor = function(e) {
 var t = {
-nukeThreat: Ev(e),
-hostiles: X(e)
-}, r = Cv(e, t), o = function(e, t, r) {
+nukeThreat: Tv(e),
+hostiles: Z(e)
+}, r = Sv(e, t), o = function(e, t, r) {
 var o;
-return t === Pe.CRITICAL ? {
+return t === Ie.CRITICAL ? {
 tickModulo: void 0,
 tickOffset: void 0
-} : t === Pe.HIGH && (null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? {
+} : t === Ie.HIGH && (null === (o = e.controller) || void 0 === o ? void 0 : o.my) ? {
 tickModulo: 5,
 tickOffset: r % 5
-} : t === Pe.MEDIUM ? {
+} : t === Ie.MEDIUM ? {
 tickModulo: 10,
 tickOffset: r % 10
-} : t === Pe.LOW ? {
+} : t === Ie.LOW ? {
 tickModulo: 20,
 tickOffset: r % 20
 } : {
@@ -36350,9 +36352,9 @@ tickOffset: void 0
 };
 }(e, r, this.getRoomIndex(e.name));
 return {
-name: Tv(e, t.nukeThreat),
+name: Cv(e, t.nukeThreat),
 priority: r,
-cpuBudget: Sv(e, t),
+cpuBudget: wv(e, t),
 tickModulo: o.tickModulo,
 tickOffset: o.tickOffset,
 minBucket: this.getMinBucketForPriority(r)
@@ -36367,7 +36369,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Ii.getProcess(i), c = this.getRoomProcessDescriptor(n);
+var i = "room:".concat(o), s = Gi.getProcess(i), c = this.getRoomProcessDescriptor(n);
 this.registeredRooms.has(o) ? s && this.hasDescriptorChanged(s, c) && this.updateRoomProcess(n, c) : this.registerRoomProcess(n, c);
 }
 try {
@@ -36388,7 +36390,7 @@ if (e) throw e.error;
 }, e.prototype.registerRoomProcess = function(e, t) {
 void 0 === t && (t = this.getRoomProcessDescriptor(e));
 var r = "room:".concat(e.name);
-Ii.registerProcess({
+Gi.registerProcess({
 id: r,
 name: t.name,
 priority: t.priority,
@@ -36404,16 +36406,16 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && hv.runRoom(t);
+t && Rv.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var o = t.tickModulo ? "(mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset, ")") : "(every tick)";
-ml.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
+dl.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t) {
 var r = "room:".concat(e.name);
-Ii.unregisterProcess(r), Ii.registerProcess({
+Gi.unregisterProcess(r), Gi.registerProcess({
 id: r,
 name: t.name,
 priority: t.priority,
@@ -36429,32 +36431,32 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && hv.runRoom(t);
+t && Rv.runRoom(t);
 }
 });
 var o = t.tickModulo ? "mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset) : "every tick";
-ml.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
+dl.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.unregisterRoomProcess = function(e) {
 var t = "room:".concat(e);
-Ii.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
-Rv.delete(e), ml.debug("Unregistered room process: ".concat(e), {
+Gi.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
+Ev.delete(e), dl.debug("Unregistered room process: ".concat(e), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.getMinBucketForPriority = function(e) {
-var t = kr().cpu.bucketThresholds.lowMode;
-return e >= Pe.HIGH ? 0 : t;
+var t = Mr().cpu.bucketThresholds.lowMode;
+return e >= Ie.HIGH ? 0 : t;
 }, e.prototype.getStats = function() {
 var e, t, r, o, n, i = {}, s = 0;
 try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = Cv(m, {
-nukeThreat: Ev(m),
-hostiles: X(m)
-}), p = null !== (r = Pe[d]) && void 0 !== r ? r : "UNKNOWN";
+var d = Sv(m, {
+nukeThreat: Tv(m),
+hostiles: Z(m)
+}), p = null !== (r = Ie[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
 }
 }
@@ -36479,12 +36481,12 @@ ownedRooms: s
 this.lastSyncTick = -1, this.syncRoomProcesses();
 }, e.prototype.reset = function() {
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
-this.lastSyncTick = -1, Rv.clear();
+this.lastSyncTick = -1, Ev.clear();
 }, e;
-}(), bv = new xv, Ov = function() {
+}(), Ov = new bv, kv = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
-var e = Ii.getStatsSummary(), t = Ii.getConfig();
+var e = Gi.getStatsSummary(), t = Gi.getConfig();
 return function(e) {
 var t, r, o, n, i = [ "=== Kernel Stats ===", "Bucket Mode: ".concat(e.bucketMode.toUpperCase()), "CPU Bucket: ".concat(e.cpuBucket), "CPU Limit: ".concat(e.cpuLimit.toFixed(2), " (").concat((100 * e.targetCpuUsage).toFixed(0), "% of ").concat(e.gameCpuLimit, ")"), "Remaining CPU: ".concat(e.remainingCpu.toFixed(2)), "", "Processes: ".concat(e.stats.totalProcesses, " total (").concat(e.stats.activeProcesses, " active, ").concat(e.stats.suspendedProcesses, " suspended)"), "Total CPU Used: ".concat(e.stats.totalCpuUsed.toFixed(3)), "Avg CPU/Process: ".concat(e.stats.avgCpuPerProcess.toFixed(4)), "Avg Health Score: ".concat(e.stats.avgHealthScore.toFixed(1), "/100"), "", "Top CPU Consumers:" ];
 try {
@@ -36522,16 +36524,16 @@ if (o) throw o.error;
 }
 return i.join("\n");
 }({
-bucketMode: Ii.getBucketMode(),
+bucketMode: Gi.getBucketMode(),
 cpuBucket: Game.cpu.bucket,
-cpuLimit: Ii.getCpuLimit(),
+cpuLimit: Gi.getCpuLimit(),
 targetCpuUsage: t.targetCpuUsage,
 gameCpuLimit: Game.cpu.limit,
-remainingCpu: Ii.getRemainingCpu(),
+remainingCpu: Gi.getRemainingCpu(),
 stats: e
 });
 }, e.prototype.listProcesses = function() {
-var e = Ii.getProcesses();
+var e = Gi.getProcesses();
 return 0 === e.length ? "No processes registered with kernel." : function(e) {
 var t, r;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36558,11 +36560,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(by(e.summary.byLayer)), "Groups: ".concat(by(e.summary.byGroup)), "States: ".concat(by(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Oy(e.summary.byLayer)), "Groups: ".concat(Oy(e.summary.byGroup)), "States: ".concat(Oy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(Oy)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(ky)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(wy(m));
+c.push(xy(m));
 }
 } catch (e) {
 t = {
@@ -36599,19 +36601,19 @@ if (o) throw o.error;
 }
 }
 return c.join("\n");
-}(Ii.getProcessTopology());
+}(Gi.getProcessTopology());
 }, e.prototype.suspendProcess = function(e) {
-var t = Ii.suspendProcess(e);
+var t = Gi.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = Ii.resumeProcess(e);
+var t = Gi.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return Ii.resetStats(), "Kernel statistics reset.";
+return Gi.resetStats(), "Kernel statistics reset.";
 }, e.prototype.showProcessHealth = function() {
-var e = Ii.getProcesses();
+var e = Gi.getProcesses();
 if (0 === e.length) return "No processes registered with kernel.";
-var t = Ii.getStatsSummary();
+var t = Gi.getStatsSummary();
 return function(e, t, r) {
 var o, n;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36638,7 +36640,7 @@ return c.push("", "Average Health: ".concat(r.avgHealthScore.toFixed(1), "/100")
 c.join("\n");
 }(e, Game.time, t);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = Ii.getProcesses().filter(function(e) {
+var e, t, r = Gi.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -36646,7 +36648,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Ii.resumeProcess(s.id) && o++;
+Gi.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -36661,7 +36663,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = Sy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = wy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36680,7 +36682,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = bv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = Ov.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36699,7 +36701,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o = Ii.getProcesses().filter(function(e) {
+var t, r, o = Gi.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (o = o.filter(function(t) {
@@ -36728,7 +36730,7 @@ if (t) throw t.error;
 }
 return n + "\nTotal: ".concat(o.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r = Ii.getProcesses().filter(function(e) {
+var e, t, r = Gi.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === r.length) return "No room processes registered.";
@@ -36754,113 +36756,113 @@ if (e) throw e.error;
 }
 }
 return o + "\nTotal: ".concat(r.length, " room processes");
-}, n([ Xr({
+}, n([ Zr({
 name: "showKernelStats",
 description: "Show kernel statistics including CPU usage and process info",
 usage: "showKernelStats()",
 examples: [ "showKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showKernelStats", null), n([ Xr({
+}) ], e.prototype, "showKernelStats", null), n([ Zr({
 name: "listProcesses",
 description: "List all registered kernel processes",
 usage: "listProcesses()",
 examples: [ "listProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "listProcesses", null), n([ Xr({
+}) ], e.prototype, "listProcesses", null), n([ Zr({
 name: "showProcessTopology",
 description: "Show observable process topology with scheduling and health metadata",
 usage: "showProcessTopology()",
 examples: [ "showProcessTopology()" ],
 category: "Kernel"
-}) ], e.prototype, "showProcessTopology", null), n([ Xr({
+}) ], e.prototype, "showProcessTopology", null), n([ Zr({
 name: "suspendProcess",
 description: "Suspend a kernel process by ID",
 usage: "suspendProcess(processId)",
 examples: [ "suspendProcess('empire:manager')", "suspendProcess('cluster:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "suspendProcess", null), n([ Xr({
+}) ], e.prototype, "suspendProcess", null), n([ Zr({
 name: "resumeProcess",
 description: "Resume a suspended kernel process",
 usage: "resumeProcess(processId)",
 examples: [ "resumeProcess('empire:manager')" ],
 category: "Kernel"
-}) ], e.prototype, "resumeProcess", null), n([ Xr({
+}) ], e.prototype, "resumeProcess", null), n([ Zr({
 name: "resetKernelStats",
 description: "Reset all kernel process statistics",
 usage: "resetKernelStats()",
 examples: [ "resetKernelStats()" ],
 category: "Kernel"
-}) ], e.prototype, "resetKernelStats", null), n([ Xr({
+}) ], e.prototype, "resetKernelStats", null), n([ Zr({
 name: "showProcessHealth",
 description: "Show health status of all processes with detailed metrics",
 usage: "showProcessHealth()",
 examples: [ "showProcessHealth()" ],
 category: "Kernel"
-}) ], e.prototype, "showProcessHealth", null), n([ Xr({
+}) ], e.prototype, "showProcessHealth", null), n([ Zr({
 name: "resumeAllProcesses",
 description: "Resume all suspended processes (use with caution)",
 usage: "resumeAllProcesses()",
 examples: [ "resumeAllProcesses()" ],
 category: "Kernel"
-}) ], e.prototype, "resumeAllProcesses", null), n([ Xr({
+}) ], e.prototype, "resumeAllProcesses", null), n([ Zr({
 name: "showCreepStats",
 description: "Show statistics about creep processes managed by the kernel",
 usage: "showCreepStats()",
 examples: [ "showCreepStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showCreepStats", null), n([ Xr({
+}) ], e.prototype, "showCreepStats", null), n([ Zr({
 name: "showRoomStats",
 description: "Show statistics about room processes managed by the kernel",
 usage: "showRoomStats()",
 examples: [ "showRoomStats()" ],
 category: "Kernel"
-}) ], e.prototype, "showRoomStats", null), n([ Xr({
+}) ], e.prototype, "showRoomStats", null), n([ Zr({
 name: "listCreepProcesses",
 description: "List all creep processes with their details",
 usage: "listCreepProcesses(role?)",
 examples: [ "listCreepProcesses()", "listCreepProcesses('harvester')" ],
 category: "Kernel"
-}) ], e.prototype, "listCreepProcesses", null), n([ Xr({
+}) ], e.prototype, "listCreepProcesses", null), n([ Zr({
 name: "listRoomProcesses",
 description: "List all room processes with their details",
 usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), kv = function() {
+}(), Mv = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
-debug: Ou.DEBUG,
-info: Ou.INFO,
-warn: Ou.WARN,
-error: Ou.ERROR,
-none: Ou.NONE
+debug: ku.DEBUG,
+info: ku.INFO,
+warn: ku.WARN,
+error: ku.ERROR,
+none: ku.NONE
 }[e.toLowerCase()];
-return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Qu({
+return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Xu({
 level: t
 }), "Log level set to: ".concat(e.toUpperCase()));
 }, e.prototype.toggleDebug = function() {
-var e = !kr().debug;
-return Mr({
+var e = !Mr().debug;
+return Ar({
 debug: e
-}), Qu({
-level: e ? Ou.DEBUG : Ou.INFO
+}), Xu({
+level: e ? ku.DEBUG : ku.INFO
 }), "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
-}, n([ Xr({
+}, n([ Zr({
 name: "setLogLevel",
 description: "Set the log level for the bot",
 usage: "setLogLevel(level)",
 examples: [ "setLogLevel('debug')", "setLogLevel('info')", "setLogLevel('warn')", "setLogLevel('error')", "setLogLevel('none')" ],
 category: "Logging"
-}) ], e.prototype, "setLogLevel", null), n([ Xr({
+}) ], e.prototype, "setLogLevel", null), n([ Zr({
 name: "toggleDebug",
 description: "Toggle debug mode on/off (affects log level and debug features)",
 usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), Mv = function() {
+}(), Av = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36900,20 +36902,20 @@ hostileCount: null !== (l = null !== (u = null !== (s = this.toNumber(null === (
 var o, n, a, i, s = this.asRecord(null === (o = this.asRecord(e)) || void 0 === o ? void 0 : o.metrics), c = this.asRecord(null == s ? void 0 : s.energy);
 return null !== (i = null !== (a = null !== (n = this.toNumber(null == s ? void 0 : s[t])) && void 0 !== n ? n : this.toNumber(null == c ? void 0 : c[r])) && void 0 !== a ? a : this.toNumber(null == s ? void 0 : s[r])) && void 0 !== i ? i : 0;
 }, e.prototype.showStats = function() {
-var e = ns.getLatestStats();
+var e = as.getLatestStats();
 return e ? "=== SwarmBot Stats (Tick ".concat(e.tick, ") ===\nCPU: ").concat(e.cpuUsed.toFixed(2), "/").concat(e.cpuLimit, " (Bucket: ").concat(e.cpuBucket, ")\nGCL: ").concat(e.gclLevel, " (").concat((100 * e.gclProgress).toFixed(1), "%)\nGPL: ").concat(e.gplLevel, "\nCreeps: ").concat(e.totalCreeps, "\nRooms: ").concat(e.totalRooms, "\n").concat(e.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks.";
 }, e.prototype.cacheStats = function() {
-var e, t = Re.getCacheStats(it);
+var e, t = Ee.getCacheStats(st);
 return "=== Object Cache Statistics ===\nCache Size: ".concat(t.size, " entries\nCache Hits: ").concat(t.hits, "\nCache Misses: ").concat(t.misses, "\nHit Rate: ").concat(t.hitRate.toFixed(2), "%\nEstimated CPU Saved: ").concat((null !== (e = t.cpuSaved) && void 0 !== e ? e : 0).toFixed(3), " CPU\n\nPerformance: ").concat(t.hitRate >= 80 ? "Excellent" : t.hitRate >= 60 ? "Good" : t.hitRate >= 40 ? "Fair" : "Poor");
 }, e.prototype.resetCacheStats = function() {
-return Re.clear(it), "Cache statistics reset";
+return Ee.clear(st), "Cache statistics reset";
 }, e.prototype.roomFindCacheStats = function() {
 var e = function() {
-var e, t, r = Re.getCacheStats(lt), o = new Set;
+var e, t, r = Ee.getCacheStats(mt), o = new Set;
 try {
-for (var n = a(Re.keys(lt)), s = n.next(); !s.done; s = n.next()) {
+for (var n = a(Ee.keys(mt)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value.split(":"), 1)[0];
 c && o.add(c);
 }
@@ -36939,23 +36941,23 @@ hitRate: r.hitRate
 }(), t = (100 * e.hitRate).toFixed(2), r = e.hits + e.misses, o = e.rooms > 0 ? (e.totalEntries / e.rooms).toFixed(1) : "0", n = (.05 * e.hits).toFixed(3);
 return "=== Room.find() Cache Statistics ===\nCached Rooms: ".concat(e.rooms, "\nTotal Entries: ").concat(e.totalEntries, "\nAvg Entries/Room: ").concat(o, "\n\nTotal Queries: ").concat(r, "\nCache Hits: ").concat(e.hits, "\nCache Misses: ").concat(e.misses, "\nHit Rate: ").concat(t, "%\n\nCache Invalidations: ").concat(e.invalidations, "\nEstimated CPU Saved: ~").concat(n, " CPU this tick\n\nPerformance: ").concat(e.hitRate >= .8 ? "Excellent OK" : e.hitRate >= .6 ? "Good" : e.hitRate >= .5 ? "Fair" : "Poor - Consider more caching");
 }, e.prototype.clearRoomFindCache = function() {
-return Re.clear(lt), "Room.find() cache cleared and statistics reset";
+return Ee.clear(mt), "Room.find() cache cleared and statistics reset";
 }, e.prototype.toggleProfiling = function() {
-var e = !kr().profiling;
-return Mr({
+var e = !Mr().profiling;
+return Ar({
 profiling: e
-}), ts.setEnabled(e), Qu({
+}), rs.setEnabled(e), Xu({
 cpuLogging: e
 }), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.enableCpuDetails = function(e, t, r) {
 var o, n, a;
 void 0 === e && (e = 500), void 0 === t && (t = 1);
-var i = ts.enableCpuDetails(e, t, r);
+var i = rs.enableCpuDetails(e, t, r);
 return "CPU details enabled until tick ".concat(null !== (o = i.expiresTick) && void 0 !== o ? o : "unknown", " (sampleRate=").concat(null !== (n = i.sampleRate) && void 0 !== n ? n : 1, ", labels=").concat((null !== (a = i.labels) && void 0 !== a ? a : []).join(",") || "all", ")");
 }, e.prototype.disableCpuDetails = function() {
-return ts.disableCpuDetails(), "CPU details disabled";
+return rs.disableCpuDetails(), "CPU details disabled";
 }, e.prototype.cpuDetails = function() {
-var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = ts.getCpuDetailsStatus();
+var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = rs.getCpuDetailsStatus();
 if (!u) return "CPU details ".concat(l.enabled ? "enabled" : "disabled", "; no samples published yet");
 var m = Object.entries(null !== (o = u.entries) && void 0 !== o ? o : {}), d = Array.isArray(u.labels) ? u.labels.join(",") : "", p = [ "=== CPU Details ===", "Enabled: ".concat(String(u.enabled), " | Expires: ").concat(null !== (n = u.expires_tick) && void 0 !== n ? n : "n/a", " | Sample rate: ").concat(null !== (s = u.sample_rate) && void 0 !== s ? s : 1, " | Labels: ").concat(d || "all") ];
 try {
@@ -37093,7 +37095,7 @@ I.push("");
 }
 return I.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n = ts.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
+var e, t, r, o, n = rs.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
 if (i += "Rooms Evaluated: ".concat(n.roomsEvaluated, "\n"), i += "Within Budget: ".concat(n.roomsWithinBudget, "\n"),
 i += "Over Budget: ".concat(n.roomsOverBudget, "\n\n"), 0 === n.alerts.length) i += "OK All rooms within budget!\n"; else {
 i += "Alerts: ".concat(n.alerts.length, "\n");
@@ -37140,7 +37142,7 @@ if (r) throw r.error;
 }
 return i;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n = ts.detectAnomalies();
+var e, t, r, o, n = rs.detectAnomalies();
 if (0 === n.length) return "OK No CPU anomalies detected";
 var i = "=== CPU Anomalies Detected: ".concat(n.length, " ===\n\n"), s = n.filter(function(e) {
 return "spike" === e.type;
@@ -37189,7 +37191,7 @@ return i;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n;
 void 0 === e && (e = !1);
-var i = ts.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
+var i = rs.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
 s += "Total: ".concat(i.cpu.used.toFixed(2), " / ").concat(i.cpu.limit, " (").concat(i.cpu.percent.toFixed(1), "%)\n"),
 s += "Bucket: ".concat(i.cpu.bucket, "\n"), s += "Heap: ".concat(i.cpu.heapUsed.toFixed(2), " MB\n\n");
 var c = Object.values(i.rooms).sort(function(e, t) {
@@ -37198,7 +37200,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 s += "Top ".concat(u.length, " Rooms by CPU:\n");
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = ts.postureCodeToName(p);
+var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = rs.postureCodeToName(p);
 s += "  ".concat(d.name, " (RCL").concat(d.rcl, ", ").concat(f, "): avg ").concat(d.profiler.avgCpu.toFixed(3), " | peak ").concat(d.profiler.peakCpu.toFixed(3), " | samples ").concat(d.profiler.samples, "\n");
 }
 } catch (e) {
@@ -37239,9 +37241,9 @@ return s;
 var t, r, o, n;
 if (!e) return "Error: Room name required. Usage: diagnoseRoom('W16S52')";
 if (!Game.rooms[e]) return "Error: Room ".concat(e, " not visible. Make sure you have vision in this room.");
-var s = ts.getCurrentSnapshot(), c = s.rooms[e];
+var s = rs.getCurrentSnapshot(), c = s.rooms[e];
 if (!c) return "Error: No stats available for ".concat(e, ". The room may not have been processed yet.");
-var u = "room:".concat(e), l = s.processes[u], m = Sr.getSwarmState(e), d = m && ("war" === m.posture || "siege" === m.posture || m.danger >= 2), p = d ? .25 : .1, f = null !== (o = null == l ? void 0 : l.tickModulo) && void 0 !== o ? o : 1, y = p * f, v = "----------------------------------------------\n";
+var u = "room:".concat(e), l = s.processes[u], m = wr.getSwarmState(e), d = m && ("war" === m.posture || "siege" === m.posture || m.danger >= 2), p = d ? .25 : .1, f = null !== (o = null == l ? void 0 : l.tickModulo) && void 0 !== o ? o : 1, y = p * f, v = "----------------------------------------------\n";
 v += "  Room Diagnostic: ".concat(e, "\n"), v += "----------------------------------------------\n\n";
 var g = this.getRoomBrainMetrics(c), h = {
 energyHarvested: this.getRoomMetricValue(c, "energyHarvested", "harvested"),
@@ -37249,7 +37251,7 @@ energyCapacityTotal: this.getRoomMetricValue(c, "energyCapacityTotal", "capacity
 constructionSites: this.getRoomMetricValue(c, "constructionSites", "construction_sites")
 };
 v += "SUMMARY Basic Info:\n", v += "  RCL: ".concat(c.rcl, "\n"), v += "  Controller Progress: ".concat(c.controller.progressPercent.toFixed(1), "%\n"),
-v += "  Posture: ".concat(ts.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
+v += "  Posture: ".concat(rs.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
 v += "  Hostiles: ".concat(g.hostileCount, "\n\n"), v += "CPU CPU Analysis:\n",
 v += "  Average CPU: ".concat(c.profiler.avgCpu.toFixed(3), "\n"), v += "  Peak CPU: ".concat(c.profiler.peakCpu.toFixed(3), "\n"),
 v += "  Samples: ".concat(c.profiler.samples, "\n"), v += "  Budget: ".concat(y.toFixed(3), " (base ").concat(p, ", modulo ").concat(f, ")\n");
@@ -37300,160 +37302,160 @@ v += "     - Monitor for increases in CPU usage\n") : v += "  OK Room is perform
 g.hostileCount > 0 && (v += "  WARNING  ".concat(g.hostileCount, " hostiles detected - defense active\n"),
 v += "     - War mode increases CPU budget to ".concat(d ? y.toFixed(3) : (.25 * f).toFixed(3), "\n")),
 v += "\n", (v += "Use cpuBreakdown('room') to see all rooms\n") + "Use cpuProfile() for detailed profiling";
-}, n([ Xr({
+}, n([ Zr({
 name: "showStats",
 description: "Show current bot statistics from memory segment",
 usage: "showStats()",
 examples: [ "showStats()" ],
 category: "Statistics"
-}) ], e.prototype, "showStats", null), n([ Xr({
+}) ], e.prototype, "showStats", null), n([ Zr({
 name: "cacheStats",
 description: "Show object cache statistics (hits, misses, hit rate, CPU savings)",
 usage: "cacheStats()",
 examples: [ "cacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "cacheStats", null), n([ Xr({
+}) ], e.prototype, "cacheStats", null), n([ Zr({
 name: "resetCacheStats",
 description: "Reset cache statistics counters (for benchmarking)",
 usage: "resetCacheStats()",
 examples: [ "resetCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "resetCacheStats", null), n([ Xr({
+}) ], e.prototype, "resetCacheStats", null), n([ Zr({
 name: "roomFindCacheStats",
 description: "Show room.find() cache statistics (hits, misses, hit rate)",
 usage: "roomFindCacheStats()",
 examples: [ "roomFindCacheStats()" ],
 category: "Statistics"
-}) ], e.prototype, "roomFindCacheStats", null), n([ Xr({
+}) ], e.prototype, "roomFindCacheStats", null), n([ Zr({
 name: "clearRoomFindCache",
 description: "Clear all room.find() cache entries and reset stats",
 usage: "clearRoomFindCache()",
 examples: [ "clearRoomFindCache()" ],
 category: "Statistics"
-}) ], e.prototype, "clearRoomFindCache", null), n([ Xr({
+}) ], e.prototype, "clearRoomFindCache", null), n([ Zr({
 name: "toggleProfiling",
 description: "Toggle CPU profiling on/off",
 usage: "toggleProfiling()",
 examples: [ "toggleProfiling()" ],
 category: "Statistics"
-}) ], e.prototype, "toggleProfiling", null), n([ Xr({
+}) ], e.prototype, "toggleProfiling", null), n([ Zr({
 name: "enableCpuDetails",
 description: "Enable temporary fine-grained CPU detail profiling",
 usage: "enableCpuDetails(ttl?, sampleRate?, labels?)",
 examples: [ "enableCpuDetails(500, 1)", "enableCpuDetails(200, 5, ['remoteInfrastructure', 'taskBoard'])" ],
 category: "Statistics"
-}) ], e.prototype, "enableCpuDetails", null), n([ Xr({
+}) ], e.prototype, "enableCpuDetails", null), n([ Zr({
 name: "disableCpuDetails",
 description: "Disable temporary fine-grained CPU detail profiling",
 usage: "disableCpuDetails()",
 examples: [ "disableCpuDetails()" ],
 category: "Statistics"
-}) ], e.prototype, "disableCpuDetails", null), n([ Xr({
+}) ], e.prototype, "disableCpuDetails", null), n([ Zr({
 name: "cpuDetails",
 description: "Show temporary fine-grained CPU detail profiler output",
 usage: "cpuDetails()",
 examples: [ "cpuDetails()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuDetails", null), n([ Xr({
+}) ], e.prototype, "cpuDetails", null), n([ Zr({
 name: "cpuBreakdown",
 description: "Show detailed CPU breakdown by process, room, creep, and subsystem",
 usage: "cpuBreakdown(type?)",
 examples: [ "cpuBreakdown() // Show all breakdowns", "cpuBreakdown('process') // Show only process breakdown", "cpuBreakdown('room') // Show only room breakdown", "cpuBreakdown('creep') // Show only creep breakdown", "cpuBreakdown('subsystem') // Show only subsystem breakdown" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBreakdown", null), n([ Xr({
+}) ], e.prototype, "cpuBreakdown", null), n([ Zr({
 name: "cpuBudget",
 description: "Show CPU budget status and violations for all rooms",
 usage: "cpuBudget()",
 examples: [ "cpuBudget()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuBudget", null), n([ Xr({
+}) ], e.prototype, "cpuBudget", null), n([ Zr({
 name: "cpuAnomalies",
 description: "Detect and show CPU usage anomalies (spikes and sustained high usage)",
 usage: "cpuAnomalies()",
 examples: [ "cpuAnomalies()" ],
 category: "Statistics"
-}) ], e.prototype, "cpuAnomalies", null), n([ Xr({
+}) ], e.prototype, "cpuAnomalies", null), n([ Zr({
 name: "cpuProfile",
 description: "Show comprehensive CPU profiling breakdown by room and subsystem",
 usage: "cpuProfile(showAll?)",
 examples: [ "cpuProfile()", "cpuProfile(true)" ],
 category: "Statistics"
-}) ], e.prototype, "cpuProfile", null), n([ Xr({
+}) ], e.prototype, "cpuProfile", null), n([ Zr({
 name: "diagnoseRoom",
 description: "Comprehensive diagnostic for a specific room showing CPU usage, budget status, and potential issues",
 usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Av = function() {
+}(), Uv = function() {
 function e() {}
 return e.prototype.listCommands = function() {
-return Qr.generateHelp();
+return Xr.generateHelp();
 }, e.prototype.commandHelp = function(e) {
-return Qr.generateCommandHelp(e);
-}, n([ Xr({
+return Xr.generateCommandHelp(e);
+}, n([ Zr({
 name: "listCommands",
 description: "List all available commands (alias for help)",
 usage: "listCommands()",
 examples: [ "listCommands()" ],
 category: "System"
-}) ], e.prototype, "listCommands", null), n([ Xr({
+}) ], e.prototype, "listCommands", null), n([ Zr({
 name: "commandHelp",
 description: "Get detailed help for a specific command",
 usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), Uv = function() {
+}(), _v = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? mm.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? dm.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? mm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? dm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return mm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
-}, n([ Xr({
+return dm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+}, n([ Zr({
 name: "tasks",
 description: "Show room creep task queue",
 usage: "tasks(roomName?)",
 examples: [ "tasks('W1N1')" ],
 category: "Tasks"
-}) ], e.prototype, "tasks", null), n([ Xr({
+}) ], e.prototype, "tasks", null), n([ Zr({
 name: "taskAssignments",
 description: "Show creep task reservations for a room",
 usage: "taskAssignments(roomName?)",
 examples: [ "taskAssignments('W1N1')" ],
 category: "Tasks"
-}) ], e.prototype, "taskAssignments", null), n([ Xr({
+}) ], e.prototype, "taskAssignments", null), n([ Zr({
 name: "clearTasks",
 description: "Clear creep task queue/reservations",
 usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), _v = ((wv = {})[MOVE] = 50, wv[WORK] = 100, wv[CARRY] = 50, wv[ATTACK] = 80,
-wv[RANGED_ATTACK] = 150, wv[HEAL] = 250, wv[CLAIM] = 600, wv[TOUGH] = 10, wv);
+}(), Nv = ((xv = {})[MOVE] = 50, xv[WORK] = 100, xv[CARRY] = 50, xv[ATTACK] = 80,
+xv[RANGED_ATTACK] = 150, xv[HEAL] = 250, xv[CLAIM] = 600, xv[TOUGH] = 10, xv);
 
-function Nv(e, t) {
+function Pv(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, _v), t);
+var r = o(o({}, Nv), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : _v[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : Nv[t]);
 }, 0);
 }
 
-function Pv(e, t) {
+function Iv(e, t) {
 void 0 === t && (t = 0);
-var r = Nv(e);
+var r = Pv(e);
 return {
 parts: e,
 cost: r,
@@ -37461,7 +37463,7 @@ minCapacity: t || r
 };
 }
 
-function Iv() {
+function Gv() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -37469,11 +37471,11 @@ return Array(o).fill(r);
 });
 }
 
-var Gv, Lv, Dv, Bv = {
+var Lv, Dv, Bv, Fv = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Pv([ WORK, CARRY ], 150), Pv([ WORK, CARRY, MOVE ], 200), Pv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Pv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Pv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Iv([ WORK, CARRY ], 150), Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Iv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -37481,7 +37483,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Pv([ WORK, CARRY, MOVE ], 200), Pv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Pv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Pv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37489,7 +37491,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Pv([ WORK, CARRY, MOVE, MOVE ], 250), Pv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37497,7 +37499,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Pv([ WORK, CARRY, MOVE ], 200), Pv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Pv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Pv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Iv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37505,7 +37507,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Pv([ CARRY, CARRY, MOVE, MOVE ], 200), Pv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Pv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Iv([ CARRY, CARRY, MOVE, MOVE ], 200), Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37513,7 +37515,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Pv([ WORK, CARRY, MOVE ], 200), Pv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -37521,7 +37523,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Pv([ WORK, CARRY, MOVE, MOVE ], 250), Pv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37529,7 +37531,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Pv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37537,7 +37539,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Pv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ Iv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37545,7 +37547,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Pv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37553,7 +37555,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Pv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37561,7 +37563,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Pv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Pv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Pv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ Iv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37569,7 +37571,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Pv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Pv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37577,7 +37579,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Pv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Pv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37585,16 +37587,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Pv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Pv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Pv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Pv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Iv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Iv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Iv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Fv = {
+}, Wv = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Pv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Pv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Pv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Pv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ Iv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37602,7 +37604,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Pv([ TOUGH, ATTACK, MOVE, MOVE ], 190), Pv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Pv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ Iv([ TOUGH, ATTACK, MOVE, MOVE ], 190), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Iv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37610,7 +37612,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Pv([ HEAL, MOVE, MOVE ], 350), Pv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Pv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Pv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ Iv([ HEAL, MOVE, MOVE ], 350), Iv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37618,7 +37620,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Pv([ ATTACK, ATTACK, MOVE, MOVE ], 260), Pv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Pv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ Iv([ ATTACK, ATTACK, MOVE, MOVE ], 260), Iv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37626,7 +37628,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Pv([ WORK, WORK, MOVE, MOVE ], 300), Pv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Pv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ Iv([ WORK, WORK, MOVE, MOVE ], 300), Iv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37634,7 +37636,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Pv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Pv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Pv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Pv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ Iv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Iv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Iv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37642,16 +37644,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Pv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Pv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Pv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ Iv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Iv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Wv = {
+}, Hv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Pv(Iv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Pv(Iv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ Iv(Gv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Iv(Gv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37659,16 +37661,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Pv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Pv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ Iv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Iv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Hv = {
+}, Kv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Pv([ MOVE ], 50) ],
+bodies: [ Iv([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37676,7 +37678,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Pv([ MOVE ], 50) ],
+bodies: [ Iv([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37684,7 +37686,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Pv([ CLAIM, MOVE ], 650) ],
+bodies: [ Iv([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37692,7 +37694,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Pv([ CLAIM, MOVE ], 650), Pv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ Iv([ CLAIM, MOVE ], 650), Iv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37700,7 +37702,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Pv([ WORK, CARRY, MOVE, MOVE ], 250), Pv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37708,30 +37710,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Pv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Pv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Kv = o(o(o(o({}, Bv), Fv), Hv), Wv);
+}, Yv = o(o(o(o({}, Fv), Wv), Kv), Hv);
 
 try {
-for (var Yv = a(Object.values(Kv)), Vv = Yv.next(); !Vv.done; Vv = Yv.next()) Vv.value.bodies.sort(function(e, t) {
+for (var Vv = a(Object.values(Yv)), qv = Vv.next(); !qv.done; qv = Vv.next()) qv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Gv = {
+Lv = {
 error: e
 };
 } finally {
 try {
-Vv && !Vv.done && (Lv = Yv.return) && Lv.call(Yv);
+qv && !qv.done && (Dv = Vv.return) && Dv.call(Vv);
 } finally {
-if (Gv) throw Gv.error;
+if (Lv) throw Lv.error;
 }
 }
 
-function qv(e) {
+function jv(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37746,11 +37748,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return jv(o);
+return zv(o);
 }
 
-function jv(e) {
-var t = Nv(e);
+function zv(e) {
+var t = Pv(e);
 return {
 parts: e,
 cost: t,
@@ -37758,16 +37760,16 @@ minCapacity: t
 };
 }
 
-function zv(e, t) {
+function Qv(e, t) {
 var r;
-return null !== (r = e.map(jv).filter(function(e) {
+return null !== (r = e.map(zv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Qv(e) {
+function Xv(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37781,7 +37783,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = Nv(a);
+var s = Pv(a);
 return {
 parts: a,
 cost: s,
@@ -37806,8 +37808,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: Nv(p),
-minCapacity: Nv(p)
+cost: Pv(p),
+minCapacity: Pv(p)
 };
 }(e);
 
@@ -37818,7 +37820,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return qv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return jv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37839,7 +37841,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return qv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return jv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37848,13 +37850,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(jv).filter(function(e) {
+var u = n.map(zv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = zv(n, t);
+var l = Qv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37864,7 +37866,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = zv(n, t);
+var u = Qv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37873,14 +37875,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = zv(r, t);
+var a = Qv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Xv(e) {
+function Zv(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37891,9 +37893,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Zv(e, t) {
+function Jv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Xv(t)
+memory: Zv(t)
 });
 var r;
 }
@@ -37901,9 +37903,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Dv || (Dv = {}));
+}(Bv || (Bv = {}));
 
-var Jv = function() {
+var $v = function() {
 function e() {
 this.queues = new Map, this.revision = 0;
 }
@@ -38001,7 +38003,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Zv(m, d);
+var p = Jv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -38021,7 +38023,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Dv.EMERGENCY;
+return e.priority >= Bv.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -38039,7 +38041,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Dv.EMERGENCY ? n.emergency++ : c.priority >= Dv.HIGH ? n.high++ : c.priority >= Dv.NORMAL ? n.normal++ : n.low++;
+c.priority >= Bv.EMERGENCY ? n.emergency++ : c.priority >= Bv.HIGH ? n.high++ : c.priority >= Bv.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -38054,14 +38056,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), $v = new Jv, eg = {
+}(), eg = new $v, tg = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, tg = {
+}, rg = {
 predictConsumption: function() {
 return 0;
 },
@@ -38080,7 +38082,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, rg = {
+}, og = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -38098,85 +38100,85 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, og = {
+}, ng = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function ng(e, t, r, o, n) {
-return fc(e, t, r, o, n);
+function ag(e, t, r, o, n) {
+return yc(e, t, r, o, n);
 }
 
-var ag = new Map, ig = -1, sg = null, cg = null;
+var ig = new Map, sg = -1, cg = null, ug = null;
 
-function ug() {
-ig === Game.time && sg === Game.creeps || (ag.clear(), cg = null, ig = Game.time,
-sg = Game.creeps);
+function lg() {
+sg === Game.time && cg === Game.creeps || (ig.clear(), ug = null, sg = Game.time,
+cg = Game.creeps);
 }
 
-function lg(e) {
+function mg(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function mg(e, t) {
+function dg(e, t) {
 var r;
-void 0 === t && (t = !1), ug();
-var o = t ? "".concat(e, "_active") : e, n = ag.get(o);
+void 0 === t && (t = !1), lg();
+var o = t ? "".concat(e, "_active") : e, n = ig.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = lg(c);
+var u = mg(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return ag.set(o, a), a;
-}
-
-function dg(e, t, r) {
-return "".concat(e).concat("").concat(t).concat("").concat(r);
+return ig.set(o, a), a;
 }
 
 function pg(e, t, r) {
+return "".concat(e).concat("").concat(t).concat("").concat(r);
+}
+
+function fg(e, t, r) {
 var o;
 return null !== (o = function() {
 var e;
-if (ug(), cg) return cg;
+if (lg(), ug) return ug;
 var t = new Map;
 for (var r in Game.creeps) {
 var o = Game.creeps[r].memory, n = o.homeRoom, a = o.role, i = o.targetRoom;
 if (n && a && i) {
-var s = dg(n, a, i);
+var s = pg(n, a, i);
 t.set(s, (null !== (e = t.get(s)) && void 0 !== e ? e : 0) + 1);
 }
 }
-return cg = t, t;
-}().get(dg(e, t, r))) && void 0 !== o ? o : 0;
+return ug = t, t;
+}().get(pg(e, t, r))) && void 0 !== o ? o : 0;
 }
 
-function fg(e) {
+function yg(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var yg = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
-
-function vg(e) {
-return yg.includes(e);
-}
+var vg = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
 function gg(e) {
+return vg.includes(e);
+}
+
+function hg(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function hg(e, t, r, o) {
+function Rg(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
-return e ? pt(e).length : 2;
+return e ? ft(e).length : 2;
 }(o);
 
 case "remoteHauler":
@@ -38185,10 +38187,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return ng(e, t, pt(r).length, o, {
-reserved: gg(r)
+if (r) return ag(e, t, ft(r).length, o, {
+reserved: hg(r)
 }).recommendedHaulers;
-var n = ng(e, t, 2, o, {
+var n = ag(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -38199,7 +38201,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: fg
+filter: yg
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -38210,7 +38212,7 @@ return 2;
 }
 }
 
-function Rg(e, t) {
+function Eg(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -38220,13 +38222,13 @@ return null;
 }
 }
 
-function Eg() {
+function Tg() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function Tg(e) {
-var t = Eg(), r = function(e) {
+function Cg(e) {
+var t = Tg(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -38238,22 +38240,22 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function Cg(e) {
-var t = Sr.getEmpire().knownRooms[e];
+function Sg(e) {
+var t = wr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Eg();
+var r = Tg();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function Sg(e, t) {
-return void 0 === t && (t = X(e)), t.some(io);
+function wg(e, t) {
+return void 0 === t && (t = Z(e)), t.some(so);
 }
 
-function wg(e) {
+function xg(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function xg() {
+function bg() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -38263,9 +38265,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var bg = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var Og = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function Og(e, t) {
+function kg(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -38277,8 +38279,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(xg()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = $v.getPendingRequests(c).some(function(r) {
+for (var i = a(bg()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = eg.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -38298,7 +38300,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function kg() {
+function Mg() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -38319,8 +38321,8 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function Mg(e, t) {
-var r, o, n, c, u = Sr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
+function Ag(e, t) {
+var r, o, n, c, u = wr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }), m = l.length < (null !== (o = null === (r = Game.gcl) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1), d = m && !0 !== (null === (n = u.objectives) || void 0 === n ? void 0 : n.expansionPaused), p = m && function() {
@@ -38329,15 +38331,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !Og(e.roomName, "claim");
+return !kg(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || Sg(t));
+return !(!r || r.my || r.owner || r.reservation || wg(t));
 }
-return !Cg(e);
+return !Sg(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -38348,11 +38350,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = kg().filter(function(e) {
-return !Og(e, "claim");
+var r, o, n = Mg().filter(function(e) {
+return !kg(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = Eg();
+var r, o, n = Game.rooms[e], a = Tg();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -38361,9 +38363,9 @@ if (i.my || s === a) return !1;
 if (s) return !1;
 var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
-return X(e).some(function(e) {
+return Z(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && bg.has(e.type);
+return e.hits > 0 && Og.has(e.type);
 });
 });
 }(n));
@@ -38375,7 +38377,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = Rg(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = Eg(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -38390,14 +38392,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(kg()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(Mg()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !Og(e.roomName, "claim");
+return !e.claimed && !kg(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -38409,20 +38411,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Eg();
+var l = Tg();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !Og(p, "claim")) {
+if (!t.has(p) && !kg(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || Tg(y)) continue;
-if (Sg(f)) continue;
+if (y.owner || Cg(y)) continue;
+if (wg(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !Og(p, "reserve")) return p;
-} else if (!Cg(p) && !Og(p, "reserve")) return p;
+if ((!v || g < 3e3) && !kg(p, "reserve")) return p;
+} else if (!Sg(p) && !kg(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -38444,22 +38446,22 @@ task: "reserve"
 } : null;
 }
 
-var Ag, Ug, _g = new Map;
+var Ug, _g, Ng = new Map;
 
-function Ng(e) {
+function Pg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Pg(e) {
+function Ig(e) {
 var t, r;
-r = Game.time, Ag === Game && Ug === r || (_g.clear(), Ag = Game, Ug = r);
+r = Game.time, Ug === Game && _g === r || (Ng.clear(), Ug = Game, _g = r);
 var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}(), n = _g.get(e.name);
+}(), n = Ng.get(e.name);
 if (n && n.fallbackEnabled === o) return n.value;
 var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
@@ -38470,7 +38472,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Ng(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Pg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38491,7 +38493,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Ng(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Pg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38505,20 +38507,20 @@ if (o) throw o.error;
 }
 return i;
 }(e)) : i;
-return _g.set(e.name, {
+return Ng.set(e.name, {
 fallbackEnabled: o,
 value: s
 }), s;
 }
 
-var Ig, Gg, Lg, Dg = new Map;
+var Gg, Lg, Dg, Bg = new Map;
 
-function Bg(e, t) {
+function Fg(e, t) {
 var r;
-return null !== (r = Rg(e, t)) && void 0 !== r ? r : 999;
+return null !== (r = Eg(e, t)) && void 0 !== r ? r : 999;
 }
 
-function Fg(e) {
+function Wg(e) {
 try {
 return e.find(FIND_MY_SPAWNS).filter(function(e) {
 return !e.spawning;
@@ -38528,16 +38530,16 @@ return 0;
 }
 }
 
-function Wg(e, t) {
+function Hg(e, t) {
 var r, o = null !== (r = e.energyCapacityAvailable) && void 0 !== r ? r : 0;
 if (o < 200) return null;
 var n, a, i = function(e, t) {
 var r, o;
-Ig === Game && Gg === Game.map && Lg === Game.time || (Dg.clear(), Ig = Game, Gg = Game.map,
-Lg = Game.time);
+Gg === Game && Lg === Game.map && Dg === Game.time || (Bg.clear(), Gg = Game, Lg = Game.map,
+Dg = Game.time);
 var n = "".concat(e, "->").concat(t);
-if (Dg.has(n)) return null !== (r = Dg.get(n)) && void 0 !== r ? r : null;
-var a = Bg(e, t);
+if (Bg.has(n)) return null !== (r = Bg.get(n)) && void 0 !== r ? r : null;
+var a = Fg(e, t);
 try {
 if ("function" == typeof (null === (o = Game.map) || void 0 === o ? void 0 : o.findRoute)) {
 var i = Game.map.findRoute(e, t, {
@@ -38546,79 +38548,79 @@ return function(e, t) {
 var r;
 if (e === t) return 1;
 var o = Game.rooms[e];
-return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && Tg(o.controller) || Cg(e) || o && Sg(o) ? 1 / 0 : 1;
+return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && Cg(o.controller) || Sg(e) || o && wg(o) ? 1 / 0 : 1;
 }(e, t);
 }
 });
 a = i === ERR_NO_PATH ? null : i.length;
 }
 } catch (r) {
-a = Bg(e, t);
+a = Fg(e, t);
 }
-return Dg.set(n, a), a;
+return Bg.set(n, a), a;
 }(e.name, t.name);
 return null === i ? null : {
 room: e,
 routeDistance: i,
-linearDistance: Bg(e.name, t.name),
-queuePressure: (n = e.name, a = t.name, $v.getPendingRequests(n).reduce(function(e, t) {
+linearDistance: Fg(e.name, t.name),
+queuePressure: (n = e.name, a = t.name, eg.getPendingRequests(n).reduce(function(e, t) {
 var r;
-return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Dv.EMERGENCY;
+return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Bv.EMERGENCY;
 }, 0)),
 energyCapacity: o,
-hasAvailableSpawn: Fg(e) > 0,
-hasReadyEnergy: Pg(e) >= 200
+hasAvailableSpawn: Wg(e) > 0,
+hasReadyEnergy: Ig(e) >= 200
 };
 }
 
-function Hg(e, t) {
+function Kg(e, t) {
 return Number(t.hasReadyEnergy) - Number(e.hasReadyEnergy) || Number(t.hasAvailableSpawn) - Number(e.hasAvailableSpawn) || e.queuePressure - t.queuePressure || t.energyCapacity - e.energyCapacity || e.routeDistance - t.routeDistance || e.linearDistance - t.linearDistance || e.room.name.localeCompare(t.room.name);
 }
 
-function Kg(e) {
+function Yg(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function Yg(e) {
-return Kg(e) ? Dv.EMERGENCY : Dv.HIGH;
-}
-
-function Vg(e, t, r) {
-var o, n;
-if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!wg(e)) return !1;
-var a = e.name === t ? r : Sr.getSwarmState(e.name);
-return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
+function Vg(e) {
+return Yg(e) ? Bv.EMERGENCY : Bv.HIGH;
 }
 
 function qg(e, t, r) {
 var o, n;
+if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
+if (!xg(e)) return !1;
+var a = e.name === t ? r : wr.getSwarmState(e.name);
+return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
+}
+
+function jg(e, t, r) {
+var o, n;
 return null !== (n = null === (o = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return Vg(e, t, r);
+return qg(e, t, r);
 }).map(function(t) {
-return Wg(t, e);
+return Hg(t, e);
 }).filter(function(e) {
 return null !== e;
-}).sort(Hg)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
+}).sort(Kg)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function jg(e, t) {
+function zg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !Vg(n, e, t)) return null;
+if (!n || !qg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !wg(e);
+return !xg(e);
 }).filter(function(e) {
-var t = X(e);
-return !Sg(e, t) || lo(e, t);
+var t = Z(e);
+return !wg(e, t) || mo(e, t);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -38639,9 +38641,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(xg()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(bg()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += $v.getPendingRequests(d).filter(function(t) {
+i += eg.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -38658,11 +38660,11 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (Kg(e) ? 3 : 1);
+}(e.name) < (Yg(e) ? 3 : 1);
 }).map(function(e) {
 return {
 room: e,
-homeScore: Wg(n, e)
+homeScore: Hg(n, e)
 };
 }).filter(function(e) {
 return null !== e.homeScore;
@@ -38672,10 +38674,10 @@ return e.homeScore.routeDistance - t.homeScore.routeDistance || e.homeScore.line
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (qg(u.room, e, t) === e) return {
+if (jg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: Yg(u.room)
+priority: Vg(u.room)
 };
 }
 } catch (e) {
@@ -38692,10 +38694,10 @@ if (r) throw r.error;
 return null;
 }
 
-function zg(e, t) {
+function Qg(e, t) {
 if (t <= 0) return null;
 try {
-var r = Qv({
+var r = Xv({
 maxEnergy: t,
 role: e
 });
@@ -38705,36 +38707,36 @@ return null;
 }
 }
 
-function Qg(e, t, r) {
-return "healer" === e || "ranger" === e && No(r) ? null : zg(e, t);
-}
-
-function Xg(e) {
-return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
+function Xg(e, t, r) {
+return "healer" === e || "ranger" === e && Po(r) ? null : Qg(e, t);
 }
 
 function Zg(e) {
-var t, r = Game.rooms[e.roomName];
-return r ? X(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
+return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
 function Jg(e) {
-var t = e.defenseRequests;
-return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Xg);
+var t, r = Game.rooms[e.roomName];
+return r ? Z(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-var $g = [ "guard", "ranger", "healer" ];
+function $g(e) {
+var t = e.defenseRequests;
+return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Zg);
+}
 
-function eh(e, t) {
+var eh = [ "guard", "ranger", "healer" ];
+
+function th(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-var th = null;
+var rh = null;
 
-function rh() {
-var e = $v.getRevision();
-return th && th.game === Game && th.creeps === Game.creeps && th.tick === Game.time && th.queueRevision === e ? th : th = {
+function oh() {
+var e = eg.getRevision();
+return rh && rh.game === Game && rh.creeps === Game.creeps && rh.tick === Game.time && rh.queueRevision === e ? rh : rh = {
 game: Game,
 creeps: Game.creeps,
 tick: Game.time,
@@ -38747,37 +38749,37 @@ canSpawn: new Map
 };
 }
 
-function oh(e) {
-var t = rh(), r = Game.rooms[e], o = t.threats.get(e);
+function nh(e) {
+var t = oh(), r = Game.rooms[e], o = t.threats.get(e);
 if (o && o.room === r) return o.threatProfile;
-var n = ko(e);
+var n = Mo(e);
 return t.threats.set(e, {
 room: r,
 threatProfile: n
 }), n;
 }
 
-function nh(e) {
-return Game.rooms[e.roomName] ? null !== oh(e.roomName) : Zg(e);
-}
-
 function ah(e) {
+return Game.rooms[e.roomName] ? null !== nh(e.roomName) : Jg(e);
+}
+
+function ih(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === yi ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function ih(e, t) {
+function sh(e, t) {
 var r, o;
-return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === yi && e.targetRoom === t;
+return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === vi && e.targetRoom === t;
 }
 
-function sh(e, t, r) {
-var o = So(r), n = e[t];
-e[t] = n ? xo(n, o) : o;
+function ch(e, t, r) {
+var o = wo(r), n = e[t];
+e[t] = n ? bo(n, o) : o;
 }
 
-function ch(e) {
-var t = rh(), r = t.assigned.get(e);
+function uh(e) {
+var t = oh(), r = t.assigned.get(e);
 if (r) return r;
 var o = function(e) {
 var t, r, o, n, i, s, c = {
@@ -38788,12 +38790,12 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = d.memory, f = null !== (i = p.role) && void 0 !== i ? i : "";
-if (Do(f) && ah(p) === e) {
+if (Bo(f) && ih(p) === e) {
 c[f]++;
 var y = (null !== (s = d.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-y.length > 0 && sh(u, f, y);
+y.length > 0 && ch(u, f, y);
 }
 }
 } catch (e) {
@@ -38808,9 +38810,9 @@ if (t) throw t.error;
 }
 }
 for (var v in Game.rooms) try {
-for (var g = (o = void 0, a($v.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
+for (var g = (o = void 0, a(eg.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Do(R.role) && ih(R, e) && (c[R.role]++, sh(u, R.role, R.body.parts));
+Bo(R.role) && sh(R, e) && (c[R.role]++, ch(u, R.role, R.body.parts));
 }
 } catch (e) {
 o = {
@@ -38831,12 +38833,12 @@ power: u
 return t.assigned.set(e, o), o;
 }
 
-function uh(e) {
-var t = rh(), r = t.canSpawn.get(e.name);
+function lh(e) {
+var t = oh(), r = t.canSpawn.get(e.name);
 if (r && r.room === e) return r.value;
 var o = function(e) {
 var t;
-return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === X(e).length;
+return !!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) && 0 !== e.find(FIND_MY_SPAWNS).length && 0 === Z(e).length;
 }(e);
 return t.canSpawn.set(e.name, {
 room: e,
@@ -38844,20 +38846,20 @@ value: o
 }), o;
 }
 
-function lh(e, t) {
-var r, o, n = rh(), i = function(e, t) {
+function mh(e, t) {
+var r, o, n = oh(), i = function(e, t) {
 var r, o, n, a, i;
 return [ t.name, e.roomName, t.energyCapacityAvailable, Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0), Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0), null !== (a = e.urgency) && void 0 !== a ? a : "", null !== (i = e.createdAt) && void 0 !== i ? i : "" ].join(":");
 }(e, t), s = n.helperPlans.get(i);
 if (s) return s;
-var c = oh(e.roomName), u = ch(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Lo(d, c, function(e, t) {
+var c = nh(e.roomName), u = uh(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Do(d, c, function(e, t) {
 return {
-guard: Math.max(0, eh(e, "guard") - t.guard),
-ranger: Math.max(0, eh(e, "ranger") - t.ranger),
-healer: Math.max(0, eh(e, "healer") - t.healer)
+guard: Math.max(0, th(e, "guard") - t.guard),
+ranger: Math.max(0, th(e, "ranger") - t.ranger),
+healer: Math.max(0, th(e, "healer") - t.healer)
 };
 }(e, l), m), f = function(e, t) {
-var r, o, n, i, s = rh(), c = s.capableHelpers.get(e);
+var r, o, n, i, s = oh(), c = s.capableHelpers.get(e);
 if (c) return c;
 var u = {
 guard: 0,
@@ -38867,10 +38869,10 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.rooms)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d.name !== e && uh(d)) try {
-for (var p = (n = void 0, a($g)), f = p.next(); !f.done; f = p.next()) {
+if (d.name !== e && lh(d)) try {
+for (var p = (n = void 0, a(eh)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Po(y, d.energyCapacityAvailable, t) && u[y]++;
+Io(y, d.energyCapacityAvailable, t) && u[y]++;
 }
 } catch (e) {
 n = {
@@ -38898,9 +38900,9 @@ if (r) throw r.error;
 return s.capableHelpers.set(e, u), u;
 }(e.roomName, c), y = {};
 try {
-for (var v = a($g), g = v.next(); !g.done; g = v.next()) {
+for (var v = a(eh), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
-y[h] = Po(h, d, c);
+y[h] = Io(h, d, c);
 }
 } catch (e) {
 r = {
@@ -38925,43 +38927,43 @@ helperBodies: y
 return n.helperPlans.set(i, R), R;
 }
 
-function mh(e, t, r) {
-var o = eh(e, t);
-if (!Do(t)) return o;
+function dh(e, t, r) {
+var o = th(e, t);
+if (!Bo(t)) return o;
 if (!r.threatProfile) return o;
 var n = r.assignedCounts[t] + r.aggregatePlan.counts[t], a = o > 0 ? function(e, t, r) {
 return function(e, t, r) {
-var o = Po(e, t, null), n = null == r ? void 0 : r.strongest;
+var o = Io(e, t, null), n = null == r ? void 0 : r.strongest;
 if (!o) return 0;
 if (!n) return 1;
-var a = So(o.parts), i = Math.floor(n.score / Math.max(1, a.score)) + 1, s = Math.ceil(n.partCount / Math.max(1, a.partCount)), c = null == r ? void 0 : r.total, u = c ? Math.floor(c.score / Math.max(1, a.score)) + 1 : 1, l = c ? Math.ceil(c.partCount / Math.max(1, a.partCount)) : 1;
+var a = wo(o.parts), i = Math.floor(n.score / Math.max(1, a.score)) + 1, s = Math.ceil(n.partCount / Math.max(1, a.partCount)), c = null == r ? void 0 : r.total, u = c ? Math.floor(c.score / Math.max(1, a.score)) + 1 : 1, l = c ? Math.ceil(c.partCount / Math.max(1, a.partCount)) : 1;
 return Math.min(8, Math.max(1, i, s, u, l));
 }(e, t, r);
 }(t, r.helperEnergyCapacity, r.threatProfile) : 0, i = o > 0 ? r.capableHelpers[t] : 0;
 return Math.max(o, n, a, i);
 }
 
-function dh(e, t, r) {
-void 0 === r && (r = lh(e, t));
+function ph(e, t, r) {
+void 0 === r && (r = mh(e, t));
 var o = r.aggregatePlan.counts.guard + r.aggregatePlan.counts.ranger + r.aggregatePlan.counts.healer;
 if (o > 0) return o;
-var n = $g.filter(function(t) {
-return !(mh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
+var n = eh.filter(function(t) {
+return !(dh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
 });
 return Math.max(1, n.length);
 }
 
-function ph(e, t, r, o) {
+function fh(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : Qg("guard", Pg(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : Xg("guard", Ig(r), o) ? 1 : 0;
 }
 
-function fh(e, t) {
+function yh(e, t) {
 if (!function(e) {
-return Do(e);
+return Bo(e);
 }(t)) return null;
 var r = Game.rooms[e];
-if (!r || !uh(r)) return null;
+if (!r || !lh(r)) return null;
 var o = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38988,15 +38990,15 @@ if (t) throw t.error;
 var n = function(e, t) {
 var r;
 void 0 === t && (t = {});
-var o = Jg(e), n = function(e) {
+var o = $g(e), n = function(e) {
 return e.map(function(e) {
 var t, r, o, n, a;
 return [ e.roomName, Math.max(0, null !== (t = e.guardsNeeded) && void 0 !== t ? t : 0), Math.max(0, null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.healersNeeded) && void 0 !== o ? o : 0), null !== (n = e.urgency) && void 0 !== n ? n : "", null !== (a = e.createdAt) && void 0 !== a ? a : "" ].join(":");
 }).join("|");
-}(o), a = rh();
+}(o), a = oh();
 if ((null === (r = a.activeRequests) || void 0 === r ? void 0 : r.signature) === n) return t.prune && Array.isArray(e.defenseRequests) && a.activeRequests.requests.length !== o.length && (e.defenseRequests = a.activeRequests.requests),
 a.activeRequests.requests;
-var i = o.filter(nh);
+var i = o.filter(ah);
 return a.activeRequests = {
 signature: n,
 requests: i
@@ -39007,17 +39009,17 @@ prune: !0
 }).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var o = lh(e, r);
+var o = mh(e, r);
 return {
 request: e,
 plan: o,
-helperNeed: Math.max(mh(e, t, o), ph(e, t, r, o.threatProfile))
+helperNeed: Math.max(dh(e, t, o), fh(e, t, r, o.threatProfile))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
 return function(e, t) {
-return Do(t) ? ch(e).counts[t] : 0;
+return Bo(t) ? uh(e).counts[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -39027,7 +39029,7 @@ return f !== y ? f - y : (null !== (m = t.request.createdAt) && void 0 !== m ? m
 }), s = n[0];
 return s ? function(e, t, r, o) {
 var n;
-void 0 === o && (o = lh(r, t));
+void 0 === o && (o = mh(r, t));
 var a = function(e, t) {
 var r = function() {
 var e, t = Memory;
@@ -39044,29 +39046,29 @@ return r[o] = s, s;
 }(e, r);
 return {
 targetRoom: r.roomName,
-task: yi,
-priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Dv.EMERGENCY : Dv.HIGH,
-defenseSquadId: vi(e, r.roomName, a.createdAt),
-defenseSquadSize: dh(r, t, o),
+task: vi,
+priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Bv.EMERGENCY : Bv.HIGH,
+defenseSquadId: gi(e, r.roomName, a.createdAt),
+defenseSquadSize: ph(r, t, o),
 defenseSquadCreatedAt: a.createdAt
 };
 }(e, r, s.request, s.plan) : null;
 }
 
-var yh = "defenseRefuel", vh = {
+var vh = "defenseRefuel", gh = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function gh(e, t) {
+function hh(e, t) {
 if ("hauler" !== t) return null;
 var r = Game.rooms[e];
 if (!r || !function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || X(e).length > 0 || e.energyCapacityAvailable < vh.cost);
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || Z(e).length > 0 || e.energyCapacityAvailable < gh.cost);
 }(r)) return null;
-if (Pg(r) >= 200) return null;
+if (Ig(r) >= 200) return null;
 var o = function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(function(t) {
 var r, o;
@@ -39074,7 +39076,7 @@ if (!t || t.roomName === e) return !1;
 if ((null !== (r = t.urgency) && void 0 !== r ? r : 1) < 2) return !1;
 if (Game.time - (null !== (o = t.createdAt) && void 0 !== o ? o : Game.time) > 500) return !1;
 var n = Game.rooms[t.roomName];
-return Boolean(n && X(n).length > 0);
+return Boolean(n && Z(n).length > 0);
 });
 var t;
 }(e);
@@ -39090,7 +39092,7 @@ return t.pos.getRangeTo(e.pos) <= 2;
 }).reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
 }, 0);
-}(r) >= 100 || Ei(r.terminal))) return null;
+}(r) >= 100 || Ti(r.terminal))) return null;
 var n = o.some(function(e) {
 var t, r, o;
 return (null !== (t = e.urgency) && void 0 !== t ? t : 1) >= 3 && ((null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0) > 0 || (null !== (o = e.healersNeeded) && void 0 !== o ? o : 0) > 0);
@@ -39099,7 +39101,7 @@ var t, r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value.memory;
-"hauler" === l.role && l.homeRoom === e && l.task === yh && s++;
+"hauler" === l.role && l.homeRoom === e && l.task === vh && s++;
 }
 } catch (e) {
 t = {
@@ -39113,9 +39115,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a($v.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(eg.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === yh && s++;
+"hauler" === p.role && f === vh && s++;
 }
 } catch (e) {
 o = {
@@ -39148,9 +39150,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a($v.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(eg.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === yh && s++;
+"hauler" === p.role && f === vh && s++;
 }
 } catch (e) {
 o = {
@@ -39166,35 +39168,35 @@ if (o) throw o.error;
 return s;
 }(e);
 return i >= (n ? 4 : 2) ? null : {
-task: yh,
-priority: Dv.EMERGENCY,
-body: vh
+task: vh,
+priority: Bv.EMERGENCY,
+body: gh
 };
-}
-
-function hh(e) {
-var t = Game.rooms[e];
-return t ? !!t.controller && !Tg(t.controller) && !Sg(t) : !Cg(e);
 }
 
 function Rh(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !Tg(t.controller) : !Cg(e);
+return t ? !!t.controller && !Cg(t.controller) && !wg(t) : !Sg(e);
 }
 
-function Eh(e, t, r) {
-var o = Kv[t];
+function Eh(e) {
+var t = Game.rooms[e];
+return (null == t ? void 0 : t.controller) ? !Cg(t.controller) : !Sg(e);
+}
+
+function Th(e, t, r) {
+var o = Yv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
 if (0 === r.danger && "war" !== r.posture && "siege" !== r.posture && (n = a.controller.level <= 3 ? 4 : a.controller.level <= 6 ? 7 : 12,
 r.clusterId)) {
-var i = Sr.getCluster(r.clusterId);
+var i = wr.getCluster(r.clusterId);
 (null == i ? void 0 : i.focusRoom) === e && (n += 2);
 }
 (function(e) {
 return function(e) {
-var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Ys(null == e ? void 0 : e.storage), s = Ys(null == e ? void 0 : e.terminal), c = a && i < Ks, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
+var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Vs(null == e ? void 0 : e.storage), s = Vs(null == e ? void 0 : e.terminal), c = a && i < Ys, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
 return {
 controllerLevel: n,
 isMatureOwnedRoom: a,
@@ -39211,13 +39213,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Th(e, t, r) {
+function Ch(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (hh(l) && pg(e, t, l) < hg(e, l, t, Game.rooms[l])) return l;
+if (Rh(l) && fg(e, t, l) < Rg(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -39233,15 +39235,15 @@ if (o) throw o.error;
 return null;
 }
 
-function Ch(e, t, r, o) {
+function Sh(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Kv[t];
+var p = Yv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
 return "military" === e.family && 0 === t && !e.remoteRole;
-}(p, f ? X(f).length : 0)) {
+}(p, f ? Z(f).length : 0)) {
 var y = function(e, t, r) {
 var o, n, a = 0 === t.danger && "war" !== t.posture && "siege" !== t.posture, i = null !== (n = null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0;
 return a && (r || i > 0 && i <= 2) ? 0 : 1;
@@ -39250,36 +39252,36 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Kv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Kv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Yv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Yv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, mg(e), y)) return !1;
+}(t, dg(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (vg(t)) return !("remoteWorker" === t && function(e, t) {
-ug();
-var r = "".concat(e, ":").concat(t), o = ag.get(r);
+if (gg(t)) return !("remoteWorker" === t && function(e, t) {
+lg();
+var r = "".concat(e, ":").concat(t), o = ig.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return ag.set(r, n), n;
-}(e, t) >= Eh(e, t, r)) && null !== Th(e, t, r);
+return ig.set(r, n), n;
+}(e, t) >= Th(e, t, r)) && null !== Ch(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Rh(R)) {
+if (Eh(R)) {
 var E = Game.rooms[R];
 if (E) {
-var T = X(E).filter(io);
-if (T.length > 0 && pg(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+var T = Z(E).filter(so);
+if (T.length > 0 && fg(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -39296,9 +39298,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = mg(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== jg(e, r);
-if (C >= Eh(e, t, r)) return !1;
+var C = null !== (u = dg(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== zg(e, r);
+if (C >= Th(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -39306,18 +39308,18 @@ if ("defensive" === r.posture || "war" === r.posture || "siege" === r.posture) r
 var S = (null !== (l = r.remoteAssignments) && void 0 !== l ? l : []).length > 0;
 return "expand" === r.posture && C < p.maxPerRoom || !(0 !== C || !S && !function(e, t) {
 void 0 === t && (t = 2);
-var r = Sr.getEmpire();
+var r = wr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = Rg(e, o);
+var a = Eg(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== Mg(e, r);
+if ("claimer" === t) return null !== Ag(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -39341,7 +39343,7 @@ if ("queenCarrier" === t && !f.storage) return !1;
 if ("builder" === t && 0 === f.find(FIND_MY_CONSTRUCTION_SITES).length && C > 0) return !1;
 if ("interRoomCarrier" === t) {
 if (!r.clusterId) return !1;
-var x = Sr.getCluster(r.clusterId);
+var x = wr.getCluster(r.clusterId);
 if (!x || !x.resourceRequests || 0 === x.resourceRequests.length) return !1;
 var b = x.resourceRequests.some(function(e) {
 if (e.fromRoom !== f.name) return !1;
@@ -39353,7 +39355,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = eg.getActiveRequests) || void 0 === m ? void 0 : m.call(eg)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = tg.getActiveRequests) || void 0 === m ? void 0 : m.call(tg)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -39381,17 +39383,17 @@ return s < i && c < 3;
 return !0;
 }
 
-function Sh(e) {
+function wh(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function wh(e) {
-return 0 === Sh(mg(e, !0));
+function xh(e) {
+return 0 === wh(dg(e, !0));
 }
 
-function xh(e) {
-var t = pt(e);
+function bh(e) {
+var t = ft(e);
 return [ {
 role: "harvester",
 minCount: 1
@@ -39413,14 +39415,14 @@ minCount: 1
 } ];
 }
 
-function bh(e, t) {
-var r, o, n, i, s = mg(e, !0);
-if (0 === Sh(s)) return !0;
+function Oh(e, t) {
+var r, o, n, i, s = dg(e, !0);
+if (0 === wh(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = mg(e, !1), u = xh(t);
+var c = dg(e, !1), u = bh(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -39440,36 +39442,36 @@ if (r) throw r.error;
 return !1;
 }
 
-var Oh = [ "guard", "ranger", "healer" ];
+var kh = [ "guard", "ranger", "healer" ];
 
-function kh(e, t, r) {
+function Mh(e, t, r) {
 void 0 === r && (r = 1), e[t] += r, e.total += r;
 }
 
-function Mh(e, t) {
+function Ah(e, t) {
 var r, o;
-return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === yi ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
+return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === vi ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
 }
 
-function Ah(e) {
+function Uh(e) {
 var t;
-return Do(e.role) && void 0 !== Mh(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
+return Bo(e.role) && void 0 !== Ah(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
 }
 
-function Uh(e, t) {
+function _h(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function _h(e, t) {
-return 0 === t.length ? e : xo(e, So(t));
-}
-
 function Nh(e, t) {
-e.assignedPower = _h(e.assignedPower, t);
+return 0 === t.length ? e : bo(e, wo(t));
 }
 
 function Ph(e, t) {
+e.assignedPower = Nh(e.assignedPower, t);
+}
+
+function Ih(e, t) {
 var r, o;
 if (void 0 !== t.defenseAssistReleasedAt) {
 var n = null !== (r = t.defenseAssistReleaseReason) && void 0 !== r ? r : "unknown";
@@ -39479,10 +39481,10 @@ e.released.lastReason = n);
 }
 }
 
-function Ih(e, t) {
+function Gh(e, t) {
 e.parityPercent = e.targetScore > 0 ? Math.min(100, t.score / e.targetScore * 100) : 0,
 e.blockReason = function(e) {
-var t = Oh.filter(function(t) {
+var t = kh.filter(function(t) {
 return e.queued[t] > 0;
 });
 if (t.length > 0 && t.every(function(t) {
@@ -39494,50 +39496,50 @@ return e.requested.total > 0 && 0 === r ? "no-local-assist" : "none";
 }(e);
 }
 
-function Gh(e) {
+function Lh(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Lh(e, t, r) {
-var n = Eh(e.name, r.roleName, t);
+function Dh(e, t, r) {
+var n = Th(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Dh(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Dv.EMERGENCY;
+function Bh(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Bv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Dv.HIGH;
-if (og.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Bv.HIGH;
+if (ng.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
-var o = mo(e), n = yo(e);
+var o = po(e), n = vo(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Dv.EMERGENCY;
-if (a > 0) return Dv.HIGH;
+if (a >= 100) return Bv.EMERGENCY;
+if (a > 0) return Bv.HIGH;
 }
 return function(e) {
-return e >= 90 ? Dv.HIGH : e >= 60 ? Dv.NORMAL : Dv.LOW;
+return e >= 90 ? Bv.HIGH : e >= 60 ? Bv.NORMAL : Bv.LOW;
 }(o);
 }
 
-function Bh(e, t) {
+function Fh(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u, l;
-Gh(e);
-var m = mg(e.name), d = wh(e.name), p = [], f = gh(e.name, "hauler");
-if (f && (R = Kv.hauler)) return [ {
+Lh(e);
+var m = dg(e.name), d = xh(e.name), p = [], f = hh(e.name, "hauler");
+if (f && (R = Yv.hauler)) return [ {
 roleName: "hauler",
 def: R,
 current: E = null !== (n = m.get("hauler")) && void 0 !== n ? n : 0,
@@ -39547,14 +39549,14 @@ priority: f.priority,
 task: f.task,
 bodyOverride: f.body
 } ];
-if (bh(e.name, e)) {
+if (Oh(e.name, e)) {
 var y = function(e, t, r) {
 var o, n, i;
-if (0 === Sh(mg(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === wh(dg(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = mg(e, !1), c = xh(t);
+var s = dg(e, !1), c = bh(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -39569,7 +39571,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Ch(e, m.role, r, !0);
+var p = Sh(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -39600,17 +39602,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return y && (R = Kv[y]) && Ch(e.name, y, t, !0) ? (p.push(Lh(e, t, {
+return y && (R = Yv[y]) && Sh(e.name, y, t, !0) ? (p.push(Dh(e, t, {
 roleName: y,
 def: R,
 current: null !== (s = m.get(y)) && void 0 !== s ? s : 0,
-priority: Dh(e, 0, y, R.priority, d),
+priority: Bh(e, 0, y, R.priority, d),
 bootstrap: !0
 })), p) : p;
 }
 try {
-for (var v = a(Object.entries(Kv)), g = v.next(); !g.done; g = v.next()) {
-var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (c = m.get(y)) && void 0 !== c ? c : 0, T = gh(e.name, y);
+for (var v = a(Object.entries(Yv)), g = v.next(); !g.done; g = v.next()) {
+var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (c = m.get(y)) && void 0 !== c ? c : 0, T = hh(e.name, y);
 if (T) p.push({
 roleName: y,
 def: R,
@@ -39621,7 +39623,7 @@ priority: T.priority,
 task: T.task,
 bodyOverride: T.body
 }); else {
-var C = fh(e.name, y);
+var C = yh(e.name, y);
 if (C) p.push({
 roleName: y,
 def: R,
@@ -39635,8 +39637,8 @@ assistTarget: C.targetRoom,
 defenseSquadId: C.defenseSquadId,
 defenseSquadSize: C.defenseSquadSize,
 defenseSquadCreatedAt: C.defenseSquadCreatedAt
-}); else if (Ch(e.name, y, t, d)) {
-var S = vg(y), w = S ? Th(e.name, y, t) : null, x = "claimer" === y ? Mg(e.name, t) : null, b = "pioneer" === y ? jg(e.name, t) : null;
+}); else if (Sh(e.name, y, t, d)) {
+var S = gg(y), w = S ? Ch(e.name, y, t) : null, x = "claimer" === y ? Ag(e.name, t) : null, b = "pioneer" === y ? zg(e.name, t) : null;
 S && !w || ("claimer" !== y || x) && ("pioneer" !== y || b) && (b ? p.push({
 roleName: y,
 def: R,
@@ -39646,11 +39648,11 @@ missing: 1,
 priority: b.priority,
 targetRoom: b.targetRoom,
 task: b.task
-}) : p.push(Lh(e, t, {
+}) : p.push(Dh(e, t, {
 roleName: y,
 def: R,
 current: E,
-priority: Dh(e, 0, y, R.priority, d),
+priority: Bh(e, 0, y, R.priority, d),
 targetRoom: null !== (l = null !== (u = null == x ? void 0 : x.targetRoom) && void 0 !== u ? u : w) && void 0 !== l ? l : void 0,
 task: null == x ? void 0 : x.task
 })));
@@ -39672,7 +39674,7 @@ return p;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Fh(e, l.value);
+var m = Wh(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -39693,16 +39695,16 @@ requests: c
 };
 }
 
-function Fh(e, t) {
+function Wh(e, t) {
 var r, n, i, s = e.energyCapacityAvailable;
 try {
-var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = tg.getMaxAffordableInTicks(e, c), l = Pg(e), m = t.priority >= Dv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Do(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Dv.EMERGENCY, y = t.assistTarget ? ko(t.assistTarget) : null, v = d ? Po(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = rg.getMaxAffordableInTicks(e, c), l = Ig(e), m = t.priority >= Bv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Bo(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Bv.EMERGENCY, y = t.assistTarget ? Mo(t.assistTarget) : null, v = d ? Io(d, s, y) : null, g = d && f ? function(e, t, r, o) {
 var n;
-return null !== (n = [ Po(e, t, r), Qg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return null !== (n = [ Io(e, t, r), Xg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
 return function(e, t, r) {
 if (!t) return !1;
 if ("ranger" !== e) return !0;
-if (r && !No(r)) return !0;
+if (r && !Po(r)) return !0;
 var o = t.parts.filter(function(e) {
 return e === RANGED_ATTACK;
 }).length;
@@ -39731,7 +39733,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, m)) && void 0 !== i ? i : Qv({
+}(t.def, m)) && void 0 !== i ? i : Xv({
 maxEnergy: m,
 role: t.roleName
 }), E = t.bodyOverride ? s : h ? f ? l : s : m;
@@ -39767,44 +39769,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Wh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Hh = new Set([ "guard", "ranger", "healer" ]);
+var Hh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Kh = new Set([ "guard", "ranger", "healer" ]);
 
-function Kh() {
+function Yh() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Yh(e) {
+function Vh(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Vh(e) {
-var t;
-return e.priority >= Dv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
-}
-
 function qh(e) {
 var t;
-return e.priority >= Dv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Bv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function jh(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Pg(e), m = Oo(X(e)), d = function(e) {
+function jh(e) {
+var t;
+return e.priority >= Bv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+}
+
+function zh(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Ig(e), m = ko(Z(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Dv.EMERGENCY : Dv.HIGH, f = d ? u : p === Dv.EMERGENCY ? l : u, y = function(e, t) {
+}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Bv.EMERGENCY : Bv.HIGH, f = d ? u : p === Bv.EMERGENCY ? l : u, y = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a($v.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(eg.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || zh(u, e) && ("guard" === u.role && (n.guards++,
-Xh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Xh(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Xh(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Qh(u, e) && ("guard" === u.role && (n.guards++,
+Zh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Zh(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Zh(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -39832,7 +39834,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Xh(n, u, l);
+0 !== l.length && Zh(n, u, l);
 }
 }
 }
@@ -39853,7 +39855,7 @@ var r, n, i = o({}, e);
 try {
 for (var s = a([ "guard", "ranger", "healer" ]), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t[u];
-l && (i[u] = i[u] ? xo(i[u], l) : l);
+l && (i[u] = i[u] ? bo(i[u], l) : l);
 }
 } catch (e) {
 r = {
@@ -39867,30 +39869,30 @@ if (r) throw r.error;
 }
 }
 return i;
-}(v, y.power), h = Lo(f, m, {
+}(v, y.power), h = Do(f, m, {
 guard: Math.max(0, r.guards - n.guards - y.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - y.counts.healers)
-}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Qh("guard", f, m);
-if (R > 0 && E) for (var T = 0; T < R; T++) Jh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
-var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Qh("ranger", f, m);
-if (C > 0 && S) for (T = 0; T < C; T++) Jh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
-var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Qh("healer", f, m);
-if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) Jh(e, "healer", "military", Dv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Xh("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) $h(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Xh("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) $h(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Xh("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) $h(e, "healer", "military", Bv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
-if (!(t < Dv.EMERGENCY || function(e, t) {
+if (!(t < Bv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Hh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Kh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a($v.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(eg.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Dv.EMERGENCY || Hh.has(c.role) && zh(c, e.name) && c.body.cost <= t && n++;
+c.priority < Bv.EMERGENCY || Kh.has(c.role) && Qh(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39907,7 +39909,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = zg(t, e);
+var r = Qg(t, e);
 return r ? {
 role: t,
 body: r
@@ -39918,49 +39920,49 @@ return Boolean(e);
 if (0 === o.length) return null;
 var n = null == t ? void 0 : t.strongest;
 return null !== (r = o.sort(function(e, t) {
-var r = So(t.body.parts).score - So(e.body.parts).score;
+var r = wo(t.body.parts).score - wo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Jh(e, n.role, "military", Dv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && $h(e, n.role, "military", Bv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, p, l, m), (R > 0 || C > 0 || w > 0) && U.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function zh(e, t) {
+function Qh(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Qh(e, t, r) {
-return r ? Po(e, t, r) : null;
-}
-
 function Xh(e, t, r) {
-var o = So(r);
-e[t] = e[t] ? xo(e[t], o) : o;
+return r ? Io(e, t, r) : null;
 }
 
 function Zh(e, t, r) {
-return $v.getPendingRequests(e).filter(function(e) {
+var o = wo(r);
+e[t] = e[t] ? bo(e[t], o) : o;
+}
+
+function Jh(e, t, r) {
+return eg.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Jh(e, t, r, o, n, a, i, s, c) {
+function $h(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : Qv({
+var u = null != i ? i : Xv({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-$v.addRequest({
+eg.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -39978,34 +39980,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function $h(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Dv.HIGH) return !1;
+function eR(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Bv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Dv.NORMAL) {
-if (tg.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Bv.NORMAL) {
+if (rg.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Dv.NORMAL && o / e.energyCapacityAvailable < .3 && tg.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Bv.NORMAL && o / e.energyCapacityAvailable < .3 && rg.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function eR(e, t) {
+function tR(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Gh(e);
-var s = $v.getQueueSize(e.name);
+Lh(e);
+var s = eg.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = bh(e.name, e), u = wh(e.name) && !$v.hasEmergencySpawns(e.name), l = mo(e), m = yo(e);
+var c = Oh(e.name, e), u = xh(e.name) && !eg.hasEmergencySpawns(e.name), l = po(e), m = vo(e);
 if (c) {
-s > 0 && $v.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && jh(e, t, l, m);
+s > 0 && eg.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && zh(e, t, l, m);
 try {
-for (var d = a(Bh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Fh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-$v.addRequest(f);
+eg.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -40018,8 +40020,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && jh(e, t, l, m), function(e) {
-var t, r, o = rg.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && zh(e, t, l, m), function(e) {
+var t, r, o = og.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -40031,17 +40033,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = Dv.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = Bv.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Zh(e.name, "powerHarvester", f), g = Zh(e.name, "healer", f), h = Zh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Jh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Jh(e.name, "powerHarvester", f), g = Jh(e.name, "healer", f), h = Jh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) $h(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Jh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) $h(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Jh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) $h(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -40070,13 +40072,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set($v.getPendingRequests(e.name).map(Yh));
+var c = new Set(eg.getPendingRequests(e.name).map(Vh));
 try {
-for (var u = a(Bh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Dv.HIGH, p = "claimer" === m.role && Kh(), f = Vh(m), y = qh(m);
-if (Wh.has(m.role) || d || p || f || y) {
-var v = Yh(m);
-c.has(v) || ($v.addRequest(m), c.add(v));
+for (var u = a(Fh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Bv.HIGH, p = "claimer" === m.role && Yh(), f = qh(m), y = jh(m);
+if (Hh.has(m.role) || d || p || f || y) {
+var v = Vh(m);
+c.has(v) || (eg.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -40093,8 +40095,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Bh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-$v.addRequest(f);
+for (var y = a(Fh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+eg.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -40106,32 +40108,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = $v.getQueueStats(e.name);
+var g = eg.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && $v.clearQueue(e.name);
+} else s > 0 && eg.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = $v.getAvailableSpawns(e.name);
+var t, r, o = eg.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Pg(e);
+var n = 0, i = Ig(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = $v.getNextRequest(e.name, i);
+var u = c.value, l = eg.getNextRequest(e.name, i);
 if (!l) break;
-if ($h(e, l, i)) {
+if (eR(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Zv(u, l);
-m === OK ? (n++, i -= l.body.cost, $v.markInProgress(e.name, l.id, u.id), $v.removeRequest(e.name, l.id),
+var m = Jv(u, l);
+m === OK ? (n++, i -= l.body.cost, eg.markInProgress(e.name, l.id, u.id), eg.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && ($v.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (eg.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -40147,12 +40149,12 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = $v.getQueueStats(e.name), n = function(e) {
+}(e), o = eg.getQueueStats(e.name), n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T = Game.rooms[e];
 if (!T) return [];
-var C = Pg(T), S = new Map, w = new Map, x = function(e, t) {
+var C = Ig(T), S = new Map, w = new Map, x = function(e, t) {
 var r;
-w.set(e, _h(null !== (r = w.get(e)) && void 0 !== r ? r : {
+w.set(e, Nh(null !== (r = w.get(e)) && void 0 !== r ? r : {
 partCount: 0,
 attack: 0,
 ranged: 0,
@@ -40225,11 +40227,11 @@ blockReason: "none"
 };
 }(e, t, r);
 return function(e, t, r) {
-var o, n, i, s = ko(e.targetRoom);
+var o, n, i, s = Mo(e.targetRoom);
 e.targetScore = null !== (i = null == s ? void 0 : s.total.score) && void 0 !== i ? i : 0;
 try {
-for (var c = a(Oh), u = c.next(); !u.done; u = c.next()) {
-var l = u.value, m = Po(l, t.energyCapacityAvailable, s);
+for (var c = a(kh), u = c.next(); !u.done; u = c.next()) {
+var l = u.value, m = Io(l, t.energyCapacityAvailable, s);
 m ? (e.bodyCost[l] = m.cost, e.affordable[l] = m.cost <= r) : e.affordable[l] = !1;
 }
 } catch (e) {
@@ -40248,15 +40250,15 @@ if (o) throw o.error;
 try {
 for (var O = a(function(e, t) {
 void 0 === t && (t = {});
-var r = Jg(e), o = r.filter(Zg);
+var r = $g(e), o = r.filter(Jg);
 return t.prune && Array.isArray(e.defenseRequests) && o.length !== r.length && (e.defenseRequests = o),
 o;
 }(Memory)), k = O.next(); !k.done; k = O.next()) if ((I = k.value).roomName !== e) {
 var M = b(I.roomName, null !== (f = I.urgency) && void 0 !== f ? f : 0);
 try {
-for (var A = (o = void 0, a(Oh)), U = A.next(); !U.done; U = A.next()) {
+for (var A = (o = void 0, a(kh)), U = A.next(); !U.done; U = A.next()) {
 var _ = U.value;
-kh(M.requested, _, Uh(I, _));
+Mh(M.requested, _, _h(I, _));
 }
 } catch (e) {
 o = {
@@ -40282,11 +40284,11 @@ if (t) throw t.error;
 }
 }
 try {
-for (var N = a($v.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
+for (var N = a(eg.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
 var I;
-Ah(I = P.value) && (D = Mh(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (kh((M = b(D)).queued, I.role),
+Uh(I = P.value) && (D = Ah(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Mh((M = b(D)).queued, I.role),
 M.bodyCost[I.role] = Math.max(null !== (v = M.bodyCost[I.role]) && void 0 !== v ? v : 0, I.body.cost),
-M.affordable[I.role] = I.body.cost <= C, Nh(M, I.body.parts));
+M.affordable[I.role] = I.body.cost <= C, Ph(M, I.body.parts));
 }
 } catch (e) {
 c = {
@@ -40302,13 +40304,13 @@ if (c) throw c.error;
 try {
 for (var G = a(Object.values(Game.creeps)), L = G.next(); !L.done; L = G.next()) {
 var D, B = L.value, F = null !== (g = B.memory) && void 0 !== g ? g : {};
-if (F.homeRoom === e && Do(_ = null !== (h = F.role) && void 0 !== h ? h : "") && (D = Mh(F))) {
+if (F.homeRoom === e && Bo(_ = null !== (h = F.role) && void 0 !== h ? h : "") && (D = Ah(F))) {
 M = b(D);
 var W = (null !== (R = B.body) && void 0 !== R ? R : []).filter(function(e) {
 return e.hits > 0;
 });
-B.spawning ? kh(M.spawning, _) : void 0 === F.defenseAssistReleasedAt && B.room.name === e ? (kh(M.staged, _),
-x(D, W)) : B.room.name === D ? kh(M.arrived, _) : kh(M.moving, _), Ph(M, F), Nh(M, W);
+B.spawning ? Mh(M.spawning, _) : void 0 === F.defenseAssistReleasedAt && B.room.name === e ? (Mh(M.staged, _),
+x(D, W)) : B.room.name === D ? Mh(M.arrived, _) : Mh(M.moving, _), Ih(M, F), Ph(M, W);
 }
 }
 } catch (e) {
@@ -40324,7 +40326,7 @@ if (l) throw l.error;
 }
 var H = s([], i(S.values()), !1);
 try {
-for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) Ih(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : wo());
+for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) Gh(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : xo());
 } catch (e) {
 d = {
 error: e
@@ -40354,7 +40356,7 @@ defenseAssist: n
 }(e, t);
 }
 
-var tR = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, rR = /^(\d{1,2})\|(.+)$/, oR = M("SS2TerminalComms"), nR = function() {
+var rR = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, oR = /^(\d{1,2})\|(.+)$/, nR = M("SS2TerminalComms"), aR = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -40414,11 +40416,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(tR);
+var t = e.match(rR);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(rR);
+var i = a.match(oR);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -40453,7 +40455,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-oR.warn("Missing packet in multi-packet message", {
+nR.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -40469,7 +40471,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), oR.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), nR.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -40493,7 +40495,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && oR.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && nR.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -40505,7 +40507,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return oR.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return nR.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -40513,14 +40515,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), oR.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), nR.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (oR.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (nR.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -40545,7 +40547,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-oR.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+nR.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -40557,7 +40559,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-oR.info("Completed sending multi-packet message", {
+nR.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -40565,25 +40567,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? oR.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? nR.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (oR.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (nR.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else oR.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else nR.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else oR.warn("Terminal not found for queue item, removing from queue", {
+} else nR.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -40617,7 +40619,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && oR.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && nR.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -40627,7 +40629,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-oR.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+nR.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -40718,7 +40720,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (oR.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (nR.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -40740,7 +40742,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return oR.error("Error parsing JSON", {
+return nR.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -40751,7 +40753,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), aR = [ {
+}(), iR = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -40771,7 +40773,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], iR = function() {
+} ], sR = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -40809,7 +40811,7 @@ return e.clusters || (e.clusters = {}), e.clusters;
 }, e.prototype.getCluster = function(e, t) {
 var r = this.getClusters();
 if (!r[e] && t) {
-r[e] = Wt(e, t);
+r[e] = Ht(e, t);
 var o = this.getEmpire();
 o.clusters.includes(e) || o.clusters.push(e);
 }
@@ -40818,9 +40820,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), sR = new iR;
+}(), cR = new sR;
 
-function cR(e) {
+function uR(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -40828,19 +40830,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function uR(e, t) {
+function lR(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function lR(e, t) {
+function mR(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var mR = {
+var dR = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -40851,9 +40853,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, dR = function() {
+}, pR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, mR), e);
+void 0 === e && (e = {}), this.config = o(o({}, dR), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -40874,7 +40876,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = sR.getSwarmState(r.toRoom);
+var o = cR.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -40887,7 +40889,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = sR.getSwarmState(c);
+var l = cR.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -40957,9 +40959,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(uR), u = n.filter(function(e) {
+}).sort(lR), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(lR), l = [], m = [], d = function(t) {
+}).sort(mR), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -40981,11 +40983,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return cR({
+return uR({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + cR({
+}) + uR({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -41084,7 +41086,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), pR = new dR, fR = {
+}(), fR = new pR, yR = {
 1: {
 guards: 1,
 rangers: 1,
@@ -41105,14 +41107,14 @@ siegeUnits: 1
 }
 };
 
-function yR(e) {
+function vR(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function vR(e) {
+function gR(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -41135,9 +41137,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function gR(e) {
+function hR(e) {
 var t, r, o;
-vR(e);
+gR(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -41161,20 +41163,20 @@ if (t) throw t.error;
 return n;
 }
 
-function hR(e) {
+function RR(e) {
 var t;
-vR(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = gR(e);
+gR(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = hR(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function RR(e) {
-return !!hR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function ER(e) {
+return !!RR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-vR(e);
+gR(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -41185,12 +41187,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = gR(e);
+var d = hR(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function ER(e, t) {
+function TR(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -41211,20 +41213,20 @@ if (r) throw r.error;
 return n;
 }
 
-function TR(e, t) {
+function CR(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = fR[r]) && void 0 !== t ? t : fR[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = yR[r]) && void 0 !== t ? t : yR[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = ER(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = TR(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: yR(r),
+targetComposition: vR(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -41236,7 +41238,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function CR(e) {
+function SR(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -41248,7 +41250,7 @@ if ("attacking" === e.state) {
 var r = e.targetRooms[0];
 if (r) {
 var o = Game.rooms[r];
-if (o && 0 === X(o).length && t > 100) return U.info("Squad ".concat(e.id, " mission complete, no more hostiles"), {
+if (o && 0 === Z(o).length && t > 100) return U.info("Squad ".concat(e.id, " mission complete, no more hostiles"), {
 subsystem: "Squad"
 }), !0;
 }
@@ -41256,9 +41258,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function SR(e) {
+function wR(e) {
 var t = e.members.length;
-vR(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+gR(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -41272,7 +41274,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && RR(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && ER(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -41301,7 +41303,7 @@ subsystem: "Squad"
 }
 }
 
-var wR = {
+var xR = {
 harassment: {
 composition: {
 harassers: 3,
@@ -41388,7 +41390,7 @@ prioritizeDefenses: !0
 }
 };
 
-function xR(e, t) {
+function bR(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -41403,8 +41405,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function bR(e, t) {
-var r, o, n, i = wR[t], s = 0;
+function OR(e, t) {
+var r, o, n, i = xR[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -41430,7 +41432,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var OR, kR, MR, AR = {
+var kR, MR, AR, UR = {
 move: 50,
 work: 100,
 carry: 50,
@@ -41439,11 +41441,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, UR = new Map;
+}, _R = new Map;
 
-function _R(e, t) {
+function NR(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (UR.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (_R.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -41455,7 +41457,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = wR[p].composition;
+d = xR[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -41470,19 +41472,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (UR.set(m, y), function(e, t, r, o) {
+v ? (_R.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = wR[s].useBoosts;
+i = xR[s].useBoosts;
 }
-var c = Dv.NORMAL;
-"siege" === t.type ? c = Dv.HIGH : "defense" === t.type && (c = Dv.EMERGENCY);
+var c = Bv.NORMAL;
+"siege" === t.type ? c = Bv.HIGH : "defense" === t.type && (c = Bv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = NR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + AR[t];
-}, 0), m = i ? IR(r) : [], d = {
+var u = PR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + UR[t];
+}, 0), m = i ? GR(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -41511,7 +41513,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-$v.addRequest(d), o.spawnRequests.add(d.id);
+eg.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -41525,42 +41527,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function NR(e, t, r) {
+function PR(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return PR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return IR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return PR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return IR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return PR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return IR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return PR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return IR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return PR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return IR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return PR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return IR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function PR(e, t, r) {
+function IR(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + AR[t];
+return e + UR[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + AR[t];
+return e + UR[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function IR(e) {
+function GR(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -41591,45 +41593,45 @@ return [];
 }
 }
 
-function GR(e) {
-return UR.has(e);
-}
-
 function LR(e) {
-return hR(e) || RR(e);
+return _R.has(e);
 }
 
-(OR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, OR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-OR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (kR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-kR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, kR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-kR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (MR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-MR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, MR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-MR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, MR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+function DR(e) {
+return RR(e) || ER(e);
+}
 
-var DR = {
+(kR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, kR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+kR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (MR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+MR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, MR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+MR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (AR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+AR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, AR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+AR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, AR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+
+var BR = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function BR(e, t) {
-var r = DR[t], o = sR.getClusters();
+function FR(e, t) {
+var r = BR[t], o = cR.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function FR(e, t, r) {
+function WR(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = sR.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = cR.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: BR(e, i.danger),
+reservedEnergy: FR(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -41719,7 +41721,7 @@ success: !1
 });
 }
 
-var WR = {
+var HR = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -41729,7 +41731,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function HR(e, t, r) {
+function KR(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -41760,7 +41762,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function KR(e, t, r, o) {
+function YR(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -41770,7 +41772,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function YR(e, t) {
+function VR(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -41791,19 +41793,19 @@ if (r) throw r.error;
 return n;
 }
 
-function VR() {
-var e = sR.getEmpire();
+function qR() {
+var e = cR.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function qR(e) {
-VR()[e.id] = e;
+function jR(e) {
+qR()[e.id] = e;
 }
 
-function jR(e) {
+function zR(e) {
 e.lastUpdate = Game.time;
-var t = sR.getCluster(e.clusterId);
-if (!t) return e.state = "failed", qR(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = cR.getCluster(e.clusterId);
+if (!t) return e.state = "failed", jR(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -41813,12 +41815,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (LR(r) || GR(e) || _R(0, r), LR(r));
+return !!r && (DR(r) || LR(e) || NR(0, r), DR(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), qR(e);
+})), jR(e);
 }(e, t);
 break;
 
@@ -41829,7 +41831,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (SR(o), CR(o)) {
+if (wR(o), SR(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -41858,7 +41860,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = sR.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = cR.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -41885,19 +41887,19 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), qR(e);
+})), jR(e);
 }(e, t);
 }
 }
 
-function zR(e, t, r) {
+function QR(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
 });
 return "guard" === e ? r.includes(ATTACK) || r.includes(RANGED_ATTACK) : "ranger" === e ? r.includes(RANGED_ATTACK) : r.includes(HEAL);
 }(t, r)) {
-var o = So(r), n = e.power[t];
+var o = wo(r), n = e.power[t];
 e.counts[t]++, e.power[t] = n ? {
 partCount: n.partCount + o.partCount,
 attack: n.attack + o.attack,
@@ -41909,11 +41911,11 @@ score: n.score + o.score
 }
 }
 
-function QR(e, t, r) {
-return Po(e, t, r);
+function XR(e, t, r) {
+return Io(e, t, r);
 }
 
-function XR(e, t) {
+function ZR(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -41926,11 +41928,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function ZR(e) {
+function JR(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function JR(e, t, r) {
+function $R(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -41943,25 +41945,25 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function $R(e, t, r) {
-var o = QR(t, e.energyCapacityAvailable, r);
+function eE(e, t, r) {
+var o = XR(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
-var a = So(o.parts);
+var a = wo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function eE(e, t, r, o) {
+function tE(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = $R(e, t, o);
-if (s !== $R(n, t, o)) return s ? -1 : 1;
+var a, i, s = eE(e, t, o);
+if (s !== eE(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function tE(e, t) {
+function rE(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -42045,39 +42047,39 @@ if (r) throw r.error;
 return u;
 }
 
-function rE(e, t) {
+function oE(e, t) {
 return {
-guard: Math.max(0, XR(e, "guard") - t.counts.guard),
-ranger: Math.max(0, XR(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, XR(e, "healer") - t.counts.healer)
+guard: Math.max(0, ZR(e, "guard") - t.counts.guard),
+ranger: Math.max(0, ZR(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, ZR(e, "healer") - t.counts.healer)
 };
 }
 
-function oE(e) {
+function nE(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function nE(e, t) {
+function aE(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return oE(e.role);
+return nE(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
 role: e.role,
 targetRoom: null !== (o = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.assistTarget) && void 0 !== r ? r : e.targetRoom) && void 0 !== o ? o : "",
-power: So(e.body.parts)
+power: wo(e.body.parts)
 };
 }).filter(function(e) {
 return e.targetRoom.length > 0;
 });
 }
 
-function aE(e) {
+function iE(e) {
 var t;
-return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === yi ? e.targetRoom : void 0;
+return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function iE(e) {
+function sE(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -42089,7 +42091,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-oE(m) && aE(l) === e && !u.spawning && zR(i, m, u.body.filter(function(e) {
+nE(m) && iE(l) === e && !u.spawning && QR(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -42107,7 +42109,7 @@ if (t) throw t.error;
 return i;
 }
 
-function sE(e, t, r) {
+function cE(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -42131,22 +42133,22 @@ var d = s.find(FIND_MY_SPAWNS);
 return {
 roomName: e,
 owned: Boolean(null === (i = s.controller) || void 0 === i ? void 0 : i.my),
-safe: 0 === X(s).length,
+safe: 0 === Z(s).length,
 availableSpawns: d.filter(function(e) {
 return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: nE(e, r)
+pendingAssist: aE(e, r)
 };
 }
 }
 
-function cE(e, t) {
+function uE(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = QR(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = XR(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -42167,7 +42169,7 @@ subsystem: "Cluster"
 }
 }
 
-function uE(e, t, r) {
+function lE(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -42187,7 +42189,7 @@ safety: 0,
 centrality: 0,
 exitAccess: 0
 };
-var m = X(e);
+var m = Z(e);
 if (m.length > 0) {
 var d = Math.min.apply(Math, s([], i(m.map(function(e) {
 return t.getRangeTo(e);
@@ -42209,20 +42211,20 @@ exitAccess: a
 };
 }
 
-function lE(e, t) {
+function mE(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function mE(e, t, r) {
+function dE(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function dE(e) {
+function pE(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function pE(e, t) {
+function fE(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -42233,7 +42235,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function fE(e, t, r) {
+function yE(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -42244,8 +42246,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = dE(g);
-h && (hi(g) || pE(v, h) && (t.assignedCreeps.includes(v.name) || lE(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = pE(g);
+h && (Ri(g) || fE(v, h) && (t.assignedCreeps.includes(v.name) || mE(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -42282,7 +42284,7 @@ return e.distance - t.distance;
 });
 }
 
-function yE(e, t) {
+function vE(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -42307,21 +42309,21 @@ if (r) throw r.error;
 return i;
 }
 
-function vE(e) {
+function gE(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var gE = {
+var hE = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, hE = function() {
+}, RE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, gE), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, hE), e);
 }
 return e.prototype.run = function() {
-var e = sR.getClusters();
+var e = cR.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -42340,7 +42342,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: aR.map(function(t) {
+steps: iR.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -42359,7 +42361,7 @@ focusRoom: e.focusRoom
 }(e);
 }, e.prototype.runCluster = function(e) {
 var t, r, o = this, n = Game.cpu.getUsed(), i = this.getClusterOperationIntent(e), s = function(t) {
-ts.measureSubsystem(t.statsKey, function() {
+rs.measureSubsystem(t.statsKey, function() {
 o.executeClusterOperation(t.name, e);
 });
 };
@@ -42396,7 +42398,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-pR.processCluster(t);
+fR.processCluster(t);
 break;
 
 case "squads":
@@ -42428,7 +42430,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = uE(e, new RoomPosition(s, c, e.name), "defense");
+var u = lE(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -42477,9 +42479,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = sR.getSwarmState(i);
+var i = n.value, s = cR.getSwarmState(i);
 if (s) {
-var c = BR(i, s.danger);
+var c = FR(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -42510,7 +42512,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = sR.getSwarmState(m);
+var m = l.value, d = cR.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -42542,7 +42544,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += vE(l.controller.level));
+}).length, i += gE(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -42659,7 +42661,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-SR(i), "gathering" !== i.state || LR(i) || GR(i.id) || _R(0, i), CR(i) && (i.state = "dissolving");
+wR(i), "gathering" !== i.state || DR(i) || LR(i.id) || NR(0, i), SR(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -42684,7 +42686,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = TR(e, s);
+var s = i.value, c = CR(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -42701,7 +42703,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(VR()).filter(function(e) {
+var t = (a = e.id, Object.values(qR()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -42712,22 +42714,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, WR), n), m = [], d = sR.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, HR), n), m = [], d = cR.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = HR(f, y, d);
+var g = KR(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = YR(e, f);
+var h = VR(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = KR(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = YR(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = xR(f, {
+var C = bR(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -42762,29 +42764,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-bR(e, n.doctrine) ? function(e, t, r) {
+OR(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = sR.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = cR.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = HR(e, o, r);
+var n = KR(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (sR.getEmpire().knownRooms || {})[t], n = null != r ? r : xR(t, {
+var o = (cR.getEmpire().knownRooms || {})[t], n = null != r ? r : bR(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!bR(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!OR(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -42797,7 +42799,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-qR(i);
+jR(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -42811,13 +42813,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = ER(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = TR(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: yR(n),
+targetComposition: vR(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -42832,8 +42834,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), qR(i), _R(0, c), i.state = "forming", i.lastUpdate = Game.time,
-qR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), jR(i), NR(0, c), i.state = "forming", i.lastUpdate = Game.time,
+jR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -42852,11 +42854,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(UR.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(_R.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), UR.delete(c));
+}), _R.delete(c));
 }
 } catch (t) {
 e = {
@@ -42870,10 +42872,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = VR();
-for (var t in e) jR(e[t]);
+var e = qR();
+for (var t in e) zR(e[t]);
 !function() {
-var e = VR();
+var e = qR();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -42951,14 +42953,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = sR.getCluster(t, e);
+var t = "cluster_".concat(e), r = cR.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = sR.getCluster(e);
+var o = cR.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -42975,7 +42977,7 @@ subsystem: "Cluster"
 }), !1;
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
-var o = X(r), n = Z(r).filter(function(e) {
+var o = Z(r), n = J(r).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
 return 0 !== o.length || 0 !== n.length || (U.info("Defense request for ".concat(e.roomName, " resolved - no more hostiles"), {
@@ -42987,7 +42989,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && FR(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && WR(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -43004,19 +43006,19 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = sR.getSwarmState(t);
+var n, a, i = cR.getSwarmState(t);
 if (!i) return "continue";
-if (vo(r, i)) {
+if (go(r, i)) {
 var s = e.defenseRequests.find(function(e) {
 return e.roomName === t;
 });
 if (s) {
-var c = go(r, i);
+var c = ho(r, i);
 c && (n = s, (a = c).urgency !== n.urgency || a.guardsNeeded !== n.guardsNeeded || a.rangersNeeded !== n.rangersNeeded || a.healersNeeded !== n.healersNeeded || a.threat !== n.threat) && (s.urgency = c.urgency,
 s.guardsNeeded = c.guardsNeeded, s.rangersNeeded = c.rangersNeeded, s.healersNeeded = c.healersNeeded,
 s.createdAt = c.createdAt, s.threat = c.threat);
 } else {
-var l = go(r, i);
+var l = ho(r, i);
 l && e.defenseRequests.push(o(o({}, l), {
 assignedCreeps: []
 }));
@@ -43045,7 +43047,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = ko(g), f[g] = iE(g);
+p[g] = Mo(g), f[g] = sE(g);
 }
 } catch (e) {
 r = {
@@ -43061,7 +43063,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = sE(E, m, t);
+d[E] = cE(E, m, t);
 }
 } catch (e) {
 n = {
@@ -43080,13 +43082,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = JR(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = $R(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = tE(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = rE(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Lo(T, R, rE(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Do(T, R, oE(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = eE(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = tE(h, b, g.roomName, R), M = 0; M < O; M++) {
 var A = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -43098,13 +43100,13 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(A.roomName, "_").con
 roomName: A.roomName,
 role: b,
 family: "military",
-priority: ZR(g.urgency),
+priority: JR(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
 targetRoom: g.roomName,
-task: yi,
-defenseSquadId: vi(A.roomName, g.roomName, e.now),
+task: vi,
+defenseSquadId: gi(A.roomName, g.roomName, e.now),
 defenseSquadSize: S,
 defenseSquadCreatedAt: e.now
 },
@@ -43144,7 +43146,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) cE(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) uE(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -43159,7 +43161,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, $v);
+}(e, eg);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -43171,7 +43173,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = yE(f, fE(e, f, t)), v = y.reduce(function(e, t) {
+var y = vE(f, yE(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -43179,12 +43181,12 @@ e;
 try {
 for (var g = (n = void 0, a(y)), h = g.next(); !h.done; h = g.next()) {
 var R = h.value, E = Math.max(1, Math.min(3, null !== (u = v.get(R.room.name)) && void 0 !== u ? u : 1));
-gi(R.creep, {
+hi(R.creep, {
 homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), mE(f, R.role, lE(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), dE(f, R.role, mE(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -43224,7 +43226,7 @@ getDistance: function(e, t) {
 return Game.map.getRoomLinearDistance(e, t);
 },
 isRoomSafe: function(e) {
-return 0 === X(e).length;
+return 0 === Z(e).length;
 }
 });
 try {
@@ -43245,34 +43247,34 @@ c && !c.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-}, n([ Qe("cluster:manager", "Cluster Manager", {
-priority: Pe.MEDIUM,
+}, n([ Xe("cluster:manager", "Cluster Manager", {
+priority: Ie.MEDIUM,
 interval: 10,
 minBucket: 0,
 cpuBudget: .03
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), RE = new hE, EE = /^([WE])(\d+)([NS])(\d+)$/;
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), EE = new RE, TE = /^([WE])(\d+)([NS])(\d+)$/;
 
-function TE(e) {
-return EE.test(e);
+function CE(e) {
+return TE.test(e);
 }
 
-var CE = {
+var SE = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, SE = function() {
+}, wE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, CE), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, SE), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = Df();
-this.updateEnemyIntelligence(e), Bf(e, {
+var e = Bf();
+this.updateEnemyIntelligence(e), Ff(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
-var t, r, n, c = Sr.getEmpire(), u = Object.entries(null !== (t = c.knownRooms) && void 0 !== t ? t : {}).map(function(e) {
+var t, r, n, c = wr.getEmpire(), u = Object.entries(null !== (t = c.knownRooms) && void 0 !== t ? t : {}).map(function(e) {
 var t, r, o = i(e, 2), n = o[0], a = o[1];
 return {
 roomName: n,
@@ -43331,7 +43333,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (TE(x)) {
+if (e.isAlly(x)) f.add(x); else if (CE(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -43396,18 +43398,18 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return Df().globalTargets.enemies || [];
-}, n([ Xe("empire:crossShardIntel", "Cross-Shard Intel", {
-priority: Pe.LOW,
+return Bf().globalTargets.enemies || [];
+}, n([ Ze("empire:crossShardIntel", "Cross-Shard Intel", {
+priority: Ie.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), wE = new SE, xE = function() {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), xE = new wE, bE = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
-var e = Sr.getClusters(), t = Object.values(Game.rooms).filter(function(e) {
+var e = wr.getClusters(), t = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }), r = function(r) {
@@ -43480,9 +43482,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), bE = new xE, OE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), OE = new bE, kE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function kE(e, t) {
+function ME(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -43505,22 +43507,22 @@ if (r) throw r.error;
 return n;
 }
 
-function ME(e) {
+function AE(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function AE(e, t, r) {
-if (!ME(e)) return 0;
-var o = kE(e.name, t);
+function UE(e, t, r) {
+if (!AE(e)) return 0;
+var o = ME(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
-return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += yc(e.mineralType),
-n -= 5 * o, n -= vc(e.name), n -= 15 * e.threatLevel, n += gc(e.terrain), hc(e.name) && (n += 10),
-n += Rc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
-n += Tc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
+return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += vc(e.mineralType),
+n -= 5 * o, n -= gc(e.name), n -= 15 * e.threatLevel, n += hc(e.terrain), Rc(e.name) && (n += 10),
+n += Ec(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
+n += Cc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function UE(e, t) {
+function _E(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -43528,15 +43530,15 @@ if ((null === (n = s.controller) || void 0 === n ? void 0 : n.my) || c === t) re
 if (c) return "owned by ".concat(c);
 var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === i ? void 0 : i.username;
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
-return X(e).some(function(e) {
+return Z(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && OE.has(e.type);
+return e.hits > 0 && kE.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function _E(e, t, r) {
+function NE(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -43546,19 +43548,19 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function NE(e) {
+function PE(e) {
 return function(e) {
-var t = ee(e);
+var t = te(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
 return {
-isHighway: re(t.x) || re(t.y),
-isSK: te(t.x) && te(t.y)
+isHighway: oe(t.x) || oe(t.y),
+isSK: re(t.x) && re(t.y)
 };
 }(e);
 }
 
-function PE(e) {
-var t = NE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function IE(e) {
+var t = PE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -43577,14 +43579,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var IE = {
+var GE = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, GE = function() {
+}, LE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, IE), e);
+void 0 === e && (e = {}), this.config = o(o({}, GE), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -43675,7 +43677,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = NE(e);
+var t = PE(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -43687,15 +43689,15 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return PE(LE(e));
+return IE(DE(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = PE(LE(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = IE(DE(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function LE(e) {
-for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = X(e), c = Z(e), u = e.find(FIND_STRUCTURES, {
+function DE(e) {
+for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = Z(e), c = J(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
 }
@@ -43726,11 +43728,11 @@ swamps: d
 };
 }
 
-var DE = new GE, BE = /^([WE])(\d+)([NS])(\d+)$/, FE = {
+var BE = new LE, FE = /^([WE])(\d+)([NS])(\d+)$/, WE = {
 allies: []
-}, WE = function() {
+}, HE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, FE), e);
+void 0 === e && (e = {}), this.config = o(o({}, WE), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -43750,7 +43752,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!BE.test(e)) return !1;
+if (!FE.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -43858,7 +43860,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return BE.test(e);
+return FE.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -43885,7 +43887,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), HE = new WE, KE = {
+}(), KE = new HE, YE = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -43898,37 +43900,37 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, YE = function() {
+}, VE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, KE), e);
+void 0 === e && (e = {}), this.config = o(o({}, YE), e);
 }
 return e.prototype.run = function() {
-var e, t = this, r = Game.cpu.getUsed(), o = Sr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
+var e, t = this, r = Game.cpu.getUsed(), o = wr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
 if (n < this.config.minBucket) Game.time % 100 == 0 && U.warn("Empire manager skipped - bucket ".concat(n.toFixed(0), " below minimum ").concat(this.config.minBucket), {
 subsystem: "Empire"
 }); else {
 var a = this.getBucketMode(n), i = this.shouldRunDegradedModeWork(a), s = this.shouldRunNormalModeWork(a), c = this.shouldRunFullModeWork(a);
-o.lastUpdate = Game.time, s && (ts.measureSubsystem("empire:expansion", function() {
+o.lastUpdate = Game.time, s && (rs.measureSubsystem("empire:expansion", function() {
 t.updateExpansionQueue(o);
-}), ts.measureSubsystem("empire:powerBanks", function() {
+}), rs.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
-})), ts.measureSubsystem("empire:warTargets", function() {
-HE.updateWarTargets(o);
-}), ts.measureSubsystem("empire:objectives", function() {
+})), rs.measureSubsystem("empire:warTargets", function() {
+KE.updateWarTargets(o);
+}), rs.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
-}), ts.measureSubsystem("empire:gclTracking", function() {
+}), rs.measureSubsystem("empire:gclTracking", function() {
 t.trackGCLProgress(o);
-}), s && ts.measureSubsystem("empire:expansionReadiness", function() {
+}), s && rs.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
-}), i && (ts.measureSubsystem("empire:intelRefresh", function() {
-DE.refreshRoomIntel(o);
-}), ts.measureSubsystem("empire:roomDiscovery", function() {
-DE.discoverNearbyRooms(o);
-})), s && ts.measureSubsystem("empire:nukeCandidates", function() {
+}), i && (rs.measureSubsystem("empire:intelRefresh", function() {
+BE.refreshRoomIntel(o);
+}), rs.measureSubsystem("empire:roomDiscovery", function() {
+BE.discoverNearbyRooms(o);
+})), s && rs.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
-}), c && (ts.measureSubsystem("empire:clusterHealth", function() {
-bE.monitorClusterHealth();
-}), ts.measureSubsystem("empire:powerBankProfitability", function() {
+}), c && (rs.measureSubsystem("empire:clusterHealth", function() {
+OE.monitorClusterHealth();
+}), rs.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
 var u = Game.cpu.getUsed() - r, l = Game.cpu.limit * this.config.maxCpuBudget;
@@ -44010,22 +44012,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = UE(f, u);
+var y = Boolean(Game.rooms[f]), v = _E(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = kE(f, t);
+var g = ME(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = _E(h, u, y);
+var h = e.knownRooms[f], R = NE(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? AE(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? UE(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -44069,10 +44071,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && ME(a)) {
-var i = kE(a.name, t);
+if (a && AE(a)) {
+var i = ME(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = AE(a, t, r);
+var s = UE(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -44251,12 +44253,12 @@ U.info("War mode disabled - no active war targets", {
 subsystem: "Empire"
 }));
 }, e.prototype.getNextExpansionTarget = function() {
-var e = Sr.getEmpire().claimQueue.filter(function(e) {
+var e = wr.getEmpire().claimQueue.filter(function(e) {
 return !e.claimed;
 });
 return e.length > 0 ? e[0] : null;
 }, e.prototype.markExpansionClaimed = function(e) {
-var t = Sr.getEmpire().claimQueue.find(function(t) {
+var t = wr.getEmpire().claimQueue.find(function(t) {
 return t.roomName === e;
 });
 t && (t.claimed = !0, U.info("Marked expansion target as claimed: ".concat(e), {
@@ -44386,19 +44388,19 @@ if (t) throw t.error;
 }
 }
 }
-}, n([ Xe("empire:manager", "Empire Manager", {
-priority: Pe.MEDIUM,
+}, n([ Ze("empire:manager", "Empire Manager", {
+priority: Ie.MEDIUM,
 interval: 30,
 minBucket: 0,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), VE = new YE;
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), qE = new VE;
 
-function qE(e) {
+function jE(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var jE = {
+var zE = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -44406,21 +44408,21 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, zE = function() {
+}, QE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, jE), e);
+this.config = o(o({}, zE), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
 this.lastRun = Game.time, 0 === this.scanQueue.length && this.buildScanQueue(),
-ts.measureSubsystem("intel:scanning", function() {
+rs.measureSubsystem("intel:scanning", function() {
 e.scanRooms();
-}), ts.measureSubsystem("intel:enemyTracking", function() {
+}), rs.measureSubsystem("intel:enemyTracking", function() {
 e.updateEnemyTracking();
-}), ts.measureSubsystem("intel:threatDetection", function() {
+}), rs.measureSubsystem("intel:threatDetection", function() {
 e.detectThreats();
-}), ts.measureSubsystem("intel:threatUpdate", function() {
+}), rs.measureSubsystem("intel:threatUpdate", function() {
 e.updateRoomThreatLevels();
 });
 var r = Game.cpu.getUsed() - t;
@@ -44428,7 +44430,7 @@ Game.time % 500 == 0 && U.info("Intel scanner completed in ".concat(r.toFixed(2)
 subsystem: "Intel"
 });
 }, e.prototype.buildScanQueue = function() {
-var e, t, r = Sr.getEmpire(), o = (e = {
+var e, t, r = wr.getEmpire(), o = (e = {
 time: Game.time,
 rescanInterval: this.config.rescanInterval,
 roomsPerTick: this.config.roomsPerTick,
@@ -44454,7 +44456,7 @@ this.scanQueue = o.scanQueue, U.debug("Built scan queue with ".concat(this.scanQ
 subsystem: "Intel"
 });
 }, e.prototype.scanRooms = function() {
-for (var e = Sr.getEmpire(), t = 0; t < this.config.roomsPerTick && this.scanQueue.length > 0; ) {
+for (var e = wr.getEmpire(), t = 0; t < this.config.roomsPerTick && this.scanQueue.length > 0; ) {
 var r = this.scanQueue.shift();
 if (!r) break;
 var o = Game.rooms[r];
@@ -44471,7 +44473,7 @@ o.sources = n.length, e.controller && (o.controllerLevel = e.controller.level, e
 e.controller.reservation ? o.reserver = e.controller.reservation.username : o.reserver = void 0);
 var a = e.find(FIND_MINERALS);
 a.length > 0 && (o.mineralType = a[0].mineralType);
-var i = Z(e).filter(function(e) {
+var i = J(e).filter(function(e) {
 return !r.isConfiguredAllyStructure(e, t);
 });
 o.towerCount = i.filter(function(e) {
@@ -44484,8 +44486,8 @@ filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
 }
 });
-o.hasPortal = s.length > 0, o.terrain = this.classifyTerrain(e), o.isHighway = oe(e.name),
-o.isSK = ne(e.name), t.knownRooms[e.name] = o;
+o.hasPortal = s.length > 0, o.terrain = this.classifyTerrain(e), o.isHighway = ne(e.name),
+o.isSK = ae(e.name), t.knownRooms[e.name] = o;
 }, e.prototype.createDefaultIntel = function(e) {
 return {
 name: e,
@@ -44495,8 +44497,8 @@ controllerLevel: 0,
 threatLevel: 0,
 scouted: !1,
 terrain: "mixed",
-isHighway: oe(e),
-isSK: ne(e)
+isHighway: ne(e),
+isSK: ae(e)
 };
 }, e.prototype.classifyTerrain = function(e) {
 for (var t = e.getTerrain(), r = 0, o = 0, n = 0; n < 50; n++) for (var a = 0; a < 50; a++) {
@@ -44509,7 +44511,7 @@ var e, t, r, o, n, c, u, l, m, d, p, f, y, v, g = [], h = [];
 for (var R in Game.rooms) {
 var E = Game.rooms[R];
 if (E) {
-var T = X(E);
+var T = Z(E);
 try {
 for (var C = (e = void 0, a(T)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value, x = w.owner.username, b = this.isAllyUsername(x);
@@ -44553,7 +44555,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, qE(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, jE(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -44677,13 +44679,13 @@ return this.isConfiguredAllyOwned(e, t);
 }, e.prototype.isAggressiveCreep = function(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 2;
 }, e.prototype.detectThreats = function() {
-var e = this, t = Sr.getEmpire();
+var e = this, t = wr.getEmpire();
 for (var r in Game.rooms) {
 var o = Game.rooms[r];
 if (o) {
 var n = t.knownRooms[r];
 if (n) {
-var a = X(o).filter(function(r) {
+var a = Z(o).filter(function(r) {
 return !e.isConfiguredAllyCreep(r, t);
 }), i = a.filter(function(t) {
 return e.isAggressiveCreep(t);
@@ -44695,7 +44697,7 @@ subsystem: "Intel"
 }
 }
 }, e.prototype.updateRoomThreatLevels = function() {
-var e, t, r = Sr.getEmpire();
+var e, t, r = wr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 Game.time - n.lastSeen > 100 && n.threatLevel > 0 && (n.threatLevel = Math.max(0, n.threatLevel - 1));
@@ -44722,23 +44724,23 @@ r.warTargets = s([], i(new Set(c)), !1);
 return this.enemyPlayers.get(e);
 }, e.prototype.getAllEnemies = function() {
 return Array.from(this.enemyPlayers.values());
-}, n([ Xe("empire:intelScanner", "Intel Scanner", {
-priority: Pe.MEDIUM,
+}, n([ Ze("empire:intelScanner", "Intel Scanner", {
+priority: Ie.MEDIUM,
 interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), QE = new zE, XE = function() {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), XE = new QE, ZE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new dc(o(o({}, Vs), e), {
+void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new pc(o(o({}, qs), e), {
 getEmpire: function() {
-return Sr.getEmpire();
+return wr.getEmpire();
 },
 getSwarmState: function(e) {
-return Sr.getSwarmState(e);
+return wr.getSwarmState(e);
 },
 getClusters: function() {
-return Sr.getClusters();
+return wr.getClusters();
 }
 });
 }
@@ -44760,16 +44762,16 @@ return e.structureType === STRUCTURE_NUKER;
 return this.coordinator.getConfig();
 }, e.prototype.updateConfig = function(e) {
 this.coordinator.updateConfig(e);
-}, n([ Xe("empire:nuke", "Nuke Manager", {
-priority: Pe.LOW,
+}, n([ Ze("empire:nuke", "Nuke Manager", {
+priority: Ie.LOW,
 interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), ZE = new XE, JE = function() {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), JE = new ZE, $E = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
-var e = Sr.getEmpire();
+var e = wr.getEmpire();
 if (e.market) {
 var t = e.market;
 t.pixelBuying || (t.pixelBuying = {
@@ -44781,39 +44783,39 @@ lastScan: 0
 });
 }
 }, e.prototype.getPixelBuyingMemory = function() {
-var e = Sr.getEmpire();
+var e = wr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), $E = new (function(e) {
+}(), eT = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new JE) || this;
+return void 0 === t && (t = {}), e.call(this, t, new $E) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
-}, n([ Xe("empire:pixelBuying", "Pixel Buying Manager", {
-priority: Pe.IDLE,
+}, n([ Ze("empire:pixelBuying", "Pixel Buying Manager", {
+priority: Ie.IDLE,
 interval: 200,
 minBucket: 9e3,
 cpuBudget: .01
-}) ], t.prototype, "run", null), n([ Je() ], t);
-}(Fi));
+}) ], t.prototype, "run", null), n([ $e() ], t);
+}(Wi));
 
-function eT() {
+function tT() {
 return global;
 }
 
-function tT(e) {
+function rT(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function rT(e) {
+function oT(e) {
 return Number(null != e ? e : 0);
 }
 
-var oT = function() {
+var nT = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = eT();
+var e = tT();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -44821,12 +44823,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return eT()._pixelGenerationMemory;
+return tT()._pixelGenerationMemory;
 }, e;
-}(), nT = function(e) {
+}(), aT = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new oT) || this;
+var r = e.call(this, t, new nT) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -44843,7 +44845,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(tT).length : Object.values(null != t ? t : {}).filter(tT).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(rT).length : Object.values(null != t ? t : {}).filter(rT).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -44854,9 +44856,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (rT(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (rT(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = rT(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = rT(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (oT(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (oT(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = oT(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = oT(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -44872,15 +44874,15 @@ if (e) throw e.error;
 }
 }, t.prototype.run = function() {
 e.prototype.run.call(this);
-}, n([ Xe("empire:pixelGeneration", "Pixel Generation Manager", {
-priority: Pe.IDLE,
+}, n([ Ze("empire:pixelGeneration", "Pixel Generation Manager", {
+priority: Ie.IDLE,
 interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
-}) ], t.prototype, "run", null), n([ Je() ], t);
-}(Hi), aT = new nT;
+}) ], t.prototype, "run", null), n([ $e() ], t);
+}(Ki), iT = new aT;
 
-function iT(e, t) {
+function sT(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !j(e.controller.owner.username)) return {
 lost: !0,
@@ -44890,7 +44892,7 @@ var n, a = (n = Object.values(Game.spawns)).length > 0 ? n[0].owner.username : "
 return (null === (o = e.controller) || void 0 === o ? void 0 : o.reservation) && e.controller.reservation.username !== a && !j(e.controller.reservation.username) ? {
 lost: !0,
 reason: "enemyReserved"
-} : X(e).filter(function(e) {
+} : Z(e).filter(function(e) {
 return e.body.some(function(e) {
 return e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK;
 });
@@ -44902,13 +44904,13 @@ lost: !1
 };
 }
 
-function sT(e, t, r) {
-var o, n = Sr.getSwarmState(e);
+function cT(e, t, r) {
+var o, n = wr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
 if (-1 !== i) {
 a.splice(i, 1), n.remoteAssignments = a;
-var s = Sr.getEmpire().knownRooms[t];
+var s = wr.getEmpire().knownRooms[t];
 s && (s.threatLevel = 3, s.lastSeen = Game.time), U.warn("Removed remote room ".concat(t, " from ").concat(e, " due to: ").concat(r), {
 subsystem: "RemoteRoomManager"
 });
@@ -44916,38 +44918,38 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var cT = kr().cpu.bucketThresholds.highMode + 1800, uT = {
+var uT = Mr().cpu.bucketThresholds.highMode + 1800, lT = {
 updateInterval: 250,
-minBucket: cT,
+minBucket: uT,
 maxSitesPerRemotePerTick: 2
 };
 
-function lT(e, t) {
+function mT(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var mT = function() {
+var dT = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, uT), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, lT), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }), i = function(e) {
-var t = Sr.getSwarmState(e.name);
+var t = wr.getSwarmState(e.name);
 if (!t) return "continue";
 !function(e) {
-var t, r, o, n = Sr.getSwarmState(e);
+var t, r, o, n = wr.getSwarmState(e);
 if (n) {
 var i = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [];
 if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = iT(l);
-m.lost && m.reason && sT(e, u, m.reason);
+var m = sT(l);
+m.lost && m.reason && cT(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -44965,10 +44967,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = lT("remoteInfrastructure.intent", function() {
+var i = mT("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-lT("remoteInfrastructure.execute", function() {
+mT("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -45134,13 +45136,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = lT("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = mT("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = lT("remoteInfrastructure.roomSnapshot", function() {
+u[t] = mT("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -45173,8 +45175,8 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = lT("remoteInfrastructure.calculateRemoteRoads", function() {
-return xa(e, t);
+var n = mT("remoteInfrastructure.calculateRemoteRoads", function() {
+return ba(e, t);
 });
 return this.remoteRoadCache.set(r, {
 expires: Game.time + 1500,
@@ -45202,14 +45204,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = lT("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = mT("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? lT("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? mT("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -45226,7 +45228,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? lT("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? mT("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -45244,7 +45246,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return lT("remoteInfrastructure.findSources", function() {
+return mT("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -45338,25 +45340,25 @@ if (s) throw s.error;
 }, e.prototype.getMyUsername = function() {
 var e = Object.values(Game.spawns);
 return e.length > 0 ? e[0].owner.username : "";
-}, n([ Qe("remote:infrastructure", "Remote Infrastructure Manager", {
-priority: Pe.LOW,
+}, n([ Xe("remote:infrastructure", "Remote Infrastructure Manager", {
+priority: Ie.LOW,
 interval: 1e3,
-minBucket: cT,
+minBucket: uT,
 cpuBudget: .05
-}) ], e.prototype, "run", null), n([ Je() ], e);
-}(), dT = new mT, pT = new (function(e) {
+}) ], e.prototype, "run", null), n([ $e() ], e);
+}(), pT = new dT, fT = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
-}, n([ Xe("empire:shard", "Shard Manager", {
-priority: Pe.LOW,
+}, n([ Ze("empire:shard", "Shard Manager", {
+priority: Ie.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
-}) ], t.prototype, "run", null), n([ Je() ], t);
-}(qf)), fT = function() {
+}) ], t.prototype, "run", null), n([ $e() ], t);
+}(jf)), yT = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -45372,13 +45374,13 @@ e = JSON.stringify(Memory).length;
 e = 0;
 }
 var o = 2097152, n = e / o * 100;
-n > 90 ? ml.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+n > 90 ? dl.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
-}) : n > 75 && ml.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+}) : n > 75 && dl.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
 });
 }, e.prototype.updateMemorySegmentStats = function() {
-ns.run();
+as.run();
 }, e.prototype.runPheromoneDiffusion = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45386,7 +45388,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }), o = new Map;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Sr.getSwarmState(s.name);
+var s = i.value, c = wr.getSwarmState(s.name);
 c && o.set(s.name, c);
 }
 } catch (t) {
@@ -45400,7 +45402,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Gy.applyDiffusion(o);
+Ly.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45409,7 +45411,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Nu.initialize(i.name);
+Pu.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -45422,31 +45424,31 @@ n && !n.done && (t = o.return) && t.call(o);
 if (e) throw e.error;
 }
 }
-}, e.prototype.precacheRoomPaths = function() {}, n([ Xe("core:memoryCleanup", "Memory Cleanup", {
-priority: Pe.LOW,
+}, e.prototype.precacheRoomPaths = function() {}, n([ Ze("core:memoryCleanup", "Memory Cleanup", {
+priority: Ie.LOW,
 interval: 50,
 cpuBudget: .01
-}) ], e.prototype, "cleanupMemory", null), n([ Ze("core:memorySizeCheck", "Memory Size Check", {
+}) ], e.prototype, "cleanupMemory", null), n([ Je("core:memorySizeCheck", "Memory Size Check", {
 interval: 100,
 cpuBudget: .005
-}) ], e.prototype, "checkMemorySize", null), n([ Ze("core:memorySegmentStats", "Memory Segment Stats", {
+}) ], e.prototype, "checkMemorySize", null), n([ Je("core:memorySegmentStats", "Memory Segment Stats", {
 interval: 500,
-minBucket: kr().cpu.bucketThresholds.highMode,
+minBucket: Mr().cpu.bucketThresholds.highMode,
 cpuBudget: .01
-}) ], e.prototype, "updateMemorySegmentStats", null), n([ Qe("cluster:pheromoneDiffusion", "Pheromone Diffusion", {
-priority: Pe.LOW,
+}) ], e.prototype, "updateMemorySegmentStats", null), n([ Xe("cluster:pheromoneDiffusion", "Pheromone Diffusion", {
+priority: Ie.LOW,
 interval: 50,
-minBucket: kr().cpu.bucketThresholds.lowMode,
+minBucket: Mr().cpu.bucketThresholds.lowMode,
 cpuBudget: .02
-}) ], e.prototype, "runPheromoneDiffusion", null), n([ Xe("room:labConfig", "Lab Config Manager", {
-priority: Pe.LOW,
+}) ], e.prototype, "runPheromoneDiffusion", null), n([ Ze("room:labConfig", "Lab Config Manager", {
+priority: Ie.LOW,
 interval: 200,
 cpuBudget: .01
-}) ], e.prototype, "initializeLabConfigs", null), n([ Ze("room:pathCachePrecache", "Path Cache Precache (Disabled)", {
+}) ], e.prototype, "initializeLabConfigs", null), n([ Je("room:pathCachePrecache", "Path Cache Precache (Disabled)", {
 interval: 1e3,
 cpuBudget: .01
-}) ], e.prototype, "precacheRoomPaths", null), n([ Je() ], e);
-}(), yT = new fT, vT = new (function() {
+}) ], e.prototype, "precacheRoomPaths", null), n([ $e() ], e);
+}(), vT = new yT, gT = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -45467,88 +45469,88 @@ this.runProcesses(), this.processQueuedEvents();
 this.processesRegistered = !1;
 }, e;
 }())({
-kernel: Ii,
-eventBus: Le,
+kernel: Gi,
+eventBus: De,
 getCpuConfig: function() {
-return kr().cpu;
+return Mr().cpu;
 },
 registerProcesses: function() {
 var e;
-ml.info("Registering all processes with kernel...", {
+dl.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), Gi(yT, Is, Fs, ps, VE, kc, QE, dT, As, $E, aT, ZE, cu, pu, pT, wE, ru, RE, Ui),
+}), Li(vT, Gs, Ws, fs, qE, Mc, XE, pT, Us, eT, iT, JE, uu, fu, fT, xE, ou, EE, _i),
 function() {
-var e, t, r = kr().cpu.bucketThresholds.lowMode, o = [ {
+var e, t, r = Mr().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
 name: "Terminal Manager",
-priority: Pe.MEDIUM,
+priority: Ie.MEDIUM,
 frequency: "medium",
 interval: 20,
 minBucket: 0,
 cpuBudget: .1,
 execute: function() {
-return Is.run();
+return Gs.run();
 }
 }, {
 id: "factory:manager",
 name: "Factory Manager",
-priority: Pe.LOW,
+priority: Ie.LOW,
 frequency: "medium",
 interval: 30,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return Fs.run();
+return Ws.run();
 }
 }, {
 id: "link:manager",
 name: "Link Manager",
-priority: Pe.MEDIUM,
+priority: Ie.MEDIUM,
 frequency: "medium",
 interval: 5,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return ps.run();
+return fs.run();
 }
 }, {
 id: "empire:market",
 name: "Market Manager",
-priority: Pe.LOW,
+priority: Ie.LOW,
 frequency: "low",
 interval: 300,
 minBucket: r,
 cpuBudget: .02,
 execute: function() {
-return As.run();
+return Us.run();
 }
 }, {
 id: "cluster:manager",
 name: "Cluster Manager",
-priority: Pe.MEDIUM,
+priority: Ie.MEDIUM,
 frequency: "medium",
 interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return RE.run();
+return EE.run();
 }
 }, {
 id: "cluster:evacuation",
 name: "Evacuation Manager",
-priority: Pe.HIGH,
+priority: Ie.HIGH,
 frequency: "medium",
 interval: 5,
 minBucket: 0,
 cpuBudget: .02,
 execute: function() {
-return Ui.run();
+return _i.run();
 }
 } ], n = [];
 try {
 for (var i = a(o), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-Ii.getProcess(c.id) || (Ii.registerProcess(c), n.push(c.id));
+Gi.getProcess(c.id) || (Gi.registerProcess(c), n.push(c.id));
 }
 } catch (t) {
 e = {
@@ -45561,20 +45563,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-n.length > 0 && ml.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
+n.length > 0 && dl.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
 subsystem: "ProcessRegistry",
 meta: {
 processIds: n
 }
 });
-}(), (e = Ii.getProcess("empire:market")) && (e.interval = 300, e.minBucket = kr().cpu.bucketThresholds.lowMode),
-ml.info("Registered ".concat(Ii.getProcesses().length, " processes with kernel"), {
+}(), (e = Gi.getProcess("empire:market")) && (e.interval = 300, e.minBucket = Mr().cpu.bucketThresholds.lowMode),
+dl.info("Registered ".concat(Gi.getProcesses().length, " processes with kernel"), {
 subsystem: "ProcessRegistry"
 });
 }
 });
 
-function gT(e) {
+function hT(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -45584,20 +45586,20 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var hT = ul("NativeCallsTracker");
+var RT = ll("NativeCallsTracker");
 
-function RT(e, t, r) {
+function ET(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) hT.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) RT.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
 }); else try {
 var a = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return ts.recordNativeCall(r), o.apply(this, e);
+return rs.recordNativeCall(r), o.apply(this, e);
 };
 a.__nativeCallsTrackerWrapped = !0, Object.defineProperty(e, t, {
 value: a,
@@ -45606,7 +45608,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-hT.warn("Failed to wrap method", {
+RT.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -45616,30 +45618,30 @@ error: String(e)
 }
 }
 
-var ET, TT = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], CT = "shard1", ST = {
+var TT, CT = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], ST = "shard1", wT = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, wT = {
+}, xT = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, xT = {
+}, bT = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function bT() {
+function OT() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function OT() {
+function kT() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: TT,
+targetShards: CT,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -45649,12 +45651,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = TT),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = CT),
 Memory.interShardOperation;
 }
 
-function kT() {
-return Df({
+function MT() {
+return Bf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -45667,32 +45669,32 @@ checksum: 0
 });
 }
 
-function MT(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), Bf(e, {
+function AT(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), Ff(e, {
 updatedSections: t
 });
 }
 
-function AT() {
-var e, t, r, o, n, i, s, c = kT(), u = bT();
+function UT() {
+var e, t, r, o, n, i, s, c = MT(), u = OT();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: TT,
+targetShards: CT,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : TT,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : CT,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && UT() ? "established" : "unreached",
+status: p === u && _T() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -45710,7 +45712,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === CT ? "core" : "frontier",
+role: u === ST ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -45727,24 +45729,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), MT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), AT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function UT() {
+function _T() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function _T() {
+function NT() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function NT(e, t) {
+function PT(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -45763,9 +45765,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(_T()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(NT()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += $v.getPendingRequests(p.name).filter(function(r) {
+s += eg.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -45784,7 +45786,7 @@ if (n) throw n.error;
 return s;
 }
 
-function PT(e) {
+function IT(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -45828,7 +45830,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = kT().shards[bT()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = MT().shards[OT()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -45838,8 +45840,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function IT(e, t) {
-if (!(NT("scout", t) >= 1)) {
+function GT(e, t) {
+if (!(PT("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -45877,13 +45879,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && $v.addRequest({
+r && eg.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: xT,
-priority: Dv.LOW + 5,
+body: bT,
+priority: Bv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -45894,14 +45896,14 @@ task: "interShardPortalScout"
 }
 }
 
-function GT(e, t, r) {
-NT("interShardClaimer", t) >= 1 || $v.addRequest({
+function LT(e, t, r) {
+PT("interShardClaimer", t) >= 1 || eg.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: ST,
-priority: Dv.NORMAL + 50,
+body: wT,
+priority: Bv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45914,14 +45916,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function LT(e, t, r) {
-NT("interShardScout", t) >= 1 || $v.addRequest({
+function DT(e, t, r) {
+PT("interShardScout", t) >= 1 || eg.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: xT,
-priority: Dv.NORMAL,
+body: bT,
+priority: Bv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45934,15 +45936,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function DT(e, t, r) {
+function BT(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (NT("interShardPioneer", t.shard) >= 3 || $v.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (PT("interShardPioneer", t.shard) >= 3 || eg.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: wT,
-priority: Dv.NORMAL + 25,
+body: xT,
+priority: Bv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45955,19 +45957,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function BT(e) {
+function FT(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = bT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = OT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : TT), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : CT), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? _f(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Nf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -45999,9 +46001,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(_T()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(NT()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += $v.getPendingRequests(l.name).filter(function(e) {
+n += eg.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -46020,22 +46022,22 @@ return n;
 }() < o;
 }
 
-(ET = {
-optimizeBody: Qv,
+(TT = {
+optimizeBody: Xv,
 spawnQueue: {
 addRequest: function(e) {
-return $v.addRequest(e);
+return eg.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Dv.LOW,
-NORMAL: Dv.NORMAL,
-HIGH: Dv.HIGH
+LOW: Bv.LOW,
+NORMAL: Bv.NORMAL,
+HIGH: Bv.HIGH
 }
-}).optimizeBody && (zf.optimizeBody = ET.optimizeBody), ET.spawnQueue && (zf.spawnQueue = ET.spawnQueue),
-ET.spawnPriorities && (zf.spawnPriorities = o(o({}, zf.spawnPriorities), ET.spawnPriorities));
+}).optimizeBody && (Qf.optimizeBody = TT.optimizeBody), TT.spawnQueue && (Qf.spawnQueue = TT.spawnQueue),
+TT.spawnPriorities && (Qf.spawnPriorities = o(o({}, Qf.spawnPriorities), TT.spawnPriorities));
 
-var FT, WT = function() {
+var WT, HT = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -46079,7 +46081,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function HT(e) {
+function KT(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -46100,7 +46102,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function KT(e, t, r) {
+function YT(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -46112,8 +46114,8 @@ roomCallback: function(e) {
 return function(e, t) {
 var r, o, n, i, s = Game.rooms[e];
 if (!s) return !0;
-if (!oe(e)) {
-var c = Z(s).filter(function(e) {
+if (!ne(e)) {
+var c = J(s).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER && e.structureType !== STRUCTURE_KEEPER_LAIR;
 });
 if (c.length > 0) return t && t.debug("Avoiding room ".concat(e, " with hostile structures"), {
@@ -46166,16 +46168,16 @@ return u;
 });
 }
 
-function YT(e) {
+function VT(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(FT || (FT = {}));
+}(WT || (WT = {}));
 
-var VT = function() {
+var qT = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -46213,8 +46215,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = KT(h.pos, T.pos, this.logger);
-if (YT(C)) {
+var T = E.value, C = YT(h.pos, T.pos, this.logger);
+if (VT(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -46241,8 +46243,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, M = KT(k, u.pos, this.logger);
-YT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, M = YT(k, u.pos, this.logger);
+VT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -46281,8 +46283,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = KT(e, t, this.logger);
-if (YT(n)) {
+var n = YT(e, t, this.logger);
+if (VT(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -46292,7 +46294,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), qT = function() {
+}(), jT = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -46302,7 +46304,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = HT(s);
+var c = KT(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -46328,7 +46330,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), jT = function() {
+}(), zT = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -46377,7 +46379,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), zT = {
+}(), QT = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -46390,19 +46392,19 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, QT = {
+}, XT = {
 getCachedPath: function(e, t) {
-var r = ct(e, t), o = Re.get(r, {
-namespace: st
+var r = ut(e, t), o = Ee.get(r, {
+namespace: ct
 });
 if (!o) return null;
 try {
 return Room.deserializePath(o);
 } catch (e) {
-return Re.invalidate(r, st), null;
+return Ee.invalidate(r, ct), null;
 }
 },
-cachePath: ut,
+cachePath: lt,
 convertRoomPositionsToPathSteps: function(e) {
 for (var t = [], r = 0; r < e.length; r++) {
 var o = e[r], n = r > 0 ? e[r - 1] : null, a = TOP, i = 0, s = 0;
@@ -46417,26 +46419,26 @@ direction: a
 }
 return t;
 }
-}, XT = {
+}, ZT = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = sd.MEDIUM), hd.register({
+void 0 === o && (o = cd.MEDIUM), Rd.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== sd.CRITICAL
+skippable: o !== cd.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, ZT = new VT(QT, zT), JT = new qT(zT, XT, ZT), $T = new jT(zT, QT, ZT, Ol.moveTo);
+}, JT = new qT(XT, QT), $T = new jT(QT, ZT, JT), eC = new zT(QT, XT, JT, kl.moveTo);
 
-function eC(e, t, r, o) {
-return $T.moveToWithRemoteCache(e, t, r, o);
+function tC(e, t, r, o) {
+return eC.moveToWithRemoteCache(e, t, r, o);
 }
 
-var tC, rC = function() {
+var rC, oC = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -46449,17 +46451,17 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), oC = function() {
+}(), nC = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
-Le.on(e, t);
+De.on(e, t);
 }, e;
-}(), nC = function() {
+}(), aC = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
 var t = e.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), r = new RegExp("^".concat(t, ":|:").concat(t, ":|:").concat(t, "$"));
-Re.invalidatePattern(r, st);
+Ee.invalidatePattern(r, ct);
 }(e);
 }, e.prototype.cacheCommonRoutes = function(e) {
 !function(e) {
@@ -46474,7 +46476,7 @@ var u = c.value, l = e.findPath(n.pos, u.pos, {
 ignoreCreeps: !0,
 serialize: !1
 });
-l.length > 0 && (ut(n.pos, u.pos, l), ut(u.pos, n.pos, l));
+l.length > 0 && (lt(n.pos, u.pos, l), lt(u.pos, n.pos, l));
 }
 } catch (e) {
 t = {
@@ -46493,34 +46495,34 @@ ignoreCreeps: !0,
 range: 3,
 serialize: !1
 });
-m.length > 0 && ut(n.pos, e.controller.pos, m);
+m.length > 0 && lt(n.pos, e.controller.pos, m);
 }
 }
 }
 }(e);
 }, e;
-}(), aC = function() {
+}(), iC = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return HT(e);
+return KT(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-ZT.precacheRemoteRoutes(e, t);
+JT.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), iC = new WT(new rC, new oC, new nC, new aC), sC = {
+}(), sC = new HT(new oC, new nC, new aC, new iC), cC = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, cC = function() {
+}, uC = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, sC), e);
+this.config = o(o({}, cC), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -46529,10 +46531,10 @@ lastRun: 0
 }, e.prototype.unregisterTask = function(e) {
 this.tasks.delete(e);
 }, e.prototype.getBucketMode = function() {
-return Ii.getBucketMode();
+return Gi.getBucketMode();
 }, e.prototype.updateBucketMode = function() {
 var e = this.getBucketMode();
-e !== this.currentMode && (ml.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
+e !== this.currentMode && (dl.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
 subsystem: "Scheduler"
 }), this.currentMode = e);
 }, e.prototype.getCpuLimit = function() {
@@ -46580,13 +46582,13 @@ try {
 i.execute(), i.lastRun = Game.time;
 } catch (e) {
 var c = e instanceof Error ? e.message : String(e);
-ml.error("Task ".concat(i.name, " failed: ").concat(c), {
+dl.error("Task ".concat(i.name, " failed: ").concat(c), {
 subsystem: "Scheduler"
 });
 }
 var u = Game.cpu.getUsed() - s;
 if (this.tickCpuUsed += u, !this.hasCpuBudget()) {
-ml.warn("CPU budget exhausted, skipping remaining tasks", {
+dl.warn("CPU budget exhausted, skipping remaining tasks", {
 subsystem: "Scheduler"
 });
 break;
@@ -46614,123 +46616,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new cC, (tC = {})[FIND_STRUCTURES] = {
+new uC, (rC = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, tC[FIND_MY_STRUCTURES] = {
+}, rC[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, tC[FIND_HOSTILE_STRUCTURES] = {
+}, rC[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, tC[FIND_SOURCES_ACTIVE] = {
+}, rC[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, tC[FIND_SOURCES] = {
+}, rC[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, tC[FIND_MINERALS] = {
+}, rC[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, tC[FIND_DEPOSITS] = {
+}, rC[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, tC[FIND_MY_CONSTRUCTION_SITES] = {
+}, rC[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, tC[FIND_CONSTRUCTION_SITES] = {
+}, rC[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, tC[FIND_CREEPS] = {
+}, rC[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, tC[FIND_MY_CREEPS] = {
+}, rC[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, tC[FIND_HOSTILE_CREEPS] = {
+}, rC[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, tC[FIND_DROPPED_RESOURCES] = {
+}, rC[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, tC[FIND_TOMBSTONES] = {
+}, rC[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, tC[FIND_RUINS] = {
+}, rC[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, tC[FIND_FLAGS] = {
+}, rC[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, tC[FIND_MY_SPAWNS] = {
+}, rC[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, tC[FIND_HOSTILE_SPAWNS] = {
+}, rC[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, tC[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, rC[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, tC[FIND_NUKES] = {
+}, rC[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, tC[FIND_POWER_CREEPS] = {
+}, rC[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, tC[FIND_MY_POWER_CREEPS] = {
+}, rC[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, tC[FIND_HOSTILE_POWER_CREEPS] = {
+}, rC[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, tC[FIND_EXIT_TOP] = {
+}, rC[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, tC[FIND_EXIT_RIGHT] = {
+}, rC[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, tC[FIND_EXIT_BOTTOM] = {
+}, rC[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, tC[FIND_EXIT_LEFT] = {
+}, rC[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, tC[FIND_EXIT] = {
+}, rC[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var uC = new pe({}, Sr), lC = new _t({}, Sr);
+var lC = new fe({}, wr), mC = new Nt({}, wr);
 
-function mC(e) {
+function dC(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -46738,16 +46740,16 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var dC = !1;
+var pC = !1;
 
-function pC() {
+function fC() {
 var e, t;
-dC || (Qu({
-level: (t = kr()).debug ? Ou.DEBUG : Ou.INFO,
+pC || (Xu({
+level: (t = Mr()).debug ? ku.DEBUG : ku.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
 maxBatchSize: 50
-}), ml.info("Bot initialized", {
+}), dl.info("Bot initialized", {
 subsystem: "SwarmBot",
 meta: {
 debug: t.debug,
@@ -46757,11 +46759,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (eg.getPendingTransfers = function(e) {
+r.getPendingTransfers && (tg.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (eg.needsCarrier = function(e) {
+}), r.needsCarrier && (tg.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (eg.getActiveRequests = function() {
+}), r.getActiveRequests && (tg.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -46775,66 +46777,66 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (tg.predictConsumption = function(e) {
+a.predictConsumption && (rg.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (tg.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (rg.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (tg.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (rg.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (tg.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (rg.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (rg.getActivePowerBanks = function() {
+i.getActivePowerBanks && (og.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (rg.needsHarvesters = function(e) {
+}), i.needsHarvesters && (og.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (rg.needsCarriers = function(e) {
+}), i.needsCarriers && (og.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (rg.requestSpawns = function(e) {
+}), i.requestSpawns && (og.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-og.getEmergencyState = function(e) {
+ng.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
-energyFlowPredictor: to,
-powerBankHarvestingManager: cu,
-resourceTransferCoordinator: Xf,
-emergencyResponseManager: Ci,
-kernel: Ii
+energyFlowPredictor: ro,
+powerBankHarvestingManager: uu,
+resourceTransferCoordinator: Zf,
+emergencyResponseManager: Si,
+kernel: Gi
 }), function(e) {
 var t, r, o, n;
-lp = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : up.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : up.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : up.getLabOverflow
-} : up;
+mp = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : lp.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : lp.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : lp.getLabOverflow
+} : lp;
 }({
 getLabResourceNeeds: function(e) {
-return Iu.getLabResourceNeeds(e);
+return Gu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return Iu.getLabResourceNeeds(e);
+return Gu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return Iu.getLabOverflow(e);
+return Gu.getLabOverflow(e);
 }
-}), ts.initialize(), t.profiling && (function() {
+}), rs.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) hT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) RT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
 for (var e = [], r = 0; r < arguments.length; r++) e[r] = arguments[r];
-return ts.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
+return rs.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
 };
 r.__nativeCallsTrackerWrapped = !0, Object.defineProperty(PathFinder, "search", {
 value: r,
@@ -46843,7 +46845,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-hT.warn("Failed to wrap PathFinder.search", {
+RT.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -46851,64 +46853,64 @@ error: String(e)
 }
 }
 }
-}(), RT(e = Creep.prototype, "moveTo", "moveTo"), RT(e, "move", "move"), RT(e, "harvest", "harvest"),
-RT(e, "transfer", "transfer"), RT(e, "withdraw", "withdraw"), RT(e, "build", "build"),
-RT(e, "repair", "repair"), RT(e, "upgradeController", "upgradeController"), RT(e, "attack", "attack"),
-RT(e, "rangedAttack", "rangedAttack"), RT(e, "heal", "heal"), RT(e, "dismantle", "dismantle"),
-RT(e, "say", "say")), function(e) {
-void 0 === e && (e = Ae);
+}(), ET(e = Creep.prototype, "moveTo", "moveTo"), ET(e, "move", "move"), ET(e, "harvest", "harvest"),
+ET(e, "transfer", "transfer"), ET(e, "withdraw", "withdraw"), ET(e, "build", "build"),
+ET(e, "repair", "repair"), ET(e, "upgradeController", "upgradeController"), ET(e, "attack", "attack"),
+ET(e, "rangedAttack", "rangedAttack"), ET(e, "heal", "heal"), ET(e, "dismantle", "dismantle"),
+ET(e, "say", "say")), function(e) {
+void 0 === e && (e = Ue);
 var t = e.cacheManager, r = e.coherenceManager;
-r.registerCache("object", t, Te.L1, {
+r.registerCache("object", t, Ce.L1, {
 priority: 100,
 maxMemory: 5242880
-}), r.registerCache("bodypart", t, Te.L1, {
+}), r.registerCache("bodypart", t, Ce.L1, {
 priority: 95,
 maxMemory: 2097152
-}), r.registerCache("path", t, Te.L2, {
+}), r.registerCache("path", t, Ce.L2, {
 priority: 70,
 maxMemory: 10485760
-}), r.registerCache("roomFind", t, Te.L2, {
+}), r.registerCache("roomFind", t, Ce.L2, {
 priority: 65,
 maxMemory: 8388608
-}), r.registerCache("role", t, Te.L2, {
+}), r.registerCache("role", t, Ce.L2, {
 priority: 60,
 maxMemory: 3145728
-}), r.registerCache("closest", t, Te.L2, {
+}), r.registerCache("closest", t, Ce.L2, {
 priority: 55,
 maxMemory: 5242880
-}), r.registerCache("collectionPoint", t, Te.L2, {
+}), r.registerCache("collectionPoint", t, Ce.L2, {
 priority: 50,
 maxMemory: 1048576
-}), r.registerCache("patrol", t, Te.L2, {
+}), r.registerCache("patrol", t, Ce.L2, {
 priority: 50,
 maxMemory: 2097152
-}), r.registerCache("targetAssignment", t, Te.L1, {
+}), r.registerCache("targetAssignment", t, Ce.L1, {
 priority: 90,
 maxMemory: 1048576
-}), r.registerCache("evolution:structures", t, Te.L2, {
+}), r.registerCache("evolution:structures", t, Ce.L2, {
 priority: 50,
 maxMemory: 1048576
-}), r.registerCache("game", t, Te.L1, {
+}), r.registerCache("game", t, Ce.L1, {
 priority: 98,
 maxMemory: 2097152
-}), r.registerCache("structures", t, Te.L2, {
+}), r.registerCache("structures", t, Ce.L2, {
 priority: 75,
 maxMemory: 3145728
 });
 }(), function(e) {
 var t, r;
 void 0 === e && (e = {});
-var o = null !== (t = e.eventBus) && void 0 !== t ? t : Le, n = null !== (r = e.coherenceManager) && void 0 !== r ? r : Me;
+var o = null !== (t = e.eventBus) && void 0 !== t ? t : De, n = null !== (r = e.coherenceManager) && void 0 !== r ? r : Ae;
 !function(e, t) {
 var r, o;
-return null !== (o = null === (r = at.get(e)) || void 0 === r ? void 0 : r.has(t)) && void 0 !== o && o;
+return null !== (o = null === (r = it.get(e)) || void 0 === r ? void 0 : r.has(t)) && void 0 !== o && o;
 }(o, n) ? (o.on("creep.died", function(e) {
 var t = {
 type: "creep",
 creepName: e.creepName,
 namespaces: [ "object", "role", "closest" ]
 }, r = n.invalidate(t);
-r > 0 && nt.debug("Invalidated ".concat(r, " cache entries for died creep ").concat(e.creepName));
+r > 0 && at.debug("Invalidated ".concat(r, " cache entries for died creep ").concat(e.creepName));
 }, {
 priority: 75
 }), o.on("structure.destroyed", function(e) {
@@ -46930,7 +46932,7 @@ roomName: t,
 structureType: r,
 namespaces: [ "roomFind" ]
 }, s = n.invalidate(i);
-nt.debug("Invalidated caches for destroyed ".concat(r, " in ").concat(t), {
+at.debug("Invalidated caches for destroyed ".concat(r, " in ").concat(t), {
 meta: {
 invalidated: s,
 structureType: r,
@@ -46951,7 +46953,7 @@ type: "room",
 roomName: t,
 namespaces: [ "roomFind" ]
 }, i = n.invalidate(a);
-nt.debug("Invalidated caches for completed ".concat(r, " in ").concat(t), {
+at.debug("Invalidated caches for completed ".concat(r, " in ").concat(t), {
 meta: {
 invalidated: i,
 structureType: r,
@@ -46966,7 +46968,7 @@ type: "room",
 roomName: t,
 namespaces: [ "closest", "roomFind" ]
 }, o = n.invalidate(r);
-nt.debug("Invalidated ".concat(o, " cache entries for hostile in ").concat(t), {
+at.debug("Invalidated ".concat(o, " cache entries for hostile in ").concat(t), {
 meta: {
 invalidated: o,
 roomName: t
@@ -46988,7 +46990,7 @@ var t = e.remoteRoom, r = {
 type: "room",
 roomName: t
 }, o = n.invalidate(r);
-nt.info("Invalidated ".concat(o, " cache entries for lost remote ").concat(t), {
+at.info("Invalidated ".concat(o, " cache entries for lost remote ").concat(t), {
 meta: {
 invalidated: o,
 remoteRoom: t
@@ -47011,7 +47013,7 @@ type: "room",
 roomName: t,
 namespaces: [ "roomFind", "path" ]
 }, o = n.invalidate(r);
-nt.info("Invalidated ".concat(o, " cache entries for RCL upgrade in ").concat(t), {
+at.info("Invalidated ".concat(o, " cache entries for RCL upgrade in ").concat(t), {
 meta: {
 invalidated: o,
 roomName: t,
@@ -47021,11 +47023,11 @@ newLevel: e.newLevel
 }, {
 priority: 50
 }), function(e, t) {
-var r = at.get(e);
-r || (r = new WeakSet, at.set(e, r)), r.add(t);
-}(o, n), nt.info("Cache event handlers initialized")) : nt.debug("Cache event handlers already initialized");
+var r = it.get(e);
+r || (r = new WeakSet, it.set(e, r)), r.add(t);
+}(o, n), at.info("Cache event handlers initialized")) : at.debug("Cache event handlers already initialized");
 }({
-eventBus: Le
+eventBus: De
 }), function(e, t, r) {
 e.on("structure.destroyed", function(e) {
 var o = t.getSwarmState(e.roomName);
@@ -47042,15 +47044,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Ii, Sr, Gy), iC.initializePathCacheEvents(), JT.initialize(sd.MEDIUM), fm = eC,
-Zt.initialize(), pT.initialize(), dC = !0), Sr.initialize();
-var r = vT.configureForCurrentTick();
-"critical" === r && Game.time % 10 == 0 && ml.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
+}(Gi, wr, Ly), sC.initializePathCacheEvents(), $T.initialize(cd.MEDIUM), ym = tC,
+Jt.initialize(), fT.initialize(), pC = !0), wr.initialize();
+var r = gT.configureForCurrentTick();
+"critical" === r && Game.time % 10 == 0 && dl.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = OT();
-if (!1 !== r.enabled && (r.lastRun = Game.time, AT(), function() {
-var e, t, r, o, n = kT(), a = n.footprintOperation, i = bT(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = kT();
+if (!1 !== r.enabled && (r.lastRun = Game.time, UT(), function() {
+var e, t, r, o, n = MT(), a = n.footprintOperation, i = OT(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -47063,15 +47065,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, MT(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, AT(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = OT();
+var e, t, r, n, i, s, c = kT();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : TT), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === CT ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : CT), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === ST ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -47089,10 +47091,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !UT())) try {
+}(), !_T())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || dy(s), "interShardPioneer" === c && my(s);
+"interShardClaimer" !== c && "interShardScout" !== c || py(s), "interShardPioneer" === c && dy(s);
 }
 } catch (t) {
 e = {
@@ -47106,18 +47108,18 @@ if (e) throw e.error;
 }
 }
 }();
-var n = Tt();
-if (0 === n.length) return Game.time % 100 == 0 && ml.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
+var n = Ct();
+if (0 === n.length) return Game.time % 100 == 0 && dl.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), ts.publishIdleTick(), void ml.flush();
-Game.time % 10 == 0 && ml.info("SwarmBot loop executing at tick ".concat(Game.time), {
+}), rs.publishIdleTick(), void dl.flush();
+Game.time % 10 == 0 && dl.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: dC
+systemsInitialized: pC
 }
-}), vT.ensureProcessesRegistered(), ts.startTick(), Rl.clear(), vT.startEventTick(),
-ts.measureSubsystem("taskBoard", function() {
-var e, t, r = kr(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
+}), gT.ensureProcessesRegistered(), rs.startTick(), El.clear(), gT.startEventTick(),
+rs.measureSubsystem("taskBoard", function() {
+var e, t, r = Mr(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
 try {
 for (var i = a(function(e) {
 var t = Math.max(1, Math.floor(e.interval));
@@ -47130,7 +47132,7 @@ rooms: n,
 interval: o
 })), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-mm.refreshRoom(c);
+dm.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -47143,20 +47145,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-}), ts.measureSubsystem("spawns", function() {
+}), rs.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = OT();
+var e, t, r, o = kT();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = AT();
+var n = UT();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : TT), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : CT), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== bT()) try {
+if (d !== OT()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = _f(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Nf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -47174,20 +47176,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = _T().sort(function(e, t) {
+var i = NT().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : TT), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : CT), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== bT()) {
+if (u !== OT()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = PT(u);
+var m = IT(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? DT(i, l, m) : BT() ? GT(i, u, m) : (LT(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (IT(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? BT(i, l, m) : FT() ? LT(i, u, m) : (DT(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (GT(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -47204,19 +47206,19 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = kT();
-d.footprintOperation = n, MT(d);
+var d = MT();
+d.footprintOperation = n, AT(d);
 }
 }
 })(), function(e) {
-var t, r, o = Game.cpu.bucket < kr().cpu.bucketThresholds.lowMode;
+var t, r, o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if (!o || mC(s)) {
-var c = eR(s, Sr.getOrInitSwarmState(s.name));
-ts.recordSpawnQueue(s.name, c.stats, c.spawned), ts.recordDefenseAssist(s.name, c.defenseAssist);
-} else ts.recordDefenseAssist(s.name, []);
+if (!o || dC(s)) {
+var c = tR(s, wr.getOrInitSwarmState(s.name));
+rs.recordSpawnQueue(s.name, c.stats, c.spawned), rs.recordDefenseAssist(s.name, c.defenseAssist);
+} else rs.recordDefenseAssist(s.name, []);
 }
 } catch (e) {
 t = {
@@ -47230,21 +47232,21 @@ if (t) throw t.error;
 }
 }
 }(n);
-}), Ol.preTick(), ts.measureSubsystem("processSync", function() {
-Sy.syncCreepProcesses(), bv.syncRoomProcesses();
-}), ts.measureSubsystem("kernel", function() {
-vT.runProcesses();
-}), ts.measureSubsystem("eventQueue", function() {
-vT.processQueuedEvents();
-}), ts.measureSubsystem("ss2PacketQueue", function() {
-nR.processQueue();
-}), Ii.hasCpuBudget() && ts.measureSubsystem("powerCreeps", function() {
+}), kl.preTick(), rs.measureSubsystem("processSync", function() {
+wy.syncCreepProcesses(), Ov.syncRoomProcesses();
+}), rs.measureSubsystem("kernel", function() {
+gT.runProcesses();
+}), rs.measureSubsystem("eventQueue", function() {
+gT.processQueuedEvents();
+}), rs.measureSubsystem("ss2PacketQueue", function() {
+aR.processQueue();
+}), Gi.hasCpuBudget() && rs.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && py(n);
+void 0 !== n.ticksToLive && fy(n);
 }
 } catch (t) {
 e = {
@@ -47258,18 +47260,18 @@ if (e) throw e.error;
 }
 }
 }();
-}), gT({
-hasCpuBudget: Ii.hasCpuBudget(),
+}), hT({
+hasCpuBudget: Gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && ts.measureSubsystem("visualizations", function() {
+}) && rs.measureSubsystem("visualizations", function() {
 var e;
 !function(e, t) {
 var r, o;
-if (kr().visualizations) {
+if (Mr().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = uC.getConfig(), s = lC.getConfig();
-uC.setConfig(n.roomVisualizerConfig), n.renderMap && lC.setConfig(n.mapVisualizerConfig);
+var i = lC.getConfig(), s = mC.getConfig();
+lC.setConfig(n.roomVisualizerConfig), n.renderMap && mC.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -47280,10 +47282,10 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-uC.draw(m);
+lC.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
-ml.error("Visualization error in ".concat(m.name, ": ").concat(d), {
+dl.error("Visualization error in ".concat(m.name, ": ").concat(d), {
 subsystem: "visualizations",
 room: m.name
 });
@@ -47302,19 +47304,19 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-lC.draw();
+mC.draw();
 } catch (e) {
-d = e instanceof Error ? e.message : String(e), ml.error("Map visualization error: ".concat(d), {
+d = e instanceof Error ? e.message : String(e), dl.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-uC.setConfig(i), lC.setConfig(s);
+lC.setConfig(i), mC.setConfig(s);
 }
 }
 }
 }(n, (e = {
-hasCpuBudget: Ii.hasCpuBudget(),
+hasCpuBudget: Gi.hasCpuBudget(),
 bucketMode: r,
 bucket: Game.cpu.bucket,
 ownedRoomCount: n.length
@@ -47394,35 +47396,26 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), Ol.reconcileTraffic(), gT({
-hasCpuBudget: Ii.hasCpuBudget(),
+}), kl.reconcileTraffic(), hT({
+hasCpuBudget: Gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && ts.measureSubsystem("scheduledTasks", function() {
+}) && rs.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), hd.run(e);
-}), Sr.persistHeapCache(), ts.collectProcessStats(Ii.getProcesses().reduce(function(e, t) {
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Rd.run(e);
+}), wr.persistHeapCache(), rs.collectProcessStats(Gi.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
-}, new Map)), ts.collectKernelBudgetStats(Ii), ts.setSkippedProcesses(Ii.getSkippedProcessesThisTick()),
-ts.finalizeTick(), ml.flush();
+}, new Map)), rs.collectKernelBudgetStats(Gi), rs.setSkippedProcesses(Gi.getSkippedProcessesThisTick()),
+rs.finalizeTick(), dl.flush();
 }
 
-var fC = function() {
+var yC = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
-var e = !kr().visualizations;
-return Mr({
+var e = !Mr().visualizations;
+return Ar({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = uC.getConfig(), r = Object.keys(t).filter(function(e) {
-return e.startsWith("show") && "boolean" == typeof t[e];
-});
-if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
-var o = e;
-uC.toggle(o);
-var n = uC.getConfig()[o];
-return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
-}, e.prototype.toggleMapVisualization = function(e) {
 var t = lC.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
@@ -47430,9 +47423,18 @@ if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.
 var o = e;
 lC.toggle(o);
 var n = lC.getConfig()[o];
+return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
+}, e.prototype.toggleMapVisualization = function(e) {
+var t = mC.getConfig(), r = Object.keys(t).filter(function(e) {
+return e.startsWith("show") && "boolean" == typeof t[e];
+});
+if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
+var o = e;
+mC.toggle(o);
+var n = mC.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = lC.getConfig();
+var e = mC.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -47442,13 +47444,13 @@ var t = [ "debug", "presentation", "minimal", "performance" ];
 return t.includes(e) ? (f.setMode(e), "Visualization mode set to: ".concat(e)) : "Invalid mode: ".concat(e, ". Valid modes: ").concat(t.join(", "));
 }, e.prototype.toggleVisLayer = function(e) {
 var t = {
-pheromones: Nt.Pheromones,
-paths: Nt.Paths,
-traffic: Nt.Traffic,
-defense: Nt.Defense,
-economy: Nt.Economy,
-construction: Nt.Construction,
-performance: Nt.Performance
+pheromones: Pt.Pheromones,
+paths: Pt.Paths,
+traffic: Pt.Traffic,
+defense: Pt.Defense,
+economy: Pt.Economy,
+construction: Pt.Construction,
+performance: Pt.Performance
 }, r = t[e.toLowerCase()];
 if (!r) return "Unknown layer: ".concat(e, ". Valid layers: ").concat(Object.keys(t).join(", "));
 f.toggleLayer(r);
@@ -47478,9 +47480,9 @@ return o;
 }, e.prototype.showVisConfig = function() {
 var e, t, r, o = f.getConfig(), n = "=== Visualization Configuration ===\n";
 n += "Mode: ".concat(o.mode, "\n"), n += "\nEnabled Layers:\n";
-var s = ((e = {})[Nt.Pheromones] = "Pheromones", e[Nt.Paths] = "Paths", e[Nt.Traffic] = "Traffic",
-e[Nt.Defense] = "Defense", e[Nt.Economy] = "Economy", e[Nt.Construction] = "Construction",
-e[Nt.Performance] = "Performance", e);
+var s = ((e = {})[Pt.Pheromones] = "Pheromones", e[Pt.Paths] = "Paths", e[Pt.Traffic] = "Traffic",
+e[Pt.Defense] = "Defense", e[Pt.Economy] = "Economy", e[Pt.Construction] = "Construction",
+e[Pt.Performance] = "Performance", e);
 try {
 for (var c = a(Object.entries(s)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1], p = parseInt(m, 10), y = 0 !== (o.enabledLayers & p);
@@ -47500,70 +47502,70 @@ if (t) throw t.error;
 return n;
 }, e.prototype.clearVisCache = function(e) {
 return f.clearCache(e), e ? "Visualization cache cleared for room: ".concat(e) : "All visualization caches cleared";
-}, n([ Xr({
+}, n([ Zr({
 name: "toggleVisualizations",
 description: "Toggle all visualizations on/off",
 usage: "toggleVisualizations()",
 examples: [ "toggleVisualizations()" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualizations", null), n([ Xr({
+}) ], e.prototype, "toggleVisualizations", null), n([ Zr({
 name: "toggleVisualization",
 description: "Toggle a specific room visualization feature",
 usage: "toggleVisualization(key)",
 examples: [ "toggleVisualization('showPheromones')", "toggleVisualization('showPaths')", "toggleVisualization('showCombat')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisualization", null), n([ Xr({
+}) ], e.prototype, "toggleVisualization", null), n([ Zr({
 name: "toggleMapVisualization",
 description: "Toggle a specific map visualization feature",
 usage: "toggleMapVisualization(key)",
 examples: [ "toggleMapVisualization('showRoomStatus')", "toggleMapVisualization('showConnections')", "toggleMapVisualization('showThreats')", "toggleMapVisualization('showExpansion')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleMapVisualization", null), n([ Xr({
+}) ], e.prototype, "toggleMapVisualization", null), n([ Zr({
 name: "showMapConfig",
 description: "Show current map visualization configuration",
 usage: "showMapConfig()",
 examples: [ "showMapConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showMapConfig", null), n([ Xr({
+}) ], e.prototype, "showMapConfig", null), n([ Zr({
 name: "setVisMode",
 description: "Set visualization mode preset (debug, presentation, minimal, performance)",
 usage: "setVisMode(mode)",
 examples: [ "setVisMode('debug')", "setVisMode('presentation')", "setVisMode('minimal')", "setVisMode('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "setVisMode", null), n([ Xr({
+}) ], e.prototype, "setVisMode", null), n([ Zr({
 name: "toggleVisLayer",
 description: "Toggle a specific visualization layer",
 usage: "toggleVisLayer(layer)",
 examples: [ "toggleVisLayer('pheromones')", "toggleVisLayer('paths')", "toggleVisLayer('defense')", "toggleVisLayer('economy')", "toggleVisLayer('performance')" ],
 category: "Visualization"
-}) ], e.prototype, "toggleVisLayer", null), n([ Xr({
+}) ], e.prototype, "toggleVisLayer", null), n([ Zr({
 name: "showVisPerf",
 description: "Show visualization performance metrics",
 usage: "showVisPerf()",
 examples: [ "showVisPerf()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisPerf", null), n([ Xr({
+}) ], e.prototype, "showVisPerf", null), n([ Zr({
 name: "showVisConfig",
 description: "Show current visualization configuration",
 usage: "showVisConfig()",
 examples: [ "showVisConfig()" ],
 category: "Visualization"
-}) ], e.prototype, "showVisConfig", null), n([ Xr({
+}) ], e.prototype, "showVisConfig", null), n([ Zr({
 name: "clearVisCache",
 description: "Clear visualization cache",
 usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), yC = function() {
+}(), vC = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = pT.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = fT.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = pT.getAllShards();
+var e, t, r = fT.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -47585,9 +47587,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (pT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (fT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = pT.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = fT.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -47612,19 +47614,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = pT.getOptimalPortalRoute(e, t);
+var r, o = fT.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (pT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (fT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (pT.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (fT.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Xf.getActiveRequests();
+var e, t, r = Zf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -47645,7 +47647,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = pT.getCurrentShardState();
+var e, t, r = fT.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -47666,7 +47668,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = pT.getActiveTransferTasks();
+var e, t, r, o = fT.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -47687,16 +47689,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = pT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(If, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = fT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Gf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = pT.getMemoryStats();
+var e = fT.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return pT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return fT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = kT().footprintOperation;
+var e, t, r, o = MT().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -47717,94 +47719,94 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }();
-}, n([ Xr({
+}, n([ Zr({
 name: "shard.status",
 description: "Display current shard status and metrics",
 usage: "shard.status()",
 examples: [ "shard.status()" ],
 category: "Shard"
-}) ], e.prototype, "status", null), n([ Xr({
+}) ], e.prototype, "status", null), n([ Zr({
 name: "shard.all",
 description: "List all known shards with summary info",
 usage: "shard.all()",
 examples: [ "shard.all()" ],
 category: "Shard"
-}) ], e.prototype, "all", null), n([ Xr({
+}) ], e.prototype, "all", null), n([ Zr({
 name: "shard.setRole",
 description: "Manually set the role for the current shard",
 usage: "shard.setRole(role)",
 examples: [ "shard.setRole('core')", "shard.setRole('frontier')", "shard.setRole('resource')", "shard.setRole('backup')", "shard.setRole('war')" ],
 category: "Shard"
-}) ], e.prototype, "setRole", null), n([ Xr({
+}) ], e.prototype, "setRole", null), n([ Zr({
 name: "shard.portals",
 description: "List all known portals from the current shard",
 usage: "shard.portals(targetShard?)",
 examples: [ "shard.portals()", "shard.portals('shard1')" ],
 category: "Shard"
-}) ], e.prototype, "portals", null), n([ Xr({
+}) ], e.prototype, "portals", null), n([ Zr({
 name: "shard.bestPortal",
 description: "Find the optimal portal route to a target shard",
 usage: "shard.bestPortal(targetShard, fromRoom?)",
 examples: [ "shard.bestPortal('shard1')", "shard.bestPortal('shard2', 'E1N1')" ],
 category: "Shard"
-}) ], e.prototype, "bestPortal", null), n([ Xr({
+}) ], e.prototype, "bestPortal", null), n([ Zr({
 name: "shard.createTask",
 description: "Create a cross-shard task",
 usage: "shard.createTask(type, targetShard, targetRoom?, priority?)",
 examples: [ "shard.createTask('colonize', 'shard1', 'E5N5', 80)", "shard.createTask('reinforce', 'shard2', 'W1N1', 90)", "shard.createTask('evacuate', 'shard0', 'E1N1', 100)" ],
 category: "Shard"
-}) ], e.prototype, "createTask", null), n([ Xr({
+}) ], e.prototype, "createTask", null), n([ Zr({
 name: "shard.transferResource",
 description: "Create a cross-shard resource transfer task",
 usage: "shard.transferResource(targetShard, targetRoom, resourceType, amount, priority?)",
 examples: [ "shard.transferResource('shard1', 'E5N5', 'energy', 50000, 70)", "shard.transferResource('shard2', 'W1N1', 'U', 5000, 80)" ],
 category: "Shard"
-}) ], e.prototype, "transferResource", null), n([ Xr({
+}) ], e.prototype, "transferResource", null), n([ Zr({
 name: "shard.transfers",
 description: "List active cross-shard resource transfers",
 usage: "shard.transfers()",
 examples: [ "shard.transfers()" ],
 category: "Shard"
-}) ], e.prototype, "transfers", null), n([ Xr({
+}) ], e.prototype, "transfers", null), n([ Zr({
 name: "shard.cpuHistory",
 description: "Display CPU allocation history for the current shard",
 usage: "shard.cpuHistory()",
 examples: [ "shard.cpuHistory()" ],
 category: "Shard"
-}) ], e.prototype, "cpuHistory", null), n([ Xr({
+}) ], e.prototype, "cpuHistory", null), n([ Zr({
 name: "shard.tasks",
 description: "List all inter-shard tasks",
 usage: "shard.tasks()",
 examples: [ "shard.tasks()" ],
 category: "Shard"
-}) ], e.prototype, "tasks", null), n([ Xr({
+}) ], e.prototype, "tasks", null), n([ Zr({
 name: "shard.syncStatus",
 description: "Display InterShardMemory sync status and health",
 usage: "shard.syncStatus()",
 examples: [ "shard.syncStatus()" ],
 category: "Shard"
-}) ], e.prototype, "syncStatus", null), n([ Xr({
+}) ], e.prototype, "syncStatus", null), n([ Zr({
 name: "shard.memoryStats",
 description: "Display InterShardMemory size breakdown",
 usage: "shard.memoryStats()",
 examples: [ "shard.memoryStats()" ],
 category: "Shard"
-}) ], e.prototype, "memoryStats", null), n([ Xr({
+}) ], e.prototype, "memoryStats", null), n([ Zr({
 name: "shard.forceSync",
 description: "Force a full InterShardMemory sync with validation",
 usage: "shard.forceSync()",
 examples: [ "shard.forceSync()" ],
 category: "Shard"
-}) ], e.prototype, "forceSync", null), n([ Xr({
+}) ], e.prototype, "forceSync", null), n([ Zr({
 name: "shard.footprint",
 description: "Display peaceful all-shard footprint/colonization operation status",
 usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), vC = new yC;
+}(), gC = new vC;
 
-function gC(e) {
+function hC(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -47825,7 +47827,7 @@ desc: "Parameter: ".concat(e)
 function e() {}
 e.prototype.uiHelp = function(e) {
 return e ? function(e) {
-var t = Qr.getCommandsByCategory(), r = t.get(e);
+var t = Xr.getCommandsByCategory(), r = t.get(e);
 if (!r || 0 === r.length) return 'Category "'.concat(e, '" not found. Available categories: ').concat(Array.from(t.keys()).join(", "));
 var o = r.map(function(e) {
 var t, r;
@@ -47834,16 +47836,16 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? gC(e.metadata.usage) : void 0
+params: e.metadata.usage ? hC(e.metadata.usage) : void 0
 };
 });
-return Od({
+return kd({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
 });
 }(e) : function() {
-var e, t, r = Qr.getCommandsByCategory(), o = [];
+var e, t, r = Xr.getCommandsByCategory(), o = [];
 try {
 for (var n = a(r), c = n.next(); !c.done; c = n.next()) {
 var u = i(c.value, 2), l = u[0], m = u[1].map(function(e) {
@@ -47888,12 +47890,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return Od.apply(void 0, s([], i(o), !1));
+return kd.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return wd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return xd("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return bd.form("spawnCreep", [ {
+return Od.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -47927,20 +47929,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return wd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return xd("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += wd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += wd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += bd.button({
+o += '<div style="margin-bottom: 10px;">', o += xd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += xd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Od.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += bd.button({
+}), o += " ", (o += Od.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return bd.form("configureLogging", [ {
+return Od.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -47965,7 +47967,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return bd.form("configureVisualization", [ {
+return Od.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -47989,55 +47991,55 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += bd.button({
+e += Od.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += bd.button({
+}), e += " ", (e += Od.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += wd("✓ Success message", "green", !0) + "\n", e += wd("⚠ Warning message", "yellow", !0) + "\n",
-e += wd("✗ Error message", "red", !0) + "\n", e += wd("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + wd("colored text", "green") + " normal text\n") + "Bold text: " + wd("important", null, !0) + "\n";
-}, n([ Xr({
+return e += xd("✓ Success message", "green", !0) + "\n", e += xd("⚠ Warning message", "yellow", !0) + "\n",
+e += xd("✗ Error message", "red", !0) + "\n", e += xd("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + xd("colored text", "green") + " normal text\n") + "Bold text: " + xd("important", null, !0) + "\n";
+}, n([ Zr({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
 usage: "uiHelp()",
 examples: [ "uiHelp()", 'uiHelp("Logging")', 'uiHelp("Visualization")' ],
 category: "System"
-}) ], e.prototype, "uiHelp", null), n([ Xr({
+}) ], e.prototype, "uiHelp", null), n([ Zr({
 name: "spawnForm",
 description: "Show interactive form for spawning creeps",
 usage: "spawnForm(roomName)",
 examples: [ 'spawnForm("W1N1")', 'spawnForm("E2S3")' ],
 category: "Spawning"
-}) ], e.prototype, "spawnForm", null), n([ Xr({
+}) ], e.prototype, "spawnForm", null), n([ Zr({
 name: "roomControl",
 description: "Show interactive room control panel",
 usage: "roomControl(roomName)",
 examples: [ 'roomControl("W1N1")' ],
 category: "Room Management"
-}) ], e.prototype, "roomControl", null), n([ Xr({
+}) ], e.prototype, "roomControl", null), n([ Zr({
 name: "logForm",
 description: "Show interactive form for configuring logging",
 usage: "logForm()",
 examples: [ "logForm()" ],
 category: "Logging"
-}) ], e.prototype, "logForm", null), n([ Xr({
+}) ], e.prototype, "logForm", null), n([ Zr({
 name: "visForm",
 description: "Show interactive form for visualization settings",
 usage: "visForm()",
 examples: [ "visForm()" ],
 category: "Visualization"
-}) ], e.prototype, "visForm", null), n([ Xr({
+}) ], e.prototype, "visForm", null), n([ Zr({
 name: "quickActions",
 description: "Show quick action buttons for common operations",
 usage: "quickActions()",
 examples: [ "quickActions()" ],
 category: "System"
-}) ], e.prototype, "quickActions", null), n([ Xr({
+}) ], e.prototype, "quickActions", null), n([ Zr({
 name: "colorDemo",
 description: "Show color demonstration for console output",
 usage: "colorDemo()",
@@ -48046,39 +48048,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var hC = new kv, RC = new fC, EC = new Mv, TC = new dl, CC = new Ov, SC = new Av, wC = new Uv, xC = "__screepsGlobalRuntimeDiagnostics";
+var RC = new Mv, EC = new yC, TC = new Av, CC = new pl, SC = new kv, wC = new Uv, xC = new _v, bC = "__screepsGlobalRuntimeDiagnostics";
 
-function bC() {
+function OC() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function OC(e, t) {
+function kC(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function kC(e, t) {
+function MC(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function MC(e) {
+function AC(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function AC(e) {
+function UC(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: OC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: OC(n.switchCount, 0),
-lastTick: kC(n.lastTick, Game.time),
-lastResetTick: kC(n.lastResetTick, Game.time),
-lastSwitchTick: MC(n.lastSwitchTick),
-lastSwitchPreviousTick: MC(n.lastSwitchPreviousTick),
-lastWarningTick: MC(n.lastWarningTick)
+resetCount: kC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: kC(n.switchCount, 0),
+lastTick: MC(n.lastTick, Game.time),
+lastResetTick: MC(n.lastResetTick, Game.time),
+lastSwitchTick: AC(n.lastSwitchTick),
+lastSwitchPreviousTick: AC(n.lastSwitchPreviousTick),
+lastWarningTick: AC(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -48092,33 +48094,33 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var UC = ul("Main");
+var _C = ll("Main");
 
-xr.register(), function(e) {
+br.register(), function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Qr.initialize(), Zr(hC), Zr(RC), Zr(EC), Zr(TC), Zr(CC), Zr(SC), Zr(wC), Zr(Bu),
-Zr(Fu), Zr(Wu), Zr(vC), Zr(oo), Zr(Ac), Zr(au), global.tooangel = ou;
+Xr.initialize(), Jr(RC), Jr(EC), Jr(TC), Jr(CC), Jr(SC), Jr(wC), Jr(xC), Jr(Fu),
+Jr(Wu), Jr(Hu), Jr(gC), Jr(no), Jr(Uc), Jr(iu), global.tooangel = nu;
 var e = global;
 e.botConfig = {
-getConfig: kr,
-updateConfig: Mr
+getConfig: Mr,
+updateConfig: Ar
 }, e.botLogger = {
-configureLogger: Qu
-}, e.botVisualizationManager = f, e.botCacheManager = Re, Qr.exposeToGlobal();
+configureLogger: Xu
+}, e.botVisualizationManager = f, e.botCacheManager = Ee, Xr.exposeToGlobal();
 };
-e ? (Qr.initialize(), Qr.enableLazyLoading(t), Qr.exposeToGlobal()) : t();
-}(kr().lazyLoadConsoleCommands), exports.loop = function() {
+e ? (Xr.initialize(), Xr.enableLazyLoading(t), Xr.exposeToGlobal()) : t();
+}(Mr().lazyLoadConsoleCommands), exports.loop = function() {
 try {
-xr.run(), function(e) {
+br.run(), function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : bC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[xC];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : OC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[bC];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[xC] = s, function(e, t) {
-var r, o = AC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[bC] = s, function(e, t) {
+var r, o = UC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -48136,7 +48138,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = AC(e.heapId);
+var n, a = UC(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -48157,14 +48159,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = AC(s.heapId);
+var u = UC(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 }({
-logger: UC
-}), pC();
+logger: _C
+}), fC();
 } catch (e) {
-throw UC.error("Critical error in main loop: ".concat(String(e)), {
+throw _C.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-defense/src/tower/targetSelection.ts
+++ b/packages/screeps-defense/src/tower/targetSelection.ts
@@ -1,3 +1,4 @@
+import { filterKnownAllyCreeps } from "../alliance/nonAggressionPact";
 import type { TowerTargetOptions } from "./policyTypes";
 
 /**
@@ -6,12 +7,15 @@ import type { TowerTargetOptions } from "./policyTypes";
  * The score favors creeps that can heal, fight, claim, or dismantle. When two
  * hostiles have equal tactical priority, wounded creeps are preferred so towers
  * finish kills instead of spreading damage.
+ *
+ * The policy filters allies at its public boundary instead of trusting every
+ * caller to have already filtered raw FIND_HOSTILE_CREEPS results.
  */
 export function selectTowerTarget(hostiles: Creep[], options: TowerTargetOptions = {}): Creep | null {
   const preferWoundedTargets = options.preferWoundedTargets !== false;
   let bestTarget: Creep | null = null;
 
-  for (const hostile of hostiles) {
+  for (const hostile of filterKnownAllyCreeps(hostiles)) {
     if (!bestTarget || compareTowerTargets(hostile, bestTarget, preferWoundedTargets) < 0) {
       bestTarget = hostile;
     }

--- a/packages/screeps-defense/test/towerActionPolicy.test.ts
+++ b/packages/screeps-defense/test/towerActionPolicy.test.ts
@@ -59,6 +59,38 @@ describe("tower action policy", () => {
     expect(target).to.equal(woundedRanger);
   });
 
+  it("fails closed for permanent allies and selects only a real hostile", () => {
+    const ally = hostile("ally", { [HEAL]: 1 });
+    (ally as any).owner = { username: "TooAngel" };
+    const enemy = hostile("enemy", { [ATTACK]: 1 });
+
+    expect(selectTowerTarget([ally])).to.equal(null);
+    expect(selectTowerTarget([ally, enemy])).to.equal(enemy);
+  });
+
+  it("fails closed for configured allies in tower actions", () => {
+    const previousMemory = (globalThis as any).Memory;
+    const configuredAlly = hostile("configured-ally", { [ATTACK]: 1 });
+    (configuredAlly as any).owner = { username: "FriendlyNeighbor" };
+
+    try {
+      (globalThis as any).Memory = { empire: { diplomacy: { allies: ["FriendlyNeighbor"] } } };
+      const action = selectTowerAction({
+        tower: tower(),
+        hostiles: [configuredAlly],
+        posture: "eco",
+        rcl: 8,
+        danger: 1,
+        isCombatPosture: false,
+        wallRepairTarget: 1000,
+      });
+
+      expect(action).to.deep.equal({ type: "idle" });
+    } finally {
+      (globalThis as any).Memory = previousMemory;
+    }
+  });
+
   it("allows wounded hostile tie-breaker rollback", () => {
     const fullRanger = hostile("full-ranger", { [RANGED_ATTACK]: 1 }, false, 500, 500);
     const woundedRanger = hostile("wounded-ranger", { [RANGED_ATTACK]: 1 }, false, 125, 500);

--- a/packages/screeps-server/Dockerfile
+++ b/packages/screeps-server/Dockerfile
@@ -26,7 +26,10 @@ RUN apt-get update \
 
 WORKDIR /screeps
 COPY packages/screeps-server/docker-entrypoint.sh /usr/local/bin/screeps-ci-entrypoint
-RUN chmod +x /usr/local/bin/screeps-ci-entrypoint \
+COPY packages/screeps-server/steam-webapi-ci-stub.cjs /tmp/steam-webapi-ci-stub.cjs
+RUN cp /tmp/steam-webapi-ci-stub.cjs /usr/local/lib/node_modules/screeps/node_modules/steam-webapi/index.js \
+  && rm /tmp/steam-webapi-ci-stub.cjs \
+  && chmod +x /usr/local/bin/screeps-ci-entrypoint \
   && useradd --create-home --shell /bin/bash screeps \
   && chown -R screeps:screeps /screeps
 

--- a/packages/screeps-server/steam-webapi-ci-stub.cjs
+++ b/packages/screeps-server/steam-webapi-ci-stub.cjs
@@ -1,0 +1,14 @@
+"use strict";
+
+/**
+ * Offline private-server smoke tests never authenticate through Steam.
+ * Keep the pinned server from retrying an unavailable external API and
+ * starving the local game loop while token-authenticated test users run.
+ */
+function SteamWebApi() {}
+
+SteamWebApi.ready = function ready(callback) {
+  if (typeof callback === "function") callback(null);
+};
+
+module.exports = SteamWebApi;

--- a/packages/screeps-server/test/scripts/steam-webapi-ci-stub.test.ts
+++ b/packages/screeps-server/test/scripts/steam-webapi-ci-stub.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const SteamWebApi = require("../../steam-webapi-ci-stub.cjs") as {
+  ready: (callback: (error: Error | null) => void) => void;
+};
+
+describe("offline private-server Steam API stub", () => {
+  it("starts the server without an external Steam request", () => {
+    let callbackError: Error | null | undefined;
+
+    SteamWebApi.ready(error => {
+      callbackError = error;
+    });
+
+    expect(callbackError).to.equal(null);
+  });
+
+  it("is installed only by the private-server CI image", () => {
+    const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+
+    expect(dockerfile).to.include("steam-webapi-ci-stub.cjs");
+    expect(dockerfile).to.include("/usr/local/lib/node_modules/screeps/node_modules/steam-webapi/index.js");
+  });
+});


### PR DESCRIPTION
## Summary

Harden the framework tower policy so ally safety is enforced at the public target-selection boundary, and make the offline private-server smoke environment deterministic.

## Linked issues

Closes #3400
Refs #3402

## Research

- Repository alliance contract in `AGENTS.md` and ROADMAP Section 25.
- Shared `filterKnownAllyCreeps` implementation in `@ralphschuler/screeps-core`.
- Official Screeps API docs fetched directly for current API reference; SearXNG backend was unavailable (HTTP 403).
- CI rerun evidence showed repeated unavailable Steam Web API 403 responses and stalled runtime warmup; local Node 24 smoke reproduced the valid path after the CI-only stub.

## Changes

- Filter permanent and runtime-configured allies before tower target scoring.
- Add regression coverage for permanent allies, configured allies, mixed ally/enemy input, and idle action behavior.
- Install a CI-only `steam-webapi` stub in the private-server image so offline smoke does not retry unavailable external authentication.
- Add a server-package regression test for the stub/image contract.

## Defense impact

- Threat detection: unchanged.
- Defensive response: tower action policy cannot attack known allies even when passed raw hostile arrays.
- Construction adaptation: unchanged.
- Recovery: unchanged.
- CPU/Memory impact: one bounded ally-filter pass per target-selection call; CI-only stub removes external retry load from test infrastructure.

## Tests

- `npm test -w @ralphschuler/screeps-defense` — 106 passing.
- `npm run lint -w @ralphschuler/screeps-defense -- --max-warnings=0` — pass.
- `npm run build -w @ralphschuler/screeps-defense` — pass.
- `npm run check:alliance-safety` — pass.
- `npm run typecheck -w @ralphschuler/screeps-server` — pass.
- Offline private-server smoke with stub — 47/47 assertions, 0 skipped, 0 failed, 1,231 ticks.
- CI rerun before stub failed with 37 skipped checks after only 98 ticks; strict validation was preserved.

## Live evidence

No live tactical details included. Current bounded read-only shard1 observation found no incoming nukes and excluded configured permanent allies from hostile sightings. Live artifacts remain untracked and are not included in this PR.

## Deployment impact

Safe runtime policy hardening. Deploy after required checks pass.

## Follow-up issues

- #3371 remains the next P1 nuke-observation consolidation slice.
- #3347 remains the broader diagnostics/transport follow-up.
