### PR TITLE
fix(defense): unify incoming nuke evacuation handling

### DIFF
--- a/docs/NUKE_EXAMPLES.md
+++ b/docs/NUKE_EXAMPLES.md
@@ -155,12 +155,13 @@ detectIncomingNukes()
 // Log: "INCOMING NUKE DETECTED in W1N1! Landing at (25, 25), 
 //       impact in 50000 ticks. Source: W5N5. Threatened structures: 2"
 
-// Critical structures threatened (spawn, storage):
-triggerEvacuation(room, alert)
-
-// timeToLand = 50000 >= 5000
-// → posture: "defensive" (prepare, not evacuate yet)
-// → pheromones.defense: 100
+// Critical structures are recorded in the persisted alert. The room defense
+// coordinator forwards its same-tick nuke snapshot to emergency handling, while
+// EvacuationManager consumes Memory.empire.incomingNukes without rescanning.
+//
+// impactTick is the authoritative deadline. Evacuation starts only when:
+// impactTick - Game.time <= nukeEvacuationLeadTime (default: 5000 ticks).
+// At 50000 ticks remaining, the room stays in defensive preparation posture.
 
 // Log: "NUKE DEFENSE PREPARATION in W1N1: 
 //       Critical structures in blast radius"

--- a/packages/@ralphschuler/screeps-empire/src/nuke/defense.ts
+++ b/packages/@ralphschuler/screeps-empire/src/nuke/defense.ts
@@ -5,40 +5,10 @@
  */
 
 import { logger } from "@ralphschuler/screeps-core";
-import type { IncomingNukeAlert, EmpireMemory, SwarmState } from "../types";
+import type { EmpireMemory, SwarmState } from "../types";
 import { isKnownAllyNukeTarget } from "./allySafety";
 import type { NukeConfig } from "./types";
 import { NUKE_COST } from "./types";
-
-/**
- * Trigger evacuation procedures for a room under nuke threat
- */
-export function triggerEvacuation(
-  room: Room,
-  alert: IncomingNukeAlert,
-  swarm: SwarmState
-): void {
-  // Update posture to evacuate if impact is imminent
-  if (alert.timeToLand < 5000) {
-    swarm.posture = "evacuate";
-    logger.warn(
-      `EVACUATION TRIGGERED for ${room.name}: Critical structures threatened by nuke!`,
-      { subsystem: "Nuke" }
-    );
-  } else {
-    // Set defensive posture and prepare
-    if (swarm.posture !== "war" && swarm.posture !== "evacuate") {
-      swarm.posture = "defensive";
-    }
-    logger.warn(
-      `NUKE DEFENSE PREPARATION in ${room.name}: Critical structures in blast radius`,
-      { subsystem: "Nuke" }
-    );
-  }
-
-  // Increase defense pheromone
-  swarm.pheromones.defense = 100;
-}
 
 /**
  * Process counter-nuke strategies

--- a/packages/@ralphschuler/screeps-empire/src/nuke/detection.ts
+++ b/packages/@ralphschuler/screeps-empire/src/nuke/detection.ts
@@ -224,16 +224,3 @@ export function identifyThreatenedStructures(room: Room, landingPos: RoomPositio
 
   return threatened;
 }
-
-/**
- * Check if an alert contains critical structures
- */
-export function hasCriticalStructuresThreatened(alert: IncomingNukeAlert): boolean {
-  if (!alert.threatenedStructures) return false;
-  
-  return alert.threatenedStructures.some(s => 
-    s.includes(STRUCTURE_SPAWN) || 
-    s.includes(STRUCTURE_STORAGE) || 
-    s.includes(STRUCTURE_TERMINAL)
-  );
-}

--- a/packages/@ralphschuler/screeps-empire/src/nuke/index.ts
+++ b/packages/@ralphschuler/screeps-empire/src/nuke/index.ts
@@ -8,8 +8,8 @@ import { logger } from "@ralphschuler/screeps-core";
 import { terminalManager } from "@ralphschuler/screeps-economy";
 import type { NukeConfig } from "./types";
 import { DEFAULT_NUKE_CONFIG } from "./types";
-import { detectIncomingNukes, hasCriticalStructuresThreatened } from "./detection";
-import { triggerEvacuation, processCounterNukeStrategies, canAffordNuke } from "./defense";
+import { detectIncomingNukes } from "./detection";
+import { processCounterNukeStrategies, canAffordNuke } from "./defense";
 import { evaluateNukeCandidates } from "./targeting";
 import { loadNukers, manageNukeResources, createResourceTransferRequest } from "./logistics";
 import {
@@ -70,7 +70,6 @@ export class NukeCoordinator {
     initializeNukeTracking(empire);
     const defensiveStart = this.getCpuUsed();
     detectIncomingNukes(empire, this.getSwarmState);
-    this.handleEvacuations(empire);
     this.recordCpu("defensiveObservationCpu", defensiveStart);
 
     if (!offensive) {
@@ -140,29 +139,6 @@ export class NukeCoordinator {
     const current = this.getCpuUsed();
     if (current === undefined) return;
     logger.stat?.(key, Math.max(0, current - start), "cpu", { subsystem: "Nuke" });
-  }
-
-  /**
-   * Handle evacuation triggers for rooms with incoming nukes
-   */
-  private handleEvacuations(empire: EmpireMemory): void {
-    if (!empire.incomingNukes) return;
-
-    for (const alert of empire.incomingNukes) {
-      if (alert.evacuationTriggered) continue;
-
-      const hasCriticalStructures = hasCriticalStructuresThreatened(alert);
-      if (!hasCriticalStructures) continue;
-
-      const room = Game.rooms[alert.roomName];
-      if (!room) continue;
-
-      const swarm = this.getSwarmState(alert.roomName);
-      if (!swarm) continue;
-
-      triggerEvacuation(room, alert, swarm);
-      alert.evacuationTriggered = true;
-    }
   }
 
   /**

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -8129,9 +8129,11 @@ isDismantler: R
 };
 }
 
-function Wo(e) {
-var t, r, o = Z(e), n = e.find(FIND_NUKES);
-if (0 === o.length && 0 === n.length) return {
+function Wo(e, t) {
+var r, o, n, i;
+void 0 === t && (t = {});
+var s = null !== (n = t.hostiles) && void 0 !== n ? n : Z(e), c = null !== (i = t.nukes) && void 0 !== i ? i : e.find(FIND_NUKES);
+if (0 === s.length && 0 === c.length) return {
 roomName: e.name,
 dangerLevel: 0,
 threatScore: 0,
@@ -8148,42 +8150,42 @@ assistanceRequired: !1,
 assistancePriority: 0,
 recommendedResponse: "monitor"
 };
-var i = 0, s = 0, c = 0, u = 0, l = 0, m = 0, d = 0, p = 0, f = function() {
+var u = 0, l = 0, m = 0, d = 0, p = 0, f = 0, y = 0, v = 0, g = function() {
 var e;
 return "undefined" == typeof Memory || !1 !== (null === (e = Memory.defenseSettings) || void 0 === e ? void 0 : e.workPartThreatScoring);
 }();
 try {
-for (var y = a(o), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = Fo(g, {
-scoreWorkPartThreats: f
+for (var h = a(s), R = h.next(); !R.done; R = h.next()) {
+var E = R.value, T = Fo(E, {
+scoreWorkPartThreats: g
 });
-s += h.dps, c += g.hits, i += h.scoreContribution, h.isBoosted && u++, h.isHealer && l++,
-h.isRanged && m++, h.isMelee && d++, h.isDismantler && p++;
+l += T.dps, m += E.hits, u += T.scoreContribution, T.isBoosted && d++, T.isHealer && p++,
+T.isRanged && f++, T.isMelee && y++, T.isDismantler && v++;
 }
 } catch (e) {
-t = {
+r = {
 error: e
 };
 } finally {
 try {
-v && !v.done && (r = y.return) && r.call(y);
+R && !R.done && (o = h.return) && o.call(h);
 } finally {
-if (t) throw t.error;
+if (r) throw r.error;
 }
 }
-var R, E = e.find(FIND_MY_STRUCTURES, {
+var C, S = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_TOWER;
 }
-}), T = 0 === o.length ? 0 : E.reduce(function(e, t) {
-var r, n, a = t;
-if (a.structureType !== STRUCTURE_TOWER) return e;
-if ((null !== (n = null === (r = a.store) || void 0 === r ? void 0 : r.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0) < 10) return e;
-var i, s = o.reduce(function(e, r) {
+}), w = 0 === s.length ? 0 : S.reduce(function(e, t) {
+var r, o, n = t;
+if (n.structureType !== STRUCTURE_TOWER) return e;
+if ((null !== (o = null === (r = n.store) || void 0 === r ? void 0 : r.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== o ? o : 0) < 10) return e;
+var a, i = s.reduce(function(e, r) {
 return e + t.pos.getRangeTo(r.pos);
 }, 0);
-return e + ((i = s / o.length) <= 5 ? 600 : i >= 20 ? 150 : 600 - 30 * (i - 5));
-}, 0), C = s > 1.5 * T, S = Math.min(100, Math.max(0, (s - T) / 10)), w = function(e, t, r) {
+return e + ((a = i / s.length) <= 5 ? 600 : a >= 20 ? 150 : 600 - 30 * (a - 5));
+}, 0), x = l > 1.5 * w, b = Math.min(100, Math.max(0, (l - w) / 10)), O = function(e, t, r) {
 if (Array.isArray(e)) {
 var o = e.reduce(function(e, t) {
 return e + Vo(t.body.filter(function(e) {
@@ -8199,26 +8201,26 @@ var n = Qo("guard"), a = Qo("ranger"), i = Xo(n), s = Xo(a), c = (i.avgDps + s.a
 t = null != t ? t : c, r = null != r ? r : u;
 }
 return t <= 0 && (t = 300, r = 1300), Math.ceil(e / t) * r;
-}(s), x = Math.max(1, function(e) {
+}(l), k = Math.max(1, function(e) {
 return 0 === e || e < Ho ? 0 : e < Ko ? 1 : e < Yo ? 2 : 3;
-}(i));
-return R = i < 100 ? "monitor" : i < 500 && !C ? "defend" : C && i < 1e3 ? "assist" : i > 1e3 || u > 3 ? "safemode" : "defend",
-n.length > 0 && (i += 500, R = "safemode", x = 3), {
+}(u));
+return C = u < 100 ? "monitor" : u < 500 && !x ? "defend" : x && u < 1e3 ? "assist" : u > 1e3 || d > 3 ? "safemode" : "defend",
+c.length > 0 && (u += 500, C = "safemode", k = 3), {
 roomName: e.name,
-dangerLevel: x,
-threatScore: i,
-hostileCount: o.length,
-totalHostileHitPoints: c,
-totalHostileDPS: s,
-healerCount: l,
-rangedCount: m,
-meleeCount: d,
-boostedCount: u,
-dismantlerCount: p,
-estimatedDefenderCost: w,
-assistanceRequired: C,
-assistancePriority: S,
-recommendedResponse: R
+dangerLevel: k,
+threatScore: u,
+hostileCount: s.length,
+totalHostileHitPoints: m,
+totalHostileDPS: l,
+healerCount: p,
+rangedCount: f,
+meleeCount: y,
+boostedCount: d,
+dismantlerCount: v,
+estimatedDefenderCost: O,
+assistanceRequired: x,
+assistancePriority: b,
+recommendedResponse: C
 };
 }
 
@@ -12437,42 +12439,45 @@ var Ci = function() {
 function e() {
 this.emergencyStates = new Map;
 }
-return e.prototype.assess = function(e, t) {
-var r, o, n = this.emergencyStates.get(e.name), a = this.calculateEmergencyLevel(e, t);
-if (a === yi.NONE && this.clearBoostPriority(e.name), a === yi.NONE && !n) return {
+return e.prototype.assess = function(e, t, r) {
+var o, n, a = this.emergencyStates.get(e.name), i = this.calculateEmergencyLevel(e, t, r);
+if (i === yi.NONE && this.clearBoostPriority(e.name), i === yi.NONE && !a) return {
 level: yi.NONE,
 startedAt: Game.time,
 assistanceRequested: !1,
 boostsAllocated: !1,
 lastEscalation: 0
 };
-var i = null !== (r = null == n ? void 0 : n.level) && void 0 !== r ? r : yi.NONE;
-return n ? (o = n).level = a : (o = {
-level: a,
+var s = null !== (o = null == a ? void 0 : a.level) && void 0 !== o ? o : yi.NONE;
+return a ? (n = a).level = i : (n = {
+level: i,
 startedAt: Game.time,
 assistanceRequested: !1,
 boostsAllocated: !1,
 lastEscalation: 0
-}, this.emergencyStates.set(e.name, o)), a === yi.NONE ? (n && (U.info("Emergency resolved in ".concat(e.name), {
+}, this.emergencyStates.set(e.name, n)), i === yi.NONE ? (a && (U.info("Emergency resolved in ".concat(e.name), {
 subsystem: "Defense"
-}), this.emergencyStates.delete(e.name)), o) : (n && a > i && (U.warn("Emergency escalated in ".concat(e.name, ": Level ").concat(i, " → ").concat(a), {
+}), this.emergencyStates.delete(e.name)), n) : (a && i > s && (U.warn("Emergency escalated in ".concat(e.name, ": Level ").concat(s, " → ").concat(i), {
 subsystem: "Defense"
-}), o.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, o), o);
-}, e.prototype.calculateEmergencyLevel = function(e, t) {
-var r = Z(e), o = e.find(FIND_MY_STRUCTURES, {
+}), n.lastEscalation = Game.time), this.executeEmergencyResponse(e, t, n), n);
+}, e.prototype.calculateEmergencyLevel = function(e, t, r) {
+var o = Z(e), n = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return (e.structureType === STRUCTURE_SPAWN || e.structureType === STRUCTURE_STORAGE || e.structureType === STRUCTURE_TERMINAL) && e.hits < .3 * e.hitsMax;
 }
-}), n = e.find(FIND_NUKES);
-if (0 === t.danger && 0 === r.length && 0 === o.length && 0 === n.length) return yi.NONE;
-var a = po(e), i = vo(e), s = Wo(e);
-if (o.length > 0 || n.length > 0) return yi.CRITICAL;
-var c = r.filter(function(e) {
+}), a = null != r ? r : e.find(FIND_NUKES);
+if (0 === t.danger && 0 === o.length && 0 === n.length && 0 === a.length) return yi.NONE;
+var i = po(e), s = vo(e), c = Wo(e, {
+hostiles: o,
+nukes: a
+});
+if (n.length > 0 || a.length > 0) return yi.CRITICAL;
+var u = o.filter(function(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && e.boost;
 });
-}), u = Math.max(0, a.guards - i.guards) + Math.max(0, a.rangers - i.rangers) + Math.max(0, a.healers - i.healers);
-return c.length > 0 && u >= 2 || r.length >= 5 && 0 === i.guards && 0 === i.rangers || s.dangerLevel >= 2 && u >= 2 ? yi.HIGH : (t.danger >= 2 || s.dangerLevel >= 2) && u >= 1 ? yi.MEDIUM : t.danger >= 1 || r.length > 0 ? yi.LOW : yi.NONE;
+}), l = Math.max(0, i.guards - s.guards) + Math.max(0, i.rangers - s.rangers) + Math.max(0, i.healers - s.healers);
+return u.length > 0 && l >= 2 || o.length >= 5 && 0 === s.guards && 0 === s.rangers || c.dangerLevel >= 2 && l >= 2 ? yi.HIGH : (t.danger >= 2 || c.dangerLevel >= 2) && l >= 1 ? yi.MEDIUM : t.danger >= 1 || o.length > 0 ? yi.LOW : yi.NONE;
 }, e.prototype.executeEmergencyResponse = function(e, t, r) {
 r.level >= yi.LOW && this.requestDefenseAssistance(e, t) && (r.assistanceRequested = !0),
 r.level >= yi.MEDIUM && !r.boostsAllocated && e.controller && e.controller.level >= 6 && (this.allocateBoostsForDefense(e, t),
@@ -12760,37 +12765,49 @@ void 0 !== e.deadline && (r.deadline = e.deadline), t.evacuationIntent = r;
 var t = wr.getSwarmState(e);
 t && delete t.evacuationIntent;
 }, e.prototype.checkEvacuationTriggers = function() {
-var e, t, r, o;
-for (var n in Game.rooms) {
-var a = Game.rooms[n];
-if ((null === (e = a.controller) || void 0 === e ? void 0 : e.my) && !this.evacuations.has(n)) {
-var i = wr.getSwarmState(n);
-if (i) {
-var s = a.find(FIND_NUKES);
-if (s.length > 0) {
-var c = s.reduce(function(e, t) {
-var r, o;
-return (null !== (r = e.timeToLand) && void 0 !== r ? r : 1 / 0) < (null !== (o = t.timeToLand) && void 0 !== o ? o : 1 / 0) ? e : t;
-});
-if ((null !== (t = c.timeToLand) && void 0 !== t ? t : 1 / 0) <= this.config.nukeEvacuationLeadTime) {
-i.nukeDetected || (i.nukeDetected = !0);
-var u = s.length;
-U.warn("Triggering evacuation for ".concat(n, ": ").concat(u, " nuke(s) detected, impact in ").concat(null !== (r = c.timeToLand) && void 0 !== r ? r : 0, " ticks"), {
+var e, t, r = this, o = function(o) {
+var i, s, c = Game.rooms[o];
+if (!(null === (e = c.controller) || void 0 === e ? void 0 : e.my)) return "continue";
+if (n.evacuations.has(o)) return "continue";
+var u = wr.getSwarmState(o);
+if (!u) return "continue";
+var l = (null !== (t = wr.getEmpire().incomingNukes) && void 0 !== t ? t : []).filter(function(e) {
+return e.roomName === o && !e.evacuationTriggered && Number.isFinite(e.impactTick) && e.impactTick > Game.time && e.impactTick - Game.time <= r.config.nukeEvacuationLeadTime;
+}), m = l.filter(function(e) {
+return r.hasCriticalStructures(e);
+}).sort(function(e, t) {
+return e.impactTick - t.impactTick;
+})[0];
+if (m) {
+var d = m.impactTick - Game.time;
+if (U.warn("Triggering evacuation for ".concat(o, ": ").concat(l.length, " nuke(s) detected, impact in ").concat(d, " ticks"), {
 subsystem: "Evacuation"
-}), this.startEvacuation(n, "nuke", Game.time + (null !== (o = c.timeToLand) && void 0 !== o ? o : 0));
-continue;
+}), n.startEvacuation(o, "nuke", m.impactTick)) try {
+for (var p = (i = void 0, a(l)), f = p.next(); !f.done; f = p.next()) f.value.evacuationTriggered = !0;
+} catch (e) {
+i = {
+error: e
+};
+} finally {
+try {
+f && !f.done && (s = p.return) && s.call(p);
+} finally {
+if (i) throw i.error;
 }
 }
-if (i.danger >= this.config.triggerDangerLevel && "siege" === i.posture) {
-var l = Z(a), m = yo(a);
-if (l.length > 3 * m) {
-this.startEvacuation(n, "siege");
-continue;
+return "continue";
 }
+if (u.danger >= n.config.triggerDangerLevel && "siege" === u.posture) {
+var y = Z(c), v = yo(c);
+if (y.length > 3 * v) return n.startEvacuation(o, "siege"), "continue";
 }
-}
-}
-}
+}, n = this;
+for (var i in Game.rooms) o(i);
+}, e.prototype.hasCriticalStructures = function(e) {
+var t;
+return (null !== (t = e.threatenedStructures) && void 0 !== t ? t : []).some(function(e) {
+return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
+});
 }, e.prototype.startEvacuation = function(e, t, r) {
 var o;
 if (this.evacuations.has(e)) return !1;
@@ -17774,13 +17791,7 @@ subsystem: "Nuke"
 }
 }
 
-function tc(e) {
-return !!e.threatenedStructures && e.threatenedStructures.some(function(e) {
-return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
-});
-}
-
-function rc(e, t) {
+function tc(e, t) {
 var r = {
 empire: t
 };
@@ -17792,27 +17803,18 @@ return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 });
 }
 
-function oc(e, t) {
+function rc(e, t) {
 var r, o, n;
 if (!e) return !1;
 var a = null === (r = t.knownRooms) || void 0 === r ? void 0 : r[e], i = Game.rooms[e], s = null == i ? void 0 : i.controller, c = {
 empire: t
 };
 return j(e, c) || j(null == a ? void 0 : a.owner, c) || j(null == a ? void 0 : a.reserver, c) || j(null === (o = null == s ? void 0 : s.owner) || void 0 === o ? void 0 : o.username, c) || j(null === (n = null == s ? void 0 : s.reservation) || void 0 === n ? void 0 : n.username, c) || !!i && function(e, t) {
-return rc(e.find(FIND_CREEPS), t) || rc(e.find(FIND_POWER_CREEPS), t) || rc(e.find(FIND_STRUCTURES), t) || rc(e.find(FIND_CONSTRUCTION_SITES), t);
+return tc(e.find(FIND_CREEPS), t) || tc(e.find(FIND_POWER_CREEPS), t) || tc(e.find(FIND_STRUCTURES), t) || tc(e.find(FIND_CONSTRUCTION_SITES), t);
 }(i, t);
 }
 
-function nc(e, t, r) {
-t.timeToLand < 5e3 ? (r.posture = "evacuate", U.warn("EVACUATION TRIGGERED for ".concat(e.name, ": Critical structures threatened by nuke!"), {
-subsystem: "Nuke"
-})) : ("war" !== r.posture && "evacuate" !== r.posture && (r.posture = "defensive"),
-U.warn("NUKE DEFENSE PREPARATION in ".concat(e.name, ": Critical structures in blast radius"), {
-subsystem: "Nuke"
-})), r.pheromones.defense = 100;
-}
-
-function ac() {
+function oc() {
 var e, t = 0, r = 0;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
@@ -17822,14 +17824,14 @@ n.terminal && (t += n.terminal.store.getUsedCapacity(RESOURCE_ENERGY) || 0, r +=
 return t >= 6e5 && r >= 1e4;
 }
 
-function ic(e, t, r, o) {
+function nc(e, t, r, o) {
 var n = 0, a = [], c = t.knownRooms[e];
 if (!c) return {
 roomName: e,
 score: 0,
 reasons: [ "No intel" ]
 };
-if (oc(e, t)) return {
+if (rc(e, t)) return {
 roomName: e,
 score: 0,
 reasons: [ "Allied room" ]
@@ -17856,7 +17858,7 @@ return Game.map.getRoomLinearDistance(e, t.name);
 n -= 2 * d, a.push("".concat(d, " rooms away"));
 }
 t.warTargets.includes(e) && (n += 15, a.push("War target"));
-var p = new RoomPosition(25, 25, e), f = cc(e, p, t);
+var p = new RoomPosition(25, 25, e), f = ic(e, p, t);
 return f >= r.roiThreshold ? (n += Math.min(20, Math.floor(5 * f)), a.push("ROI: ".concat(f.toFixed(1), "x"))) : (n -= 20,
 a.push("Low ROI: ".concat(f.toFixed(1), "x"))), {
 roomName: e,
@@ -17865,7 +17867,7 @@ reasons: a
 };
 }
 
-function sc(e, t, r) {
+function ac(e, t, r) {
 var o, n, i = {
 estimatedDamage: 0,
 estimatedValue: 0,
@@ -17884,7 +17886,7 @@ try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? js : zs;
 p.hits <= v ? (i.estimatedDamage += p.hits, i.threatenedStructures.push("".concat(p.structureType, "-").concat(p.pos.x, ",").concat(p.pos.y)),
-i.estimatedValue += uc(p)) : i.estimatedDamage += v;
+i.estimatedValue += sc(p)) : i.estimatedDamage += v;
 }
 } catch (e) {
 o = {
@@ -17900,16 +17902,16 @@ if (o) throw o.error;
 return i;
 }
 
-function cc(e, t, r) {
-var o = sc(e, t, r);
+function ic(e, t, r) {
+var o = ac(e, t, r);
 return 0 === o.estimatedValue ? 0 : o.estimatedValue / 305e3;
 }
 
-function uc(e) {
+function sc(e) {
 return Qs[e.structureType] || 1e3;
 }
 
-function lc(e) {
+function cc(e) {
 if (e.nukesInFlight && (e.nukesInFlight = e.nukesInFlight.filter(function(e) {
 return e.impactTick > Game.time;
 })), e.incomingNukes) {
@@ -17924,7 +17926,7 @@ subsystem: "Nuke"
 }
 }
 
-function mc(e, t) {
+function uc(e, t) {
 var r, o, n;
 if (e.siegeSquadId) {
 try {
@@ -17952,7 +17954,7 @@ delete e.siegeSquadId;
 }
 }
 
-function dc(e, t, r) {
+function lc(e, t, r) {
 var o, n, i, s = null;
 try {
 for (var c = a(Object.values(t)), u = c.next(); !u.done; u = c.next()) {
@@ -18002,7 +18004,7 @@ subsystem: "Nuke"
 }), !0;
 }
 
-var pc = function() {
+var mc = function() {
 function e(e, t) {
 void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, qs), e),
 this.getEmpire = t.getEmpire, this.getSwarmState = t.getSwarmState, this.getClusters = t.getClusters;
@@ -18031,11 +18033,10 @@ var a = t(o);
 a && ec(e, n, a);
 }
 }
-}(r, this.getSwarmState), this.handleEvacuations(r), this.recordCpu("defensiveObservationCpu", n),
-o) {
+}(r, this.getSwarmState), this.recordCpu("defensiveObservationCpu", n), o) {
 var a = this.getCpuUsed();
 this.runOffensiveCoordination(r), this.recordCpu("offensiveCoordinationCpu", a);
-} else lc(r);
+} else cc(r);
 }, e.prototype.runOffensiveCoordination = function(e) {
 var t = this;
 !function(e, t, r, o) {
@@ -18045,7 +18046,7 @@ for (var c = a(e.incomingNukes), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.sourceRoom && !e.warTargets.includes(l.sourceRoom)) {
 var m = e.knownRooms[l.sourceRoom];
-if (m) if (oc(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
+if (m) if (rc(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
 subsystem: "Nuke"
 }); else if (!(m.controllerLevel < 8)) {
 var d = r(l.roomName);
@@ -18074,7 +18075,7 @@ u && !u.done && (i = c.return) && i.call(c);
 if (n) throw n.error;
 }
 }
-}(e, this.config, this.getSwarmState, ac), function(e, t, r, o) {
+}(e, this.config, this.getSwarmState, oc), function(e, t, r, o) {
 var n, a;
 if (e.objectives.warMode) for (var i in Game.rooms) {
 var s = Game.rooms[i];
@@ -18126,10 +18127,10 @@ if (e.nukeCandidates = [], e.objectives.warMode) {
 try {
 for (var i = a(e.warTargets), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (oc(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
+if (rc(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
 subsystem: "Nuke"
 }); else {
-var u = ic(c, e, t, r);
+var u = nc(c, e, t, r);
 u.score >= t.minScore && (e.nukeCandidates.push({
 roomName: c,
 score: u.score,
@@ -18173,11 +18174,11 @@ var d = r();
 try {
 for (var p = a(e.nukesInFlight), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (oc(y.targetRoom, e)) mc(y, d), U.warn("Skipping siege coordination for allied nuke target ".concat(y.targetRoom), {
+if (rc(y.targetRoom, e)) uc(y, d), U.warn("Skipping siege coordination for allied nuke target ".concat(y.targetRoom), {
 subsystem: "Nuke"
 }); else {
 var v = y.impactTick - Game.time;
-y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && dc(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
+y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && lc(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
 subsystem: "Nuke"
 });
 }
@@ -18206,7 +18207,7 @@ if (!r) return "continue";
 var o = null === (m = e.nukesInFlight) || void 0 === m ? void 0 : m.find(function(e) {
 return e.targetRoom === r;
 });
-if (oc(r, e)) return (null == o ? void 0 : o.siegeSquadId) === t.id && (delete o.siegeSquadId,
+if (rc(r, e)) return (null == o ? void 0 : o.siegeSquadId) === t.id && (delete o.siegeSquadId,
 t.state = "dissolving"), "continue";
 o && !o.siegeSquadId && (o.siegeSquadId = t.id, U.info("Linked siege squad ".concat(t.id, " with nuke on ").concat(r), {
 subsystem: "Nuke"
@@ -18316,14 +18317,14 @@ return e.structureType === STRUCTURE_NUKER;
 if (0 !== c.length) try {
 for (var m = a(e.nukeCandidates), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!p.launched) if (oc(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
+if (!p.launched) if (rc(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
 subsystem: "Nuke"
 }); else {
 try {
 for (var f = (n = void 0, a(c)), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (!(Game.map.getRoomLinearDistance(v.room.name, p.roomName) > 10)) {
-var g = new RoomPosition(25, 25, p.roomName), h = sc(p.roomName, g, e), R = cc(p.roomName, g, e);
+var g = new RoomPosition(25, 25, p.roomName), h = ac(p.roomName, g, e), R = ic(p.roomName, g, e);
 if (R < t.roiThreshold) U.warn("Skipping nuke launch on ".concat(p.roomName, ": ROI ").concat(R.toFixed(2), "x below threshold ").concat(t.roiThreshold, "x"), {
 subsystem: "Nuke"
 }); else {
@@ -18390,7 +18391,7 @@ if (r) throw r.error;
 }
 }
 }
-}(e, this.config), lc(e);
+}(e, this.config), cc(e);
 }, e.prototype.getCpuUsed = function() {
 var e;
 return "undefined" != typeof Game && "function" == typeof (null === (e = Game.cpu) || void 0 === e ? void 0 : e.getUsed) ? Game.cpu.getUsed() : void 0;
@@ -18401,30 +18402,6 @@ var o = this.getCpuUsed();
 void 0 !== o && (null === (r = U.stat) || void 0 === r || r.call(U, e, Math.max(0, o - t), "cpu", {
 subsystem: "Nuke"
 }));
-}
-}, e.prototype.handleEvacuations = function(e) {
-var t, r;
-if (e.incomingNukes) try {
-for (var o = a(e.incomingNukes), n = o.next(); !n.done; n = o.next()) {
-var i = n.value;
-if (!i.evacuationTriggered && tc(i)) {
-var s = Game.rooms[i.roomName];
-if (s) {
-var c = this.getSwarmState(i.roomName);
-c && (nc(s, i, c), i.evacuationTriggered = !0);
-}
-}
-}
-} catch (e) {
-t = {
-error: e
-};
-} finally {
-try {
-n && !n.done && (r = o.return) && r.call(o);
-} finally {
-if (t) throw t.error;
-}
 }
 }, e.prototype.requestResourceTransfer = function(e, t, r) {
 !function(e, t, r, o, n) {
@@ -18462,7 +18439,7 @@ return o({}, this.config);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e);
 }, e;
-}(), fc = [ {
+}(), dc = [ {
 carryParts: 4,
 capacity: 200,
 moveParts: 4,
@@ -18484,7 +18461,7 @@ moveParts: 24,
 cost: 2400
 } ];
 
-function yc(e, t, r, o, n) {
+function pc(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = {});
 var c = n.reserved, u = void 0 !== c && c, l = n.pathLength, m = n.terrainFactor, d = void 0 === m ? 1.2 : m, p = n.safetyBuffer, f = void 0 === p ? 1.2 : p, y = function(e, t) {
@@ -18507,9 +18484,9 @@ var r = 50 * e * t;
 return Math.ceil(2 * r);
 }(y, d), g = function(e, t) {
 return e * (t ? 3e3 : 1500) / 300;
-}(r, u), h = fc[0];
+}(r, u), h = dc[0];
 try {
-for (var R = a(fc), E = R.next(); !E.done; E = R.next()) {
+for (var R = a(dc), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.cost <= o)) break;
 h = T;
@@ -18538,7 +18515,7 @@ energyPerTick: g
 };
 }
 
-function vc(e) {
+function fc(e) {
 var t;
 return e ? null !== (t = {
 X: 15,
@@ -18551,12 +18528,12 @@ H: 8
 }[e]) && void 0 !== t ? t : 5 : 0;
 }
 
-function gc(e) {
-var t, r, o = wr.getEmpire(), n = 0, i = Sc(e);
+function yc(e) {
+var t, r, o = wr.getEmpire(), n = 0, i = Tc(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-l && (l.owner && !wc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
+l && (l.owner && !Cc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
 l.towerCount && l.towerCount > 0 && (n += 5 * l.towerCount));
 }
 } catch (e) {
@@ -18573,12 +18550,12 @@ if (t) throw t.error;
 return n;
 }
 
-function hc(e) {
+function vc(e) {
 return "plains" === e ? 15 : "swamp" === e ? -10 : 0;
 }
 
-function Rc(e) {
-var t, r, o = Sc(e);
+function gc(e) {
+var t, r, o = Tc(e);
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (ne(i.value)) return !0;
 } catch (e) {
@@ -18595,7 +18572,7 @@ if (t) throw t.error;
 return !1;
 }
 
-function Ec(e) {
+function hc(e) {
 var t = wr.getEmpire(), r = t.knownRooms[e];
 if (null == r ? void 0 : r.hasPortal) return 20;
 var o = function(e, t) {
@@ -18613,34 +18590,34 @@ return null === r || r > 3 ? null : r;
 return null === o ? 0 : o <= 1 ? 10 : o <= 2 ? 6 : o <= 3 ? 3 : 0;
 }
 
-function Tc(e, t) {
+function Rc(e, t) {
 var r = e < 0 ? "W" : "E", o = t < 0 ? "N" : "S", n = Math.abs(e) - (e < 0 ? 1 : 0), a = Math.abs(t) - (t < 0 ? 1 : 0);
 return "".concat(r).concat(n).concat(o).concat(a);
 }
 
-function Cc(e, t, r) {
+function Ec(e, t, r) {
 return 0 === t.length ? 0 : r <= 2 ? 25 : r <= 3 ? 15 : r <= 5 ? 5 : 0;
 }
 
-function Sc(e) {
+function Tc(e) {
 var t = ee(e);
 if (!t) return [];
-for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(Tc(r + a, o + i));
+for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(Rc(r + a, o + i));
 return n;
 }
 
-function wc(e) {
+function Cc(e) {
 return j(e, {
 empire: wr.getEmpire()
 });
 }
 
-function xc(e, t, r, o) {
+function Sc(e, t, r, o) {
 var n, a = Game.map.getRoomLinearDistance(t, e);
 if (!Number.isFinite(a) || a <= 0) throw new Error("calculateRemoteProfitability: invalid distance ".concat(a, " between ").concat(t, " and ").concat(e));
 if (r.sources <= 0) throw new Error("calculateRemoteProfitability: intel.sources must be positive, got ".concat(r.sources, " for ").concat(e));
 if (void 0 !== r.threatLevel && null !== r.threatLevel && (r.threatLevel < 0 || r.threatLevel > 3)) throw new Error("calculateRemoteProfitability: intel.threatLevel must be in [0, 3], got ".concat(r.threatLevel, " for ").concat(e));
-var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = yc(t, e, r.sources, 800, {
+var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = pc(t, e, r.sources, 800, {
 reserved: m
 }), f = (650 * r.sources + p.haulerConfig.cost * p.recommendedHaulers) / 1500, y = 5e3 * r.sources + 50 * a * 300, v = y / 5e4, g = d * (null !== (n = [ 0, .1, .3, .6 ][r.threatLevel]) && void 0 !== n ? n : 0), h = d - f - v - g, R = f + v, E = R > 0 ? h / R : 0;
 return {
@@ -18664,9 +18641,9 @@ isProfitable: E > 2 && h > 0
 };
 }
 
-var bc = Mr().cpu.bucketThresholds.highMode + 1e3, Oc = {
+var wc = Mr().cpu.bucketThresholds.highMode + 1e3, xc = {
 updateInterval: 500,
-minBucket: bc,
+minBucket: wc,
 maxRemoteDistance: 2,
 maxRemotesPerRoom: 5,
 minRemoteSources: 1,
@@ -18675,10 +18652,10 @@ minRclForClaiming: 1,
 minGclProgressForClaim: 0,
 clusterExpansionDistance: 5,
 minStableRoomPercentage: 0
-}, kc = function() {
+}, bc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedUsername = "", this.usernameLastTick = 0,
-this.config = o(o({}, Oc), e);
+this.config = o(o({}, xc), e);
 }
 return e.prototype.run = function() {
 var e = wr.getEmpire();
@@ -18773,7 +18750,7 @@ for (var i in t.knownRooms) if (!r.includes(i) && !this.isRemoteAssignedElsewher
 var s = t.knownRooms[i], c = Game.map.getRoomLinearDistance(e, i);
 if ((s.scouted || !(c > 1)) && !s.owner && !(s.reserver && s.reserver !== a || s.isHighway || s.isSK || s.threatLevel >= 2 || c < 1 || c > this.config.maxRemoteDistance)) if (s.scouted) {
 if (!(s.sources < this.config.minRemoteSources)) {
-var u = xc(i, e, s);
+var u = Sc(i, e, s);
 if (u.isProfitable) {
 var l = this.scoreRemoteCandidate(s, c);
 n.push({
@@ -18805,10 +18782,10 @@ return r += 50 * e.sources, r -= 20 * t, r -= 30 * e.threatLevel, "plains" === e
 r;
 }, e.prototype.scoreClaimCandidate = function(e, t, r) {
 var o = 0;
-return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += vc(e.mineralType),
-o -= 5 * t, o -= gc(e.name), o -= 15 * e.threatLevel, o += hc(e.terrain), Rc(e.name) && (o += 10),
-o += Ec(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
-o + Cc(e.name, r, t);
+return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += fc(e.mineralType),
+o -= 5 * t, o -= yc(e.name), o -= 15 * e.threatLevel, o += vc(e.terrain), gc(e.name) && (o += 10),
+o += hc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
+o + Ec(e.name, r, t);
 }, e.prototype.isRemoteAssignedElsewhere = function(e, t) {
 var r, o, n, i = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -19156,13 +19133,13 @@ return this.cachedUsername;
 var r, o, n = [], i = function(e) {
 var t = [], r = ee(e);
 if (!r) return [];
-for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(Tc(o + a, n + i));
+for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(Rc(o + a, n + i));
 return t;
 }(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t.knownRooms[u];
-l && (l.owner && !wc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
+l && (l.owner && !Cc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
 l.towerCount && l.towerCount > 0 && n.push("".concat(l.towerCount, " towers in ").concat(u)),
 l.spawnCount && l.spawnCount > 0 && n.push("".concat(l.spawnCount, " spawns in ").concat(u)),
 l.threatLevel >= 2 && n.push("Threat level ".concat(l.threatLevel, " in ").concat(u)));
@@ -19179,11 +19156,11 @@ if (r) throw r.error;
 }
 }
 return function(e) {
-var t, r, o = wr.getEmpire(), n = Sc(e), i = new Set;
+var t, r, o = wr.getEmpire(), n = Tc(e), i = new Set;
 try {
 for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-(null == l ? void 0 : l.owner) && !wc(l.owner) && i.add(l.owner);
+(null == l ? void 0 : l.owner) && !Cc(l.owner) && i.add(l.owner);
 }
 } catch (e) {
 t = {
@@ -19298,10 +19275,10 @@ subsystem: "Expansion"
 }, n([ Xe("expansion:manager", "Expansion Manager", {
 priority: Ie.LOW,
 interval: 500,
-minBucket: bc,
+minBucket: wc,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), Mc = new kc, Ac = function() {
+}(), Oc = new bc, kc = function() {
 function e() {}
 return e.prototype.status = function() {
 var e, t, r, o, n, i, s, c, u, l, m = wr.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
@@ -19393,9 +19370,9 @@ return wr.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use ex
 }, e.prototype.resume = function() {
 return wr.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
 }, e.prototype.addRemote = function(e, t) {
-return Mc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
+return Oc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
 }, e.prototype.removeRemote = function(e, t) {
-return Mc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
+return Oc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
 }, e.prototype.clearQueue = function() {
 var e = wr.getEmpire(), t = e.claimQueue.length;
 return e.claimQueue = [], "Cleared ".concat(t, " candidates from claim queue. Queue will repopulate on next empire tick.");
@@ -19436,21 +19413,21 @@ usage: "expansion.clearQueue()",
 examples: [ "expansion.clearQueue()" ],
 category: "Empire"
 }) ], e.prototype, "clearQueue", null), e;
-}(), Uc = new Ac;
+}(), Mc = new kc;
 
-function _c(e) {
+function Ac(e) {
 return function(e) {
 return "string" == typeof e && e.trimStart().startsWith("{");
 }(e) ? e.trim() : null;
 }
 
-function Nc(e) {
+function Uc(e) {
 var t;
 if (!e.controller) return null;
 var r = e.controller;
 if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
 var o = function(e) {
-var t = _c(e);
+var t = Ac(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19468,12 +19445,12 @@ availableQuests: [ o.id ]
 };
 }
 
-function Pc() {
+function _c() {
 var e;
 return (null === (e = Memory.tooangel) || void 0 === e ? void 0 : e.npcRooms) || {};
 }
 
-function Ic(e) {
+function Nc(e) {
 var t = Memory;
 t.tooangel || (t.tooangel = {}), t.tooangel.npcRooms || (t.tooangel.npcRooms = {});
 var r = t.tooangel.npcRooms[e.roomName];
@@ -19484,7 +19461,7 @@ e.availableQuests = Array.from(o);
 t.tooangel.npcRooms[e.roomName] = e;
 }
 
-function Gc() {
+function Pc() {
 var e = Memory;
 return e.tooangel || (e.tooangel = {
 enabled: !0,
@@ -19506,14 +19483,14 @@ Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionI
 e.tooangel;
 }
 
-var Lc = [ "applied", "active" ];
+var Ic = [ "applied", "active" ];
 
-function Dc(e) {
+function Gc(e) {
 var t, r;
 return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
 }
 
-function Bc(e, t) {
+function Lc(e, t) {
 return !!function(e, t) {
 if (e.sender) return "TooAngel" === e.sender.username;
 var r = function(e) {
@@ -19521,7 +19498,7 @@ var t, r, o = new Set(Object.keys(e.npcRooms || {}));
 try {
 for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Lc.includes(s.status) && s.originRoom && o.add(s.originRoom);
+Ic.includes(s.status) && s.originRoom && o.add(s.originRoom);
 }
 } catch (e) {
 t = {
@@ -19535,25 +19512,25 @@ if (t) throw t.error;
 }
 }
 return o;
-}(Gc());
+}(Pc());
 return !!r.has(e.from) && (void 0 === t || r.has(t));
 }(e, t) && !function(e) {
-return Gc().recentTransactionIds.includes(Dc(e));
+return Pc().recentTransactionIds.includes(Gc(e));
 }(e) && (function(e) {
-var t = Gc(), r = Dc(e);
+var t = Pc(), r = Gc(e);
 t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
 }(e), !0);
 }
 
-var Fc = {
+var Dc = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function Wc(e) {
-var t = _c(e);
+function Bc(e) {
+var t = Ac(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19564,24 +19541,24 @@ subsystem: "TooAngel"
 return null;
 }
 
-function Hc() {
-return Gc().activeQuests || {};
+function Fc() {
+return Pc().activeQuests || {};
 }
 
-function Kc() {
-var e = Hc();
+function Wc() {
+var e = Fc();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < Fc.MAX_ACTIVE_QUESTS;
+}).length < Dc.MAX_ACTIVE_QUESTS;
 }
 
-function Yc(e) {
-return Fc.SUPPORTED_TYPES.includes(e);
+function Hc(e) {
+return Dc.SUPPORTED_TYPES.includes(e);
 }
 
-function Vc(e, t, r) {
+function Kc(e, t, r) {
 var o, n;
-if (!Kc()) return U.debug("Cannot accept more quests (at max capacity)", {
+if (!Wc()) return U.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19598,17 +19575,17 @@ if (!n || !n.terminal || !n.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < Fc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Fc.MIN_APPLICATION_ENERGY), {
+if (l < Dc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Dc.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, Fc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, Dc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (U.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
-}), Gc().activeQuests[e] = {
+}), Pc().activeQuests[e] = {
 id: e,
 type: "buildcs",
 status: "applied",
@@ -19621,8 +19598,8 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function qc(e) {
-var t = Gc(), r = t.activeQuests[e.id];
+function Yc(e) {
+var t = Pc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (U.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
 }), r.status = "completed") : (U.warn("Quest ".concat(e.id, " failed"), {
@@ -19632,13 +19609,13 @@ subsystem: "TooAngel"
 });
 }
 
-function jc() {
+function Vc() {
 var e;
-return (null === (e = Gc().reputation) || void 0 === e ? void 0 : e.value) || 0;
+return (null === (e = Pc().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function zc(e) {
-var t = _c(e);
+function qc(e) {
+var t = Ac(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19647,8 +19624,8 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function Qc(e) {
-var t, r, o, n = Gc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
+function jc(e) {
+var t, r, o, n = Pc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return U.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
 }), !1;
@@ -19663,7 +19640,7 @@ if (!o || !o.terminal || !o.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var c = function(e) {
-var t = Pc(), r = null, o = 1 / 0;
+var t = _c(), r = null, o = 1 / 0;
 for (var n in t) {
 var a = Game.map.getRoomLinearDistance(e, n);
 a < o && (o = a, r = t[n]);
@@ -19687,7 +19664,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Xc(e) {
+function zc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19777,7 +19754,7 @@ l.notifyComplete && (U.info("Quest ".concat(e.id, " (buildcs) completed! All con
 subsystem: "TooAngel"
 }), function(e, t) {
 var r, o, n = function(e) {
-return Hc()[e] || null;
+return Fc()[e] || null;
 }(e);
 if (!n) return U.warn("Cannot notify completion for unknown quest: ".concat(e), {
 subsystem: "TooAngel"
@@ -19829,7 +19806,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Zc, Jc, $c = Mr().cpu.bucketThresholds.highMode + 1e3, eu = $c, tu = /^tooangel_error_\d+$/, ru = function() {
+var Qc, Xc, Zc = Mr().cpu.bucketThresholds.highMode + 1e3, Jc = Zc, $c = /^tooangel_error_\d+$/, eu = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19847,19 +19824,19 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, U.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < eu)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < Jc)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Gc();
+var r = Pc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = zc(i.description);
-null !== s && Bc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
+var s = qc(i.description);
+null !== s && Lc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19886,7 +19863,7 @@ if (e) throw e.error;
 }(), function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Gc();
+var r = Pc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
@@ -19894,12 +19871,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = Wc(i.description);
-if (s && Bc(i, s.origin)) {
+var s = Bc(i.description);
+if (s && Lc(i, s.origin)) {
 if (U.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-qc(s);
+Yc(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19913,7 +19890,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Yc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
+}, Hc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19950,15 +19927,15 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (U.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Xc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? zc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
 }(), function() {
-var e = Gc().activeQuests || {};
+var e = Pc().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - Fc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - Dc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19970,9 +19947,9 @@ var e = String(t);
 (function(e) {
 !function() {
 var e = Memory;
-for (var t in e) tu.test(t) && delete e[t];
+for (var t in e) $c.test(t) && delete e[t];
 }();
-var t = Gc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
+var t = Pc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
 return t.errorThrottle = {
 lastErrorTick: i ? Game.time : o,
 count: i ? 1 : n + 1,
@@ -19986,7 +19963,7 @@ subsystem: "TooAngel"
 var e, t, r = function() {
 var e = [];
 for (var t in Game.rooms) {
-var r = Nc(Game.rooms[t]);
+var r = Uc(Game.rooms[t]);
 r && (U.info("Detected TooAngel NPC room: ".concat(t), {
 subsystem: "TooAngel"
 }), e.push(r));
@@ -19994,7 +19971,7 @@ subsystem: "TooAngel"
 return e;
 }();
 try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) Ic(n.value);
+for (var o = a(r), n = o.next(); !n.done; n = o.next()) Nc(n.value);
 } catch (t) {
 e = {
 error: t
@@ -20010,12 +19987,12 @@ r.length > 0 && U.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-Qc();
+jc();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (Kc()) {
-var r = Pc(), o = Hc();
+if (Wc()) {
+var r = _c(), o = Fc();
 for (var n in r) {
 var i = r[n];
 try {
@@ -20023,7 +20000,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return U.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void Vc(u, n);
+}), void Kc(u, n);
 }
 } catch (t) {
 e = {
@@ -20040,11 +20017,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return jc();
+return Vc();
 }, e.prototype.getActiveQuests = function() {
-return Hc();
+return Fc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return Vc(e, t, r);
+return Kc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -20061,27 +20038,27 @@ return n.join("\n");
 }, n([ Ze("empire:tooangel", "TooAngel Manager", {
 priority: Ie.LOW,
 interval: 100,
-minBucket: $c
+minBucket: Zc
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), ou = new ru, nu = {
+}(), tu = new eu, ru = {
 status: function() {
-return ou.getStatus();
+return tu.getStatus();
 },
 enable: function() {
-return ou.enable(), "TooAngel integration enabled";
+return tu.enable(), "TooAngel integration enabled";
 },
 disable: function() {
-return ou.disable(), "TooAngel integration disabled";
+return tu.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = jc();
+var e = Vc();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return Qc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return jc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
-var e, t = Hc(), r = [ "Active Quests:" ];
+var e, t = Fc(), r = [ "Active Quests:" ];
 if (0 === Object.keys(t).length) r.push("  No active quests"); else for (var o in t) {
 var n = t[o], a = n.deadline - Game.time, i = (null === (e = n.assignedCreeps) || void 0 === e ? void 0 : e.length) || 0;
 r.push("  ".concat(o, ":")), r.push("    Type: ".concat(n.type)), r.push("    Target: ".concat(n.targetRoom)),
@@ -20091,7 +20068,7 @@ r.push("    Assigned creeps: ".concat(i));
 return r.join("\n");
 },
 npcs: function() {
-var e = Pc(), t = [ "TooAngel NPC Rooms:" ];
+var e = _c(), t = [ "TooAngel NPC Rooms:" ];
 if (0 === Object.keys(e).length) t.push("  No NPC rooms discovered"); else for (var r in e) {
 var o = e[r];
 t.push("  ".concat(r, ":")), t.push("    Has terminal: ".concat(o.hasTerminal)),
@@ -20100,12 +20077,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return Vc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return Kc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, au = function() {
+}, ou = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -20273,16 +20250,16 @@ usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), iu = new au, su = {
+}(), nu = new ou, au = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, cu = function() {
+}, iu = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, su), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, au), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
@@ -20646,16 +20623,16 @@ interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), uu = new cu, lu = {
+}(), su = new iu, cu = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, mu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], du = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], pu = function() {
+}, uu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], lu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], mu = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, lu), e);
+this.config = o(o({}, cu), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20809,7 +20786,7 @@ return l.homeRoom = a, l.role = o, U.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? mu : du).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? uu : lu).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20953,211 +20930,211 @@ interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), fu = new pu, yu = {
+}(), du = new mu, pu = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, vu = ((Zc = {})[RESOURCE_HYDROXIDE] = {
+}, fu = ((Qc = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Zc[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Qc[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Zc[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Qc[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Zc[RESOURCE_GHODIUM] = {
+}, Qc[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Zc[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Qc[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Zc[RESOURCE_UTRIUM_OXIDE] = {
+}, Qc[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Zc[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Qc[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Zc[RESOURCE_KEANIUM_OXIDE] = {
+}, Qc[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Zc[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Qc[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Zc[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Qc[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Zc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Qc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Zc[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Qc[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Zc[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Qc[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Zc[RESOURCE_GHODIUM_OXIDE] = {
+}, Qc[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Zc[RESOURCE_UTRIUM_ACID] = {
+}, Qc[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Qc[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_KEANIUM_ACID] = {
+}, Qc[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Qc[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_LEMERGIUM_ACID] = {
+}, Qc[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Qc[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_ZYNTHIUM_ACID] = {
+}, Qc[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Qc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_GHODIUM_ACID] = {
+}, Qc[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Qc[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Zc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Qc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Qc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Qc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Qc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Qc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Qc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Qc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Qc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Qc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Qc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Zc), gu = ((Jc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Jc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Jc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Jc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Jc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Jc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Jc[RESOURCE_GHODIUM] = 5e3, Jc[RESOURCE_HYDROXIDE] = 5e3, Jc);
+}, Qc), yu = ((Xc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Xc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Xc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Xc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Xc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Xc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Xc[RESOURCE_GHODIUM] = 5e3, Xc[RESOURCE_HYDROXIDE] = 5e3, Xc);
 
-function hu(e, t) {
-var r, o, n, a = null !== (r = gu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function vu(e, t) {
+var r, o, n, a = null !== (r = yu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function Ru(e) {
+function gu(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var Eu = function() {
+var hu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : yu;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : pu;
 }
 return e.prototype.getReaction = function(e) {
-return vu[e];
+return fu[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = vu[e];
+var c = fu[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -21179,11 +21156,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = Ru(t);
+var d = gu(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (vu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < hu(y, t)) {
+if (fu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < vu(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -21242,12 +21219,12 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = Ru(t);
+var h = gu(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = vu[T];
+var T = E.value, C = fu[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = hu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = vu(T, t), x = w - S;
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), k = {};
 try {
@@ -21363,7 +21340,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), Tu = [ {
+}(), Ru = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21381,13 +21358,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function Cu(e) {
-return Tu.find(function(t) {
+function Eu(e) {
+return Ru.find(function(t) {
 return t.role === e;
 });
 }
 
-function Su(e, t) {
+function Tu(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21404,29 +21381,29 @@ return;
 }
 }
 
-function wu(e, t) {
+function Cu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function xu(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : Ou(e, t) && Ou(e, r) ? "output" : "boost";
+function Su(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : xu(e, t) && xu(e, r) ? "output" : "boost";
 }
 
-function bu(e, t) {
+function wu(e, t) {
 return t.filter(function(t) {
-return e.id !== t.id && Ou(e, t);
+return e.id !== t.id && xu(e, t);
 }).length;
 }
 
-function Ou(e, t) {
+function xu(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var ku, Mu = function() {
+var bu, Ou = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : yu;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : pu;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21542,7 +21519,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Su(s.role, o);
+var s = i.value, c = Tu(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21564,13 +21541,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, bu(t, e) ];
+return [ t.id, wu(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && Ou(e, s) && Ou(e, c);
+return t !== a && t !== i && xu(e, s) && xu(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21583,19 +21560,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(wu)[0];
+return n.sort(Cu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: xu(e, t.input1, t.input2)
+role: Su(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, bu(r, e));
+return Math.max(t, wu(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21739,17 +21716,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), Au = function() {
+}(), ku = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = Cu(o.role);
+var n = Eu(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = Cu(n.role);
+var r, o, n = e.memory, i = Eu(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21827,7 +21804,7 @@ return 0 === c.length && (n.boosted = !0, U.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = Cu(t);
+var r, o, n = Eu(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21858,7 +21835,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = Cu(t);
+var r, o, n = Eu(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21892,7 +21869,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ Cu("soldier"), Cu("ranger"), Cu("healer"), Cu("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ Eu("soldier"), Eu("ranger"), Eu("healer"), Eu("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21949,7 +21926,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = Cu(e);
+var r = Eu(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21959,7 +21936,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = Cu(e);
+var n = Eu(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21993,7 +21970,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), Uu = new Au, _u = {
+}(), Mu = new ku, Au = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -22006,10 +21983,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Nu = function() {
+}, Uu = function() {
 function e() {
-this.manager = new Mu({
-logger: _u
+this.manager = new Ou({
+logger: Au
 });
 }
 return e.prototype.initialize = function(e) {
@@ -22079,14 +22056,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), Pu = new Nu, Iu = function() {
+}(), _u = new Uu, Nu = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = Pu.getConfig(e);
+var s = _u.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = Pu.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = _u.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -22098,7 +22075,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = Pu.getBoostLabs(e), f = function(e) {
+var p = _u.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -22129,9 +22106,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = Pu.getConfig(e);
+var c = _u.getConfig(e);
 if (!c) return [];
-var u = [], l = Pu.getOutputLabs(e);
+var u = [], l = _u.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -22156,7 +22133,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = Pu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = _u.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -22192,15 +22169,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = Pu.getConfig(e);
+var r, o, n, i, s = _u.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = Pu.getInputLabs(e), u = c.input1, l = c.input2;
+var c = _u.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = Pu.getOutputLabs(e);
+var m = _u.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -22222,23 +22199,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-Pu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
+_u.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = Pu.setActiveReaction(e, t, r, o);
+var n = _u.setActiveReaction(e, t, r, o);
 return n && U.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return Pu.runReactions(e);
+return _u.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return Pu.getBoostLabs(e).length > 0;
+return _u.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = Pu.getConfig(e);
+var r, o, n, i, s, c = _u.getConfig(e);
 if (!c) return null;
-var u = Pu.getBoostLabs(e);
+var u = _u.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -22342,17 +22319,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = Pu.getConfig(e);
+var t = _u.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-Pu.loadFromMemory(e), Pu.initialize(e);
+_u.loadFromMemory(e), _u.initialize(e);
 }, e.prototype.save = function(e) {
-Pu.saveToMemory(e);
+_u.saveToMemory(e);
 }, e;
-}(), Gu = new Iu, Lu = function() {
+}(), Pu = new Nu, Iu = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = Pu.getConfig(e);
+var t, r, o, n, i, s, c, u, l = _u.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22375,7 +22352,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = Gu.getLabResourceNeeds(e);
+var h = Pu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22395,7 +22372,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = Gu.getLabOverflow(e);
+var C = Pu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22417,13 +22394,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return Gu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return Pu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return Gu.clearReactions(e), "Cleared active reactions in ".concat(e);
+return Pu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = Uu.areBoostLabsReady(n, t), s = Uu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = Mu.areBoostLabsReady(n, t), s = Mu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22469,7 +22446,7 @@ usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), Du = function() {
+}(), Gu = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22526,10 +22503,10 @@ usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), Bu = function() {
+}(), Lu = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = fu.getGPLState();
+var e = du.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22538,7 +22515,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = fu.getAssignments();
+var e, t, r = du.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22560,7 +22537,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = uu.getActiveOperations();
+var e, t, r = su.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22585,7 +22562,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return fu.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return du.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22659,31 +22636,31 @@ usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), Fu = new Lu, Wu = new Du, Hu = new Bu;
+}(), Du = new Iu, Bu = new Gu, Fu = new Lu;
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(ku || (ku = {}));
+}(bu || (bu = {}));
 
-var Ku = {
-level: ku.INFO,
+var Wu = {
+level: bu.INFO,
 cpuLogging: !1,
 enableBatching: !0,
 maxBatchSize: 50,
 debugSampleRate: 1,
 maxEntriesPerSubsystemPerTick: 0,
 maxEntriesPerTick: 0
-}, Yu = o({}, Ku), Vu = [], qu = {
+}, Hu = o({}, Wu), Ku = [], Yu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
 debugSampleCounter: 0
 };
 
-function ju() {
+function Vu() {
 var e = "undefined" != typeof Game && "number" == typeof Game.time ? Game.time : 0;
-qu.tick !== e && (qu = {
+Yu.tick !== e && (Yu = {
 tick: e,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22691,47 +22668,47 @@ debugSampleCounter: 0
 });
 }
 
-function zu(e, t) {
+function qu(e, t) {
 return !!function(e) {
-if (e !== ku.DEBUG) return !0;
-ju();
-var t, r = (t = Yu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
+if (e !== bu.DEBUG) return !0;
+Vu();
+var t, r = (t = Hu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
 if (r >= 1) return !0;
 if (r <= 0) return !1;
-qu.debugSampleCounter += 1;
+Yu.debugSampleCounter += 1;
 var o = Math.max(1, Math.ceil(1 / r));
-return qu.debugSampleCounter % o === 0;
+return Yu.debugSampleCounter % o === 0;
 }(e) && function(e) {
-var t, r, o = Qu(Yu.maxEntriesPerTick), n = Qu(Yu.maxEntriesPerSubsystemPerTick);
+var t, r, o = ju(Hu.maxEntriesPerTick), n = ju(Hu.maxEntriesPerSubsystemPerTick);
 if (0 === o && 0 === n) return !0;
-if (ju(), o > 0 && qu.totalCount >= o) return !1;
+if (Vu(), o > 0 && Yu.totalCount >= o) return !1;
 if (n > 0) {
 var a = null != e ? e : "global";
-if ((null !== (t = qu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
+if ((null !== (t = Yu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
 }
-qu.totalCount += 1;
+Yu.totalCount += 1;
 var i = null != e ? e : "global";
-return qu.perSubsystemCounts.set(i, (null !== (r = qu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
+return Yu.perSubsystemCounts.set(i, (null !== (r = Yu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
 !0;
 }(null == t ? void 0 : t.subsystem);
 }
 
-function Qu(e) {
+function ju(e) {
 return Number.isFinite(e) && e > 0 ? Math.floor(e) : 0;
 }
 
-function Xu(e) {
-Vu.length > 0 && $u();
-var t = Yu;
-Yu = o(o(o({}, Ku), e), {
+function zu(e) {
+Ku.length > 0 && Zu();
+var t = Hu;
+Hu = o(o(o({}, Wu), e), {
 level: "level" in e ? e.level : t.level,
 cpuLogging: "cpuLogging" in e ? e.cpuLogging : t.cpuLogging,
 enableBatching: "enableBatching" in e ? e.enableBatching : t.enableBatching,
 maxBatchSize: "maxBatchSize" in e ? e.maxBatchSize : t.maxBatchSize,
 debugSampleRate: "debugSampleRate" in e ? e.debugSampleRate : t.debugSampleRate,
-maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Ku.maxEntriesPerSubsystemPerTick,
-maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Ku.maxEntriesPerTick
-}), Vu = [], qu = {
+maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Wu.maxEntriesPerSubsystemPerTick,
+maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Wu.maxEntriesPerTick
+}), Ku = [], Yu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22739,21 +22716,21 @@ debugSampleCounter: 0
 };
 }
 
+function Qu() {
+return o({}, Hu);
+}
+
+function Xu(e) {
+Hu.enableBatching ? (Ku.push(e), Ku.length >= Hu.maxBatchSize && Zu()) : console.log(e);
+}
+
 function Zu() {
-return o({}, Yu);
+0 !== Ku.length && (console.log(Ku.join("\n")), Ku = []);
 }
 
-function Ju(e) {
-Yu.enableBatching ? (Vu.push(e), Vu.length >= Yu.maxBatchSize && $u()) : console.log(e);
-}
+var Ju = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
 
-function $u() {
-0 !== Vu.length && (console.log(Vu.join("\n")), Vu = []);
-}
-
-var el = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
-
-function tl(e) {
+function $u(e) {
 return JSON.stringify(e, (t = new WeakSet, function(e, r) {
 return "bigint" == typeof r ? r.toString() : "object" != typeof r || null === r ? r : t.has(r) ? "[Circular]" : (t.add(r),
 r);
@@ -22761,7 +22738,7 @@ r);
 var t;
 }
 
-function rl(e, t, r, o) {
+function el(e, t, r, o) {
 void 0 === o && (o = "log");
 var n = {
 type: o,
@@ -22772,35 +22749,35 @@ shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (r.shard && (n.shard = r.shard), r.subsystem && (n.subsystem = r.subsystem),
 r.room && (n.room = r.room), r.creep && (n.creep = r.creep), r.processId && (n.processId = r.processId),
-r.meta)) for (var a in r.meta) el.has(a) || (n[a] = r.meta[a]);
-return tl(n);
+r.meta)) for (var a in r.meta) Ju.has(a) || (n[a] = r.meta[a]);
+return $u(n);
+}
+
+function tl(e, t) {
+Hu.level <= bu.DEBUG && qu(bu.DEBUG, t) && Xu(el("DEBUG", e, t));
+}
+
+function rl(e, t) {
+Hu.level <= bu.INFO && qu(bu.INFO, t) && Xu(el("INFO", e, t));
 }
 
 function ol(e, t) {
-Yu.level <= ku.DEBUG && zu(ku.DEBUG, t) && Ju(rl("DEBUG", e, t));
+Hu.level <= bu.WARN && qu(bu.WARN, t) && Xu(el("WARN", e, t));
 }
 
 function nl(e, t) {
-Yu.level <= ku.INFO && zu(ku.INFO, t) && Ju(rl("INFO", e, t));
+Hu.level <= bu.ERROR && qu(bu.ERROR, t) && Xu(el("ERROR", e, t));
 }
 
-function al(e, t) {
-Yu.level <= ku.WARN && zu(ku.WARN, t) && Ju(rl("WARN", e, t));
-}
-
-function il(e, t) {
-Yu.level <= ku.ERROR && zu(ku.ERROR, t) && Ju(rl("ERROR", e, t));
-}
-
-function sl(e, t, r) {
-if (!Yu.cpuLogging) return t();
+function al(e, t, r) {
+if (!Hu.cpuLogging) return t();
 var o = Game.cpu.getUsed(), n = t(), a = Game.cpu.getUsed() - o;
-return ol("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
+return tl("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 }
 
-var cl = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
+var il = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function ul(e, t, r, o) {
+function sl(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -22809,14 +22786,14 @@ tick: "undefined" != typeof Game ? Game.time : 0,
 shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (n.unit = r), o && (o.shard && (n.shard = o.shard), o.subsystem && (n.subsystem = o.subsystem),
-o.room && (n.room = o.room), o.meta)) for (var a in o.meta) cl.has(a) || (n[a] = o.meta[a]);
-zu(ku.INFO, o) && Ju(tl(n));
+o.room && (n.room = o.room), o.meta)) for (var a in o.meta) il.has(a) || (n[a] = o.meta[a]);
+qu(bu.INFO, o) && Xu($u(n));
 }
 
-function ll(e) {
+function cl(e) {
 return {
 debug: function(t, r) {
-ol(t, "string" == typeof r ? {
+tl(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -22824,7 +22801,7 @@ subsystem: e
 }, r));
 },
 info: function(t, r) {
-nl(t, "string" == typeof r ? {
+rl(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -22832,7 +22809,7 @@ subsystem: e
 }, r));
 },
 warn: function(t, r) {
-al(t, "string" == typeof r ? {
+ol(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -22840,7 +22817,7 @@ subsystem: e
 }, r));
 },
 error: function(t, r) {
-il(t, "string" == typeof r ? {
+nl(t, "string" == typeof r ? {
 subsystem: e,
 room: r
 } : o({
@@ -22848,7 +22825,7 @@ subsystem: e
 }, r));
 },
 stat: function(t, r, n, a) {
-ul(t, r, n, "string" == typeof a ? {
+sl(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -22856,7 +22833,7 @@ subsystem: e
 }, a));
 },
 measureCpu: function(t, r, n) {
-return sl(t, r, "string" == typeof n ? {
+return al(t, r, "string" == typeof n ? {
 subsystem: e,
 room: n
 } : o({
@@ -22866,22 +22843,22 @@ subsystem: e
 };
 }
 
-var ml, dl = {
-debug: ol,
-info: nl,
-warn: al,
-error: il,
-stat: ul,
-measureCpu: sl,
-configure: Xu,
-getConfig: Zu,
-createLogger: ll,
-flush: $u
-}, pl = function() {
+var ul, ll = {
+debug: tl,
+info: rl,
+warn: ol,
+error: nl,
+stat: sl,
+measureCpu: al,
+configure: zu,
+getConfig: Qu,
+createLogger: cl,
+flush: Zu
+}, ml = function() {
 function e() {}
 return e.prototype.showConfig = function() {
-var e = Mr(), t = Zu();
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(ku[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+var e = Mr(), t = Qu();
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(bu[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
 }, n([ Zr({
 name: "showConfig",
 description: "Show current bot configuration",
@@ -22889,13 +22866,13 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), fl = new Map, yl = ((ml = {})[STRUCTURE_SPAWN] = 100, ml[STRUCTURE_TOWER] = 95,
-ml[STRUCTURE_STORAGE] = 90, ml[STRUCTURE_EXTENSION] = 80, ml[STRUCTURE_TERMINAL] = 75,
-ml[STRUCTURE_LINK] = 70, ml[STRUCTURE_CONTAINER] = 65, ml[STRUCTURE_RAMPART] = 55,
-ml[STRUCTURE_WALL] = 50, ml[STRUCTURE_ROAD] = 30, ml);
+}(), dl = new Map, pl = ((ul = {})[STRUCTURE_SPAWN] = 100, ul[STRUCTURE_TOWER] = 95,
+ul[STRUCTURE_STORAGE] = 90, ul[STRUCTURE_EXTENSION] = 80, ul[STRUCTURE_TERMINAL] = 75,
+ul[STRUCTURE_LINK] = 70, ul[STRUCTURE_CONTAINER] = 65, ul[STRUCTURE_RAMPART] = 55,
+ul[STRUCTURE_WALL] = 50, ul[STRUCTURE_ROAD] = 30, ul);
 
-function vl(e) {
-var t, r, o, n, i, s = fl.get(e.name);
+function fl(e) {
+var t, r, o, n, i, s = dl.get(e.name);
 if (s && s.tick === Game.time) return s;
 var c = e.find(FIND_MY_STRUCTURES), u = {
 tick: Game.time,
@@ -22920,55 +22897,55 @@ m && !m.done && (r = l.return) && r.call(l);
 if (t) throw t.error;
 }
 }
-return fl.set(e.name, u), u;
+return dl.set(e.name, u), u;
 }
 
-function gl(e) {
+function yl(e) {
 return !e.hasStorage && e.builtTowerCount > 0;
 }
 
-function hl(e, t) {
+function vl(e, t) {
 var r;
 return function(e, t) {
 if (!t || e.structureType !== STRUCTURE_EXTENSION) return !1;
-var r = vl(t);
-return r.controllerLevel >= 4 && gl(r) && r.energyCapacityAvailable < 650;
+var r = fl(t);
+return r.controllerLevel >= 4 && yl(r) && r.energyCapacityAvailable < 650;
 }(e, t) ? 98 : function(e, t) {
 if (!t || e.structureType !== STRUCTURE_STORAGE) return !1;
-var r = vl(t);
-return r.controllerLevel >= 4 && gl(r);
-}(e, t) ? 97 : null !== (r = yl[e.structureType]) && void 0 !== r ? r : 50;
+var r = fl(t);
+return r.controllerLevel >= 4 && yl(r);
+}(e, t) ? 97 : null !== (r = pl[e.structureType]) && void 0 !== r ? r : 50;
 }
 
-var Rl = M("CreepContext"), El = new Map;
+var gl = M("CreepContext"), hl = new Map;
 
-function Tl(e) {
+function Rl(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function Cl(e) {
-return void 0 === e._containers && (Tl(e), e._containers = e.allStructures.filter(function(e) {
+function El(e) {
+return void 0 === e._containers && (Rl(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 }
 
-function Sl(e) {
+function Tl(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(t, r) {
 return function(e, t, r) {
-return hl(t, r) - hl(e, r);
+return vl(t, r) - vl(e, r);
 }(t, r, e.room);
 })), e._prioritizedSites;
 }
 
-function wl(e) {
-return void 0 === e._repairTargets && (Tl(e), e._repairTargets = e.allStructures.filter(function(e) {
+function Cl(e) {
+return void 0 === e._repairTargets && (Rl(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function xl(e) {
+function Sl(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = El.get(e.name);
+var t = hl.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22977,9 +22954,9 @@ hostiles: Z(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return El.set(e.name, r), r;
+return hl.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Rl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, gl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -23044,10 +23021,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return Sl(i).length;
+return Tl(i).length;
 },
 get damagedStructureCount() {
-return wl(i).length;
+return Cl(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -23058,7 +23035,7 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return Cl(i);
+return El(i);
 },
 get sourceContainers() {
 return function(e) {
@@ -23066,7 +23043,7 @@ if (void 0 === e._sourceContainers) {
 var t = function(e) {
 return void 0 === e._sources && (e._sources = e.room.find(FIND_SOURCES)), e._sources;
 }(e);
-0 === t.length ? e._sourceContainers = [] : e._sourceContainers = Cl(e).filter(function(e) {
+0 === t.length ? e._sourceContainers = [] : e._sourceContainers = El(e).filter(function(e) {
 return t.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
@@ -23076,7 +23053,7 @@ return e._sourceContainers;
 }(i);
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (Tl(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (Rl(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -23105,10 +23082,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return Sl(i);
+return Tl(i);
 },
 get repairTargets() {
-return wl(i);
+return Cl(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -23128,7 +23105,7 @@ e._tombstones;
 var e;
 },
 get mineralContainers() {
-return void 0 === (e = i)._mineralContainers && (Tl(e), e._mineralContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._mineralContainers && (Rl(e), e._mineralContainers = e.allStructures.filter(function(e) {
 if (e.structureType !== STRUCTURE_CONTAINER) return !1;
 var t = e;
 return Object.keys(t.store).some(function(e) {
@@ -23140,9 +23117,9 @@ var e;
 };
 }
 
-var bl, Ol = {}, kl = function() {
-if (bl) return Ol;
-bl = 1, Object.defineProperty(Ol, "__esModule", {
+var wl, xl = {}, bl = function() {
+if (wl) return xl;
+wl = 1, Object.defineProperty(xl, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== ar ? ar : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -24819,14 +24796,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, As = "_rsi";
-return Ol.CachingStrategies = vi, Ol.CoordListSerializer = fi, Ol.CoordSerializer = pi,
-Ol.Keys = ji, Ol.MoveTargetListSerializer = li, Ol.MoveTargetSerializer = ui, Ol.NumberSerializer = Oa,
-Ol.PositionListSerializer = di, Ol.PositionSerializer = mi, Ol.adjacentWalkablePositions = xi,
-Ol.blockSquare = function(e) {
+return xl.CachingStrategies = vi, xl.CoordListSerializer = fi, xl.CoordSerializer = pi,
+xl.Keys = ji, xl.MoveTargetListSerializer = li, xl.MoveTargetSerializer = ui, xl.NumberSerializer = Oa,
+xl.PositionListSerializer = di, xl.PositionSerializer = mi, xl.adjacentWalkablePositions = xi,
+xl.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, Ol.cachePath = ys, Ol.cachedPathKey = ps, Ol.calculateAdjacencyMatrix = Ti, Ol.calculateAdjacentPositions = Ci,
-Ol.calculateNearbyPositions = Si, Ol.calculatePositionsAtRange = wi, Ol.cleanAllCaches = yi,
-Ol.clearCachedPath = ks, Ol.compressPath = e => {
+}, xl.cachePath = ys, xl.cachedPathKey = ps, xl.calculateAdjacencyMatrix = Ti, xl.calculateAdjacentPositions = Ci,
+xl.calculateNearbyPositions = Si, xl.calculatePositionsAtRange = wi, xl.cleanAllCaches = yi,
+xl.clearCachedPath = ks, xl.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24835,19 +24812,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, Ol.config = Ta, Ol.decompressPath = e => {
+}, xl.config = Ta, xl.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, Ol.fastRoomPosition = Ga, Ol.fixEdgePosition = Ei, Ol.follow = function(e, t) {
+}, xl.fastRoomPosition = Ga, xl.fixEdgePosition = Ei, xl.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, Ol.followPath = hs, Ol.fromGlobalPosition = ti, Ol.generatePath = ts, Ol.getCachedPath = vs,
-Ol.getMoveIntents = ns, Ol.getRangeTo = ri, Ol.globalPosition = ei, Ol.isExit = hi,
-Ol.isPositionWalkable = bi, Ol.move = ds, Ol.moveByPath = function(e, t, r) {
+}, xl.followPath = hs, xl.fromGlobalPosition = ti, xl.generatePath = ts, xl.getCachedPath = vs,
+xl.getMoveIntents = ns, xl.getRangeTo = ri, xl.globalPosition = ei, xl.isExit = hi,
+xl.isPositionWalkable = bi, xl.move = ds, xl.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, As));
@@ -24876,9 +24853,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = Mi(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : Ms(e, d, r)) : ERR_NO_PATH;
-}, Ol.moveTo = Ms, Ol.normalizeTargets = Ri, Ol.offsetRoomPosition = Da, Ol.packCoord = qa,
-Ol.packCoordList = za, Ol.packPos = Ya, Ol.packPosList = Xa, Ol.packRoomName = ii,
-Ol.packRoomNames = ni, Ol.posAtDirection = oi, Ol.preTick = function() {
+}, xl.moveTo = Ms, xl.normalizeTargets = Ri, xl.offsetRoomPosition = Da, xl.packCoord = qa,
+xl.packCoordList = za, xl.packPos = Ya, xl.packPosList = Xa, xl.packRoomName = ii,
+xl.packRoomNames = ni, xl.posAtDirection = oi, xl.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) Ui(e), Fi(e);
 !function() {
@@ -24890,34 +24867,34 @@ n.expires && n.expires < Game.time ? (null === (e = Bi.get(n.room1)) || void 0 =
 null === (t = Bi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, Ol.reconcileTraffic = function(e) {
+}, xl.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 _a.with(Oa).set(cs, Game.time);
-}, Ol.reconciledRecently = us, Ol.resetCachedPath = gs, Ol.roomNameFromCoords = $a,
-Ol.roomNameToCoords = Ja, Ol.sameRoomPosition = La, Ol.unpackCoord = ja, Ol.unpackCoordList = Qa,
-Ol.unpackPos = Va, Ol.unpackPosList = Za, Ol.unpackRoomName = si, Ol.unpackRoomNames = ai,
-Ol;
+}, xl.reconciledRecently = us, xl.resetCachedPath = gs, xl.roomNameFromCoords = $a,
+xl.roomNameToCoords = Ja, xl.sameRoomPosition = La, xl.unpackCoord = ja, xl.unpackCoordList = Qa,
+xl.unpackPos = Va, xl.unpackPosList = Za, xl.unpackRoomName = si, xl.unpackRoomNames = ai,
+xl;
 }();
 
-function Ml(e) {
+function Ol(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var Al, Ul = 5e5;
+var kl, Ml = 5e5;
 
-function _l(e) {
+function Al(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Ul;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Ml;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Ul), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Ml), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24929,21 +24906,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(Al || (Al = {}));
+}(kl || (kl = {}));
 
-var Nl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Pl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Il = new Set([ "build", "repair", "upgrade" ]), Gl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Ul = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], _l = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Nl = new Set([ "build", "repair", "upgrade" ]), Pl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function Ll(e, t) {
+function Il(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function Dl() {
+function Gl() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function Bl() {
+function Ll() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24958,8 +24935,8 @@ rooms: {}
 };
 }
 
-function Fl(e) {
-var t = Bl();
+function Dl(e) {
+var t = Ll();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24978,42 +24955,42 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Wl(e, t, r) {
+function Bl(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Hl(e) {
+function Fl(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
+function Wl(e) {
+return _l.includes(e);
+}
+
+function Hl(e) {
+return Nl.has(e);
+}
+
 function Kl(e) {
-return Pl.includes(e);
-}
-
-function Yl(e) {
-return Il.has(e);
-}
-
-function Vl(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY);
 }
 
-function ql(e) {
+function Yl(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function jl(e, t, r) {
-if (void 0 === r && (r = {}), "harvest" === t.type) return ql(e);
-var o = Vl(e);
-return r.reserveEmptyEnergyDelivery && Kl(t.type) ? ql(e) : Math.max(1, o);
+function Vl(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return Yl(e);
+var o = Kl(e);
+return r.reserveEmptyEnergyDelivery && Wl(t.type) ? Yl(e) : Math.max(1, o);
 }
 
-function zl(e, t) {
+function ql(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function Ql(e, t, r) {
+function jl(e, t, r) {
 if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -25021,12 +24998,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return Vl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && ql(e.creep) > 0;
+return Kl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && Yl(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return Vl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return Kl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -25045,7 +25022,7 @@ return !1;
 }
 }
 
-function Xl(e, t) {
+function zl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -25062,7 +25039,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Zl(e) {
+function Ql(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -25070,36 +25047,36 @@ roomName: e.roomName
 };
 }
 
-function Jl(e, t, r, o, n) {
+function Xl(e, t, r, o, n) {
 return {
-id: Wl(e, t, r.id),
+id: Bl(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Zl(r.pos),
+targetPos: Ql(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: Nl,
+allowedRoles: Ul,
 expiresTick: Game.time + 50
 };
 }
 
-function $l(e, t) {
+function Zl(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = Dl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = Gl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < p)) {
 t.lastGeneratedTick = Game.time;
-var f = Ll("taskBoard.findMyStructures", function() {
+var f = Il("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Xl(t, Jl(e.name, "refillTower", h, g, Al.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Xl(t, Jl(e.name, "refillExtension", h, g, Al.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Xl(t, Jl(e.name, "refillSpawn", h, g, Al.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && zl(t, Xl(e.name, "refillTower", h, g, kl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && zl(t, Xl(e.name, "refillExtension", h, g, kl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && zl(t, Xl(e.name, "refillSpawn", h, g, kl.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -25112,29 +25089,29 @@ v && !v.done && (o = y.return) && o.call(y);
 if (r) throw r.error;
 }
 }
-var R = _l(e);
-R && Xl(t, Jl(e.name, "fillTerminalEnergy", R.terminal, R.amount, Al.NORMAL));
+var R = Al(e);
+R && zl(t, Xl(e.name, "fillTerminalEnergy", R.terminal, R.amount, kl.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
-var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ys ? Al.NORMAL : Al.LOW, S = Math.min(E, 1e3);
-Xl(t, Jl(e.name, "storeEnergy", e.storage, S, C));
+var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ys ? kl.NORMAL : kl.LOW, S = Math.min(E, 1e3);
+zl(t, Xl(e.name, "storeEnergy", e.storage, S, C));
 }
-var w = Ll("taskBoard.findHostiles", function() {
+var w = Il("taskBoard.findHostiles", function() {
 return Z(e);
 });
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Xl(t, {
-id: Wl(e.name, "defend", O.id),
+zl(t, {
+id: Bl(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
-priority: Al.CRITICAL,
+priority: kl.CRITICAL,
 targetId: O.id,
-targetPos: Zl(O.pos),
+targetPos: Ql(O.pos),
 amount: O.hits,
 maxAssignments: 3,
-allowedRoles: Gl,
+allowedRoles: Pl,
 expiresTick: Game.time + 50
 });
 }
@@ -25149,7 +25126,7 @@ b && !b.done && (i = x.return) && i.call(x);
 if (n) throw n.error;
 }
 }
-var k = Ll("taskBoard.findInjuredAllies", function() {
+var k = Il("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -25159,13 +25136,13 @@ return e.hits < e.hitsMax;
 try {
 for (var M = a(k.slice(0, 5)), A = M.next(); !A.done; A = M.next()) {
 var U = A.value;
-Xl(t, {
-id: Wl(e.name, "heal", U.id),
+zl(t, {
+id: Bl(e.name, "heal", U.id),
 roomName: e.name,
 type: "heal",
-priority: Al.HIGH,
+priority: kl.HIGH,
 targetId: U.id,
-targetPos: Zl(U.pos),
+targetPos: Ql(U.pos),
 amount: U.hitsMax - U.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -25186,17 +25163,17 @@ if (s) throw s.error;
 }
 }
 
-function em(e) {
+function Jl(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function tm(e) {
+function $l(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && z(e));
 }
 
-function rm(e) {
+function em(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -25208,7 +25185,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? _l(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? Al(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -25221,11 +25198,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !tm(t);
+return !$l(t);
 }
 }
 
-function om(e, t) {
+function tm(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -25247,7 +25224,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function nm(e, t) {
+function rm(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -25255,7 +25232,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (Yl(m.type)) om(e, m); else {
+if (Hl(m.type)) tm(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -25272,7 +25249,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-em(m), Game.time > m.expiresTick || !rm(m) ? om(e, m) : (Hl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Kl(m.type)) && (m.status = "assigned");
+Jl(m), Game.time > m.expiresTick || !em(m) ? tm(e, m) : (Fl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Wl(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -25290,7 +25267,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function am(e, t, r) {
+function om(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -25298,15 +25275,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-em(t);
+Jl(t);
 }
 }
 
-function im(e, t) {
+function nm(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function sm(e, t, r) {
+function am(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -25320,37 +25297,37 @@ return e.reservations[t];
 }(e, t.creep.name, t.memory.assignedTaskId);
 s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId;
 var c = null;
-if (s && im(s, r) && rm(s) && Ql(t, s, r)) {
+if (s && nm(s, r) && em(s) && jl(t, s, r)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Al.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= kl.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var u = cm(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Al.CRITICAL);
+var u = im(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : kl.CRITICAL);
 if (!u || l < m || !d) return s;
-c = u, am(0, s, t.creep.name), e.stats.preemptions++;
-} else if (s && (c = cm(e, t, r), am(0, s, t.creep.name), e.stats.preemptions++,
+c = u, om(0, s, t.creep.name), e.stats.preemptions++;
+} else if (s && (c = im(e, t, r), om(0, s, t.creep.name), e.stats.preemptions++,
 !c)) return null;
-if (null != c || (c = cm(e, t, r)), !c) return null;
-var p = jl(t.creep, c, r);
+if (null != c || (c = im(e, t, r)), !c) return null;
+var p = Vl(t.creep, c, r);
 if (p <= 0) return null;
-var f = Math.min(Math.max(1, Hl(c)), p);
+var f = Math.min(Math.max(1, Fl(c)), p);
 return t.memory.assignedTaskId = c.id, c.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, c.updatedTick = Game.time, em(c), e.stats.assigned++, c;
+}, c.updatedTick = Game.time, Jl(c), e.stats.assigned++, c;
 }
 
-function cm(e, t, r) {
+function im(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (im(l, r) && Ql(t, l, r) && rm(l) && !(Hl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Kl(l.type))) {
-var m = um(t.creep, l), d = 1e3 * l.priority - m;
+if (nm(l, r) && jl(t, l, r) && em(l) && !(Fl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Wl(l.type))) {
+var m = sm(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -25368,7 +25345,7 @@ if (o) throw o.error;
 return i;
 }
 
-function um(e, t) {
+function sm(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -25376,7 +25353,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function lm(e, t) {
+function cm(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -25390,7 +25367,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: zl(e, t.creep.name)
+amount: ql(e, t.creep.name)
 };
 
 case "build":
@@ -25419,7 +25396,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if (tm(t)) return null;
+if ($l(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -25438,83 +25415,83 @@ return null;
 }
 }
 
-var mm = function() {
+var um = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== Bl().enabled;
+return !1 !== Ll().enabled;
 }, e.prototype.setEnabled = function(e) {
-Bl().enabled = e;
+Ll().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !Dl()) return null;
-var r = Fl(e.room.name);
-Ll("taskBoard.cleanup", function() {
-return nm(r);
-}), Ll("taskBoard.generate", function() {
-return $l(e.room, r);
+if (!this.isEnabled() || !Gl()) return null;
+var r = Dl(e.room.name);
+Il("taskBoard.cleanup", function() {
+return rm(r);
+}), Il("taskBoard.generate", function() {
+return Zl(e.room, r);
 });
-var o = sm(r, e, {
+var o = am(r, e, {
 allowedTypes: t
 });
-return o ? lm(o, e) : null;
+return o ? cm(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !Dl()) return null;
-var t = Fl(e.room.name);
-Ll("taskBoard.cleanup", function() {
-return nm(t);
-}), Ll("taskBoard.generate", function() {
-return $l(e.room, t);
+if (!this.isEnabled() || !Gl()) return null;
+var t = Dl(e.room.name);
+Il("taskBoard.cleanup", function() {
+return rm(t);
+}), Il("taskBoard.generate", function() {
+return Zl(e.room, t);
 });
-var r = sm(t, e, {
+var r = am(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: Al.NORMAL,
+preemptPriority: kl.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = lm(r, e);
+var o = cm(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.reserveDeliveryWork = function(e) {
-if (!this.isEnabled() || !Dl()) return !1;
-var t = Fl(e.room.name);
-return Ll("taskBoard.cleanup", function() {
-return nm(t);
-}), Ll("taskBoard.generate", function() {
-return $l(e.room, t);
-}), Boolean(sm(t, e, {
+if (!this.isEnabled() || !Gl()) return !1;
+var t = Dl(e.room.name);
+return Il("taskBoard.cleanup", function() {
+return rm(t);
+}), Il("taskBoard.generate", function() {
+return Zl(e.room, t);
+}), Boolean(am(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: Al.NORMAL,
+preemptPriority: kl.NORMAL,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.reserveCriticalDeliveryWork = function(e) {
-if (!this.isEnabled() || !Dl()) return !1;
-var t = Fl(e.room.name);
-return Ll("taskBoard.cleanup", function() {
-return nm(t);
-}), Ll("taskBoard.generate", function() {
-return $l(e.room, t);
-}), Boolean(sm(t, e, {
+if (!this.isEnabled() || !Gl()) return !1;
+var t = Dl(e.room.name);
+return Il("taskBoard.cleanup", function() {
+return rm(t);
+}), Il("taskBoard.generate", function() {
+return Zl(e.room, t);
+}), Boolean(am(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower" ],
-preemptPriority: Al.HIGH,
+preemptPriority: kl.HIGH,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = Dl();
+var r, o = Gl();
 if (!this.isEnabled() || !o) return !1;
-var n = Fl(e);
-Ll("taskBoard.cleanup", function() {
-return nm(n);
+var n = Dl(e);
+Il("taskBoard.cleanup", function() {
+return rm(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && Ll("taskBoard.generate", function() {
-return $l(a, n);
+return a && Il("taskBoard.generate", function() {
+return Zl(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && rm(e);
+return t.includes(e.type) && em(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && Dl()) {
+if (this.isEnabled() && Gl()) {
 !function(e) {
-var t, r, o, n, s = Bl();
+var t, r, o, n, s = Ll();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -25535,20 +25512,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = Fl(e.name);
-Ll("taskBoard.cleanup", function() {
-return nm(t);
-}), Ll("taskBoard.generate", function() {
-return $l(e, t);
+var t = Dl(e.name);
+Il("taskBoard.cleanup", function() {
+return rm(t);
+}), Il("taskBoard.generate", function() {
+return Zl(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = Bl(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = Ll(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) am(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) om(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -25575,37 +25552,37 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = Bl(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && Kl(c.type) && rm(c))) return delete e.memory.assignedTaskId,
+var a = Ll(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && Wl(c.type) && em(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = zl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = ql(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-em(c), u.amount);
+Jl(c), u.amount);
 }, e.prototype.refreshAssignedDeliveryReservation = function(e) {
 var t, r = e.memory.assignedTaskId;
 if (!r) return !1;
-var o = Bl(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
-if (!(a && i && s && Kl(i.type) && rm(i))) return delete e.memory.assignedTaskId,
+var o = Ll(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && Wl(i.type) && em(i))) return delete e.memory.assignedTaskId,
 !1;
-var c = jl(e.creep, i, {
+var c = Vl(e.creep, i, {
 reserveEmptyEnergyDelivery: !0
 });
-return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Hl(i) + s.amount), c),
-s.expiresTick = Game.time + 15, i.updatedTick = Game.time, em(i), !0);
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Fl(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, Jl(i), !0);
 }, e.prototype.clear = function(e) {
-var t = Bl();
+var t = Ll();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = Dl();
+var t, r = Gl();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = Fl(e);
-Ll("taskBoard.cleanup", function() {
-return nm(n, !0);
-}), Ll("taskBoard.generate", function() {
-return $l(o, n);
+var n = Dl(e);
+Il("taskBoard.cleanup", function() {
+return rm(n, !0);
+}), Il("taskBoard.generate", function() {
+return Zl(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25630,10 +25607,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = Dl(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = Gl(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = Fl(e);
-nm(i, !0), $l(n, i);
+var i = Dl(e);
+rm(i, !0), Zl(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25655,8 +25632,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = Fl(e);
-nm(s, !0);
+var t, r, o, n, i, s = Dl(e);
+rm(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25691,15 +25668,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), dm = new mm;
+}(), lm = new um;
 
-function pm(e) {
+function mm(e) {
 return e === ERR_NO_PATH;
 }
 
-function fm(e) {
+function dm(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && pm(e.moveResult),
+clearState: void 0 !== e.moveResult && mm(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25710,11 +25687,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var ym, vm = M("ActionExecutor");
+var pm, fm = M("ActionExecutor");
 
-function gm(e, t, r) {
+function ym(e, t, r) {
 var o;
-return !!z(r) && (vm.warn("Refusing harmful action against known ally target", {
+return !!z(r) && (fm.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25722,37 +25699,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (kl.clearCachedPath(e.creep), Rt(e.creep)),
-dm.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (bl.clearCachedPath(e.creep), Rt(e.creep)),
+lm.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function hm(e, t, r) {
+function vm(e, t, r) {
 var o, n;
-if (!t || !t.type) return vm.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return fm.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && vm.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-vm.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && fm.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+fm.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25776,7 +25753,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = Em(e, function() {
+i = hm(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25790,92 +25767,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (gm(r, a.type, a.target)) {
+if (ym(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Em(e, function() {
+i = hm(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (gm(r, a.type, a.target)) {
+if (ym(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Em(e, function() {
+hm(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (gm(r, a.type, a.target)) {
+if (ym(r, a.type, a.target)) {
 i = !0;
 break;
 }
-Em(e, function() {
+hm(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-Em(e, function() {
+hm(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), pm(kl.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), mm(bl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = Em(e, function() {
+i = hm(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (gm(r, a.type, a.target)) {
+if (ym(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = Em(e, function() {
+i = hm(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-pm(kl.moveTo(e, a.target)) && (i = !0);
+mm(bl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-pm(kl.moveTo(e, {
+mm(bl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25884,11 +25861,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-pm(Rm(e, a.target, a.routeType)) && (i = !0);
+mm(gm(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), pm(Rm(e, {
+c = new RoomPosition(25, 25, a.roomName), mm(gm(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25903,44 +25880,44 @@ pos: e,
 range: 10
 };
 });
-pm(kl.moveTo(e, u, {
+mm(bl.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (kl.isExit(e.pos)) {
+if (bl.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-kl.moveTo(e, l, {
+bl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || pm(kl.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || mm(bl.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-pm(kl.moveTo(e, a.target, {
+mm(bl.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (kl.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), kl.moveTo(e, l, {
+if (bl.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), bl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = Ml(m.name);
+var d = Ol(m.name);
 if (d && !e.pos.isEqualTo(d) && function(e) {
 return "scout" !== e.role;
 }({
 role: r.memory.role
 })) {
-pm(kl.moveTo(e, d, {
+mm(bl.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25949,7 +25926,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && kl.moveTo(e, {
+p && bl.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25957,8 +25934,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, kl.clearCachedPath(e), Rt(e), dm.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || dm.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, bl.clearCachedPath(e), Rt(e), lm.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || lm.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25966,27 +25943,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function Rm(e, t, r, o) {
-if (!ym) return kl.moveTo(e, t, o);
+function gm(e, t, r, o) {
+if (!pm) return bl.moveTo(e, t, o);
 try {
-return ym(e, t, r, o);
+return pm(e, t, r, o);
 } catch (n) {
-return vm.warn("Remote movement handler failed; falling back to default movement", {
+return fm.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), kl.moveTo(e, t, o);
+}), bl.moveTo(e, t, o);
 }
 }
 
-function Em(e, t, r, o, n, a) {
+function hm(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = kl.moveTo(e, r);
-return s !== OK && vm.info("Movement attempt returned non-OK result", {
+var s = bl.moveTo(e, r);
+return s !== OK && fm.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25994,12 +25971,12 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), fm({
+}), dm({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = fm({
+var c = dm({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
@@ -26065,7 +26042,7 @@ ss(e).upgradeProgress += t;
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (vm.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (fm.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -26076,13 +26053,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Tm, Cm = M("StateMachine");
+var Rm, Em = M("StateMachine");
 
-function Sm(e) {
+function Tm(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function wm(e, t, r) {
+function Cm(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -26104,12 +26081,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== Sm(e.amount) ? {
+}, void 0 !== Tm(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), Cm.info(r, {
+}(t), Em.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26117,13 +26094,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : Cm.info("Behavior returned idle action", {
+})) : Em.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (Cm.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (Em.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26134,11 +26111,11 @@ type: "idle"
 });
 }
 
-function xm(e, t, r) {
+function Sm(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, wm(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, Cm(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -26218,7 +26195,7 @@ return !0;
 default:
 return !1;
 }
-}(a, e)) Cm.info("State completed, evaluating new action", {
+}(a, e)) Em.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26268,7 +26245,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = Sm(e.data.amount);
+var c = Tm(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -26351,12 +26328,12 @@ return null;
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(c) && dm.refreshAssignedDeliveryReservation(e), c;
-var u = e.memory.assignedTaskId, l = dm.refreshCreepReservation(e, c);
+}(c) && lm.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = lm.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-Cm.info("Task-board delivery reservation missing, re-evaluating behavior", {
+Em.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26366,7 +26343,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-Cm.info("State reconstruction failed, re-evaluating behavior", {
+Em.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26374,7 +26351,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (Cm.info("State invalid, re-evaluating behavior", {
+} else a && (Em.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -26383,33 +26360,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return wm(e, t(e), "Committed new state action");
+return Cm(e, t(e), "Committed new state action");
 }
 
-(Tm = {})[FIND_SOURCES] = 5e3, Tm[FIND_MINERALS] = 5e3, Tm[FIND_DEPOSITS] = 100,
-Tm[FIND_STRUCTURES] = 50, Tm[FIND_MY_STRUCTURES] = 50, Tm[FIND_HOSTILE_STRUCTURES] = 20,
-Tm[FIND_MY_SPAWNS] = 100, Tm[FIND_MY_CONSTRUCTION_SITES] = 20, Tm[FIND_CONSTRUCTION_SITES] = 20,
-Tm[FIND_CREEPS] = 5, Tm[FIND_MY_CREEPS] = 5, Tm[FIND_HOSTILE_CREEPS] = 3, Tm[FIND_DROPPED_RESOURCES] = 5,
-Tm[FIND_TOMBSTONES] = 10, Tm[FIND_RUINS] = 10, Tm[FIND_FLAGS] = 50, Tm[FIND_NUKES] = 20,
-Tm[FIND_POWER_CREEPS] = 10, Tm[FIND_MY_POWER_CREEPS] = 10;
+(Rm = {})[FIND_SOURCES] = 5e3, Rm[FIND_MINERALS] = 5e3, Rm[FIND_DEPOSITS] = 100,
+Rm[FIND_STRUCTURES] = 50, Rm[FIND_MY_STRUCTURES] = 50, Rm[FIND_HOSTILE_STRUCTURES] = 20,
+Rm[FIND_MY_SPAWNS] = 100, Rm[FIND_MY_CONSTRUCTION_SITES] = 20, Rm[FIND_CONSTRUCTION_SITES] = 20,
+Rm[FIND_CREEPS] = 5, Rm[FIND_MY_CREEPS] = 5, Rm[FIND_HOSTILE_CREEPS] = 3, Rm[FIND_DROPPED_RESOURCES] = 5,
+Rm[FIND_TOMBSTONES] = 10, Rm[FIND_RUINS] = 10, Rm[FIND_FLAGS] = 50, Rm[FIND_NUKES] = 20,
+Rm[FIND_POWER_CREEPS] = 10, Rm[FIND_MY_POWER_CREEPS] = 10;
 
-var bm, Om, km = {}, Mm = {}, Am = {}, Um = {};
+var wm, xm, bm = {}, Om = {}, km = {}, Mm = {};
 
-function _m() {
-if (bm) return Um;
-bm = 1;
+function Am() {
+if (wm) return Mm;
+wm = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Um.encode = function(t) {
+return Mm.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, Um;
+}, Mm;
 }
 
-function Nm() {
-if (Om) return Am;
-Om = 1;
-const e = _m();
-return Am.encode = function(t) {
+function Um() {
+if (xm) return km;
+xm = 1;
+const e = Am();
+return km.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -26417,23 +26394,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, Am;
+}, km;
 }
 
-var Pm, Im, Gm, Lm = {}, Dm = ir(Object.freeze({
+var _m, Nm, Pm, Im = {}, Gm = ir(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Bm() {
-return Im ? Pm : (Im = 1, Pm = "function" == typeof URL ? URL : Dm.URL);
+function Lm() {
+return Nm ? _m : (Nm = 1, _m = "function" == typeof URL ? URL : Gm.URL);
 }
 
-function Fm() {
-if (Gm) return Lm;
-Gm = 1;
-const e = Bm();
-Lm.getArg = function(e, t, r) {
+function Dm() {
+if (Pm) return Im;
+Pm = 1;
+const e = Lm();
+Im.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -26453,16 +26430,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Lm.toSetString = t ? r : function(e) {
+Im.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Lm.fromSetString = t ? r : function(e) {
+}, Im.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Lm.compareByGeneratedPositionsInflated = function(e, t) {
+}, Im.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Lm.parseSourceMapInput = function(e) {
+}, Im.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -26516,7 +26493,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Lm.normalize = f, Lm.join = y, Lm.relative = function(t, r) {
+return Im.normalize = f, Im.join = y, Im.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -26528,18 +26505,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Lm.computeSourceURL = function(e, t, r) {
+}, Im.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Lm;
+}, Im;
 }
 
-var Wm, Hm = {};
+var Bm, Fm = {};
 
-function Km() {
-if (Wm) return Hm;
-Wm = 1;
+function Wm() {
+if (Bm) return Fm;
+Bm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -26572,19 +26549,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Hm.ArraySet = e, Hm;
+return Fm.ArraySet = e, Fm;
 }
 
-var Ym, Vm, qm = {};
+var Hm, Km, Ym = {};
 
-function jm() {
-if (Vm) return Mm;
-Vm = 1;
-const e = Nm(), t = Fm(), r = Km().ArraySet, o = function() {
-if (Ym) return qm;
-Ym = 1;
-const e = Fm();
-return qm.MappingList = class {
+function Vm() {
+if (Km) return Om;
+Km = 1;
+const e = Um(), t = Dm(), r = Wm().ArraySet, o = function() {
+if (Hm) return Ym;
+Hm = 1;
+const e = Dm();
+return Ym.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -26604,7 +26581,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, qm;
+}, Ym;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26733,13 +26710,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Mm.SourceMapGenerator = n, Mm;
+return n.prototype._version = 3, Om.SourceMapGenerator = n, Om;
 }
 
-var zm, Qm = {}, Xm = {};
+var qm, jm = {}, zm = {};
 
-function Zm() {
-return zm || (zm = 1, function(e) {
+function Qm() {
+return qm || (qm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26751,36 +26728,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(Xm)), Xm;
+}(zm)), zm;
 }
 
-var Jm, $m, ed, td, rd = {
+var Xm, Zm, Jm, $m, ed = {
 exports: {}
 };
 
-function od() {
-if (Jm) return rd.exports;
-Jm = 1;
+function td() {
+if (Xm) return ed.exports;
+Xm = 1;
 let e = null;
-return rd.exports = function() {
+return ed.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, rd.exports.initialize = t => {
+}, ed.exports.initialize = t => {
 e = t;
-}, rd.exports;
+}, ed.exports;
 }
 
-function nd() {
-if (ed) return $m;
-ed = 1;
-const e = od();
+function rd() {
+if (Jm) return Zm;
+Jm = 1;
+const e = td();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return $m = function() {
+return Zm = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26847,28 +26824,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, $m;
+}, Zm;
 }
 
-var ad, id, sd, cd, ud = {};
+var od, nd, ad, id, sd = {};
 
-function ld(e, t, r) {
+function cd(e, t, r) {
 return e - t >= r;
 }
 
-function md(e, t) {
+function ud(e, t) {
 return e.priority - t.priority;
 }
 
-function dd(e, t, r, o) {
+function ld(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function pd(e, t, r, o) {
+function md(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function fd(e) {
+function dd(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26886,12 +26863,12 @@ if (t) throw t.error;
 return o;
 }
 
-id || (id = 1, km.SourceMapGenerator = jm().SourceMapGenerator, km.SourceMapConsumer = function() {
-if (td) return Qm;
-td = 1;
-const e = Fm(), t = Zm(), r = Km().ArraySet;
-Nm();
-const o = od(), n = nd(), a = Symbol("smcInternal");
+nd || (nd = 1, bm.SourceMapGenerator = Vm().SourceMapGenerator, bm.SourceMapConsumer = function() {
+if ($m) return jm;
+$m = 1;
+const e = Dm(), t = Qm(), r = Wm().ArraySet;
+Um();
+const o = td(), n = rd(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26928,7 +26905,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, Qm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, jm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -27118,7 +27095,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, Qm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, jm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -27227,11 +27204,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return Qm.IndexedSourceMapConsumer = c, Qm;
-}().SourceMapConsumer, km.SourceNode = function() {
-if (ad) return ud;
-ad = 1;
-const e = jm().SourceMapGenerator, t = Fm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return jm.IndexedSourceMapConsumer = c, jm;
+}().SourceMapConsumer, bm.SourceNode = function() {
+if (od) return sd;
+od = 1;
+const e = Vm().SourceMapGenerator, t = Dm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -27370,27 +27347,27 @@ map: o
 };
 }
 }
-return ud.SourceNode = n, ud;
+return sd.SourceNode = n, sd;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(cd || (cd = {}));
+}(id || (id = {}));
 
-var yd, vd = [ cd.CRITICAL, cd.HIGH, cd.MEDIUM, cd.LOW ], gd = {
-bucketThresholds: (sd = {}, sd[cd.CRITICAL] = 0, sd[cd.HIGH] = 2e3, sd[cd.MEDIUM] = 5e3,
-sd[cd.LOW] = 8e3, sd),
+var pd, fd = [ id.CRITICAL, id.HIGH, id.MEDIUM, id.LOW ], yd = {
+bucketThresholds: (ad = {}, ad[id.CRITICAL] = 0, ad[id.HIGH] = 2e3, ad[id.MEDIUM] = 5e3,
+ad[id.LOW] = 8e3, ad),
 defaultMaxCpu: 5,
 logExecution: !1
-}, hd = function() {
+}, vd = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: fd(vd),
+tasksByPriority: dd(fd),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, gd), e);
+}, this.config = o(o({}, yd), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -27404,13 +27381,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(md), l = 0;
+var u = Array.from(this.tasks.values()).sort(ud), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (ld(Game.time, p.lastRun, p.interval)) if (dd(p.priority, s, this.config.bucketThresholds, cd.CRITICAL)) this.stats.skippedThisTick++; else {
+if (cd(Game.time, p.lastRun, p.interval)) if (ld(p.priority, s, this.config.bucketThresholds, id.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (pd(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (md(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -27458,7 +27435,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = fd(vd);
+var t, r, o = dd(fd);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -27475,22 +27452,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), Rd = ((yd = global)._computationScheduler || (yd._computationScheduler = new hd),
-yd._computationScheduler), Ed = new Map;
+}(), gd = ((pd = global)._computationScheduler || (pd._computationScheduler = new vd),
+pd._computationScheduler), hd = new Map;
 
-function Td(e) {
-var t = Ed.get(e);
+function Rd(e) {
+var t = hd.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, Ed.set(e, t)), t;
+}, hd.set(e, t)), t;
 }
 
-function Cd(e, t, r) {
+function Ed(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return Sd(e, t[0], r), t[0];
-var i = Td(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Td(e, t[0], r), t[0];
+var i = Rd(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -27507,32 +27484,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && Sd(e, s, r), s;
+return s && Td(e, s, r), s;
 }
 
-function Sd(e, t, r) {
-var o = Td(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Td(e, t, r) {
+var o = Rd(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var wd = {
+var Cd = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function xd(e, t, r) {
+function Sd(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(wd[t], ";") : "";
+var o = t ? "color: ".concat(Cd[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function bd(e) {
+function wd(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var Od = {
+var xd = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -27546,7 +27523,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(bd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(wd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -27563,44 +27540,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(bd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(wd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function kd() {
+function bd() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Ud() + _d() + '<div class="module-help">'.concat(e.map(Md).join(""), "</div>");
+return Md() + Ad() + '<div class="module-help">'.concat(e.map(Od).join(""), "</div>");
 }
 
-var Md = function(e) {
-var t = e.api.map(Ad).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(xd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(xd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, Ad = function(e) {
+var Od = function(e) {
+var t = e.api.map(kd).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Sd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Sd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, kd = function(e) {
 var t = [];
-e.describe && t.push(xd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(xd(e.name, "blue"), ": ").concat(xd(e.desc, "green"));
+e.describe && t.push(Sd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(Sd(e.name, "blue"), ": ").concat(Sd(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return xd(e.name, "blue");
-}).join(", ") : "", o = xd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return Sd(e.name, "blue");
+}).join(", ") : "", o = Sd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(xd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Ud = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Sd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, Md = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, _d = function() {
+}, Ad = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Nd = M("EnergyCollection"), Pd = [ "refillSpawn", "refillExtension", "refillTower" ], Id = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, Ud = M("EnergyCollection"), _d = [ "refillSpawn", "refillExtension", "refillTower" ], Nd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function Gd(e) {
+function Pd(e) {
 if (e.droppedResources.length > 0) {
 var t = ht(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27610,15 +27587,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Cd(e.creep, r, "energy_container");
-if (o) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Ed(e.creep, r, "energy_container");
+if (o) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (Ud.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27629,8 +27606,8 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ys && Id.has(e.memory.role);
-}(e, n)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ys && Nd.has(e.memory.role);
+}(e, n)) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -27641,41 +27618,41 @@ var a = ft(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = Cd(e.creep, a, "energy_source");
-if (s) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = Ed(e.creep, a, "energy_source");
+if (s) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (Ud.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Ud.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Ld(e) {
-var t = dm.getAssignedAction(e, Pd);
+function Id(e) {
+var t = lm.getAssignedAction(e, _d);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Dd(e) {
-return dm.hasActiveTask(e.room.name, Pd);
+function Gd(e) {
+return lm.hasActiveTask(e.room.name, _d);
 }
 
-function Bd(e, t) {
+function Ld(e, t) {
 return function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(t) && dm.reserveCriticalDeliveryWork(e), t;
+}(t) && lm.reserveCriticalDeliveryWork(e), t;
 }
 
-function Fd(e, t) {
+function Dd(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27702,11 +27679,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Wd(e) {
-var t = dm.getAssignedDeliveryAction(e);
+function Bd(e) {
+var t = lm.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Dd(e)) {
-var r = Fd(e, "deliver");
+if (!Gd(e)) {
+var r = Dd(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27728,9 +27705,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Hd = /^[WE]\d+[NS]\d+$/;
+var Fd = /^[WE]\d+[NS]\d+$/;
 
-function Kd(e) {
+function Wd(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27740,28 +27717,28 @@ routeType: "hauler"
 } : null;
 }
 
-function Yd(e) {
-return Hd.test(e);
+function Hd(e) {
+return Fd.test(e);
 }
 
-function Vd(e) {
+function Kd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-if (!n || !Yd(n)) return Kd(e);
+if (!n || !Hd(n)) return Wd(e);
 var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
 return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
-} : null : Kd(e) : null;
+} : null : Wd(e) : null;
 }
 
-function qd(e) {
+function Yd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = Vd(e);
+var a = Kd(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !Yd(n)) return null;
+if (!n || !Hd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27774,7 +27751,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function jd(e) {
+function Vd(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27783,11 +27760,11 @@ var n = e.memory.working;
 return o !== n && Et(e.creep), n;
 }
 
-function zd(e) {
+function qd(e) {
 e.memory.working = !1, Et(e.creep);
 }
 
-var Qd = function() {
+var jd = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27882,20 +27859,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), Xd = new Qd, Zd = M("LarvaWorkerBehavior");
+}(), zd = new jd, Qd = M("LarvaWorkerBehavior");
 
-function Jd(e) {
-var t = jd(e), r = Vd(e);
+function Xd(e) {
+var t = Vd(e), r = Kd(e);
 if (r) return r;
 if (t) {
-Zd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = qd(e);
+Qd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = Yd(e);
 if (o) return o;
-var n = Wd(e);
-if (n) return Zd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = Bd(e);
+if (n) return Qd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = Xd.getSwarmState(e.room.name);
+var t, r = zd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27912,7 +27889,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Zd.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Qd.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27921,54 +27898,54 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Zd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Qd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Zd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-zd(e);
+Qd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+qd(e);
 }
-return Bd(e, Gd(e));
+return Ld(e, Pd(e));
 }
 
-function $d(e) {
+function Zd(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-var ep = new Map;
+var Jd = new Map;
 
-function tp(e) {
+function $d(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var rp = M("HarvesterBehavior"), op = M("HaulerBehavior"), np = Ys, ap = [ "refillSpawn", "refillExtension" ];
+var ep = M("HarvesterBehavior"), tp = M("HaulerBehavior"), rp = Ys, op = [ "refillSpawn", "refillExtension" ];
 
-function ip(e, t) {
-return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && dm.reserveDeliveryWork(e),
-"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && dm.reserveDeliveryWork(e),
+function np(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && lm.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && lm.reserveDeliveryWork(e),
 t;
 }
 
-function sp(e, t, r) {
+function ap(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return Sd(e, c, r), c;
+if (c) return Td(e, c, r), c;
 }
-var u = Cd(e, t, r);
+var u = Ed(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function cp(e) {
+function ip(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27982,9 +27959,9 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-function up(e) {
+function sp(e) {
 if (e.creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
-var t = Wd(e);
+var t = Bd(e);
 if (t) return t;
 }
 var r, o = (r = e.creep, Object.keys(r.store).find(function(e) {
@@ -28002,7 +27979,7 @@ resourceType: o
 } : null;
 }
 
-var lp = {
+var cp = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -28012,11 +27989,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, mp = lp, dp = function(e) {
-return mp.getLabResourceNeeds(e);
+}, up = cp, lp = function(e) {
+return up.getLabResourceNeeds(e);
 };
 
-function pp(e) {
+function mp(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -28038,7 +28015,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = dp(e.room.name);
+var n = lp(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -28066,7 +28043,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, mp.getLabOverflow(r));
+var t, r, o = (r = e.room.name, up.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -28081,7 +28058,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = dp(e.room.name);
+var i = lp(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -28100,8 +28077,8 @@ type: "idle"
 }(e);
 }
 
-var fp = {
-larvaWorker: Jd,
+var dp = {
+larvaWorker: Xd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -28118,7 +28095,7 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (jd(e)) {
+if (Vd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28137,7 +28114,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Gd(e);
+return Pd(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -28174,10 +28151,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some($d)) return {
+if (e.hostiles.some(Zd)) return {
 type: "idle"
 };
-if (jd(e)) {
+if (Vd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28196,10 +28173,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Gd(e);
+return Pd(e);
 },
 harvester: function(e) {
-var t, r = (t = tp(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = $d(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -28248,8 +28225,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), rp.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return rp.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), ep.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return ep.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -28277,7 +28254,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return rp.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return ep.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -28298,12 +28275,12 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (rp.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (ep.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (rp.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (ep.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
@@ -28316,8 +28293,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-var r = jd(e), o = "defenseRefuel" === e.memory.task;
-if (op.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var r = Vd(e), o = "defenseRefuel" === e.memory.task;
+if (tp.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -28330,9 +28307,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = dm.getAssignedAction(e, ap);
+var t = lm.getAssignedAction(e, op);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (dm.hasActiveTask(e.room.name, ap)) return null;
+if (lm.hasActiveTask(e.room.name, op)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -28352,17 +28329,17 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = dm.getAssignedDeliveryAction(e);
+var c = lm.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Dd(e)) {
-var u = Fd(e, "hauler");
+if (!Gd(e)) {
+var u = Dd(e, "hauler");
 if (u) return u;
 }
 var l = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = _l(e.room);
-return r < 2e4 && o > np && n > 0 || Boolean(a) ? {
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Al(e.room);
+return r < 2e4 && o > rp && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28388,12 +28365,12 @@ type: "transfer",
 target: m,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return op.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return tp.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-op.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-zd(e);
+tp.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+qd(e);
 }
 if (o) {
 var p = function(e) {
@@ -28401,7 +28378,7 @@ var t = e.sourceContainers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (t.length > 0) {
-var r = sp(e.creep, t, "energy_container");
+var r = ap(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -28422,7 +28399,7 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (p) return p;
 }
-if (e.droppedResources.length > 0 && (m = ht(e.creep, e.droppedResources, "hauler_drop", 5))) return ip(e, {
+if (e.droppedResources.length > 0 && (m = ht(e.creep, e.droppedResources, "hauler_drop", 5))) return np(e, {
 type: "pickup",
 target: m
 });
@@ -28432,7 +28409,7 @@ return e.store.getUsedCapacity() > 0;
 if (f.length > 0) {
 var y = ht(e.creep, f, "hauler_tomb", 10);
 if (y) {
-if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return ip(e, {
+if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return np(e, {
 type: "withdraw",
 target: y,
 resourceType: RESOURCE_ENERGY
@@ -28451,24 +28428,24 @@ var g = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (g.length > 0) {
-var h = sp(e.creep, g, "energy_container");
-if (h) return op.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-ip(e, {
+var h = ap(e.creep, g, "energy_container");
+if (h) return tp.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+np(e, {
 type: "withdraw",
 target: h,
 resourceType: RESOURCE_ENERGY
 });
-op.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
+tp.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
 var R = e.creep.pos.findClosestByRange(g);
-if (R) return op.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
-ip(e, {
+if (R) return tp.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
+np(e, {
 type: "withdraw",
 target: R,
 resourceType: RESOURCE_ENERGY
 });
 }
 if (e.mineralContainers.length > 0) {
-var E = sp(e.creep, e.mineralContainers, "mineral_container");
+var E = ap(e.creep, e.mineralContainers, "mineral_container");
 if (E) {
 if (T = Object.keys(E.store).find(function(e) {
 return e !== RESOURCE_ENERGY && E.store.getUsedCapacity(e) > 0;
@@ -28478,11 +28455,11 @@ target: E,
 resourceType: T
 };
 } else {
-op.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+tp.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var T, C = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (C && (T = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
-}))) return op.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
+}))) return tp.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
 {
 type: "withdraw",
 target: C,
@@ -28496,7 +28473,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > np || _l(e.room)) return {
+if (o < 2e4 && n > rp || Al(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28527,53 +28504,53 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return S ? ip(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (op.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-ip(e, {
+return S ? np(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (tp.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+np(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-})) : (op.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (tp.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 });
 },
 builder: function(e) {
-var t = jd(e), r = Vd(e);
+var t = Vd(e), r = Kd(e);
 if (r) return r;
 if (t) {
-var o = qd(e);
+var o = Yd(e);
 if (o) return o;
-var n = Ld(e);
+var n = Id(e);
 if (n) return n;
-if (!Dd(e)) {
-var a = Fd(e, "builder");
+if (!Gd(e)) {
+var a = Dd(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = tp(e), r = function(e) {
-var t = ep.get(e.name);
+var t = $d(e), r = function(e) {
+var t = Jd.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(t, r) {
-return Math.max(t, hl(r, e));
+return Math.max(t, vl(r, e));
 }, Number.NEGATIVE_INFINITY), n = {
 tick: Game.time,
 sites: r,
 highestPriority: o
 };
-return ep.set(e.name, n), n;
+return Jd.set(e.name, n), n;
 }(e.room);
 if (0 === r.sites.length) return delete t.targetId, null;
 if (t.targetId) {
 var o = Game.getObjectById(t.targetId);
 if (o && function(e, t) {
 return e.pos.roomName === t.name;
-}(o, e.room) && hl(o, e.room) >= r.highestPriority) return o;
+}(o, e.room) && vl(o, e.room) >= r.highestPriority) return o;
 delete t.targetId;
 }
 var n = function(e, t) {
 var r, o, n = t.sites.filter(function(r) {
-return hl(r, e.room) === t.highestPriority;
+return vl(r, e.room) === t.highestPriority;
 });
 return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
 }(e, r);
@@ -28592,15 +28569,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Bd(e, Gd(e));
+return Ld(e, Pd(e));
 },
 upgrader: function(e) {
-if (jd(e)) {
-if (cp(e)) {
-var t = Ld(e);
+if (Vd(e)) {
+if (ip(e)) {
+var t = Id(e);
 if (t) return t;
-if (!Dd(e)) {
-var r = Fd(e, "upgrader");
+if (!Gd(e)) {
+var r = Dd(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28611,8 +28588,8 @@ target: e.room.controller
 type: "idle"
 };
 }
-var o = cp(e), n = function(t) {
-return o ? Bd(e, t) : t;
+var o = ip(e), n = function(t) {
+return o ? Ld(e, t) : t;
 }, a = e.room.controller;
 if (a) {
 var i = a.pos.findInRange(FIND_MY_STRUCTURES, 2, {
@@ -28675,7 +28652,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (jd(e)) {
+if (Vd(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28699,7 +28676,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Wd(e) || (e.storage ? {
+} : Bd(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28718,15 +28695,15 @@ return e.pos.getRangeTo(t) <= 2;
 })[0];
 }
 }(e.room);
-return r ? Bd(e, {
+return r ? Ld(e, {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
-}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Bd(e, {
+}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Ld(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Bd(e, {
+}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Ld(e, {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28819,15 +28796,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : pp(e);
+} : mp(e);
 },
-labSupply: pp,
+labSupply: mp,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (jd(e)) {
+if (Vd(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -29007,11 +28984,11 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t, r = jd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
+var t, r = Vd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
 if (!o || o === n) return {
 type: "idle"
 };
-if (a && e.room.name === n && (t = up(e))) return t;
+if (a && e.room.name === n && (t = sp(e))) return t;
 if (e.nearbyEnemies && e.hostiles.length > 0) {
 var i = e.hostiles.filter(function(t) {
 return e.creep.pos.getRangeTo(t) <= 5 && (t.getActiveBodyparts(ATTACK) > 0 || t.getActiveBodyparts(RANGED_ATTACK) > 0);
@@ -29031,7 +29008,7 @@ if (r || a && e.room.name === n) return e.room.name !== n ? {
 type: "remoteMoveToRoom",
 roomName: n,
 routeType: "hauler"
-} : (t = up(e)) || (a && e.room.name === n ? (zd(e), {
+} : (t = sp(e)) || (a && e.room.name === n ? (qd(e), {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
@@ -29132,16 +29109,16 @@ roomName: o
 }
 };
 
-function yp(e) {
+function pp(e) {
 var t;
-return (null !== (t = fp[e.memory.role]) && void 0 !== t ? t : Jd)(e);
+return (null !== (t = dp[e.memory.role]) && void 0 !== t ? t : Xd)(e);
 }
 
-var vp = new Set([ "build", "repair", "upgrade" ]);
+var fp = new Set([ "build", "repair", "upgrade" ]);
 
-function gp(e, t) {
+function yp(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && Yd(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && Hd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -29150,12 +29127,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : qd(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Yd(e);
 }(e, t);
-return r || (vp.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || cp(e) ? Ld(e) : null : null);
+return r || (fp.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || ip(e) ? Id(e) : null : null);
 }
 
-var hp = "patrol", Rp = [ {
+var vp = "patrol", gp = [ {
 x: 10,
 y: 5
 }, {
@@ -29191,7 +29168,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], Ep = [ {
+} ], hp = [ {
 x: 10,
 y: 10
 }, {
@@ -29208,7 +29185,7 @@ x: 25,
 y: 25
 } ];
 
-function Tp(e) {
+function Rp(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -29216,7 +29193,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function Cp(e) {
+function Ep(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -29226,9 +29203,9 @@ roomName: e.roomName
 });
 }
 
-function Sp(e) {
+function Tp(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Ee.get(e.name, {
-namespace: hp
+namespace: vp
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -29248,25 +29225,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(Rp), !1), i(Ep), !1);
-}(t).map(Tp).filter(function(e) {
+}(e)), !1), i(gp), !1), i(hp), !1);
+}(t).map(Rp).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Ee.set(e.name, {
-waypoints: Cp(n),
+waypoints: Ep(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: hp,
+namespace: vp,
 ttl: 1e3
 }), n;
 }
 
-function wp(e, t) {
+function Cp(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -29276,89 +29253,89 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var xp = M("MilitaryBehaviors");
+var Sp = M("MilitaryBehaviors");
 
-function bp(e) {
+function wp(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
 delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === vi && (delete e.task,
 delete e.targetRoom);
 }
 
-function Op(e, t) {
+function xp(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function kp(e) {
+function bp(e) {
 return Po(Mo(e));
 }
 
-function Mp(e) {
+function Op(e) {
 return e.creep.room.name === e.homeRoom && Z(e.room).length > 0;
 }
 
-function Ap(e) {
+function kp(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Up(e, t) {
+function Mp(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function _p(e) {
-return Up(e, "guard") + Up(e, "ranger") + Up(e, "healer");
+function Ap(e) {
+return Mp(e, "guard") + Mp(e, "ranger") + Mp(e, "healer");
 }
 
-function Np(e, t, r) {
+function Up(e, t, r) {
 var o = e.memory;
 return Ri(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function Pp(e, t) {
+function _p(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return Np(r, e, t);
+return Up(r, e, t);
 });
 }
 
-function Ip(e) {
+function Np(e) {
 return "number" == typeof e.createdAt && Number.isFinite(e.createdAt) ? e.createdAt : Game.time;
 }
 
-function Gp(e, t, r) {
-return Up(e, t) > function(e, t) {
+function Pp(e, t, r) {
+return Mp(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
 return !r.spawning && o.role === t && Ri(o) === e;
 }).length;
-}(e.roomName, t) || _p(e) > 0 && kp(e.roomName) && function(e, t) {
-return Pp(e, t).length;
+}(e.roomName, t) || Ap(e) > 0 && bp(e.roomName) && function(e, t) {
+return _p(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Lp(e, t) {
+function Ip(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
 if (t.task && t.task !== vi) return null;
-if (Mp(e)) return null;
+if (Op(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ap).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(kp).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== Z(l).length && Gp(u, t.role, e.homeRoom)) {
-var m = Ip(u);
+if (l && 0 !== Z(l).length && Pp(u, t.role, e.homeRoom)) {
+var m = Np(u);
 return hi(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
 createdAt: m,
 squadId: gi(e.homeRoom, u.roomName, m),
-squadSize: kp(u.roomName) ? Math.max(5, _p(u)) : Math.max(1, _p(u))
+squadSize: bp(u.roomName) ? Math.max(5, Ap(u)) : Math.max(1, Ap(u))
 }), u.roomName;
 }
 }
@@ -29376,7 +29353,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Dp(e) {
+function Gp(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -29384,7 +29361,7 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Bp(e, t) {
+function Lp(e, t) {
 if (!function(e) {
 return Boolean(Ri(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
@@ -29392,11 +29369,11 @@ if (e.creep.room.name !== e.homeRoom) return null;
 var r = Ri(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = Mo(r), n = Po(o), a = n ? Pp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var o = Mo(r), n = Po(o), a = n ? _p(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
 var r = Ri(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Np(e, r, o);
+return e.memory.defenseSquadId === t && Up(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -29410,7 +29387,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return Pp(e, t).reduce(function(e, t) {
+return _p(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = wo(t.body.filter(function(e) {
 return e.hits > 0;
@@ -29432,16 +29409,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return Op(t, "parity-ready"), null;
-if (c >= u) return Op(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return xp(t, "parity-ready"), null;
+if (c >= u) return xp(t, "squad-quorum"), null;
 if (l) {
-if (!n) return Op(t, "expired-staging"), null;
+if (!n) return xp(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Dp(e) - Dp(t);
+var r = Gp(e) - Gp(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -29449,20 +29426,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return Op(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return xp(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return Op(t, "squad-quorum"), null;
-if (l) return Op(t, "expired-staging"), null;
+if (c >= u) return xp(t, "squad-quorum"), null;
+if (l) return xp(t, "expired-staging"), null;
 }
-var m = Ml(e.room.name);
+var m = Ol(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function Fp(e) {
+function Dp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -29494,21 +29471,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Wp(e, t) {
+function Bp(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Hp(e, t) {
+function Fp(e, t) {
 if (!e.swarmState) return null;
-var r = Ml(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (xp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = Ol(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (Sp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Kp(e) {
+function Wp(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -29532,7 +29509,7 @@ if (t) throw t.error;
 }
 }
 
-function Yp(e) {
+function Hp(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -29540,23 +29517,23 @@ return Boolean(e);
 });
 }
 
-function Vp(e) {
+function Kp(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function qp(e) {
+function Yp(e) {
 var t, r = e.creep.memory;
 if (Ei(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Kp(e.memory.squadId);
-if (o) return jp(e, o);
+var o = Wp(e.memory.squadId);
+if (o) return Vp(e, o);
 }
-var n = null !== (t = Lp(e, r)) && void 0 !== t ? t : Ri(r);
-if (n && !Mp(e)) {
-var a = Bp(e, r);
+var n = null !== (t = Ip(e, r)) && void 0 !== t ? t : Ri(r);
+if (n && !Op(e)) {
+var a = Lp(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -29569,9 +29546,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Fp(e);
+var s = Dp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Bp(e.creep, RANGED_ATTACK), l = Bp(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -29583,7 +29560,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Bp(e.creep, RANGED_ATTACK), l = Bp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29594,7 +29571,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (bp(r), e.creep.room.name !== e.homeRoom) return {
+} else if (wp(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29603,8 +29580,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Fp(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK),
+var m = Dp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Bp(e.creep, RANGED_ATTACK), l = Bp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -29615,7 +29592,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = Sp(e.room), p = wp(e.creep, d);
+var d = Tp(e.room), p = Cp(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -29629,7 +29606,7 @@ type: "idle"
 };
 }
 
-function jp(e, t) {
+function Vp(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -29637,7 +29614,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Vp(t);
+var n = Kp(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -29645,7 +29622,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Yp(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Hp(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29668,7 +29645,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Yp(e).filter(function(t) {
+var t, r, o = Hp(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29697,7 +29674,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Yp(t).filter(function(t) {
+var r = Hp(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29713,7 +29690,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Yp(t).sort(function(e, t) {
+var a = Hp(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29750,7 +29727,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Yp(t).filter(function(e) {
+var l = Hp(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29767,7 +29744,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Yp(e).find(function(e) {
+return null !== (t = Hp(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29778,7 +29755,7 @@ target: m
 type: "idle"
 };
 }
-var d = Fp(e);
+var d = Dp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29790,10 +29767,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Bp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Wp(e.creep, ATTACK) && p <= 1 ? {
+} : Bp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29809,10 +29786,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Bp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Wp(e.creep, ATTACK) && p <= 1 ? {
+} : Bp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29828,7 +29805,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Vp(t)
+target: Kp(t)
 };
 
 case "dissolving":
@@ -29846,8 +29823,8 @@ type: "idle"
 }
 }
 
-var zp = {
-guard: qp,
+var qp = {
+guard: Yp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29856,8 +29833,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = Sp(e.room);
-return (o = wp(e.creep, r)) ? {
+var r = Tp(e.room);
+return (o = Cp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29874,7 +29851,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = Sp(e.room), (o = wp(e.creep, r)) ? {
+} : (r = Tp(e.room), (o = Cp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29888,11 +29865,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Wp(e, HEAL);
+return Bp(e, HEAL);
 }), t.filter(function(e) {
-return Wp(e, RANGED_ATTACK);
+return Bp(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Wp(e, ATTACK);
+return Bp(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29913,7 +29890,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Wp(e.creep, RANGED_ATTACK), u = Wp(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Bp(e.creep, RANGED_ATTACK), u = Bp(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29944,19 +29921,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Kp(e.memory.squadId);
-if (o) return jp(e, o);
+var o = Wp(e.memory.squadId);
+if (o) return Vp(e, o);
 }
-var n = null !== (t = Lp(e, r)) && void 0 !== t ? t : Ri(r);
-if (n && !Mp(e)) {
-var a = Bp(e, r);
+var n = null !== (t = Ip(e, r)) && void 0 !== t ? t : Ri(r);
+if (n && !Op(e)) {
+var a = Lp(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === Z(i).length) return bp(r), {
+if (0 === Z(i).length) return wp(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -30050,7 +30027,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = Sp(e.room), v = wp(e.creep, y);
+var y = Tp(e.room), v = Cp(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -30061,8 +30038,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Kp(e.memory.squadId);
-if (r) return jp(e, r);
+var r = Wp(e.memory.squadId);
+if (r) return Vp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30084,9 +30061,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Fp(e);
+var a = Dp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Wp(e.creep, RANGED_ATTACK), c = Wp(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Bp(e.creep, RANGED_ATTACK), c = Bp(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -30105,7 +30082,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = Sp(e.room), m = wp(e.creep, l);
+var l = Tp(e.room), m = Cp(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -30127,8 +30104,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Kp(e.memory.squadId);
-if (r) return jp(e, r);
+var r = Wp(e.memory.squadId);
+if (r) return Vp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30189,9 +30166,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Hp(e, "siegeUnit");
+var p = Fp(e, "siegeUnit");
 if (p) return p;
-var f = Sp(e.room), y = wp(e.creep, f);
+var f = Tp(e.room), y = Cp(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -30202,8 +30179,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Kp(e.memory.squadId);
-if (r) return jp(e, r);
+var r = Wp(e.memory.squadId);
+if (r) return Vp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -30220,7 +30197,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Hp(e, "harasser (no target)") || {
+if (!t) return Fp(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -30262,9 +30239,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Hp(e, "harasser (no targets)");
+var c = Fp(e, "harasser (no targets)");
 if (c) return c;
-var u = Sp(e.room), l = wp(e.creep, u);
+var u = Tp(e.room), l = Cp(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -30277,9 +30254,9 @@ var t, r, o = e.creep.memory;
 if (Ei(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Kp(e.memory.squadId))) return jp(e, a);
+if (e.memory.squadId && (a = Wp(e.memory.squadId))) return Vp(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (Ri(o) && bp(o), e.room.name !== e.homeRoom) return {
+if (Ri(o) && wp(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -30293,9 +30270,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Lp(e, o)) && void 0 !== t ? t : Ri(o);
-if (i && !Mp(e)) {
-var s = Bp(e, o);
+var a, i = null !== (t = Ip(e, o)) && void 0 !== t ? t : Ri(o);
+if (i && !Op(e)) {
+var s = Lp(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -30305,14 +30282,14 @@ roomName: i
 var u = Z(c), l = J(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return bp(o), {
+if (0 === u.length && 0 === l.length) return wp(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Fp(e);
+var m = Dp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -30332,8 +30309,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Kp(e.memory.squadId))) return jp(e, a);
-var p, f = Fp(e);
+if (e.memory.squadId && (a = Wp(e.memory.squadId))) return Vp(e, a);
+var p, f = Dp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -30344,7 +30321,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = Sp(e.room), v = wp(e.creep, y);
+var y = Tp(e.room), v = Cp(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -30365,21 +30342,21 @@ type: "idle"
 }
 };
 
-function Qp(e) {
+function jp(e) {
 var t;
-return dm.getAssignedAction(e) || (null !== (t = zp[e.memory.role]) && void 0 !== t ? t : qp)(e);
+return lm.getAssignedAction(e) || (null !== (t = qp[e.memory.role]) && void 0 !== t ? t : Yp)(e);
 }
 
-var Xp = M("PowerExecutor");
+var zp = M("PowerExecutor");
 
-function Zp(e, t) {
+function Qp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Jp(e) {
+function Xp(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -30421,8 +30398,8 @@ type: "idle"
 };
 }
 
-var $p = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), ef = {
-powerHarvester: Jp,
+var Zp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Jp = {
+powerHarvester: Xp,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -30494,65 +30471,65 @@ roomName: e.homeRoom
 }
 };
 
-function tf(e) {
+function $p(e) {
 var t;
-return (null !== (t = ef[e.memory.role]) && void 0 !== t ? t : Jp)(e);
+return (null !== (t = Jp[e.memory.role]) && void 0 !== t ? t : Xp)(e);
 }
 
-function rf(e) {
+function ef(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var of = {
+var tf = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, nf = {
+}, rf = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, af = {
+}, of = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, sf = {
+}, nf = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, cf = {
+}, af = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, uf = {
+}, sf = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, lf = {
+}, cf = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, mf = {
+}, uf = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function df(e) {
+function lf(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function pf(e) {
+function mf(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -30560,7 +30537,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function ff(e) {
+function df(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -30568,12 +30545,12 @@ y: parseInt(n, 10)
 };
 }
 
-function yf(e) {
+function pf(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = vf(s);
+o[s.n] = ff(s);
 }
 } catch (e) {
 t = {
@@ -30589,23 +30566,23 @@ if (t) throw t.error;
 return o;
 }
 
-function vf(e) {
+function ff(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = nf[e.r]) && void 0 !== t ? t : "core",
-health: gf(e.h),
+role: null !== (t = rf[e.r]) && void 0 !== t ? t : "core",
+health: yf(e.h),
 activeTasks: e.t,
-portals: e.p.map(hf),
+portals: e.p.map(vf),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Rf)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(gf)
 };
 }
 
-function gf(e) {
+function yf(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = sf[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = nf[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -30618,11 +30595,11 @@ lastUpdate: e.u
 };
 }
 
-function hf(e) {
+function vf(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: pf(e.sp),
+sourcePos: mf(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -30632,7 +30609,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function Rf(e) {
+function gf(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -30641,7 +30618,7 @@ bucketLevel: e.b
 };
 }
 
-function Ef(e) {
+function hf(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30651,12 +30628,12 @@ isAlly: 1 === e.a
 };
 }
 
-function Tf(e) {
+function Rf(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Cf(u);
+i[u.n] = Ef(u);
 }
 } catch (e) {
 t = {
@@ -30679,13 +30656,13 @@ updatedAt: e.u
 };
 }
 
-function Cf(e) {
+function Ef(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: ff(e.pp),
+portalPos: df(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30696,46 +30673,46 @@ lastUpdate: e.u
 };
 }
 
-function Sf(e) {
+function Tf(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = uf[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = sf[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = mf[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = uf[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function wf(e, t) {
+function Cf(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function xf(e) {
+function Sf(e) {
 var t;
 return {
-c: null !== (t = af[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: wf(e.cpuUsage, 2),
+c: null !== (t = of[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: Cf(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: wf(e.avgRCL, 1),
+rl: Cf(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function bf(e) {
+function wf(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: df(e.sourcePos),
+sp: lf(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30744,27 +30721,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function Of(e) {
+function xf(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: wf(e.cpuUsed, 2),
+u: Cf(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function kf(e) {
+function bf(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Mf)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Of)
 };
 }
 
-function Mf(e) {
+function Of(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30774,23 +30751,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function Af(e) {
+function kf(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = cf[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = af[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = lf[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = cf[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Uf(e) {
+function Mf(e) {
 return {
 name: e,
 role: "core",
@@ -30813,7 +30790,7 @@ cpuLimit: 0
 };
 }
 
-function _f(e) {
+function Af(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30823,16 +30800,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = of[t.role]) && void 0 !== r ? r : t.role[0],
-h: xf(t.health),
+r: null !== (r = tf[t.role]) && void 0 !== r ? r : t.role[0],
+h: Sf(t.health),
 t: t.activeTasks,
-p: t.portals.map(bf),
+p: t.portals.map(wf),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Of)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(xf)
 };
 }(t[0], t[1]);
 }),
-g: kf(e.globalTargets),
+g: bf(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30846,7 +30823,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? df(t.portalPos) : void 0,
+pp: t.portalPos ? lf(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30858,20 +30835,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(Af),
+k: e.tasks.map(kf),
 ls: e.lastSync
 };
 var t;
-}(e), r = rf(JSON.stringify(t));
+}(e), r = ef(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Nf(e) {
+function Uf(e) {
 try {
-var t = JSON.parse(e), r = rf(JSON.stringify(t.d));
+var t = JSON.parse(e), r = ef(JSON.stringify(t.d));
 return t.c !== r ? (Ne.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30880,13 +30857,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: yf(a.s),
+shards: pf(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(Ef)), n),
-footprintOperation: a.o ? Tf(a.o) : void 0,
-tasks: a.k.map(Sf),
+o.en && (n.enemies = o.en.map(hf)), n),
+footprintOperation: a.o ? Rf(a.o) : void 0,
+tasks: a.k.map(Tf),
 lastSync: a.ls,
 checksum: i
 });
@@ -30898,12 +30875,12 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var Pf, If, Gf = 102400, Lf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var _f, Nf, Pf = 102400, If = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function Df(e, t, r) {
+function Gf(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = Hf(t), s = function(e, t, r) {
+var i = Ff(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30916,11 +30893,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(Wf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Lf), c = null !== (a = Hf(_f(s))) && void 0 !== a ? a : {};
+}(Bf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : If), c = null !== (a = Ff(Af(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function Bf(e) {
+function Lf(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30936,69 +30913,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = Wf(r, Hf(r))) && void 0 !== t ? t : e;
+return r && null !== (t = Bf(r, Ff(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function Ff(e, t) {
+function Df(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(Df(e, r, t)), !0;
+return InterShardMemory.setLocal(Gf(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function Wf(e, t) {
+function Bf(e, t) {
 return t && function(e) {
-return Kf(e.d) && "number" == typeof e.c;
-}(t) ? Nf(e) : null;
+return Wf(e.d) && "number" == typeof e.c;
+}(t) ? Uf(e) : null;
 }
 
-function Hf(e) {
+function Ff(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return Kf(t) ? t : null;
+return Wf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function Kf(e) {
+function Wf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(Pf || (Pf = {})), function(e) {
+}(_f || (_f = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(If || (If = {}));
+}(Nf || (Nf = {}));
 
-var Yf = null != Ne ? Ne : {
+var Hf = null != Ne ? Ne : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Vf = {
+}, Kf = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, qf = {
+}, Yf = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, jf = function() {
+}, Vf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Vf), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Kf), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -31015,19 +30992,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Nf(r);
-o && (this.interShardMemory = o, Yf.debug("Loaded InterShardMemory", {
+var o = Uf(r);
+o && (this.interShardMemory = o, Hf.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Yf.error("Failed to load InterShardMemory: ".concat(n), {
+Hf.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Uf(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Mf(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -31188,25 +31165,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Yf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Hf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Yf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Hf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Yf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Hf.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Yf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Hf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -31239,7 +31216,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Yf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Hf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31269,12 +31246,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Yf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Hf.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Yf.info("War ended, transitioning to ".concat(i), {
+Hf.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Yf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Hf.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -31300,7 +31277,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = qf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = Yf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -31352,13 +31329,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Yf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Hf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Yf.debug("Could not set shard limits: ".concat(S), {
+Hf.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -31366,27 +31343,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Yf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Hf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = Df(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = Gf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > Gf) {
-Yf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(Gf), {
+if (r.length > Pf) {
+Hf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(Pf), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = Df(this.interShardMemory, t, {
+var o = Gf(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > Gf ? (Yf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(Gf), {
+return o.length > Pf ? (Hf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(Pf), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Yf.error("Failed to sync InterShardMemory: ".concat(n), {
+Hf.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -31424,7 +31401,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Uf(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Mf(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -31442,40 +31419,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Yf.info("Repaired InterShardMemory structure", {
+Hf.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Yf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Hf.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Nf(r);
-if (!o) return void Yf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Uf(r);
+if (!o) return void Hf.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Yf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Hf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Yf.warn("InterShardMemory verification failed: ".concat(a), {
+Hf.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Yf.info("Attempting InterShardMemory recovery", {
+Hf.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Nf(r);
-if (o) return this.interShardMemory = o, void Yf.info("Recovered InterShardMemory from storage", {
+var o = Uf(r);
+if (o) return this.interShardMemory = o, void Hf.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -31490,12 +31467,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Uf(n), Yf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Mf(n), Hf.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Yf.error("InterShardMemory recovery failed: ".concat(a), {
+Hf.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31505,7 +31482,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Yf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Hf.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -31521,7 +31498,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Yf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Hf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -31537,7 +31514,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Yf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Hf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -31552,7 +31529,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Yf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Hf.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -31571,7 +31548,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Yf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Hf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -31617,11 +31594,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Yf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Hf.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = _f(this.interShardMemory).length, o = r / Gf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = Af(this.interShardMemory).length, o = r / Pf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -31648,11 +31625,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Yf.info("Forcing InterShardMemory sync with validation", {
+Hf.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = _f(this.interShardMemory).length, n = _f(o(o({}, this.interShardMemory), {
+var e, t, r = Af(this.interShardMemory).length, n = Af(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31676,8 +31653,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: Gf,
-percent: Math.round(r / Gf * 1e4) / 100,
+limit: Pf,
+percent: Math.round(r / Pf * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31685,10 +31662,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (Pf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (_f.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), zf = new jf, Qf = {
+}(), qf = new Vf, jf = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31699,11 +31676,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: If.LOW,
-NORMAL: If.NORMAL,
-HIGH: If.HIGH
+LOW: Nf.LOW,
+NORMAL: Nf.NORMAL,
+HIGH: Nf.HIGH
 }
-}, Xf = function() {
+}, zf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31713,7 +31690,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = zf.getActiveTransferTasks();
+var n = qf.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31740,7 +31717,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = zf.getOptimalPortalRoute(e.targetShard);
+var t = qf.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31808,7 +31785,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-zf.updateTaskProgress(e.taskId, t);
+qf.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31824,7 +31801,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = Qf.optimizeBody({
+i = jf.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -31835,8 +31812,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Qf.spawnPriorities.LOW;
-e.priority >= 80 ? d = Qf.spawnPriorities.HIGH : e.priority >= 50 && (d = Qf.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = jf.spawnPriorities.LOW;
+e.priority >= 80 ? d = jf.spawnPriorities.HIGH : e.priority >= 50 && (d = jf.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31854,7 +31831,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-Qf.spawnQueue.addRequest(y), Ne.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+jf.spawnQueue.addRequest(y), Ne.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31881,7 +31858,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void zf.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void qf.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", Ne.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -31893,8 +31870,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, zf.updateTaskProgress(e.taskId, 100, "complete"),
-zf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ne.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, qf.updateTaskProgress(e.taskId, 100, "complete"),
+qf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ne.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31924,12 +31901,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Zf = new Xf;
+}(), Qf = new zf;
 
-function Jf(e, t, r) {
+function Xf(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Bf({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Lf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31944,13 +31921,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Ff(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Df(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function $f(e) {
+function Zf(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31981,15 +31958,15 @@ range: 0
 type: "idle"
 };
 }(e, i);
-if (Jf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Xf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || Z(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Jf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Xf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Jf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Xf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -32006,24 +31983,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Jf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Xf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Jf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Xf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function ey(e) {
+function Jf(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function ty(e, t) {
+function $f(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -32057,12 +32034,12 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function ry(e, t) {
+function ey(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function oy(e) {
+function ty(e) {
 var t = Game.map.describeExits(e), r = t ? Object.values(t) : [], o = function(e) {
 var t = function(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
@@ -32073,20 +32050,20 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ ry(t.x, t.y - 1), ry(t.x + 1, t.y), ry(t.x, t.y + 1), ry(t.x - 1, t.y) ] : [];
+return t ? [ ey(t.x, t.y - 1), ey(t.x + 1, t.y), ey(t.x, t.y + 1), ey(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }
 
-function ny(e) {
-var t = Xd.getEmpire();
-if (kl.isExit(e.creep.pos)) return ey(e.room.name);
+function ry(e) {
+var t = zd.getEmpire();
+if (bl.isExit(e.creep.pos)) return Jf(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (o && !function(e, t) {
-return t === e || oy(e).includes(t);
+return t === e || ty(e).includes(t);
 }(e.room.name, o) && (delete e.memory.targetRoom, o = void 0), !o) {
 if (o = function(e, t, r) {
-var o, n, i, s, c = t.knownRooms, u = oy(e);
+var o, n, i, s, c = t.knownRooms, u = ty(e);
 if (0 !== u.length) {
 var l = [];
 try {
@@ -32146,13 +32123,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? (ty(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? ($f(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : (ty(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : ($f(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -32162,19 +32139,19 @@ type: "idle"
 };
 }
 
-function ay(e) {
+function oy(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function iy(e) {
-return e.hostiles.some(ay);
+function ny(e) {
+return e.hostiles.some(oy);
 }
 
-function sy(e) {
+function ay(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function cy(e) {
+function iy(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32197,8 +32174,8 @@ type: "idle"
 };
 }
 
-var uy = {
-scout: ny,
+var sy = {
+scout: ry,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -32232,7 +32209,7 @@ return {
 type: "idle"
 };
 }
-if (kl.isExit(e.creep.pos)) return ey(e.room.name);
+if (bl.isExit(e.creep.pos)) return Jf(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -32254,8 +32231,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: $f,
-interShardScout: $f,
+interShardClaimer: Zf,
+interShardScout: Zf,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -32331,8 +32308,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return cy(e);
-if (iy(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return iy(e);
+if (ny(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32373,7 +32350,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return sy(t) - sy(e);
+return ay(t) - ay(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -32393,7 +32370,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : cy(e);
+} : iy(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -32482,9 +32459,9 @@ type: "idle"
 }
 };
 
-function ly(e, t) {
+function cy(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : iy(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : ny(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -32492,26 +32469,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function my(e) {
+function uy(e) {
 var t;
-return (null !== (t = uy[e.memory.role]) && void 0 !== t ? t : ny)(e);
+return (null !== (t = sy[e.memory.role]) && void 0 !== t ? t : ry)(e);
+}
+
+function ly(e) {
+var t = Sl(e);
+vm(e, Sm(t, pp, {
+interrupt: yp
+}), t);
+}
+
+function my(e) {
+var t = Sl(e);
+vm(e, Sm(t, uy, {
+interrupt: cy
+}), t);
 }
 
 function dy(e) {
-var t = xl(e);
-hm(e, xm(t, yp, {
-interrupt: gp
-}), t);
-}
-
-function py(e) {
-var t = xl(e);
-hm(e, xm(t, my, {
-interrupt: ly
-}), t);
-}
-
-function fy(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -32552,8 +32529,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && $p.has(i) && z(s))) {
-Xp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && Zp.has(i) && z(s))) {
+zp.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -32564,16 +32541,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && kl.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && bl.moveTo(e, t.target);
 break;
 
 case "moveTo":
-kl.moveTo(e, t.target);
+bl.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-kl.moveTo(e, {
+bl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -32582,11 +32559,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && kl.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && bl.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && kl.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && bl.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -32618,7 +32595,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Zp(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Qp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -32628,7 +32605,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Qp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -32639,7 +32616,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = pt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Qp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32692,7 +32669,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Zp(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Qp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32734,7 +32711,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Zp(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Qp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32744,7 +32721,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Zp(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Qp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -32752,7 +32729,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && Z(e.room).length > 0) {
 var o = pt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Qp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32764,7 +32741,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Zp(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Qp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32772,12 +32749,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Zp(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Qp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Zp(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Qp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32811,18 +32788,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function yy(e) {
+function py(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var vy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), gy = -1, hy = Object.create(null);
+var fy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), yy = -1, vy = Object.create(null);
 
-function Ry(e) {
+function gy(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var Ey = {
+var hy = {
 harvester: Ie.CRITICAL,
 queenCarrier: Ie.CRITICAL,
 hauler: Ie.HIGH,
@@ -32857,12 +32834,12 @@ labTech: Ie.IDLE,
 factoryWorker: Ie.IDLE
 };
 
-function Ty(e) {
+function Ry(e) {
 var t;
-return null !== (t = Ey[e]) && void 0 !== t ? t : Ie.MEDIUM;
+return null !== (t = hy[e]) && void 0 !== t ? t : Ie.MEDIUM;
 }
 
-function Cy(e) {
+function Ey(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32878,30 +32855,30 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && Ry(o) === e && t++;
+o && gy(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (gy !== Game.time && (gy = Game.time, hy = function() {
+}(e) : null !== (r = (yy !== Game.time && (yy = Game.time, vy = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = Ry(o);
+var n = gy(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), hy)[e]) && void 0 !== r ? r : 0;
+}()), vy)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Mr().cpu.disableCreepBootstrapCountCache
 });
-if (o && Game.time % 50 == 0 && dl.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
+if (o && Game.time % 50 == 0 && ll.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
 subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!vy.has(t.role)) return !1;
+if (!fy.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32911,7 +32888,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !yy(r)) return !1;
+if (!r || !py(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32925,7 +32902,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !yy(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !py(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32933,7 +32910,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !yy(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !py(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32941,7 +32918,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !yy(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !py(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32949,7 +32926,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && yy(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && py(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32965,7 +32942,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !yy(r)) return !1;
+if (!r || !py(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -33005,36 +32982,36 @@ switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = xl(e);
-hm(e, xm(t, yp, {
-interrupt: gp
+var t = Sl(e);
+vm(e, Sm(t, pp, {
+interrupt: yp
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = xl(e);
-hm(e, xm(t, Qp), t);
+var t = Sl(e);
+vm(e, Sm(t, jp), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = xl(e);
-hm(e, xm(t, my), t);
+var t = Sl(e);
+vm(e, Sm(t, uy), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = xl(e);
-hm(e, xm(t, tf), t);
+var t = Sl(e);
+vm(e, Sm(t, $p), t);
 }(e);
 }
 });
 } catch (t) {
-dl.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
+ll.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
 subsystem: "CreepProcessManager",
 creep: e.name,
 meta: {
@@ -33050,7 +33027,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var Sy = function() {
+var Ty = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -33079,7 +33056,7 @@ if (e) throw e.error;
 }
 }
 var d = s < 5;
-(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && dl.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
+(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && ll.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
 subsystem: "CreepProcessManager",
 meta: {
 activeCreeps: r.size,
@@ -33091,7 +33068,7 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Ty(r), n = "creep:".concat(e.name);
+var t = e.memory, r = t.role, o = Ry(r), n = "creep:".concat(e.name);
 Gi.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
@@ -33107,14 +33084,14 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Cy(t);
+t && !t.spawning && Ey(t);
 }
-}), this.registeredCreeps.add(e.name), dl.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
+}), this.registeredCreeps.add(e.name), ll.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.unregisterCreepProcess = function(e) {
 var t = "creep:".concat(e);
-Gi.unregisterProcess(t), this.registeredCreeps.delete(e), dl.info("Unregistered creep process: ".concat(e), {
+Gi.unregisterProcess(t), this.registeredCreeps.delete(e), ll.info("Unregistered creep process: ".concat(e), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.getMinBucketForRole = function(e, t) {
@@ -33132,7 +33109,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Ty(u.memory.role), m = null !== (r = Ie[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = Ry(u.memory.role), m = null !== (r = Ie[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -33157,20 +33134,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), wy = new Sy;
+}(), Cy = new Ty;
 
-function xy(e) {
+function Sy(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, by(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, wy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function by(e) {
+function wy(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function Oy(e) {
+function xy(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -33183,14 +33160,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function ky(e, t) {
+function by(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var My = {
+var Oy = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -33218,11 +33195,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function Ay(e, t) {
+function ky(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function Uy(e) {
+function My(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -33232,9 +33209,9 @@ tick: Game.time
 }, a;
 }
 
-var _y = [ "defense", "war", "expand", "siege" ];
+var Ay = [ "defense", "war", "expand", "siege" ];
 
-function Ny(e) {
+function Uy(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -33247,11 +33224,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function Py(e, t, r) {
-t >= 2 && (e.pheromones.war = Ay(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ay(e.pheromones.siege + 20, r));
+function _y(e, t, r) {
+t >= 2 && (e.pheromones.war = ky(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = ky(e.pheromones.siege + 20, r));
 }
 
-var Iy = function() {
+var Ny = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -33266,27 +33243,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), Gy = function() {
+}(), Py = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, My), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Oy), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new Iy(10),
-energySpawning: new Iy(10),
-energyConstruction: new Iy(10),
-energyRepair: new Iy(10),
-energyTower: new Iy(10),
-controllerProgress: new Iy(10),
-hostileCount: new Iy(5),
-damageReceived: new Iy(5),
-idleWorkers: new Iy(10),
+energyHarvested: new Ny(10),
+energySpawning: new Ny(10),
+energyConstruction: new Ny(10),
+energyRepair: new Ny(10),
+energyTower: new Ny(10),
+controllerProgress: new Ny(10),
+hostileCount: new Ny(5),
+damageReceived: new Ny(5),
+idleWorkers: new Ny(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = Uy(e);
+var o = My(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -33359,7 +33336,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = Ay(e[s] * c, t);
+e[s] = ky(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -33375,43 +33352,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = Uy(t);
+var o = My(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = Ay(e.harvest + n / 3e3 * 10, r);
+e.harvest = ky(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = Ay(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = ky(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = Ay(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = ky(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = Ay(e.defense + 10 * o, r));
+o > 0 && (e.defense = ky(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = Ay(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ay(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = ky(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = ky(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = Ay(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = ky(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = Ay(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = ky(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Ay(e.pheromones.defense + 5 * t, o), Py(e, r, o),
+e.danger = r, e.pheromones.defense = ky(e.pheromones.defense + 5 * t, o), _y(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -33419,7 +33396,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = Ay(t / 10, o), Py(e, r, o);
+e.danger = r, e.pheromones.defense = ky(t / 10, o), _y(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -33432,8 +33409,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = Ay(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = Ay(f + y, o);
+var p = ky(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = ky(f + y, o);
 }
 }
 }
@@ -33452,18 +33429,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = Ay(e.pheromones.defense + 5, r), e.pheromones.build = Ay(e.pheromones.build + 10, r),
+e.pheromones.defense = ky(e.pheromones.defense + 5, r), e.pheromones.build = ky(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ay(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = ky(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = Ay(e.pheromones.siege + 50, t), e.pheromones.defense = Ay(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = ky(e.pheromones.siege + 50, t), e.pheromones.defense = ky(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = Ay(e.pheromones.expand - 10, t), e.pheromones.defense = Ay(e.pheromones.defense + 5, t);
+e.pheromones.expand = ky(e.pheromones.expand - 10, t), e.pheromones.defense = ky(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -33473,10 +33450,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Ny(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(Uy(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(_y)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(Ay)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -33530,7 +33507,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = Ay(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = ky(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -33565,7 +33542,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), Ly = new Gy, Dy = {
+}(), Iy = new Py, Gy = {
 seedNest: {
 rcl: 1
 },
@@ -33606,7 +33583,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, By = {
+}, Ly = {
 eco: {
 economy: .75,
 military: .05,
@@ -33649,7 +33626,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Fy = {
+}, Dy = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33706,13 +33683,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, Wy = function() {
+}, By = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Dy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Dy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Dy.fortifiedHive.rcl ? "fortifiedHive" : s >= Dy.matureColony.rcl ? "matureColony" : s >= Dy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Gy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Gy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Gy.fortifiedHive.rcl ? "fortifiedHive" : s >= Gy.matureColony.rcl ? "matureColony" : s >= Gy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Ee.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -33747,7 +33724,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Dy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Gy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33760,7 +33737,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Hy = function() {
+}(), Fy = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33782,9 +33759,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return By[e];
+return Ly[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return Fy[e];
+return Dy[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33794,15 +33771,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Ky = new Wy, Yy = new Hy;
+}(), Wy = new By, Hy = new Fy;
 
-function Vy(e) {
+function Ky(e) {
 return !j(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function qy(e, t, r) {
+function Yy(e, t, r) {
 if (!e) return null;
 var o = wr.getEmpire();
 if (j(e, {
@@ -33841,15 +33818,16 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function jy() {
+function Vy() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var zy = new Map, Qy = function() {
+var qy = new Map, jy = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
 var o = Z(e), n = $s(e), a = this.getDefensePostureIntent(e, t, r, o, n);
-this.executeDefensePostureIntent(e, t, o, a), ec(wr.getEmpire(), e, t, n);
+return this.executeDefensePostureIntent(e, t, o, a), ec(wr.getEmpire(), e, t, n),
+n;
 }, e.prototype.getDefensePostureIntent = function(e, t, r, o, n) {
 return void 0 === o && (o = Z(e)), void 0 === n && (n = $s(e)), function(e, t) {
 var r = e.currentStructures.spawns.length + e.currentStructures.towers.length, o = e.previousStructures;
@@ -33982,7 +33960,10 @@ if (r) throw r.error;
 }(c, u), u;
 var c, u;
 }, e.prototype.getDefensePostureSnapshot = function(e, t, r, o, n) {
-var a, i = t.clusterId ? wr.getCluster(t.clusterId) : null, s = o.length > 0 ? Wo(e) : void 0;
+var a, i = t.clusterId ? wr.getCluster(t.clusterId) : null, s = o.length > 0 ? Wo(e, {
+hostiles: o,
+nukes: n
+}) : void 0;
 return {
 roomName: e.name,
 time: Game.time,
@@ -33991,7 +33972,7 @@ nukeDetected: null !== (a = t.nukeDetected) && void 0 !== a && a,
 nukeScanPerformed: !0,
 clusterId: t.clusterId,
 clusterMemberRooms: null == i ? void 0 : i.memberRooms,
-previousStructures: zy.get(e.name),
+previousStructures: qy.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -34021,7 +34002,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && zy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && qy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -34030,7 +34011,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Vy(u) && o.add(u.owner.username);
+Ky(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -34044,7 +34025,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) qy(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) Yy(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -34060,7 +34041,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? Ly.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Ly.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Ly.onNukeDetected(t);
+"danger" === y.type ? Iy.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Iy.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Iy.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -34120,10 +34101,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = jy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = Vy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = jy()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = Vy()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -34166,7 +34147,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Yy.isCombatPosture(t.posture),
+isCombatPosture: Hy.isCombatPosture(t.posture),
 wallRepairTarget: an(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -34190,27 +34171,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), Xy = new Qy, Zy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), zy = new jy, Qy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Jy() {
+function Xy() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function $y(e, t, r, o) {
+function Zy(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Jy()
+selectedAt: Xy()
 });
 }
 
-function ev(e) {
+function Jy(e) {
 return e >= 2 && e <= 3;
 }
 
-function tv(e, t, r) {
+function $y(e, t, r) {
 var o, n = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -34223,7 +34204,7 @@ return e.structureType === t;
 return n.length + a.length + (null !== (o = null == r ? void 0 : r.getPlacedCount(t)) && void 0 !== o ? o : 0);
 }
 
-function rv(e, t) {
+function ev(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -34237,10 +34218,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var ov = function() {
+var tv = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return ev(e) ? 5 : 10;
+return Jy(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -34649,10 +34630,10 @@ y: e.y - C.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-$y(t, R, S.name, f);
+Zy(t, R, S.name, f);
 var w = f >= 3 && (t.danger >= 1 || function(e, t, r) {
-var o = rv(STRUCTURE_TOWER, t);
-return o > 0 && tv(e, STRUCTURE_TOWER, r) < o;
+var o = ev(STRUCTURE_TOWER, t);
+return o > 0 && $y(e, STRUCTURE_TOWER, r) < o;
 }(e, f, y));
 if (w) {
 var x = y.capRequested(t.danger >= 2 ? 3 : 1, {
@@ -34663,7 +34644,7 @@ var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = rv(STRUCTURE_TOWER, g), R = tv(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = ev(STRUCTURE_TOWER, g), R = $y(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -35066,7 +35047,7 @@ var o, n, i, s = jn(t);
 try {
 for (var c = a(Object.keys(s)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = null !== (i = s[l]) && void 0 !== i ? i : 0;
-if (!(m <= 0) && tv(e, l, r) < m) return !0;
+if (!(m <= 0) && $y(e, l, r) < m) return !0;
 }
 } catch (e) {
 o = {
@@ -35082,8 +35063,8 @@ if (o) throw o.error;
 return !1;
 }(e, f, y);
 if (y.canPlace() || k) {
-if (!Yy.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Jy());
+if (!Hy.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Xy());
 }(t, R)) {
 var M = function(e, t, r, o, n) {
 var i, s;
@@ -35240,7 +35221,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Zy.has(e.structureType);
+return Qy.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -35249,7 +35230,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var P = ev(f) ? 2 : 3, I = y.capRequested(P);
+var P = Jy(f) ? 2 : 3, I = y.capRequested(P);
 I > 0 && (N = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -35938,16 +35919,16 @@ return null;
 if (H && y.canPlace({
 bypassRoomLimit: !0
 })) {
-$y(t, H.anchor, H.blueprint.name, f);
+Zy(t, H.anchor, H.blueprint.name, f);
 var K = e.createConstructionSite(H.anchor.x, H.anchor.y, STRUCTURE_SPAWN);
 y.recordResult(K, STRUCTURE_SPAWN);
 }
 }
 }
 }, e;
-}(), nv = new ov;
+}(), rv = new tv;
 
-function av(e) {
+function ov(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35969,7 +35950,7 @@ siege: e.pheromones.siege
 };
 }
 
-var iv = {
+var nv = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35982,10 +35963,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, sv = new (function() {
+}, av = new (function() {
 function e() {
-this.manager = new Eu({
-logger: iv
+this.manager = new hu({
+logger: nv
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35995,23 +35976,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = av(t);
+var r = ov(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = av(t);
+var r = ov(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), cv = {
-labManager: Gu,
-boostManager: Uu,
-chemistryPlanner: sv,
-labConfigManager: Pu,
-logger: dl
-}, uv = function() {
+}()), iv = {
+labManager: Pu,
+boostManager: Mu,
+chemistryPlanner: av,
+labConfigManager: _u,
+logger: ll
+}, sv = function() {
 function e(e) {
-void 0 === e && (e = cv), this.deps = e;
+void 0 === e && (e = iv), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -36050,9 +36031,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), lv = new uv, mv = function() {
+}(), cv = new sv, uv = function() {
 function e(e) {
-void 0 === e && (e = lv), this.labWorkflow = e;
+void 0 === e && (e = cv), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -36075,27 +36056,27 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), dv = new mv, pv = {
+}(), lv = new uv, mv = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, fv = new Map;
+}, dv = new Map;
 
-function yv(e) {
+function pv(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function vv(e) {
+function fv(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var gv = function() {
+var yv = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, pv), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, mv), t);
 }
 return e.prototype.run = function(e) {
 var t, r, o, n = rs.startRoom(this.roomName);
@@ -36139,7 +36120,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = wr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = fv.get(e.name);
+var t = dv.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -36161,42 +36142,43 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return fv.set(e.name, o), o;
+return dv.set(e.name, o), o;
 }(i);
-this.config.enablePheromones && !s && Game.time % 5 == 0 && Ly.updateMetrics(i, c),
-Xy.updateThreatAssessment(i, c, {
+this.config.enablePheromones && !s && Game.time % 5 == 0 && Iy.updateMetrics(i, c);
+var l = zy.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
-}), Si.assess(i, c), ki.checkSafeMode(i, c), this.config.enableEvolution && (Ky.updateEvolutionStage(c, i, e),
-s || Ky.updateMissingStructures(c, i)), Yy.updatePosture(c), this.config.enablePheromones && !s && Ly.updatePheromones(c, i),
-this.config.enableTowers && Xy.runTowerControl(i, c, u.towers);
-var l = 0 === u.spawns.length || c.danger >= 2;
-if (this.config.enableConstruction && (!s || l)) {
-var m = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, d = nv.getConstructionInterval(m), p = Yy.allowsBuilding(c.posture), f = !p && c.danger >= 2 || s && l;
-(p || f) && function(e, t, r) {
-var o = yv(r), n = vv(e);
+});
+Si.assess(i, c, l), ki.checkSafeMode(i, c), this.config.enableEvolution && (Wy.updateEvolutionStage(c, i, e),
+s || Wy.updateMissingStructures(c, i)), Hy.updatePosture(c), this.config.enablePheromones && !s && Iy.updatePheromones(c, i),
+this.config.enableTowers && zy.runTowerControl(i, c, u.towers);
+var m = 0 === u.spawns.length || c.danger >= 2;
+if (this.config.enableConstruction && (!s || m)) {
+var d = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, p = rv.getConstructionInterval(d), f = Hy.allowsBuilding(c.posture), y = !f && c.danger >= 2 || s && m;
+(f || y) && function(e, t, r) {
+var o = pv(r), n = fv(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, d) && (nv.runConstruction(i, c, u.constructionSites, u.spawns, {
-criticalOnly: f
+}(c, Game.time, p) && (rv.runConstruction(i, c, u.constructionSites, u.spawns, {
+criticalOnly: y
 }), function(e, t, r) {
-var o = yv(r), n = vv(e);
+var o = pv(r), n = fv(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
-}(c, Game.time, d));
+}(c, Game.time, p));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && dv.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && lv.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
-var y = Game.cpu.getUsed() - n;
-rs.recordRoom(i, y);
+var v = Game.cpu.getUsed() - n;
+rs.recordRoom(i, v);
 } finally {
 rs.endRoom(this.roomName, n);
 }
 }, e;
-}(), hv = function() {
+}(), vv = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -36205,7 +36187,7 @@ var e, t, r, o, n, s, c, u = Ct(), l = u.length;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-this.nodes.has(p.name) || this.nodes.set(p.name, new gv(p.name));
+this.nodes.has(p.name) || this.nodes.set(p.name, new yv(p.name));
 }
 } catch (t) {
 e = {
@@ -36241,7 +36223,7 @@ try {
 R.run(l);
 } catch (e) {
 var E = e instanceof Error ? e.message : String(e), T = e instanceof Error && e.stack ? e.stack : void 0;
-dl.error("Error in room ".concat(R.roomName, ": ").concat(E), {
+ll.error("Error in room ".concat(R.roomName, ": ").concat(E), {
 subsystem: "RoomManager",
 room: R.roomName,
 meta: {
@@ -36268,14 +36250,14 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new gv(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new yv(e.name));
 var r = Ct().length;
 this.nodes.get(e.name).run(r);
 }
 }, e;
-}(), Rv = new hv, Ev = new Map;
+}(), gv = new vv, hv = new Map;
 
-function Tv(e) {
+function Rv(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return !1;
 if (function(e) {
@@ -36288,21 +36270,21 @@ return Array.isArray(a) && a.some(function(t) {
 return t.roomName === e && Number.isFinite(t.impactTick) && t.impactTick > Game.time;
 });
 }(e.name)) return !0;
-var r = Ev.get(e.name), o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode ? 50 : 5;
+var r = hv.get(e.name), o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode ? 50 : 5;
 if (r && Game.time - r.checkedAt < o) return r.active;
-var n = e.find(FIND_NUKES).length > 0;
-return Ev.set(e.name, {
+var n = $s(e).length > 0;
+return hv.set(e.name, {
 checkedAt: Game.time,
 active: n
 }), n;
 }
 
-function Cv(e, t) {
+function Ev(e, t) {
 var r, o = (null === (r = e.controller) || void 0 === r ? void 0 : r.my) ? " (owned)" : "", n = t ? " [nuke response]" : "";
 return "Room ".concat(e.name).concat(o).concat(n);
 }
 
-function Sv(e, t) {
+function Tv(e, t) {
 var r, o, n;
 if (t.nukeThreat || t.hostiles.length > 0) return Ie.CRITICAL;
 if (null === (r = e.controller) || void 0 === r ? void 0 : r.my) return Ie.HIGH;
@@ -36313,14 +36295,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return a && (null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.reservation) || void 0 === n ? void 0 : n.username) === a ? Ie.MEDIUM : Ie.LOW;
 }
 
-function wv(e, t) {
+function Cv(e, t) {
 var r;
 if (!(null === (r = e.controller) || void 0 === r ? void 0 : r.my)) return .02;
 var o = e.controller.level;
 return t.nukeThreat || t.hostiles.length > 0 ? .12 : o <= 3 ? .04 : o <= 6 ? .06 : .08;
 }
 
-var xv, bv = function() {
+var Sv, wv = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -36330,9 +36312,9 @@ var t = this.roomIndices.get(e);
 return void 0 === t && (t = this.nextRoomIndex++, this.roomIndices.set(e, t)), t;
 }, e.prototype.getRoomProcessDescriptor = function(e) {
 var t = {
-nukeThreat: Tv(e),
+nukeThreat: Rv(e),
 hostiles: Z(e)
-}, r = Sv(e, t), o = function(e, t, r) {
+}, r = Tv(e, t), o = function(e, t, r) {
 var o;
 return t === Ie.CRITICAL ? {
 tickModulo: void 0,
@@ -36352,9 +36334,9 @@ tickOffset: void 0
 };
 }(e, r, this.getRoomIndex(e.name));
 return {
-name: Cv(e, t.nukeThreat),
+name: Ev(e, t.nukeThreat),
 priority: r,
-cpuBudget: wv(e, t),
+cpuBudget: Cv(e, t),
 tickModulo: o.tickModulo,
 tickOffset: o.tickOffset,
 minBucket: this.getMinBucketForPriority(r)
@@ -36406,11 +36388,11 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Rv.runRoom(t);
+t && gv.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var o = t.tickModulo ? "(mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset, ")") : "(every tick)";
-dl.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
+ll.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t) {
@@ -36431,17 +36413,17 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && Rv.runRoom(t);
+t && gv.runRoom(t);
 }
 });
 var o = t.tickModulo ? "mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset) : "every tick";
-dl.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
+ll.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.unregisterRoomProcess = function(e) {
 var t = "room:".concat(e);
 Gi.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
-Ev.delete(e), dl.debug("Unregistered room process: ".concat(e), {
+hv.delete(e), ll.debug("Unregistered room process: ".concat(e), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.getMinBucketForPriority = function(e) {
@@ -36453,8 +36435,8 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = Sv(m, {
-nukeThreat: Tv(m),
+var d = Tv(m, {
+nukeThreat: Rv(m),
 hostiles: Z(m)
 }), p = null !== (r = Ie[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
@@ -36481,9 +36463,9 @@ ownedRooms: s
 this.lastSyncTick = -1, this.syncRoomProcesses();
 }, e.prototype.reset = function() {
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
-this.lastSyncTick = -1, Ev.clear();
+this.lastSyncTick = -1, hv.clear();
 }, e;
-}(), Ov = new bv, kv = function() {
+}(), xv = new wv, bv = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
 var e = Gi.getStatsSummary(), t = Gi.getConfig();
@@ -36560,11 +36542,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Oy(e.summary.byLayer)), "Groups: ".concat(Oy(e.summary.byGroup)), "States: ".concat(Oy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(xy(e.summary.byLayer)), "Groups: ".concat(xy(e.summary.byGroup)), "States: ".concat(xy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(ky)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(by)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(xy(m));
+c.push(Sy(m));
 }
 } catch (e) {
 t = {
@@ -36663,7 +36645,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = wy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = Cy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36682,7 +36664,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = Ov.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = xv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36829,25 +36811,25 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), Mv = function() {
+}(), Ov = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
-debug: ku.DEBUG,
-info: ku.INFO,
-warn: ku.WARN,
-error: ku.ERROR,
-none: ku.NONE
+debug: bu.DEBUG,
+info: bu.INFO,
+warn: bu.WARN,
+error: bu.ERROR,
+none: bu.NONE
 }[e.toLowerCase()];
-return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Xu({
+return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (zu({
 level: t
 }), "Log level set to: ".concat(e.toUpperCase()));
 }, e.prototype.toggleDebug = function() {
 var e = !Mr().debug;
 return Ar({
 debug: e
-}), Xu({
-level: e ? ku.DEBUG : ku.INFO
+}), zu({
+level: e ? bu.DEBUG : bu.INFO
 }), "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
 }, n([ Zr({
 name: "setLogLevel",
@@ -36862,7 +36844,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), Av = function() {
+}(), kv = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36946,7 +36928,7 @@ return Ee.clear(mt), "Room.find() cache cleared and statistics reset";
 var e = !Mr().profiling;
 return Ar({
 profiling: e
-}), rs.setEnabled(e), Xu({
+}), rs.setEnabled(e), zu({
 cpuLogging: e
 }), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.enableCpuDetails = function(e, t, r) {
@@ -37387,7 +37369,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Uv = function() {
+}(), Mv = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Xr.generateHelp();
@@ -37406,22 +37388,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), _v = function() {
+}(), Av = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? dm.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? lm.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? dm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? lm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return dm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return lm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ Zr({
 name: "tasks",
 description: "Show room creep task queue",
@@ -37441,21 +37423,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), Nv = ((xv = {})[MOVE] = 50, xv[WORK] = 100, xv[CARRY] = 50, xv[ATTACK] = 80,
-xv[RANGED_ATTACK] = 150, xv[HEAL] = 250, xv[CLAIM] = 600, xv[TOUGH] = 10, xv);
+}(), Uv = ((Sv = {})[MOVE] = 50, Sv[WORK] = 100, Sv[CARRY] = 50, Sv[ATTACK] = 80,
+Sv[RANGED_ATTACK] = 150, Sv[HEAL] = 250, Sv[CLAIM] = 600, Sv[TOUGH] = 10, Sv);
 
-function Pv(e, t) {
+function _v(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, Nv), t);
+var r = o(o({}, Uv), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : Nv[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : Uv[t]);
 }, 0);
 }
 
-function Iv(e, t) {
+function Nv(e, t) {
 void 0 === t && (t = 0);
-var r = Pv(e);
+var r = _v(e);
 return {
 parts: e,
 cost: r,
@@ -37463,7 +37445,7 @@ minCapacity: t || r
 };
 }
 
-function Gv() {
+function Pv() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -37471,11 +37453,11 @@ return Array(o).fill(r);
 });
 }
 
-var Lv, Dv, Bv, Fv = {
+var Iv, Gv, Lv, Dv = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Iv([ WORK, CARRY ], 150), Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Iv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Nv([ WORK, CARRY ], 150), Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Nv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -37483,7 +37465,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Nv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Nv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37491,7 +37473,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Nv([ WORK, CARRY, MOVE, MOVE ], 250), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37499,7 +37481,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Iv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Nv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Nv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37507,7 +37489,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Iv([ CARRY, CARRY, MOVE, MOVE ], 200), Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Nv([ CARRY, CARRY, MOVE, MOVE ], 200), Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37515,7 +37497,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -37523,7 +37505,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ Nv([ WORK, CARRY, MOVE, MOVE ], 250), Nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37531,7 +37513,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37539,7 +37521,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Iv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ Nv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37547,7 +37529,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37555,7 +37537,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37563,7 +37545,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Iv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ Nv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Nv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37571,7 +37553,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37579,7 +37561,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37587,16 +37569,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Iv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Iv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Iv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Nv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Nv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Nv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Wv = {
+}, Bv = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Iv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ Nv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Nv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37604,7 +37586,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Iv([ TOUGH, ATTACK, MOVE, MOVE ], 190), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Iv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ Nv([ TOUGH, ATTACK, MOVE, MOVE ], 190), Nv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Nv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37612,7 +37594,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Iv([ HEAL, MOVE, MOVE ], 350), Iv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ Nv([ HEAL, MOVE, MOVE ], 350), Nv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Nv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37620,7 +37602,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Iv([ ATTACK, ATTACK, MOVE, MOVE ], 260), Iv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ Nv([ ATTACK, ATTACK, MOVE, MOVE ], 260), Nv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37628,7 +37610,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Iv([ WORK, WORK, MOVE, MOVE ], 300), Iv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ Nv([ WORK, WORK, MOVE, MOVE ], 300), Nv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37636,7 +37618,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Iv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Iv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Iv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ Nv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Nv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Nv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37644,16 +37626,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Iv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Iv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ Nv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Nv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Nv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Hv = {
+}, Fv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Iv(Gv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Iv(Gv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ Nv(Pv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Nv(Pv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37661,16 +37643,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Iv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Iv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ Nv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Nv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Kv = {
+}, Wv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Iv([ MOVE ], 50) ],
+bodies: [ Nv([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37678,7 +37660,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Iv([ MOVE ], 50) ],
+bodies: [ Nv([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37686,7 +37668,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Iv([ CLAIM, MOVE ], 650) ],
+bodies: [ Nv([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37694,7 +37676,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Iv([ CLAIM, MOVE ], 650), Iv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ Nv([ CLAIM, MOVE ], 650), Nv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37702,7 +37684,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Nv([ WORK, CARRY, MOVE, MOVE ], 250), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37710,30 +37692,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Yv = o(o(o(o({}, Fv), Wv), Kv), Hv);
+}, Hv = o(o(o(o({}, Dv), Bv), Wv), Fv);
 
 try {
-for (var Vv = a(Object.values(Yv)), qv = Vv.next(); !qv.done; qv = Vv.next()) qv.value.bodies.sort(function(e, t) {
+for (var Kv = a(Object.values(Hv)), Yv = Kv.next(); !Yv.done; Yv = Kv.next()) Yv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Lv = {
+Iv = {
 error: e
 };
 } finally {
 try {
-qv && !qv.done && (Dv = Vv.return) && Dv.call(Vv);
+Yv && !Yv.done && (Gv = Kv.return) && Gv.call(Kv);
 } finally {
-if (Lv) throw Lv.error;
+if (Iv) throw Iv.error;
 }
 }
 
-function jv(e) {
+function Vv(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37748,11 +37730,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return zv(o);
+return qv(o);
 }
 
-function zv(e) {
-var t = Pv(e);
+function qv(e) {
+var t = _v(e);
 return {
 parts: e,
 cost: t,
@@ -37760,16 +37742,16 @@ minCapacity: t
 };
 }
 
-function Qv(e, t) {
+function jv(e, t) {
 var r;
-return null !== (r = e.map(zv).filter(function(e) {
+return null !== (r = e.map(qv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function Xv(e) {
+function zv(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37783,7 +37765,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = Pv(a);
+var s = _v(a);
 return {
 parts: a,
 cost: s,
@@ -37808,8 +37790,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: Pv(p),
-minCapacity: Pv(p)
+cost: _v(p),
+minCapacity: _v(p)
 };
 }(e);
 
@@ -37820,7 +37802,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return jv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return Vv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37841,7 +37823,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return jv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return Vv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37850,13 +37832,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(zv).filter(function(e) {
+var u = n.map(qv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = Qv(n, t);
+var l = jv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37866,7 +37848,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = Qv(n, t);
+var u = jv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37875,14 +37857,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = Qv(r, t);
+var a = jv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Zv(e) {
+function Qv(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37893,9 +37875,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Jv(e, t) {
+function Xv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Zv(t)
+memory: Qv(t)
 });
 var r;
 }
@@ -37903,9 +37885,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Bv || (Bv = {}));
+}(Lv || (Lv = {}));
 
-var $v = function() {
+var Zv = function() {
 function e() {
 this.queues = new Map, this.revision = 0;
 }
@@ -38003,7 +37985,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Jv(m, d);
+var p = Xv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -38023,7 +38005,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Bv.EMERGENCY;
+return e.priority >= Lv.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -38041,7 +38023,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Bv.EMERGENCY ? n.emergency++ : c.priority >= Bv.HIGH ? n.high++ : c.priority >= Bv.NORMAL ? n.normal++ : n.low++;
+c.priority >= Lv.EMERGENCY ? n.emergency++ : c.priority >= Lv.HIGH ? n.high++ : c.priority >= Lv.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -38056,14 +38038,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), eg = new $v, tg = {
+}(), Jv = new Zv, $v = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, rg = {
+}, eg = {
 predictConsumption: function() {
 return 0;
 },
@@ -38082,7 +38064,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, og = {
+}, tg = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -38100,81 +38082,81 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, ng = {
+}, rg = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function ag(e, t, r, o, n) {
-return yc(e, t, r, o, n);
+function og(e, t, r, o, n) {
+return pc(e, t, r, o, n);
 }
 
-var ig = new Map, sg = -1, cg = null, ug = null;
+var ng = new Map, ag = -1, ig = null, sg = null;
 
-function lg() {
-sg === Game.time && cg === Game.creeps || (ig.clear(), ug = null, sg = Game.time,
-cg = Game.creeps);
+function cg() {
+ag === Game.time && ig === Game.creeps || (ng.clear(), sg = null, ag = Game.time,
+ig = Game.creeps);
 }
 
-function mg(e) {
+function ug(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function dg(e, t) {
+function lg(e, t) {
 var r;
-void 0 === t && (t = !1), lg();
-var o = t ? "".concat(e, "_active") : e, n = ig.get(o);
+void 0 === t && (t = !1), cg();
+var o = t ? "".concat(e, "_active") : e, n = ng.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = mg(c);
+var u = ug(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return ig.set(o, a), a;
+return ng.set(o, a), a;
 }
 
-function pg(e, t, r) {
+function mg(e, t, r) {
 return "".concat(e).concat("").concat(t).concat("").concat(r);
 }
 
-function fg(e, t, r) {
+function dg(e, t, r) {
 var o;
 return null !== (o = function() {
 var e;
-if (lg(), ug) return ug;
+if (cg(), sg) return sg;
 var t = new Map;
 for (var r in Game.creeps) {
 var o = Game.creeps[r].memory, n = o.homeRoom, a = o.role, i = o.targetRoom;
 if (n && a && i) {
-var s = pg(n, a, i);
+var s = mg(n, a, i);
 t.set(s, (null !== (e = t.get(s)) && void 0 !== e ? e : 0) + 1);
 }
 }
-return ug = t, t;
-}().get(pg(e, t, r))) && void 0 !== o ? o : 0;
+return sg = t, t;
+}().get(mg(e, t, r))) && void 0 !== o ? o : 0;
 }
 
-function yg(e) {
+function pg(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var vg = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var fg = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function gg(e) {
-return vg.includes(e);
+function yg(e) {
+return fg.includes(e);
 }
 
-function hg(e) {
+function vg(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function Rg(e, t, r, o) {
+function gg(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -38187,10 +38169,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return ag(e, t, ft(r).length, o, {
-reserved: hg(r)
+if (r) return og(e, t, ft(r).length, o, {
+reserved: vg(r)
 }).recommendedHaulers;
-var n = ag(e, t, 2, o, {
+var n = og(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -38201,7 +38183,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: yg
+filter: pg
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -38212,7 +38194,7 @@ return 2;
 }
 }
 
-function Eg(e, t) {
+function hg(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -38222,13 +38204,13 @@ return null;
 }
 }
 
-function Tg() {
+function Rg() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function Cg(e) {
-var t = Tg(), r = function(e) {
+function Eg(e) {
+var t = Rg(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -38240,22 +38222,22 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function Sg(e) {
+function Tg(e) {
 var t = wr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Tg();
+var r = Rg();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function wg(e, t) {
+function Cg(e, t) {
 return void 0 === t && (t = Z(e)), t.some(so);
 }
 
-function xg(e) {
+function Sg(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function bg() {
+function wg() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -38265,9 +38247,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var Og = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var xg = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function kg(e, t) {
+function bg(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -38279,8 +38261,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(bg()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = eg.getPendingRequests(c).some(function(r) {
+for (var i = a(wg()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = Jv.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -38300,7 +38282,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function Mg() {
+function Og() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -38321,7 +38303,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function Ag(e, t) {
+function kg(e, t) {
 var r, o, n, c, u = wr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -38331,15 +38313,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !kg(e.roomName, "claim");
+return !bg(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || wg(t));
+return !(!r || r.my || r.owner || r.reservation || Cg(t));
 }
-return !Sg(e);
+return !Tg(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -38350,11 +38332,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = Mg().filter(function(e) {
-return !kg(e, "claim");
+var r, o, n = Og().filter(function(e) {
+return !bg(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = Tg();
+var r, o, n = Game.rooms[e], a = Rg();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -38365,7 +38347,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return Z(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && Og.has(e.type);
+return e.hits > 0 && xg.has(e.type);
 });
 });
 }(n));
@@ -38377,7 +38359,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = Eg(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = hg(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -38392,14 +38374,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(Mg()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(Og()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !kg(e.roomName, "claim");
+return !e.claimed && !bg(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -38411,20 +38393,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Tg();
+var l = Rg();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !kg(p, "claim")) {
+if (!t.has(p) && !bg(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || Cg(y)) continue;
-if (wg(f)) continue;
+if (y.owner || Eg(y)) continue;
+if (Cg(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !kg(p, "reserve")) return p;
-} else if (!Sg(p) && !kg(p, "reserve")) return p;
+if ((!v || g < 3e3) && !bg(p, "reserve")) return p;
+} else if (!Tg(p) && !bg(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -38446,22 +38428,22 @@ task: "reserve"
 } : null;
 }
 
-var Ug, _g, Ng = new Map;
+var Mg, Ag, Ug = new Map;
 
-function Pg(e) {
+function _g(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Ig(e) {
+function Ng(e) {
 var t, r;
-r = Game.time, Ug === Game && _g === r || (Ng.clear(), Ug = Game, _g = r);
+r = Game.time, Mg === Game && Ag === r || (Ug.clear(), Mg = Game, Ag = r);
 var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}(), n = Ng.get(e.name);
+}(), n = Ug.get(e.name);
 if (n && n.fallbackEnabled === o) return n.value;
 var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
@@ -38472,7 +38454,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += Pg(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += _g(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38493,7 +38475,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += Pg(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += _g(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38507,20 +38489,20 @@ if (o) throw o.error;
 }
 return i;
 }(e)) : i;
-return Ng.set(e.name, {
+return Ug.set(e.name, {
 fallbackEnabled: o,
 value: s
 }), s;
 }
 
-var Gg, Lg, Dg, Bg = new Map;
+var Pg, Ig, Gg, Lg = new Map;
 
-function Fg(e, t) {
+function Dg(e, t) {
 var r;
-return null !== (r = Eg(e, t)) && void 0 !== r ? r : 999;
+return null !== (r = hg(e, t)) && void 0 !== r ? r : 999;
 }
 
-function Wg(e) {
+function Bg(e) {
 try {
 return e.find(FIND_MY_SPAWNS).filter(function(e) {
 return !e.spawning;
@@ -38530,16 +38512,16 @@ return 0;
 }
 }
 
-function Hg(e, t) {
+function Fg(e, t) {
 var r, o = null !== (r = e.energyCapacityAvailable) && void 0 !== r ? r : 0;
 if (o < 200) return null;
 var n, a, i = function(e, t) {
 var r, o;
-Gg === Game && Lg === Game.map && Dg === Game.time || (Bg.clear(), Gg = Game, Lg = Game.map,
-Dg = Game.time);
+Pg === Game && Ig === Game.map && Gg === Game.time || (Lg.clear(), Pg = Game, Ig = Game.map,
+Gg = Game.time);
 var n = "".concat(e, "->").concat(t);
-if (Bg.has(n)) return null !== (r = Bg.get(n)) && void 0 !== r ? r : null;
-var a = Fg(e, t);
+if (Lg.has(n)) return null !== (r = Lg.get(n)) && void 0 !== r ? r : null;
+var a = Dg(e, t);
 try {
 if ("function" == typeof (null === (o = Game.map) || void 0 === o ? void 0 : o.findRoute)) {
 var i = Game.map.findRoute(e, t, {
@@ -38548,79 +38530,79 @@ return function(e, t) {
 var r;
 if (e === t) return 1;
 var o = Game.rooms[e];
-return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && Cg(o.controller) || Sg(e) || o && wg(o) ? 1 / 0 : 1;
+return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && Eg(o.controller) || Tg(e) || o && Cg(o) ? 1 / 0 : 1;
 }(e, t);
 }
 });
 a = i === ERR_NO_PATH ? null : i.length;
 }
 } catch (r) {
-a = Fg(e, t);
+a = Dg(e, t);
 }
-return Bg.set(n, a), a;
+return Lg.set(n, a), a;
 }(e.name, t.name);
 return null === i ? null : {
 room: e,
 routeDistance: i,
-linearDistance: Fg(e.name, t.name),
-queuePressure: (n = e.name, a = t.name, eg.getPendingRequests(n).reduce(function(e, t) {
+linearDistance: Dg(e.name, t.name),
+queuePressure: (n = e.name, a = t.name, Jv.getPendingRequests(n).reduce(function(e, t) {
 var r;
-return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Bv.EMERGENCY;
+return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Lv.EMERGENCY;
 }, 0)),
 energyCapacity: o,
-hasAvailableSpawn: Wg(e) > 0,
-hasReadyEnergy: Ig(e) >= 200
+hasAvailableSpawn: Bg(e) > 0,
+hasReadyEnergy: Ng(e) >= 200
 };
 }
 
-function Kg(e, t) {
+function Wg(e, t) {
 return Number(t.hasReadyEnergy) - Number(e.hasReadyEnergy) || Number(t.hasAvailableSpawn) - Number(e.hasAvailableSpawn) || e.queuePressure - t.queuePressure || t.energyCapacity - e.energyCapacity || e.routeDistance - t.routeDistance || e.linearDistance - t.linearDistance || e.room.name.localeCompare(t.room.name);
 }
 
-function Yg(e) {
+function Hg(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function Vg(e) {
-return Yg(e) ? Bv.EMERGENCY : Bv.HIGH;
+function Kg(e) {
+return Hg(e) ? Lv.EMERGENCY : Lv.HIGH;
 }
 
-function qg(e, t, r) {
+function Yg(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!xg(e)) return !1;
+if (!Sg(e)) return !1;
 var a = e.name === t ? r : wr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function jg(e, t, r) {
+function Vg(e, t, r) {
 var o, n;
 return null !== (n = null === (o = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return qg(e, t, r);
+return Yg(e, t, r);
 }).map(function(t) {
-return Hg(t, e);
+return Fg(t, e);
 }).filter(function(e) {
 return null !== e;
-}).sort(Kg)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
+}).sort(Wg)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function zg(e, t) {
+function qg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !qg(n, e, t)) return null;
+if (!n || !Yg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !xg(e);
+return !Sg(e);
 }).filter(function(e) {
 var t = Z(e);
-return !wg(e, t) || mo(e, t);
+return !Cg(e, t) || mo(e, t);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -38641,9 +38623,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(bg()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(wg()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += eg.getPendingRequests(d).filter(function(t) {
+i += Jv.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -38660,11 +38642,11 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (Yg(e) ? 3 : 1);
+}(e.name) < (Hg(e) ? 3 : 1);
 }).map(function(e) {
 return {
 room: e,
-homeScore: Hg(n, e)
+homeScore: Fg(n, e)
 };
 }).filter(function(e) {
 return null !== e.homeScore;
@@ -38674,10 +38656,10 @@ return e.homeScore.routeDistance - t.homeScore.routeDistance || e.homeScore.line
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (jg(u.room, e, t) === e) return {
+if (Vg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: Vg(u.room)
+priority: Kg(u.room)
 };
 }
 } catch (e) {
@@ -38694,10 +38676,10 @@ if (r) throw r.error;
 return null;
 }
 
-function Qg(e, t) {
+function jg(e, t) {
 if (t <= 0) return null;
 try {
-var r = Xv({
+var r = zv({
 maxEnergy: t,
 role: e
 });
@@ -38707,36 +38689,36 @@ return null;
 }
 }
 
-function Xg(e, t, r) {
-return "healer" === e || "ranger" === e && Po(r) ? null : Qg(e, t);
+function zg(e, t, r) {
+return "healer" === e || "ranger" === e && Po(r) ? null : jg(e, t);
 }
 
-function Zg(e) {
+function Qg(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Jg(e) {
+function Xg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? Z(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function $g(e) {
+function Zg(e) {
 var t = e.defenseRequests;
-return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Zg);
+return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Qg);
 }
 
-var eh = [ "guard", "ranger", "healer" ];
+var Jg = [ "guard", "ranger", "healer" ];
 
-function th(e, t) {
+function $g(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-var rh = null;
+var eh = null;
 
-function oh() {
-var e = eg.getRevision();
-return rh && rh.game === Game && rh.creeps === Game.creeps && rh.tick === Game.time && rh.queueRevision === e ? rh : rh = {
+function th() {
+var e = Jv.getRevision();
+return eh && eh.game === Game && eh.creeps === Game.creeps && eh.tick === Game.time && eh.queueRevision === e ? eh : eh = {
 game: Game,
 creeps: Game.creeps,
 tick: Game.time,
@@ -38749,8 +38731,8 @@ canSpawn: new Map
 };
 }
 
-function nh(e) {
-var t = oh(), r = Game.rooms[e], o = t.threats.get(e);
+function rh(e) {
+var t = th(), r = Game.rooms[e], o = t.threats.get(e);
 if (o && o.room === r) return o.threatProfile;
 var n = Mo(e);
 return t.threats.set(e, {
@@ -38759,27 +38741,27 @@ threatProfile: n
 }), n;
 }
 
-function ah(e) {
-return Game.rooms[e.roomName] ? null !== nh(e.roomName) : Jg(e);
+function oh(e) {
+return Game.rooms[e.roomName] ? null !== rh(e.roomName) : Xg(e);
 }
 
-function ih(e) {
+function nh(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function sh(e, t) {
+function ah(e, t) {
 var r, o;
 return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === vi && e.targetRoom === t;
 }
 
-function ch(e, t, r) {
+function ih(e, t, r) {
 var o = wo(r), n = e[t];
 e[t] = n ? bo(n, o) : o;
 }
 
-function uh(e) {
-var t = oh(), r = t.assigned.get(e);
+function sh(e) {
+var t = th(), r = t.assigned.get(e);
 if (r) return r;
 var o = function(e) {
 var t, r, o, n, i, s, c = {
@@ -38790,12 +38772,12 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = d.memory, f = null !== (i = p.role) && void 0 !== i ? i : "";
-if (Bo(f) && ih(p) === e) {
+if (Bo(f) && nh(p) === e) {
 c[f]++;
 var y = (null !== (s = d.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-y.length > 0 && ch(u, f, y);
+y.length > 0 && ih(u, f, y);
 }
 }
 } catch (e) {
@@ -38810,9 +38792,9 @@ if (t) throw t.error;
 }
 }
 for (var v in Game.rooms) try {
-for (var g = (o = void 0, a(eg.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
+for (var g = (o = void 0, a(Jv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Bo(R.role) && sh(R, e) && (c[R.role]++, ch(u, R.role, R.body.parts));
+Bo(R.role) && ah(R, e) && (c[R.role]++, ih(u, R.role, R.body.parts));
 }
 } catch (e) {
 o = {
@@ -38833,8 +38815,8 @@ power: u
 return t.assigned.set(e, o), o;
 }
 
-function lh(e) {
-var t = oh(), r = t.canSpawn.get(e.name);
+function ch(e) {
+var t = th(), r = t.canSpawn.get(e.name);
 if (r && r.room === e) return r.value;
 var o = function(e) {
 var t;
@@ -38846,20 +38828,20 @@ value: o
 }), o;
 }
 
-function mh(e, t) {
-var r, o, n = oh(), i = function(e, t) {
+function uh(e, t) {
+var r, o, n = th(), i = function(e, t) {
 var r, o, n, a, i;
 return [ t.name, e.roomName, t.energyCapacityAvailable, Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0), Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0), null !== (a = e.urgency) && void 0 !== a ? a : "", null !== (i = e.createdAt) && void 0 !== i ? i : "" ].join(":");
 }(e, t), s = n.helperPlans.get(i);
 if (s) return s;
-var c = nh(e.roomName), u = uh(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Do(d, c, function(e, t) {
+var c = rh(e.roomName), u = sh(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Do(d, c, function(e, t) {
 return {
-guard: Math.max(0, th(e, "guard") - t.guard),
-ranger: Math.max(0, th(e, "ranger") - t.ranger),
-healer: Math.max(0, th(e, "healer") - t.healer)
+guard: Math.max(0, $g(e, "guard") - t.guard),
+ranger: Math.max(0, $g(e, "ranger") - t.ranger),
+healer: Math.max(0, $g(e, "healer") - t.healer)
 };
 }(e, l), m), f = function(e, t) {
-var r, o, n, i, s = oh(), c = s.capableHelpers.get(e);
+var r, o, n, i, s = th(), c = s.capableHelpers.get(e);
 if (c) return c;
 var u = {
 guard: 0,
@@ -38869,8 +38851,8 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.rooms)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d.name !== e && lh(d)) try {
-for (var p = (n = void 0, a(eh)), f = p.next(); !f.done; f = p.next()) {
+if (d.name !== e && ch(d)) try {
+for (var p = (n = void 0, a(Jg)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
 Io(y, d.energyCapacityAvailable, t) && u[y]++;
 }
@@ -38900,7 +38882,7 @@ if (r) throw r.error;
 return s.capableHelpers.set(e, u), u;
 }(e.roomName, c), y = {};
 try {
-for (var v = a(eh), g = v.next(); !g.done; g = v.next()) {
+for (var v = a(Jg), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 y[h] = Io(h, d, c);
 }
@@ -38927,8 +38909,8 @@ helperBodies: y
 return n.helperPlans.set(i, R), R;
 }
 
-function dh(e, t, r) {
-var o = th(e, t);
+function lh(e, t, r) {
+var o = $g(e, t);
 if (!Bo(t)) return o;
 if (!r.threatProfile) return o;
 var n = r.assignedCounts[t] + r.aggregatePlan.counts[t], a = o > 0 ? function(e, t, r) {
@@ -38943,27 +38925,27 @@ return Math.min(8, Math.max(1, i, s, u, l));
 return Math.max(o, n, a, i);
 }
 
-function ph(e, t, r) {
-void 0 === r && (r = mh(e, t));
+function mh(e, t, r) {
+void 0 === r && (r = uh(e, t));
 var o = r.aggregatePlan.counts.guard + r.aggregatePlan.counts.ranger + r.aggregatePlan.counts.healer;
 if (o > 0) return o;
-var n = eh.filter(function(t) {
-return !(dh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
+var n = Jg.filter(function(t) {
+return !(lh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
 });
 return Math.max(1, n.length);
 }
 
-function fh(e, t, r, o) {
+function dh(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : Xg("guard", Ig(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : zg("guard", Ng(r), o) ? 1 : 0;
 }
 
-function yh(e, t) {
+function ph(e, t) {
 if (!function(e) {
 return Bo(e);
 }(t)) return null;
 var r = Game.rooms[e];
-if (!r || !lh(r)) return null;
+if (!r || !ch(r)) return null;
 var o = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38990,15 +38972,15 @@ if (t) throw t.error;
 var n = function(e, t) {
 var r;
 void 0 === t && (t = {});
-var o = $g(e), n = function(e) {
+var o = Zg(e), n = function(e) {
 return e.map(function(e) {
 var t, r, o, n, a;
 return [ e.roomName, Math.max(0, null !== (t = e.guardsNeeded) && void 0 !== t ? t : 0), Math.max(0, null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.healersNeeded) && void 0 !== o ? o : 0), null !== (n = e.urgency) && void 0 !== n ? n : "", null !== (a = e.createdAt) && void 0 !== a ? a : "" ].join(":");
 }).join("|");
-}(o), a = oh();
+}(o), a = th();
 if ((null === (r = a.activeRequests) || void 0 === r ? void 0 : r.signature) === n) return t.prune && Array.isArray(e.defenseRequests) && a.activeRequests.requests.length !== o.length && (e.defenseRequests = a.activeRequests.requests),
 a.activeRequests.requests;
-var i = o.filter(ah);
+var i = o.filter(oh);
 return a.activeRequests = {
 signature: n,
 requests: i
@@ -39009,17 +38991,17 @@ prune: !0
 }).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var o = mh(e, r);
+var o = uh(e, r);
 return {
 request: e,
 plan: o,
-helperNeed: Math.max(dh(e, t, o), fh(e, t, r, o.threatProfile))
+helperNeed: Math.max(lh(e, t, o), dh(e, t, r, o.threatProfile))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
 return function(e, t) {
-return Bo(t) ? uh(e).counts[t] : 0;
+return Bo(t) ? sh(e).counts[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -39029,7 +39011,7 @@ return f !== y ? f - y : (null !== (m = t.request.createdAt) && void 0 !== m ? m
 }), s = n[0];
 return s ? function(e, t, r, o) {
 var n;
-void 0 === o && (o = mh(r, t));
+void 0 === o && (o = uh(r, t));
 var a = function(e, t) {
 var r = function() {
 var e, t = Memory;
@@ -39047,28 +39029,28 @@ return r[o] = s, s;
 return {
 targetRoom: r.roomName,
 task: vi,
-priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Bv.EMERGENCY : Bv.HIGH,
+priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Lv.EMERGENCY : Lv.HIGH,
 defenseSquadId: gi(e, r.roomName, a.createdAt),
-defenseSquadSize: ph(r, t, o),
+defenseSquadSize: mh(r, t, o),
 defenseSquadCreatedAt: a.createdAt
 };
 }(e, r, s.request, s.plan) : null;
 }
 
-var vh = "defenseRefuel", gh = {
+var fh = "defenseRefuel", yh = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function hh(e, t) {
+function vh(e, t) {
 if ("hauler" !== t) return null;
 var r = Game.rooms[e];
 if (!r || !function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || Z(e).length > 0 || e.energyCapacityAvailable < gh.cost);
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || Z(e).length > 0 || e.energyCapacityAvailable < yh.cost);
 }(r)) return null;
-if (Ig(r) >= 200) return null;
+if (Ng(r) >= 200) return null;
 var o = function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(function(t) {
 var r, o;
@@ -39101,7 +39083,7 @@ var t, r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value.memory;
-"hauler" === l.role && l.homeRoom === e && l.task === vh && s++;
+"hauler" === l.role && l.homeRoom === e && l.task === fh && s++;
 }
 } catch (e) {
 t = {
@@ -39115,9 +39097,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(eg.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Jv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === vh && s++;
+"hauler" === p.role && f === fh && s++;
 }
 } catch (e) {
 o = {
@@ -39150,9 +39132,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(eg.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Jv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === vh && s++;
+"hauler" === p.role && f === fh && s++;
 }
 } catch (e) {
 o = {
@@ -39168,24 +39150,24 @@ if (o) throw o.error;
 return s;
 }(e);
 return i >= (n ? 4 : 2) ? null : {
-task: vh,
-priority: Bv.EMERGENCY,
-body: gh
+task: fh,
+priority: Lv.EMERGENCY,
+body: yh
 };
 }
 
-function Rh(e) {
+function gh(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !Cg(t.controller) && !wg(t) : !Sg(e);
+return t ? !!t.controller && !Eg(t.controller) && !Cg(t) : !Tg(e);
 }
 
-function Eh(e) {
+function hh(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !Cg(t.controller) : !Sg(e);
+return (null == t ? void 0 : t.controller) ? !Eg(t.controller) : !Tg(e);
 }
 
-function Th(e, t, r) {
-var o = Yv[t];
+function Rh(e, t, r) {
+var o = Hv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
@@ -39213,13 +39195,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Ch(e, t, r) {
+function Eh(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (Rh(l) && fg(e, t, l) < Rg(e, l, t, Game.rooms[l])) return l;
+if (gh(l) && dg(e, t, l) < gg(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -39235,10 +39217,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Sh(e, t, r, o) {
+function Th(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Yv[t];
+var p = Hv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -39252,36 +39234,36 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Yv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Yv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Hv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Hv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, dg(e), y)) return !1;
+}(t, lg(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (gg(t)) return !("remoteWorker" === t && function(e, t) {
-lg();
-var r = "".concat(e, ":").concat(t), o = ig.get(r);
+if (yg(t)) return !("remoteWorker" === t && function(e, t) {
+cg();
+var r = "".concat(e, ":").concat(t), o = ng.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return ig.set(r, n), n;
-}(e, t) >= Th(e, t, r)) && null !== Ch(e, t, r);
+return ng.set(r, n), n;
+}(e, t) >= Rh(e, t, r)) && null !== Eh(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (Eh(R)) {
+if (hh(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = Z(E).filter(so);
-if (T.length > 0 && fg(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && dg(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -39298,9 +39280,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = dg(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== zg(e, r);
-if (C >= Th(e, t, r)) return !1;
+var C = null !== (u = lg(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== qg(e, r);
+if (C >= Rh(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -39312,14 +39294,14 @@ var r = wr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = Eg(e, o);
+var a = hg(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== Ag(e, r);
+if ("claimer" === t) return null !== kg(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -39355,7 +39337,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = tg.getActiveRequests) || void 0 === m ? void 0 : m.call(tg)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = $v.getActiveRequests) || void 0 === m ? void 0 : m.call($v)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -39383,16 +39365,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function wh(e) {
+function Ch(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function xh(e) {
-return 0 === wh(dg(e, !0));
+function Sh(e) {
+return 0 === Ch(lg(e, !0));
 }
 
-function bh(e) {
+function wh(e) {
 var t = ft(e);
 return [ {
 role: "harvester",
@@ -39415,14 +39397,14 @@ minCount: 1
 } ];
 }
 
-function Oh(e, t) {
-var r, o, n, i, s = dg(e, !0);
-if (0 === wh(s)) return !0;
+function xh(e, t) {
+var r, o, n, i, s = lg(e, !0);
+if (0 === Ch(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = dg(e, !1), u = bh(t);
+var c = lg(e, !1), u = wh(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -39442,36 +39424,36 @@ if (r) throw r.error;
 return !1;
 }
 
-var kh = [ "guard", "ranger", "healer" ];
+var bh = [ "guard", "ranger", "healer" ];
 
-function Mh(e, t, r) {
+function Oh(e, t, r) {
 void 0 === r && (r = 1), e[t] += r, e.total += r;
 }
 
-function Ah(e, t) {
+function kh(e, t) {
 var r, o;
 return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === vi ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
 }
 
-function Uh(e) {
+function Mh(e) {
 var t;
-return Bo(e.role) && void 0 !== Ah(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
+return Bo(e.role) && void 0 !== kh(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
 }
 
-function _h(e, t) {
+function Ah(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Nh(e, t) {
+function Uh(e, t) {
 return 0 === t.length ? e : bo(e, wo(t));
 }
 
-function Ph(e, t) {
-e.assignedPower = Nh(e.assignedPower, t);
+function _h(e, t) {
+e.assignedPower = Uh(e.assignedPower, t);
 }
 
-function Ih(e, t) {
+function Nh(e, t) {
 var r, o;
 if (void 0 !== t.defenseAssistReleasedAt) {
 var n = null !== (r = t.defenseAssistReleaseReason) && void 0 !== r ? r : "unknown";
@@ -39481,10 +39463,10 @@ e.released.lastReason = n);
 }
 }
 
-function Gh(e, t) {
+function Ph(e, t) {
 e.parityPercent = e.targetScore > 0 ? Math.min(100, t.score / e.targetScore * 100) : 0,
 e.blockReason = function(e) {
-var t = kh.filter(function(t) {
+var t = bh.filter(function(t) {
 return e.queued[t] > 0;
 });
 if (t.length > 0 && t.every(function(t) {
@@ -39496,50 +39478,50 @@ return e.requested.total > 0 && 0 === r ? "no-local-assist" : "none";
 }(e);
 }
 
-function Lh(e) {
+function Ih(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Dh(e, t, r) {
-var n = Th(e.name, r.roleName, t);
+function Gh(e, t, r) {
+var n = Rh(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Bh(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Bv.EMERGENCY;
+function Lh(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Lv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Bv.HIGH;
-if (ng.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Lv.HIGH;
+if (rg.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = po(e), n = vo(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Bv.EMERGENCY;
-if (a > 0) return Bv.HIGH;
+if (a >= 100) return Lv.EMERGENCY;
+if (a > 0) return Lv.HIGH;
 }
 return function(e) {
-return e >= 90 ? Bv.HIGH : e >= 60 ? Bv.NORMAL : Bv.LOW;
+return e >= 90 ? Lv.HIGH : e >= 60 ? Lv.NORMAL : Lv.LOW;
 }(o);
 }
 
-function Fh(e, t) {
+function Dh(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u, l;
-Lh(e);
-var m = dg(e.name), d = xh(e.name), p = [], f = hh(e.name, "hauler");
-if (f && (R = Yv.hauler)) return [ {
+Ih(e);
+var m = lg(e.name), d = Sh(e.name), p = [], f = vh(e.name, "hauler");
+if (f && (R = Hv.hauler)) return [ {
 roleName: "hauler",
 def: R,
 current: E = null !== (n = m.get("hauler")) && void 0 !== n ? n : 0,
@@ -39549,14 +39531,14 @@ priority: f.priority,
 task: f.task,
 bodyOverride: f.body
 } ];
-if (Oh(e.name, e)) {
+if (xh(e.name, e)) {
 var y = function(e, t, r) {
 var o, n, i;
-if (0 === wh(dg(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === Ch(lg(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = dg(e, !1), c = bh(t);
+var s = lg(e, !1), c = wh(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -39571,7 +39553,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Sh(e, m.role, r, !0);
+var p = Th(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -39602,17 +39584,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return y && (R = Yv[y]) && Sh(e.name, y, t, !0) ? (p.push(Dh(e, t, {
+return y && (R = Hv[y]) && Th(e.name, y, t, !0) ? (p.push(Gh(e, t, {
 roleName: y,
 def: R,
 current: null !== (s = m.get(y)) && void 0 !== s ? s : 0,
-priority: Bh(e, 0, y, R.priority, d),
+priority: Lh(e, 0, y, R.priority, d),
 bootstrap: !0
 })), p) : p;
 }
 try {
-for (var v = a(Object.entries(Yv)), g = v.next(); !g.done; g = v.next()) {
-var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (c = m.get(y)) && void 0 !== c ? c : 0, T = hh(e.name, y);
+for (var v = a(Object.entries(Hv)), g = v.next(); !g.done; g = v.next()) {
+var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (c = m.get(y)) && void 0 !== c ? c : 0, T = vh(e.name, y);
 if (T) p.push({
 roleName: y,
 def: R,
@@ -39623,7 +39605,7 @@ priority: T.priority,
 task: T.task,
 bodyOverride: T.body
 }); else {
-var C = yh(e.name, y);
+var C = ph(e.name, y);
 if (C) p.push({
 roleName: y,
 def: R,
@@ -39637,8 +39619,8 @@ assistTarget: C.targetRoom,
 defenseSquadId: C.defenseSquadId,
 defenseSquadSize: C.defenseSquadSize,
 defenseSquadCreatedAt: C.defenseSquadCreatedAt
-}); else if (Sh(e.name, y, t, d)) {
-var S = gg(y), w = S ? Ch(e.name, y, t) : null, x = "claimer" === y ? Ag(e.name, t) : null, b = "pioneer" === y ? zg(e.name, t) : null;
+}); else if (Th(e.name, y, t, d)) {
+var S = yg(y), w = S ? Eh(e.name, y, t) : null, x = "claimer" === y ? kg(e.name, t) : null, b = "pioneer" === y ? qg(e.name, t) : null;
 S && !w || ("claimer" !== y || x) && ("pioneer" !== y || b) && (b ? p.push({
 roleName: y,
 def: R,
@@ -39648,11 +39630,11 @@ missing: 1,
 priority: b.priority,
 targetRoom: b.targetRoom,
 task: b.task
-}) : p.push(Dh(e, t, {
+}) : p.push(Gh(e, t, {
 roleName: y,
 def: R,
 current: E,
-priority: Bh(e, 0, y, R.priority, d),
+priority: Lh(e, 0, y, R.priority, d),
 targetRoom: null !== (l = null !== (u = null == x ? void 0 : x.targetRoom) && void 0 !== u ? u : w) && void 0 !== l ? l : void 0,
 task: null == x ? void 0 : x.task
 })));
@@ -39674,7 +39656,7 @@ return p;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Wh(e, l.value);
+var m = Bh(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -39695,12 +39677,12 @@ requests: c
 };
 }
 
-function Wh(e, t) {
+function Bh(e, t) {
 var r, n, i, s = e.energyCapacityAvailable;
 try {
-var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = rg.getMaxAffordableInTicks(e, c), l = Ig(e), m = t.priority >= Bv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Bo(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Bv.EMERGENCY, y = t.assistTarget ? Mo(t.assistTarget) : null, v = d ? Io(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = eg.getMaxAffordableInTicks(e, c), l = Ng(e), m = t.priority >= Lv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Bo(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Lv.EMERGENCY, y = t.assistTarget ? Mo(t.assistTarget) : null, v = d ? Io(d, s, y) : null, g = d && f ? function(e, t, r, o) {
 var n;
-return null !== (n = [ Io(e, t, r), Xg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return null !== (n = [ Io(e, t, r), zg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
 return function(e, t, r) {
 if (!t) return !1;
 if ("ranger" !== e) return !0;
@@ -39733,7 +39715,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, m)) && void 0 !== i ? i : Xv({
+}(t.def, m)) && void 0 !== i ? i : zv({
 maxEnergy: m,
 role: t.roleName
 }), E = t.bodyOverride ? s : h ? f ? l : s : m;
@@ -39769,44 +39751,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Hh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Kh = new Set([ "guard", "ranger", "healer" ]);
+var Fh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Wh = new Set([ "guard", "ranger", "healer" ]);
 
-function Yh() {
+function Hh() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Vh(e) {
+function Kh(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function qh(e) {
+function Yh(e) {
 var t;
-return e.priority >= Bv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Lv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function jh(e) {
+function Vh(e) {
 var t;
-return e.priority >= Bv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Lv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function zh(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Ig(e), m = ko(Z(e)), d = function(e) {
+function qh(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Ng(e), m = ko(Z(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Bv.EMERGENCY : Bv.HIGH, f = d ? u : p === Bv.EMERGENCY ? l : u, y = function(e, t) {
+}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Lv.EMERGENCY : Lv.HIGH, f = d ? u : p === Lv.EMERGENCY ? l : u, y = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(eg.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(Jv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || Qh(u, e) && ("guard" === u.role && (n.guards++,
-Zh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Zh(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Zh(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || jh(u, e) && ("guard" === u.role && (n.guards++,
+Qh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Qh(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Qh(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -39834,7 +39816,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Zh(n, u, l);
+0 !== l.length && Qh(n, u, l);
 }
 }
 }
@@ -39873,26 +39855,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - y.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - y.counts.healers)
-}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Xh("guard", f, m);
-if (R > 0 && E) for (var T = 0; T < R; T++) $h(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
-var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Xh("ranger", f, m);
-if (C > 0 && S) for (T = 0; T < C; T++) $h(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
-var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Xh("healer", f, m);
-if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) $h(e, "healer", "military", Bv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : zh("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) Zh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : zh("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) Zh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : zh("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) Zh(e, "healer", "military", Lv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
-if (!(t < Bv.EMERGENCY || function(e, t) {
+if (!(t < Lv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Kh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Wh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(eg.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(Jv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Bv.EMERGENCY || Kh.has(c.role) && Qh(c, e.name) && c.body.cost <= t && n++;
+c.priority < Lv.EMERGENCY || Wh.has(c.role) && jh(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39909,7 +39891,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = Qg(t, e);
+var r = jg(t, e);
 return r ? {
 role: t,
 body: r
@@ -39924,45 +39906,45 @@ var r = wo(t.body.parts).score - wo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && $h(e, n.role, "military", Bv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && Zh(e, n.role, "military", Lv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, p, l, m), (R > 0 || C > 0 || w > 0) && U.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function Qh(e, t) {
+function jh(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function Xh(e, t, r) {
+function zh(e, t, r) {
 return r ? Io(e, t, r) : null;
 }
 
-function Zh(e, t, r) {
+function Qh(e, t, r) {
 var o = wo(r);
 e[t] = e[t] ? bo(e[t], o) : o;
 }
 
-function Jh(e, t, r) {
-return eg.getPendingRequests(e).filter(function(e) {
+function Xh(e, t, r) {
+return Jv.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function $h(e, t, r, o, n, a, i, s, c) {
+function Zh(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : Xv({
+var u = null != i ? i : zv({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-eg.addRequest({
+Jv.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -39980,34 +39962,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function eR(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Bv.HIGH) return !1;
+function Jh(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Lv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Bv.NORMAL) {
-if (rg.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Lv.NORMAL) {
+if (eg.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Bv.NORMAL && o / e.energyCapacityAvailable < .3 && rg.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Lv.NORMAL && o / e.energyCapacityAvailable < .3 && eg.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function tR(e, t) {
+function $h(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Lh(e);
-var s = eg.getQueueSize(e.name);
+Ih(e);
+var s = Jv.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = Oh(e.name, e), u = xh(e.name) && !eg.hasEmergencySpawns(e.name), l = po(e), m = vo(e);
+var c = xh(e.name, e), u = Sh(e.name) && !Jv.hasEmergencySpawns(e.name), l = po(e), m = vo(e);
 if (c) {
-s > 0 && eg.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && zh(e, t, l, m);
+s > 0 && Jv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && qh(e, t, l, m);
 try {
-for (var d = a(Fh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Dh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-eg.addRequest(f);
+Jv.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -40020,8 +40002,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && zh(e, t, l, m), function(e) {
-var t, r, o = og.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && qh(e, t, l, m), function(e) {
+var t, r, o = tg.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -40033,17 +40015,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = Bv.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = Lv.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Jh(e.name, "powerHarvester", f), g = Jh(e.name, "healer", f), h = Jh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) $h(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Xh(e.name, "powerHarvester", f), g = Xh(e.name, "healer", f), h = Xh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Zh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) $h(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) Zh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) $h(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Zh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -40072,13 +40054,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(eg.getPendingRequests(e.name).map(Vh));
+var c = new Set(Jv.getPendingRequests(e.name).map(Kh));
 try {
-for (var u = a(Fh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Bv.HIGH, p = "claimer" === m.role && Yh(), f = qh(m), y = jh(m);
-if (Hh.has(m.role) || d || p || f || y) {
-var v = Vh(m);
-c.has(v) || (eg.addRequest(m), c.add(v));
+for (var u = a(Dh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Lv.HIGH, p = "claimer" === m.role && Hh(), f = Yh(m), y = Vh(m);
+if (Fh.has(m.role) || d || p || f || y) {
+var v = Kh(m);
+c.has(v) || (Jv.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -40095,8 +40077,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Fh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-eg.addRequest(f);
+for (var y = a(Dh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+Jv.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -40108,32 +40090,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = eg.getQueueStats(e.name);
+var g = Jv.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && eg.clearQueue(e.name);
+} else s > 0 && Jv.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = eg.getAvailableSpawns(e.name);
+var t, r, o = Jv.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Ig(e);
+var n = 0, i = Ng(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = eg.getNextRequest(e.name, i);
+var u = c.value, l = Jv.getNextRequest(e.name, i);
 if (!l) break;
-if (eR(e, l, i)) {
+if (Jh(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Jv(u, l);
-m === OK ? (n++, i -= l.body.cost, eg.markInProgress(e.name, l.id, u.id), eg.removeRequest(e.name, l.id),
+var m = Xv(u, l);
+m === OK ? (n++, i -= l.body.cost, Jv.markInProgress(e.name, l.id, u.id), Jv.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (eg.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (Jv.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -40149,12 +40131,12 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = eg.getQueueStats(e.name), n = function(e) {
+}(e), o = Jv.getQueueStats(e.name), n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T = Game.rooms[e];
 if (!T) return [];
-var C = Ig(T), S = new Map, w = new Map, x = function(e, t) {
+var C = Ng(T), S = new Map, w = new Map, x = function(e, t) {
 var r;
-w.set(e, Nh(null !== (r = w.get(e)) && void 0 !== r ? r : {
+w.set(e, Uh(null !== (r = w.get(e)) && void 0 !== r ? r : {
 partCount: 0,
 attack: 0,
 ranged: 0,
@@ -40230,7 +40212,7 @@ return function(e, t, r) {
 var o, n, i, s = Mo(e.targetRoom);
 e.targetScore = null !== (i = null == s ? void 0 : s.total.score) && void 0 !== i ? i : 0;
 try {
-for (var c = a(kh), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(bh), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Io(l, t.energyCapacityAvailable, s);
 m ? (e.bodyCost[l] = m.cost, e.affordable[l] = m.cost <= r) : e.affordable[l] = !1;
 }
@@ -40250,15 +40232,15 @@ if (o) throw o.error;
 try {
 for (var O = a(function(e, t) {
 void 0 === t && (t = {});
-var r = $g(e), o = r.filter(Jg);
+var r = Zg(e), o = r.filter(Xg);
 return t.prune && Array.isArray(e.defenseRequests) && o.length !== r.length && (e.defenseRequests = o),
 o;
 }(Memory)), k = O.next(); !k.done; k = O.next()) if ((I = k.value).roomName !== e) {
 var M = b(I.roomName, null !== (f = I.urgency) && void 0 !== f ? f : 0);
 try {
-for (var A = (o = void 0, a(kh)), U = A.next(); !U.done; U = A.next()) {
+for (var A = (o = void 0, a(bh)), U = A.next(); !U.done; U = A.next()) {
 var _ = U.value;
-Mh(M.requested, _, _h(I, _));
+Oh(M.requested, _, Ah(I, _));
 }
 } catch (e) {
 o = {
@@ -40284,11 +40266,11 @@ if (t) throw t.error;
 }
 }
 try {
-for (var N = a(eg.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
+for (var N = a(Jv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
 var I;
-Uh(I = P.value) && (D = Ah(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Mh((M = b(D)).queued, I.role),
+Mh(I = P.value) && (D = kh(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Oh((M = b(D)).queued, I.role),
 M.bodyCost[I.role] = Math.max(null !== (v = M.bodyCost[I.role]) && void 0 !== v ? v : 0, I.body.cost),
-M.affordable[I.role] = I.body.cost <= C, Ph(M, I.body.parts));
+M.affordable[I.role] = I.body.cost <= C, _h(M, I.body.parts));
 }
 } catch (e) {
 c = {
@@ -40304,13 +40286,13 @@ if (c) throw c.error;
 try {
 for (var G = a(Object.values(Game.creeps)), L = G.next(); !L.done; L = G.next()) {
 var D, B = L.value, F = null !== (g = B.memory) && void 0 !== g ? g : {};
-if (F.homeRoom === e && Bo(_ = null !== (h = F.role) && void 0 !== h ? h : "") && (D = Ah(F))) {
+if (F.homeRoom === e && Bo(_ = null !== (h = F.role) && void 0 !== h ? h : "") && (D = kh(F))) {
 M = b(D);
 var W = (null !== (R = B.body) && void 0 !== R ? R : []).filter(function(e) {
 return e.hits > 0;
 });
-B.spawning ? Mh(M.spawning, _) : void 0 === F.defenseAssistReleasedAt && B.room.name === e ? (Mh(M.staged, _),
-x(D, W)) : B.room.name === D ? Mh(M.arrived, _) : Mh(M.moving, _), Ih(M, F), Ph(M, W);
+B.spawning ? Oh(M.spawning, _) : void 0 === F.defenseAssistReleasedAt && B.room.name === e ? (Oh(M.staged, _),
+x(D, W)) : B.room.name === D ? Oh(M.arrived, _) : Oh(M.moving, _), Nh(M, F), _h(M, W);
 }
 }
 } catch (e) {
@@ -40326,7 +40308,7 @@ if (l) throw l.error;
 }
 var H = s([], i(S.values()), !1);
 try {
-for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) Gh(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : xo());
+for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) Ph(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : xo());
 } catch (e) {
 d = {
 error: e
@@ -40356,7 +40338,7 @@ defenseAssist: n
 }(e, t);
 }
 
-var rR = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, oR = /^(\d{1,2})\|(.+)$/, nR = M("SS2TerminalComms"), aR = function() {
+var eR = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, tR = /^(\d{1,2})\|(.+)$/, rR = M("SS2TerminalComms"), oR = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -40416,11 +40398,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(rR);
+var t = e.match(eR);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(oR);
+var i = a.match(tR);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -40455,7 +40437,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-nR.warn("Missing packet in multi-packet message", {
+rR.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -40471,7 +40453,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), nR.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), rR.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -40495,7 +40477,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && nR.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && rR.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -40507,7 +40489,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return nR.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return rR.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -40515,14 +40497,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), nR.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), rR.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (nR.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (rR.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -40547,7 +40529,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-nR.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+rR.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -40559,7 +40541,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-nR.info("Completed sending multi-packet message", {
+rR.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -40567,25 +40549,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? nR.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? rR.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (nR.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (rR.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else nR.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else rR.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else nR.warn("Terminal not found for queue item, removing from queue", {
+} else rR.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -40619,7 +40601,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && nR.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && rR.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -40629,7 +40611,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-nR.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+rR.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -40720,7 +40702,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (nR.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (rR.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -40742,7 +40724,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return nR.error("Error parsing JSON", {
+return rR.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -40753,7 +40735,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), iR = [ {
+}(), nR = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -40773,7 +40755,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], sR = function() {
+} ], aR = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -40820,9 +40802,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), cR = new sR;
+}(), iR = new aR;
 
-function uR(e) {
+function sR(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -40830,19 +40812,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function lR(e, t) {
+function cR(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function mR(e, t) {
+function uR(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var dR = {
+var lR = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -40853,9 +40835,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, pR = function() {
+}, mR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, dR), e);
+void 0 === e && (e = {}), this.config = o(o({}, lR), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -40876,7 +40858,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = cR.getSwarmState(r.toRoom);
+var o = iR.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -40889,7 +40871,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = cR.getSwarmState(c);
+var l = iR.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -40959,9 +40941,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(lR), u = n.filter(function(e) {
+}).sort(cR), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(mR), l = [], m = [], d = function(t) {
+}).sort(uR), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -40983,11 +40965,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return uR({
+return sR({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + uR({
+}) + sR({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -41086,7 +41068,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), fR = new pR, yR = {
+}(), dR = new mR, pR = {
 1: {
 guards: 1,
 rangers: 1,
@@ -41107,14 +41089,14 @@ siegeUnits: 1
 }
 };
 
-function vR(e) {
+function fR(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function gR(e) {
+function yR(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -41137,9 +41119,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function hR(e) {
+function vR(e) {
 var t, r, o;
-gR(e);
+yR(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -41163,20 +41145,20 @@ if (t) throw t.error;
 return n;
 }
 
-function RR(e) {
+function gR(e) {
 var t;
-gR(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = hR(e);
+yR(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = vR(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function ER(e) {
-return !!RR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function hR(e) {
+return !!gR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-gR(e);
+yR(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -41187,12 +41169,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = hR(e);
+var d = vR(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function TR(e, t) {
+function RR(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -41213,20 +41195,20 @@ if (r) throw r.error;
 return n;
 }
 
-function CR(e, t) {
+function ER(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = yR[r]) && void 0 !== t ? t : yR[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = pR[r]) && void 0 !== t ? t : pR[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = TR(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = RR(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: vR(r),
+targetComposition: fR(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -41238,7 +41220,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function SR(e) {
+function TR(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -41258,9 +41240,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function wR(e) {
+function CR(e) {
 var t = e.members.length;
-gR(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+yR(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -41274,7 +41256,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && ER(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && hR(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -41303,7 +41285,7 @@ subsystem: "Squad"
 }
 }
 
-var xR = {
+var SR = {
 harassment: {
 composition: {
 harassers: 3,
@@ -41390,7 +41372,7 @@ prioritizeDefenses: !0
 }
 };
 
-function bR(e, t) {
+function wR(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -41405,8 +41387,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function OR(e, t) {
-var r, o, n, i = xR[t], s = 0;
+function xR(e, t) {
+var r, o, n, i = SR[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -41432,7 +41414,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var kR, MR, AR, UR = {
+var bR, OR, kR, MR = {
 move: 50,
 work: 100,
 carry: 50,
@@ -41441,11 +41423,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, _R = new Map;
+}, AR = new Map;
 
-function NR(e, t) {
+function UR(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (_R.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (AR.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -41457,7 +41439,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = xR[p].composition;
+d = SR[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -41472,19 +41454,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (_R.set(m, y), function(e, t, r, o) {
+v ? (AR.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = xR[s].useBoosts;
+i = SR[s].useBoosts;
 }
-var c = Bv.NORMAL;
-"siege" === t.type ? c = Bv.HIGH : "defense" === t.type && (c = Bv.EMERGENCY);
+var c = Lv.NORMAL;
+"siege" === t.type ? c = Lv.HIGH : "defense" === t.type && (c = Lv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = PR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + UR[t];
-}, 0), m = i ? GR(r) : [], d = {
+var u = _R(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + MR[t];
+}, 0), m = i ? PR(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -41513,7 +41495,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-eg.addRequest(d), o.spawnRequests.add(d.id);
+Jv.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -41527,42 +41509,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function PR(e, t, r) {
+function _R(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return IR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return NR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return IR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return NR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return IR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return NR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return IR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return NR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return IR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return NR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return IR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return NR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function IR(e, t, r) {
+function NR(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + UR[t];
+return e + MR[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + UR[t];
+return e + MR[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function GR(e) {
+function PR(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -41593,45 +41575,45 @@ return [];
 }
 }
 
-function LR(e) {
-return _R.has(e);
+function IR(e) {
+return AR.has(e);
 }
 
-function DR(e) {
-return RR(e) || ER(e);
+function GR(e) {
+return gR(e) || hR(e);
 }
 
-(kR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, kR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-kR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (MR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-MR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, MR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-MR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (AR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-AR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, AR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-AR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, AR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(bR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, bR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+bR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (OR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+OR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, OR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+OR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (kR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+kR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, kR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+kR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, kR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var BR = {
+var LR = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function FR(e, t) {
-var r = BR[t], o = cR.getClusters();
+function DR(e, t) {
+var r = LR[t], o = iR.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function WR(e, t, r) {
+function BR(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = cR.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = iR.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: FR(e, i.danger),
+reservedEnergy: DR(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -41721,7 +41703,7 @@ success: !1
 });
 }
 
-var HR = {
+var FR = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -41731,7 +41713,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function KR(e, t, r) {
+function WR(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -41762,7 +41744,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function YR(e, t, r, o) {
+function HR(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -41772,7 +41754,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function VR(e, t) {
+function KR(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -41793,19 +41775,19 @@ if (r) throw r.error;
 return n;
 }
 
-function qR() {
-var e = cR.getEmpire();
+function YR() {
+var e = iR.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function jR(e) {
-qR()[e.id] = e;
+function VR(e) {
+YR()[e.id] = e;
 }
 
-function zR(e) {
+function qR(e) {
 e.lastUpdate = Game.time;
-var t = cR.getCluster(e.clusterId);
-if (!t) return e.state = "failed", jR(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = iR.getCluster(e.clusterId);
+if (!t) return e.state = "failed", VR(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -41815,12 +41797,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (DR(r) || LR(e) || NR(0, r), DR(r));
+return !!r && (GR(r) || IR(e) || UR(0, r), GR(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), jR(e);
+})), VR(e);
 }(e, t);
 break;
 
@@ -41831,7 +41813,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (wR(o), SR(o)) {
+if (CR(o), TR(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -41860,7 +41842,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = cR.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = iR.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -41887,12 +41869,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), jR(e);
+})), VR(e);
 }(e, t);
 }
 }
 
-function QR(e, t, r) {
+function jR(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -41911,11 +41893,11 @@ score: n.score + o.score
 }
 }
 
-function XR(e, t, r) {
+function zR(e, t, r) {
 return Io(e, t, r);
 }
 
-function ZR(e, t) {
+function QR(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -41928,11 +41910,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function JR(e) {
+function XR(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function $R(e, t, r) {
+function ZR(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -41945,8 +41927,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function eE(e, t, r) {
-var o = XR(t, e.energyCapacityAvailable, r);
+function JR(e, t, r) {
+var o = zR(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -41954,16 +41936,16 @@ var a = wo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function tE(e, t, r, o) {
+function $R(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = eE(e, t, o);
-if (s !== eE(n, t, o)) return s ? -1 : 1;
+var a, i, s = JR(e, t, o);
+if (s !== JR(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function rE(e, t) {
+function eE(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -42047,21 +42029,21 @@ if (r) throw r.error;
 return u;
 }
 
-function oE(e, t) {
+function tE(e, t) {
 return {
-guard: Math.max(0, ZR(e, "guard") - t.counts.guard),
-ranger: Math.max(0, ZR(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, ZR(e, "healer") - t.counts.healer)
+guard: Math.max(0, QR(e, "guard") - t.counts.guard),
+ranger: Math.max(0, QR(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, QR(e, "healer") - t.counts.healer)
 };
 }
 
-function nE(e) {
+function rE(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function aE(e, t) {
+function oE(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return nE(e.role);
+return rE(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -42074,12 +42056,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function iE(e) {
+function nE(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function sE(e) {
+function aE(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -42091,7 +42073,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-nE(m) && iE(l) === e && !u.spawning && QR(i, m, u.body.filter(function(e) {
+rE(m) && nE(l) === e && !u.spawning && jR(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -42109,7 +42091,7 @@ if (t) throw t.error;
 return i;
 }
 
-function cE(e, t, r) {
+function iE(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -42139,16 +42121,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: aE(e, r)
+pendingAssist: oE(e, r)
 };
 }
 }
 
-function uE(e, t) {
+function sE(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = XR(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = zR(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -42169,7 +42151,7 @@ subsystem: "Cluster"
 }
 }
 
-function lE(e, t, r) {
+function cE(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -42211,20 +42193,20 @@ exitAccess: a
 };
 }
 
-function mE(e, t) {
+function uE(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function dE(e, t, r) {
+function lE(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function pE(e) {
+function mE(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function fE(e, t) {
+function dE(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -42235,7 +42217,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function yE(e, t, r) {
+function pE(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -42246,8 +42228,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = pE(g);
-h && (Ri(g) || fE(v, h) && (t.assignedCreeps.includes(v.name) || mE(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = mE(g);
+h && (Ri(g) || dE(v, h) && (t.assignedCreeps.includes(v.name) || uE(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -42284,7 +42266,7 @@ return e.distance - t.distance;
 });
 }
 
-function vE(e, t) {
+function fE(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -42309,21 +42291,21 @@ if (r) throw r.error;
 return i;
 }
 
-function gE(e) {
+function yE(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var hE = {
+var vE = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, RE = function() {
+}, gE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, hE), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, vE), e);
 }
 return e.prototype.run = function() {
-var e = cR.getClusters();
+var e = iR.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -42342,7 +42324,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: iR.map(function(t) {
+steps: nR.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -42398,7 +42380,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-fR.processCluster(t);
+dR.processCluster(t);
 break;
 
 case "squads":
@@ -42430,7 +42412,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = lE(e, new RoomPosition(s, c, e.name), "defense");
+var u = cE(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -42479,9 +42461,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = cR.getSwarmState(i);
+var i = n.value, s = iR.getSwarmState(i);
 if (s) {
-var c = FR(i, s.danger);
+var c = DR(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -42512,7 +42494,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = cR.getSwarmState(m);
+var m = l.value, d = iR.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -42544,7 +42526,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += gE(l.controller.level));
+}).length, i += yE(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -42661,7 +42643,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-wR(i), "gathering" !== i.state || DR(i) || LR(i.id) || NR(0, i), SR(i) && (i.state = "dissolving");
+CR(i), "gathering" !== i.state || GR(i) || IR(i.id) || UR(0, i), TR(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -42686,7 +42668,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = CR(e, s);
+var s = i.value, c = ER(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -42703,7 +42685,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(qR()).filter(function(e) {
+var t = (a = e.id, Object.values(YR()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -42714,22 +42696,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, HR), n), m = [], d = cR.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, FR), n), m = [], d = iR.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = KR(f, y, d);
+var g = WR(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = VR(e, f);
+var h = KR(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = YR(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = HR(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = bR(f, {
+var C = wR(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -42764,29 +42746,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-OR(e, n.doctrine) ? function(e, t, r) {
+xR(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = cR.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = iR.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = KR(e, o, r);
+var n = WR(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (cR.getEmpire().knownRooms || {})[t], n = null != r ? r : bR(t, {
+var o = (iR.getEmpire().knownRooms || {})[t], n = null != r ? r : wR(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!OR(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!xR(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -42799,7 +42781,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-jR(i);
+VR(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -42813,13 +42795,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = TR(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = RR(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: vR(n),
+targetComposition: fR(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -42834,8 +42816,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), jR(i), NR(0, c), i.state = "forming", i.lastUpdate = Game.time,
-jR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), VR(i), UR(0, c), i.state = "forming", i.lastUpdate = Game.time,
+VR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -42854,11 +42836,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(_R.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(AR.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), _R.delete(c));
+}), AR.delete(c));
 }
 } catch (t) {
 e = {
@@ -42872,10 +42854,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = qR();
-for (var t in e) zR(e[t]);
+var e = YR();
+for (var t in e) qR(e[t]);
 !function() {
-var e = qR();
+var e = YR();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -42953,14 +42935,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = cR.getCluster(t, e);
+var t = "cluster_".concat(e), r = iR.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = cR.getCluster(e);
+var o = iR.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -42989,7 +42971,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && WR(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && BR(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -43006,7 +42988,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = cR.getSwarmState(t);
+var n, a, i = iR.getSwarmState(t);
 if (!i) return "continue";
 if (go(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -43047,7 +43029,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mo(g), f[g] = sE(g);
+p[g] = Mo(g), f[g] = aE(g);
 }
 } catch (e) {
 r = {
@@ -43063,7 +43045,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = cE(E, m, t);
+d[E] = iE(E, m, t);
 }
 } catch (e) {
 n = {
@@ -43082,13 +43064,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = $R(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = ZR(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = rE(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = eE(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Do(T, R, oE(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Do(T, R, tE(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = tE(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = $R(h, b, g.roomName, R), M = 0; M < O; M++) {
 var A = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -43100,7 +43082,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(A.roomName, "_").con
 roomName: A.roomName,
 role: b,
 family: "military",
-priority: JR(g.urgency),
+priority: XR(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -43146,7 +43128,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) uE(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) sE(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -43161,7 +43143,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, eg);
+}(e, Jv);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -43173,7 +43155,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = vE(f, yE(e, f, t)), v = y.reduce(function(e, t) {
+var y = fE(f, pE(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -43186,7 +43168,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), dE(f, R.role, mE(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), lE(f, R.role, uE(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -43253,24 +43235,24 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), EE = new RE, TE = /^([WE])(\d+)([NS])(\d+)$/;
+}(), hE = new gE, RE = /^([WE])(\d+)([NS])(\d+)$/;
 
-function CE(e) {
-return TE.test(e);
+function EE(e) {
+return RE.test(e);
 }
 
-var SE = {
+var TE = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, wE = function() {
+}, CE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, SE), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, TE), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = Bf();
-this.updateEnemyIntelligence(e), Ff(e, {
+var e = Lf();
+this.updateEnemyIntelligence(e), Df(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
@@ -43333,7 +43315,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (CE(x)) {
+if (e.isAlly(x)) f.add(x); else if (EE(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -43398,14 +43380,14 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return Bf().globalTargets.enemies || [];
+return Lf().globalTargets.enemies || [];
 }, n([ Ze("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: Ie.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), xE = new wE, bE = function() {
+}(), SE = new CE, wE = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -43482,9 +43464,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), OE = new bE, kE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), xE = new wE, bE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function ME(e, t) {
+function OE(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -43507,22 +43489,22 @@ if (r) throw r.error;
 return n;
 }
 
-function AE(e) {
+function kE(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function UE(e, t, r) {
-if (!AE(e)) return 0;
-var o = ME(e.name, t);
+function ME(e, t, r) {
+if (!kE(e)) return 0;
+var o = OE(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
-return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += vc(e.mineralType),
-n -= 5 * o, n -= gc(e.name), n -= 15 * e.threatLevel, n += hc(e.terrain), Rc(e.name) && (n += 10),
-n += Ec(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
-n += Cc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
+return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += fc(e.mineralType),
+n -= 5 * o, n -= yc(e.name), n -= 15 * e.threatLevel, n += vc(e.terrain), gc(e.name) && (n += 10),
+n += hc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
+n += Ec(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function _E(e, t) {
+function AE(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -43532,13 +43514,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return Z(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && kE.has(e.type);
+return e.hits > 0 && bE.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function NE(e, t, r) {
+function UE(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -43548,7 +43530,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function PE(e) {
+function _E(e) {
 return function(e) {
 var t = te(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -43559,8 +43541,8 @@ isSK: re(t.x) && re(t.y)
 }(e);
 }
 
-function IE(e) {
-var t = PE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function NE(e) {
+var t = _E(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -43579,14 +43561,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var GE = {
+var PE = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, LE = function() {
+}, IE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, GE), e);
+void 0 === e && (e = {}), this.config = o(o({}, PE), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -43677,7 +43659,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = PE(e);
+var t = _E(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -43689,14 +43671,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return IE(DE(e));
+return NE(GE(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = IE(DE(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = NE(GE(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function DE(e) {
+function GE(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = Z(e), c = J(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -43728,11 +43710,11 @@ swamps: d
 };
 }
 
-var BE = new LE, FE = /^([WE])(\d+)([NS])(\d+)$/, WE = {
+var LE = new IE, DE = /^([WE])(\d+)([NS])(\d+)$/, BE = {
 allies: []
-}, HE = function() {
+}, FE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, WE), e);
+void 0 === e && (e = {}), this.config = o(o({}, BE), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -43752,7 +43734,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!FE.test(e)) return !1;
+if (!DE.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -43860,7 +43842,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return FE.test(e);
+return DE.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -43887,7 +43869,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), KE = new HE, YE = {
+}(), WE = new FE, HE = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -43900,9 +43882,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, VE = function() {
+}, KE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, YE), e);
+void 0 === e && (e = {}), this.config = o(o({}, HE), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = wr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -43915,7 +43897,7 @@ t.updateExpansionQueue(o);
 }), rs.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
 })), rs.measureSubsystem("empire:warTargets", function() {
-KE.updateWarTargets(o);
+WE.updateWarTargets(o);
 }), rs.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
 }), rs.measureSubsystem("empire:gclTracking", function() {
@@ -43923,13 +43905,13 @@ t.trackGCLProgress(o);
 }), s && rs.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
 }), i && (rs.measureSubsystem("empire:intelRefresh", function() {
-BE.refreshRoomIntel(o);
+LE.refreshRoomIntel(o);
 }), rs.measureSubsystem("empire:roomDiscovery", function() {
-BE.discoverNearbyRooms(o);
+LE.discoverNearbyRooms(o);
 })), s && rs.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
 }), c && (rs.measureSubsystem("empire:clusterHealth", function() {
-OE.monitorClusterHealth();
+xE.monitorClusterHealth();
 }), rs.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
@@ -44012,22 +43994,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = _E(f, u);
+var y = Boolean(Game.rooms[f]), v = AE(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = ME(f, t);
+var g = OE(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = NE(h, u, y);
+var h = e.knownRooms[f], R = UE(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? UE(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? ME(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -44071,10 +44053,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && AE(a)) {
-var i = ME(a.name, t);
+if (a && kE(a)) {
+var i = OE(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = UE(a, t, r);
+var s = ME(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -44394,13 +44376,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), qE = new VE;
+}(), YE = new KE;
 
-function jE(e) {
+function VE(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var zE = {
+var qE = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -44408,10 +44390,10 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, QE = function() {
+}, jE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, zE), e);
+this.config = o(o({}, qE), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
@@ -44555,7 +44537,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, jE(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, VE(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -44730,9 +44712,9 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), XE = new QE, ZE = function() {
+}(), zE = new jE, QE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new pc(o(o({}, qs), e), {
+void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new mc(o(o({}, qs), e), {
 getEmpire: function() {
 return wr.getEmpire();
 },
@@ -44768,7 +44750,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), JE = new ZE, $E = function() {
+}(), XE = new QE, ZE = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = wr.getEmpire();
@@ -44786,9 +44768,9 @@ lastScan: 0
 var e = wr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), eT = new (function(e) {
+}(), JE = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new $E) || this;
+return void 0 === t && (t = {}), e.call(this, t, new ZE) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -44800,22 +44782,22 @@ cpuBudget: .01
 }) ], t.prototype, "run", null), n([ $e() ], t);
 }(Wi));
 
-function tT() {
+function $E() {
 return global;
 }
 
-function rT(e) {
+function eT(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function oT(e) {
+function tT(e) {
 return Number(null != e ? e : 0);
 }
 
-var nT = function() {
+var rT = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = tT();
+var e = $E();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -44823,12 +44805,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return tT()._pixelGenerationMemory;
+return $E()._pixelGenerationMemory;
 }, e;
-}(), aT = function(e) {
+}(), oT = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new nT) || this;
+var r = e.call(this, t, new rT) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -44845,7 +44827,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(rT).length : Object.values(null != t ? t : {}).filter(rT).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(eT).length : Object.values(null != t ? t : {}).filter(eT).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -44856,9 +44838,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (oT(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (oT(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = oT(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = oT(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (tT(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (tT(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = tT(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = tT(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -44880,9 +44862,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ $e() ], t);
-}(Ki), iT = new aT;
+}(Ki), nT = new oT;
 
-function sT(e, t) {
+function aT(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !j(e.controller.owner.username)) return {
 lost: !0,
@@ -44904,7 +44886,7 @@ lost: !1
 };
 }
 
-function cT(e, t, r) {
+function iT(e, t, r) {
 var o, n = wr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -44918,20 +44900,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var uT = Mr().cpu.bucketThresholds.highMode + 1800, lT = {
+var sT = Mr().cpu.bucketThresholds.highMode + 1800, cT = {
 updateInterval: 250,
-minBucket: uT,
+minBucket: sT,
 maxSitesPerRemotePerTick: 2
 };
 
-function mT(e, t) {
+function uT(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var dT = function() {
+var lT = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, lT), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, cT), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -44948,8 +44930,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = sT(l);
-m.lost && m.reason && cT(e, u, m.reason);
+var m = aT(l);
+m.lost && m.reason && iT(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -44967,10 +44949,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = mT("remoteInfrastructure.intent", function() {
+var i = uT("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-mT("remoteInfrastructure.execute", function() {
+uT("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -45136,13 +45118,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = mT("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = uT("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = mT("remoteInfrastructure.roomSnapshot", function() {
+u[t] = uT("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -45175,7 +45157,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = mT("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = uT("remoteInfrastructure.calculateRemoteRoads", function() {
 return ba(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -45204,14 +45186,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = mT("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = uT("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? mT("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? uT("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -45228,7 +45210,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? mT("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? uT("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -45246,7 +45228,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return mT("remoteInfrastructure.findSources", function() {
+return uT("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -45343,10 +45325,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ Xe("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Ie.LOW,
 interval: 1e3,
-minBucket: uT,
+minBucket: sT,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), pT = new dT, fT = new (function(e) {
+}(), mT = new lT, dT = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -45358,7 +45340,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ $e() ], t);
-}(jf)), yT = function() {
+}(Vf)), pT = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -45374,9 +45356,9 @@ e = JSON.stringify(Memory).length;
 e = 0;
 }
 var o = 2097152, n = e / o * 100;
-n > 90 ? dl.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+n > 90 ? ll.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
-}) : n > 75 && dl.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+}) : n > 75 && ll.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
 });
 }, e.prototype.updateMemorySegmentStats = function() {
@@ -45402,7 +45384,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Ly.applyDiffusion(o);
+Iy.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45411,7 +45393,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-Pu.initialize(i.name);
+_u.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -45448,7 +45430,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ $e() ], e);
-}(), vT = new yT, gT = new (function() {
+}(), fT = new pT, yT = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -45476,9 +45458,9 @@ return Mr().cpu;
 },
 registerProcesses: function() {
 var e;
-dl.info("Registering all processes with kernel...", {
+ll.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), Li(vT, Gs, Ws, fs, qE, Mc, XE, pT, Us, eT, iT, JE, uu, fu, fT, xE, ou, EE, _i),
+}), Li(fT, Gs, Ws, fs, YE, Oc, zE, mT, Us, JE, nT, XE, su, du, dT, SE, tu, hE, _i),
 function() {
 var e, t, r = Mr().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -45533,7 +45515,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return EE.run();
+return hE.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -45563,20 +45545,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-n.length > 0 && dl.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
+n.length > 0 && ll.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
 subsystem: "ProcessRegistry",
 meta: {
 processIds: n
 }
 });
 }(), (e = Gi.getProcess("empire:market")) && (e.interval = 300, e.minBucket = Mr().cpu.bucketThresholds.lowMode),
-dl.info("Registered ".concat(Gi.getProcesses().length, " processes with kernel"), {
+ll.info("Registered ".concat(Gi.getProcesses().length, " processes with kernel"), {
 subsystem: "ProcessRegistry"
 });
 }
 });
 
-function hT(e) {
+function vT(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -45586,13 +45568,13 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var RT = ll("NativeCallsTracker");
+var gT = cl("NativeCallsTracker");
 
-function ET(e, t, r) {
+function hT(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) RT.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) gT.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
@@ -45608,7 +45590,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-RT.warn("Failed to wrap method", {
+gT.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -45618,30 +45600,30 @@ error: String(e)
 }
 }
 
-var TT, CT = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], ST = "shard1", wT = {
+var RT, ET = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], TT = "shard1", CT = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, xT = {
+}, ST = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, bT = {
+}, wT = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function OT() {
+function xT() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function kT() {
+function bT() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: CT,
+targetShards: ET,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -45651,12 +45633,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = CT),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = ET),
 Memory.interShardOperation;
 }
 
-function MT() {
-return Bf({
+function OT() {
+return Lf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -45669,32 +45651,32 @@ checksum: 0
 });
 }
 
-function AT(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), Ff(e, {
+function kT(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), Df(e, {
 updatedSections: t
 });
 }
 
-function UT() {
-var e, t, r, o, n, i, s, c = MT(), u = OT();
+function MT() {
+var e, t, r, o, n, i, s, c = OT(), u = xT();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: CT,
+targetShards: ET,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : CT,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : ET,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && _T() ? "established" : "unreached",
+status: p === u && AT() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -45712,7 +45694,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === ST ? "core" : "frontier",
+role: u === TT ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -45729,24 +45711,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), AT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), kT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function _T() {
+function AT() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function NT() {
+function UT() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function PT(e, t) {
+function _T(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -45765,9 +45747,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(NT()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(UT()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += eg.getPendingRequests(p.name).filter(function(r) {
+s += Jv.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -45786,7 +45768,7 @@ if (n) throw n.error;
 return s;
 }
 
-function IT(e) {
+function NT(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -45830,7 +45812,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = MT().shards[OT()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = OT().shards[xT()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -45840,8 +45822,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function GT(e, t) {
-if (!(PT("scout", t) >= 1)) {
+function PT(e, t) {
+if (!(_T("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -45879,13 +45861,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && eg.addRequest({
+r && Jv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: bT,
-priority: Bv.LOW + 5,
+body: wT,
+priority: Lv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -45896,14 +45878,14 @@ task: "interShardPortalScout"
 }
 }
 
-function LT(e, t, r) {
-PT("interShardClaimer", t) >= 1 || eg.addRequest({
+function IT(e, t, r) {
+_T("interShardClaimer", t) >= 1 || Jv.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: wT,
-priority: Bv.NORMAL + 50,
+body: CT,
+priority: Lv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45916,14 +45898,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function DT(e, t, r) {
-PT("interShardScout", t) >= 1 || eg.addRequest({
+function GT(e, t, r) {
+_T("interShardScout", t) >= 1 || Jv.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: bT,
-priority: Bv.NORMAL,
+body: wT,
+priority: Lv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45936,15 +45918,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function BT(e, t, r) {
+function LT(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (PT("interShardPioneer", t.shard) >= 3 || eg.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (_T("interShardPioneer", t.shard) >= 3 || Jv.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: xT,
-priority: Bv.NORMAL + 25,
+body: ST,
+priority: Lv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45957,19 +45939,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function FT(e) {
+function DT(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = OT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = xT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : CT), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : ET), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Nf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Uf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -46001,9 +45983,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(NT()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(UT()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += eg.getPendingRequests(l.name).filter(function(e) {
+n += Jv.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -46022,22 +46004,22 @@ return n;
 }() < o;
 }
 
-(TT = {
-optimizeBody: Xv,
+(RT = {
+optimizeBody: zv,
 spawnQueue: {
 addRequest: function(e) {
-return eg.addRequest(e);
+return Jv.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Bv.LOW,
-NORMAL: Bv.NORMAL,
-HIGH: Bv.HIGH
+LOW: Lv.LOW,
+NORMAL: Lv.NORMAL,
+HIGH: Lv.HIGH
 }
-}).optimizeBody && (Qf.optimizeBody = TT.optimizeBody), TT.spawnQueue && (Qf.spawnQueue = TT.spawnQueue),
-TT.spawnPriorities && (Qf.spawnPriorities = o(o({}, Qf.spawnPriorities), TT.spawnPriorities));
+}).optimizeBody && (jf.optimizeBody = RT.optimizeBody), RT.spawnQueue && (jf.spawnQueue = RT.spawnQueue),
+RT.spawnPriorities && (jf.spawnPriorities = o(o({}, jf.spawnPriorities), RT.spawnPriorities));
 
-var WT, HT = function() {
+var BT, FT = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -46081,7 +46063,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function KT(e) {
+function WT(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -46102,7 +46084,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function YT(e, t, r) {
+function HT(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -46168,16 +46150,16 @@ return u;
 });
 }
 
-function VT(e) {
+function KT(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(WT || (WT = {}));
+}(BT || (BT = {}));
 
-var qT = function() {
+var YT = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -46215,8 +46197,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = YT(h.pos, T.pos, this.logger);
-if (VT(C)) {
+var T = E.value, C = HT(h.pos, T.pos, this.logger);
+if (KT(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -46243,8 +46225,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, M = YT(k, u.pos, this.logger);
-VT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, M = HT(k, u.pos, this.logger);
+KT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -46283,8 +46265,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = YT(e, t, this.logger);
-if (VT(n)) {
+var n = HT(e, t, this.logger);
+if (KT(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -46294,7 +46276,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), jT = function() {
+}(), VT = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -46304,7 +46286,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = KT(s);
+var c = WT(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -46330,7 +46312,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), zT = function() {
+}(), qT = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -46379,7 +46361,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), QT = {
+}(), jT = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -46392,7 +46374,7 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, XT = {
+}, zT = {
 getCachedPath: function(e, t) {
 var r = ut(e, t), o = Ee.get(r, {
 namespace: ct
@@ -46419,26 +46401,26 @@ direction: a
 }
 return t;
 }
-}, ZT = {
+}, QT = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = cd.MEDIUM), Rd.register({
+void 0 === o && (o = id.MEDIUM), gd.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== cd.CRITICAL
+skippable: o !== id.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, JT = new qT(XT, QT), $T = new jT(QT, ZT, JT), eC = new zT(QT, XT, JT, kl.moveTo);
+}, XT = new YT(zT, jT), ZT = new VT(jT, QT, XT), JT = new qT(jT, zT, XT, bl.moveTo);
 
-function tC(e, t, r, o) {
-return eC.moveToWithRemoteCache(e, t, r, o);
+function $T(e, t, r, o) {
+return JT.moveToWithRemoteCache(e, t, r, o);
 }
 
-var rC, oC = function() {
+var eC, tC = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -46451,12 +46433,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), nC = function() {
+}(), rC = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 De.on(e, t);
 }, e;
-}(), aC = function() {
+}(), oC = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -46501,28 +46483,28 @@ m.length > 0 && lt(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), iC = function() {
+}(), nC = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return KT(e);
+return WT(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-JT.precacheRemoteRoutes(e, t);
+XT.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), sC = new HT(new oC, new nC, new aC, new iC), cC = {
+}(), aC = new FT(new tC, new rC, new oC, new nC), iC = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, uC = function() {
+}, sC = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, cC), e);
+this.config = o(o({}, iC), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -46534,7 +46516,7 @@ this.tasks.delete(e);
 return Gi.getBucketMode();
 }, e.prototype.updateBucketMode = function() {
 var e = this.getBucketMode();
-e !== this.currentMode && (dl.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
+e !== this.currentMode && (ll.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
 subsystem: "Scheduler"
 }), this.currentMode = e);
 }, e.prototype.getCpuLimit = function() {
@@ -46582,13 +46564,13 @@ try {
 i.execute(), i.lastRun = Game.time;
 } catch (e) {
 var c = e instanceof Error ? e.message : String(e);
-dl.error("Task ".concat(i.name, " failed: ").concat(c), {
+ll.error("Task ".concat(i.name, " failed: ").concat(c), {
 subsystem: "Scheduler"
 });
 }
 var u = Game.cpu.getUsed() - s;
 if (this.tickCpuUsed += u, !this.hasCpuBudget()) {
-dl.warn("CPU budget exhausted, skipping remaining tasks", {
+ll.warn("CPU budget exhausted, skipping remaining tasks", {
 subsystem: "Scheduler"
 });
 break;
@@ -46616,123 +46598,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new uC, (rC = {})[FIND_STRUCTURES] = {
+new sC, (eC = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, rC[FIND_MY_STRUCTURES] = {
+}, eC[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, rC[FIND_HOSTILE_STRUCTURES] = {
+}, eC[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, rC[FIND_SOURCES_ACTIVE] = {
+}, eC[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, rC[FIND_SOURCES] = {
+}, eC[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, rC[FIND_MINERALS] = {
+}, eC[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, rC[FIND_DEPOSITS] = {
+}, eC[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, rC[FIND_MY_CONSTRUCTION_SITES] = {
+}, eC[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, rC[FIND_CONSTRUCTION_SITES] = {
+}, eC[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, rC[FIND_CREEPS] = {
+}, eC[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, rC[FIND_MY_CREEPS] = {
+}, eC[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, rC[FIND_HOSTILE_CREEPS] = {
+}, eC[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, rC[FIND_DROPPED_RESOURCES] = {
+}, eC[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, rC[FIND_TOMBSTONES] = {
+}, eC[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, rC[FIND_RUINS] = {
+}, eC[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, rC[FIND_FLAGS] = {
+}, eC[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, rC[FIND_MY_SPAWNS] = {
+}, eC[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, rC[FIND_HOSTILE_SPAWNS] = {
+}, eC[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, rC[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, eC[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, rC[FIND_NUKES] = {
+}, eC[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, rC[FIND_POWER_CREEPS] = {
+}, eC[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, rC[FIND_MY_POWER_CREEPS] = {
+}, eC[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, rC[FIND_HOSTILE_POWER_CREEPS] = {
+}, eC[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, rC[FIND_EXIT_TOP] = {
+}, eC[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, rC[FIND_EXIT_RIGHT] = {
+}, eC[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, rC[FIND_EXIT_BOTTOM] = {
+}, eC[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, rC[FIND_EXIT_LEFT] = {
+}, eC[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, rC[FIND_EXIT] = {
+}, eC[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var lC = new fe({}, wr), mC = new Nt({}, wr);
+var cC = new fe({}, wr), uC = new Nt({}, wr);
 
-function dC(e) {
+function lC(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -46740,16 +46722,16 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var pC = !1;
+var mC = !1;
 
-function fC() {
+function dC() {
 var e, t;
-pC || (Xu({
-level: (t = Mr()).debug ? ku.DEBUG : ku.INFO,
+mC || (zu({
+level: (t = Mr()).debug ? bu.DEBUG : bu.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
 maxBatchSize: 50
-}), dl.info("Bot initialized", {
+}), ll.info("Bot initialized", {
 subsystem: "SwarmBot",
 meta: {
 debug: t.debug,
@@ -46759,11 +46741,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && (tg.getPendingTransfers = function(e) {
+r.getPendingTransfers && ($v.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && (tg.needsCarrier = function(e) {
+}), r.needsCarrier && ($v.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && (tg.getActiveRequests = function() {
+}), r.getActiveRequests && ($v.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -46777,61 +46759,61 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (rg.predictConsumption = function(e) {
+a.predictConsumption && (eg.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (rg.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (eg.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (rg.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (eg.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (rg.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (eg.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (og.getActivePowerBanks = function() {
+i.getActivePowerBanks && (tg.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (og.needsHarvesters = function(e) {
+}), i.needsHarvesters && (tg.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (og.needsCarriers = function(e) {
+}), i.needsCarriers && (tg.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (og.requestSpawns = function(e) {
+}), i.requestSpawns && (tg.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-ng.getEmergencyState = function(e) {
+rg.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: ro,
-powerBankHarvestingManager: uu,
-resourceTransferCoordinator: Zf,
+powerBankHarvestingManager: su,
+resourceTransferCoordinator: Qf,
 emergencyResponseManager: Si,
 kernel: Gi
 }), function(e) {
 var t, r, o, n;
-mp = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : lp.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : lp.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : lp.getLabOverflow
-} : lp;
+up = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : cp.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : cp.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : cp.getLabOverflow
+} : cp;
 }({
 getLabResourceNeeds: function(e) {
-return Gu.getLabResourceNeeds(e);
+return Pu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return Gu.getLabResourceNeeds(e);
+return Pu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return Gu.getLabOverflow(e);
+return Pu.getLabOverflow(e);
 }
 }), rs.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) RT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) gT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
@@ -46845,7 +46827,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-RT.warn("Failed to wrap PathFinder.search", {
+gT.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -46853,11 +46835,11 @@ error: String(e)
 }
 }
 }
-}(), ET(e = Creep.prototype, "moveTo", "moveTo"), ET(e, "move", "move"), ET(e, "harvest", "harvest"),
-ET(e, "transfer", "transfer"), ET(e, "withdraw", "withdraw"), ET(e, "build", "build"),
-ET(e, "repair", "repair"), ET(e, "upgradeController", "upgradeController"), ET(e, "attack", "attack"),
-ET(e, "rangedAttack", "rangedAttack"), ET(e, "heal", "heal"), ET(e, "dismantle", "dismantle"),
-ET(e, "say", "say")), function(e) {
+}(), hT(e = Creep.prototype, "moveTo", "moveTo"), hT(e, "move", "move"), hT(e, "harvest", "harvest"),
+hT(e, "transfer", "transfer"), hT(e, "withdraw", "withdraw"), hT(e, "build", "build"),
+hT(e, "repair", "repair"), hT(e, "upgradeController", "upgradeController"), hT(e, "attack", "attack"),
+hT(e, "rangedAttack", "rangedAttack"), hT(e, "heal", "heal"), hT(e, "dismantle", "dismantle"),
+hT(e, "say", "say")), function(e) {
 void 0 === e && (e = Ue);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, Ce.L1, {
@@ -47044,15 +47026,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Gi, wr, Ly), sC.initializePathCacheEvents(), $T.initialize(cd.MEDIUM), ym = tC,
-Jt.initialize(), fT.initialize(), pC = !0), wr.initialize();
-var r = gT.configureForCurrentTick();
-"critical" === r && Game.time % 10 == 0 && dl.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
+}(Gi, wr, Iy), aC.initializePathCacheEvents(), ZT.initialize(id.MEDIUM), pm = $T,
+Jt.initialize(), dT.initialize(), mC = !0), wr.initialize();
+var r = yT.configureForCurrentTick();
+"critical" === r && Game.time % 10 == 0 && ll.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = kT();
-if (!1 !== r.enabled && (r.lastRun = Game.time, UT(), function() {
-var e, t, r, o, n = MT(), a = n.footprintOperation, i = OT(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = bT();
+if (!1 !== r.enabled && (r.lastRun = Game.time, MT(), function() {
+var e, t, r, o, n = OT(), a = n.footprintOperation, i = xT(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -47065,15 +47047,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, AT(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, kT(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = kT();
+var e, t, r, n, i, s, c = bT();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : CT), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === ST ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : ET), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === TT ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -47091,10 +47073,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !_T())) try {
+}(), !AT())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || py(s), "interShardPioneer" === c && dy(s);
+"interShardClaimer" !== c && "interShardScout" !== c || my(s), "interShardPioneer" === c && ly(s);
 }
 } catch (t) {
 e = {
@@ -47109,15 +47091,15 @@ if (e) throw e.error;
 }
 }();
 var n = Ct();
-if (0 === n.length) return Game.time % 100 == 0 && dl.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
+if (0 === n.length) return Game.time % 100 == 0 && ll.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), rs.publishIdleTick(), void dl.flush();
-Game.time % 10 == 0 && dl.info("SwarmBot loop executing at tick ".concat(Game.time), {
+}), rs.publishIdleTick(), void ll.flush();
+Game.time % 10 == 0 && ll.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: pC
+systemsInitialized: mC
 }
-}), gT.ensureProcessesRegistered(), rs.startTick(), El.clear(), gT.startEventTick(),
+}), yT.ensureProcessesRegistered(), rs.startTick(), hl.clear(), yT.startEventTick(),
 rs.measureSubsystem("taskBoard", function() {
 var e, t, r = Mr(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
 try {
@@ -47132,7 +47114,7 @@ rooms: n,
 interval: o
 })), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-dm.refreshRoom(c);
+lm.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -47147,18 +47129,18 @@ if (e) throw e.error;
 }
 }), rs.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = kT();
+var e, t, r, o = bT();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = UT();
+var n = MT();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : CT), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : ET), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== OT()) try {
+if (d !== xT()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Nf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Uf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -47176,20 +47158,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = NT().sort(function(e, t) {
+var i = UT().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : CT), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : ET), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== OT()) {
+if (u !== xT()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = IT(u);
+var m = NT(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? BT(i, l, m) : FT() ? LT(i, u, m) : (DT(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (GT(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? LT(i, l, m) : DT() ? IT(i, u, m) : (GT(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (PT(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -47206,8 +47188,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = MT();
-d.footprintOperation = n, AT(d);
+var d = OT();
+d.footprintOperation = n, kT(d);
 }
 }
 })(), function(e) {
@@ -47215,8 +47197,8 @@ var t, r, o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if (!o || dC(s)) {
-var c = tR(s, wr.getOrInitSwarmState(s.name));
+if (!o || lC(s)) {
+var c = $h(s, wr.getOrInitSwarmState(s.name));
 rs.recordSpawnQueue(s.name, c.stats, c.spawned), rs.recordDefenseAssist(s.name, c.defenseAssist);
 } else rs.recordDefenseAssist(s.name, []);
 }
@@ -47232,21 +47214,21 @@ if (t) throw t.error;
 }
 }
 }(n);
-}), kl.preTick(), rs.measureSubsystem("processSync", function() {
-wy.syncCreepProcesses(), Ov.syncRoomProcesses();
+}), bl.preTick(), rs.measureSubsystem("processSync", function() {
+Cy.syncCreepProcesses(), xv.syncRoomProcesses();
 }), rs.measureSubsystem("kernel", function() {
-gT.runProcesses();
+yT.runProcesses();
 }), rs.measureSubsystem("eventQueue", function() {
-gT.processQueuedEvents();
+yT.processQueuedEvents();
 }), rs.measureSubsystem("ss2PacketQueue", function() {
-aR.processQueue();
+oR.processQueue();
 }), Gi.hasCpuBudget() && rs.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && fy(n);
+void 0 !== n.ticksToLive && dy(n);
 }
 } catch (t) {
 e = {
@@ -47260,7 +47242,7 @@ if (e) throw e.error;
 }
 }
 }();
-}), hT({
+}), vT({
 hasCpuBudget: Gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && rs.measureSubsystem("visualizations", function() {
@@ -47270,8 +47252,8 @@ var r, o;
 if (Mr().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = lC.getConfig(), s = mC.getConfig();
-lC.setConfig(n.roomVisualizerConfig), n.renderMap && mC.setConfig(n.mapVisualizerConfig);
+var i = cC.getConfig(), s = uC.getConfig();
+cC.setConfig(n.roomVisualizerConfig), n.renderMap && uC.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -47282,10 +47264,10 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-lC.draw(m);
+cC.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
-dl.error("Visualization error in ".concat(m.name, ": ").concat(d), {
+ll.error("Visualization error in ".concat(m.name, ": ").concat(d), {
 subsystem: "visualizations",
 room: m.name
 });
@@ -47304,14 +47286,14 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-mC.draw();
+uC.draw();
 } catch (e) {
-d = e instanceof Error ? e.message : String(e), dl.error("Map visualization error: ".concat(d), {
+d = e instanceof Error ? e.message : String(e), ll.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-lC.setConfig(i), mC.setConfig(s);
+cC.setConfig(i), uC.setConfig(s);
 }
 }
 }
@@ -47396,19 +47378,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), kl.reconcileTraffic(), hT({
+}), bl.reconcileTraffic(), vT({
 hasCpuBudget: Gi.hasCpuBudget(),
 bucket: Game.cpu.bucket
 }) && rs.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Rd.run(e);
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), gd.run(e);
 }), wr.persistHeapCache(), rs.collectProcessStats(Gi.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
 }, new Map)), rs.collectKernelBudgetStats(Gi), rs.setSkippedProcesses(Gi.getSkippedProcessesThisTick()),
-rs.finalizeTick(), dl.flush();
+rs.finalizeTick(), ll.flush();
 }
 
-var yC = function() {
+var pC = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Mr().visualizations;
@@ -47416,25 +47398,25 @@ return Ar({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = lC.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = cC.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-lC.toggle(o);
-var n = lC.getConfig()[o];
+cC.toggle(o);
+var n = cC.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = mC.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = uC.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-mC.toggle(o);
-var n = mC.getConfig()[o];
+uC.toggle(o);
+var n = uC.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = mC.getConfig();
+var e = uC.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -47557,15 +47539,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), vC = function() {
+}(), fC = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = fT.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = dT.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = fT.getAllShards();
+var e, t, r = dT.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -47587,9 +47569,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (fT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (dT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = fT.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = dT.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -47614,19 +47596,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = fT.getOptimalPortalRoute(e, t);
+var r, o = dT.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (fT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (dT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (fT.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (dT.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Zf.getActiveRequests();
+var e, t, r = Qf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -47647,7 +47629,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = fT.getCurrentShardState();
+var e, t, r = dT.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -47668,7 +47650,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = fT.getActiveTransferTasks();
+var e, t, r, o = dT.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -47689,16 +47671,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = fT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Gf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = dT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Pf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = fT.getMemoryStats();
+var e = dT.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return fT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return dT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = MT().footprintOperation;
+var e, t, r, o = OT().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -47804,9 +47786,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), gC = new vC;
+}(), yC = new fC;
 
-function hC(e) {
+function vC(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -47836,10 +47818,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? hC(e.metadata.usage) : void 0
+params: e.metadata.usage ? vC(e.metadata.usage) : void 0
 };
 });
-return kd({
+return bd({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -47890,12 +47872,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return kd.apply(void 0, s([], i(o), !1));
+return bd.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return xd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return Sd("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return Od.form("spawnCreep", [ {
+return xd.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -47929,20 +47911,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return xd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return Sd("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += xd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += xd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += Od.button({
+o += '<div style="margin-bottom: 10px;">', o += Sd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += Sd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += xd.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += Od.button({
+}), o += " ", (o += xd.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return Od.form("configureLogging", [ {
+return xd.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -47967,7 +47949,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return Od.form("configureVisualization", [ {
+return xd.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -47991,18 +47973,18 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += Od.button({
+e += xd.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += Od.button({
+}), e += " ", (e += xd.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += xd("✓ Success message", "green", !0) + "\n", e += xd("⚠ Warning message", "yellow", !0) + "\n",
-e += xd("✗ Error message", "red", !0) + "\n", e += xd("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + xd("colored text", "green") + " normal text\n") + "Bold text: " + xd("important", null, !0) + "\n";
+return e += Sd("✓ Success message", "green", !0) + "\n", e += Sd("⚠ Warning message", "yellow", !0) + "\n",
+e += Sd("✗ Error message", "red", !0) + "\n", e += Sd("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + Sd("colored text", "green") + " normal text\n") + "Bold text: " + Sd("important", null, !0) + "\n";
 }, n([ Zr({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -48048,39 +48030,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var RC = new Mv, EC = new yC, TC = new Av, CC = new pl, SC = new kv, wC = new Uv, xC = new _v, bC = "__screepsGlobalRuntimeDiagnostics";
+var gC = new Ov, hC = new pC, RC = new kv, EC = new ml, TC = new bv, CC = new Mv, SC = new Av, wC = "__screepsGlobalRuntimeDiagnostics";
 
-function OC() {
+function xC() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function kC(e, t) {
+function bC(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function MC(e, t) {
+function OC(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function AC(e) {
+function kC(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function UC(e) {
+function MC(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: kC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: kC(n.switchCount, 0),
-lastTick: MC(n.lastTick, Game.time),
-lastResetTick: MC(n.lastResetTick, Game.time),
-lastSwitchTick: AC(n.lastSwitchTick),
-lastSwitchPreviousTick: AC(n.lastSwitchPreviousTick),
-lastWarningTick: AC(n.lastWarningTick)
+resetCount: bC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: bC(n.switchCount, 0),
+lastTick: OC(n.lastTick, Game.time),
+lastResetTick: OC(n.lastResetTick, Game.time),
+lastSwitchTick: kC(n.lastSwitchTick),
+lastSwitchPreviousTick: kC(n.lastSwitchPreviousTick),
+lastWarningTick: kC(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -48094,19 +48076,19 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var _C = ll("Main");
+var AC = cl("Main");
 
 br.register(), function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Xr.initialize(), Jr(RC), Jr(EC), Jr(TC), Jr(CC), Jr(SC), Jr(wC), Jr(xC), Jr(Fu),
-Jr(Wu), Jr(Hu), Jr(gC), Jr(no), Jr(Uc), Jr(iu), global.tooangel = nu;
+Xr.initialize(), Jr(gC), Jr(hC), Jr(RC), Jr(EC), Jr(TC), Jr(CC), Jr(SC), Jr(Du),
+Jr(Bu), Jr(Fu), Jr(yC), Jr(no), Jr(Mc), Jr(nu), global.tooangel = ru;
 var e = global;
 e.botConfig = {
 getConfig: Mr,
 updateConfig: Ar
 }, e.botLogger = {
-configureLogger: Xu
+configureLogger: zu
 }, e.botVisualizationManager = f, e.botCacheManager = Ee, Xr.exposeToGlobal();
 };
 e ? (Xr.initialize(), Xr.enableLazyLoading(t), Xr.exposeToGlobal()) : t();
@@ -48115,12 +48097,12 @@ try {
 br.run(), function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : OC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[bC];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : xC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[wC];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[bC] = s, function(e, t) {
-var r, o = UC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[wC] = s, function(e, t) {
+var r, o = MC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -48138,7 +48120,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = UC(e.heapId);
+var n, a = MC(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -48159,14 +48141,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = UC(s.heapId);
+var u = MC(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 }({
-logger: _C
-}), fC();
+logger: AC
+}), dC();
 } catch (e) {
-throw _C.error("Critical error in main loop: ".concat(String(e)), {
+throw AC.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-bot/src/core/managers/RoomDefenseManager.ts
+++ b/packages/screeps-bot/src/core/managers/RoomDefenseManager.ts
@@ -43,7 +43,7 @@ export class RoomDefenseManager {
     room: Room,
     swarm: SwarmState,
     cache: { spawns: StructureSpawn[]; towers: StructureTower[] }
-  ): void {
+  ): Nuke[] {
     const hostiles = getActualHostileCreeps(room);
     const nukes = getOwnedRoomNukes(room);
     const intent = this.getDefensePostureIntent(room, swarm, cache, hostiles, nukes);
@@ -53,6 +53,7 @@ export class RoomDefenseManager {
     // The detector reuses the cached nuke list and the empire coordinator skips this
     // room later in the tick, preventing duplicate scans and duplicate incident work.
     detectIncomingNukesInRoom(memoryManager.getEmpire(), room, swarm, nukes);
+    return nukes;
   }
 
   /**
@@ -77,7 +78,7 @@ export class RoomDefenseManager {
     nukes: Nuke[]
   ): DefensePostureSnapshot {
     const cluster = swarm.clusterId ? memoryManager.getCluster(swarm.clusterId) : null;
-    const threat = hostiles.length > 0 ? assessThreat(room) : undefined;
+    const threat = hostiles.length > 0 ? assessThreat(room, { hostiles, nukes }) : undefined;
     // Room processes are distributed across offsets; nuke detection must run
     // whenever this room executes rather than on a global modulo tick. The shared
     // detector cache keeps the empire coordinator from repeating this scan.

--- a/packages/screeps-bot/src/core/roomNode.ts
+++ b/packages/screeps-bot/src/core/roomNode.ts
@@ -170,11 +170,15 @@ export class RoomNode {
         pheromoneManager.updateMetrics(room, swarm);
       }
 
-      // Update threat assessment
-      roomDefenseManager.updateThreatAssessment(room, swarm, { spawns: cache.spawns, towers: cache.towers });
+      // Update threat assessment and share the bounded nuke observation with the
+      // emergency coordinator; both consumers must use the same room/tick snapshot.
+      const observedNukes = roomDefenseManager.updateThreatAssessment(room, swarm, {
+        spawns: cache.spawns,
+        towers: cache.towers
+      });
 
       // Assess emergency situation and coordinate response
-      emergencyResponseManager.assess(room, swarm);
+      emergencyResponseManager.assess(room, swarm, observedNukes);
 
       // Check safe mode trigger
       safeModeManager.checkSafeMode(room, swarm);

--- a/packages/screeps-bot/src/core/roomProcessManager.ts
+++ b/packages/screeps-bot/src/core/roomProcessManager.ts
@@ -15,6 +15,7 @@
  */
 
 import { getActualHostileCreeps } from "@ralphschuler/screeps-core";
+import { getOwnedRoomNukes } from "@ralphschuler/screeps-empire";
 import { memoryManager } from "@ralphschuler/screeps-memory";
 import { getConfig } from "../config";
 import { ProcessPriority, kernel, type Process as RoomProcess } from "./kernel";
@@ -72,7 +73,10 @@ function hasNukeThreat(room: Room): boolean {
   const scanInterval = lowBucket ? NUKE_PRIORITY_SCAN_INTERVAL_LOW_BUCKET : NUKE_PRIORITY_SCAN_INTERVAL;
   if (cached && Game.time - cached.checkedAt < scanInterval) return cached.active;
 
-  const active = room.find(FIND_NUKES).length > 0;
+  // Use the same per-room/tick observation cache consumed by room defense. The
+  // scheduler may observe first to promote the room without issuing a second
+  // FIND_NUKES query when RoomNode runs later in this tick.
+  const active = getOwnedRoomNukes(room).length > 0;
   nukePriorityScanCache.set(room.name, { checkedAt: Game.time, active });
   return active;
 }

--- a/packages/screeps-defense/README.md
+++ b/packages/screeps-defense/README.md
@@ -254,6 +254,10 @@ Emergency manager:
 - Activates safe mode for critical threats
 - Coordinates evacuation if needed
 
+### Shared nuke observation
+
+The bot room coordinator performs the bounded `FIND_NUKES` observation once per visible owned room/tick and passes that snapshot to threat and emergency policy. The empire nuke detector persists object-ID keyed alerts in `Memory.empire.incomingNukes`; `EvacuationManager` consumes those alerts idempotently and is the sole owner of evacuation-trigger mutation. This keeps stacked nukes distinct and prevents duplicate scans or competing evacuation state updates.
+
 ### Emergency helper-room refuel
 
 When a visible urgent defense request cannot afford a defender body, the spawn and

--- a/packages/screeps-defense/src/emergency/emergencyResponse.ts
+++ b/packages/screeps-defense/src/emergency/emergencyResponse.ts
@@ -65,11 +65,14 @@ export class EmergencyResponseManager {
   private emergencyStates: Map<string, EmergencyState> = new Map();
 
   /**
-   * Assess and respond to threats in a room
+   * Assess and respond to threats in a room.
+   *
+   * The room coordinator may pass its same-tick nuke observation so emergency
+   * handling does not perform a second FIND_NUKES scan.
    */
-  public assess(room: Room, swarm: SwarmState): EmergencyState {
+  public assess(room: Room, swarm: SwarmState, observedNukes?: Nuke[]): EmergencyState {
     const existingState = this.emergencyStates.get(room.name);
-    const emergencyLevel = this.calculateEmergencyLevel(room, swarm);
+    const emergencyLevel = this.calculateEmergencyLevel(room, swarm, observedNukes);
 
     if (emergencyLevel === EmergencyLevel.NONE) {
       this.clearBoostPriority(room.name);
@@ -132,7 +135,7 @@ export class EmergencyResponseManager {
   /**
    * Calculate emergency level based on room state
    */
-  private calculateEmergencyLevel(room: Room, swarm: SwarmState): EmergencyLevel {
+  private calculateEmergencyLevel(room: Room, swarm: SwarmState, observedNukes?: Nuke[]): EmergencyLevel {
     const hostiles = getActualHostileCreeps(room);
 
     // Critical structures and incoming nukes remain emergencies even when the
@@ -144,7 +147,7 @@ export class EmergencyResponseManager {
           s.structureType === STRUCTURE_TERMINAL) &&
         s.hits < s.hitsMax * 0.3
     });
-    const incomingNukes = room.find(FIND_NUKES);
+    const incomingNukes = observedNukes ?? room.find(FIND_NUKES);
 
     // No emergency if no danger signal, hostile, critical structure, or nuke.
     if (swarm.danger === 0 && hostiles.length === 0 && criticalStructures.length === 0 && incomingNukes.length === 0) {
@@ -153,7 +156,7 @@ export class EmergencyResponseManager {
 
     const needs = analyzeDefenderNeeds(room);
     const current = getCurrentDefenders(room);
-    const threat = assessThreat(room);
+    const threat = assessThreat(room, { hostiles, nukes: incomingNukes });
 
     if (criticalStructures.length > 0 || incomingNukes.length > 0) {
       return EmergencyLevel.CRITICAL;

--- a/packages/screeps-defense/src/emergency/evacuationManager.ts
+++ b/packages/screeps-defense/src/emergency/evacuationManager.ts
@@ -14,7 +14,7 @@
 
 import { logger } from "@ralphschuler/screeps-core";
 import { memoryManager } from "@ralphschuler/screeps-memory";
-import type { EvacuationIntentMemory } from "@ralphschuler/screeps-memory";
+import type { EvacuationIntentMemory, IncomingNukeAlert } from "@ralphschuler/screeps-memory";
 import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 import { getActualHostileCreeps } from "../alliance/nonAggressionPact";
 import { countActiveCombatDefenders } from "../analysis/defenderNeeds";
@@ -236,29 +236,34 @@ export class EvacuationManager {
       const swarm = memoryManager.getSwarmState(roomName);
       if (!swarm) continue;
 
-      // Check for nuke - primary condition is nuke presence
-      const nukes = room.find(FIND_NUKES);
-      if (nukes.length > 0) {
-        const nearestNuke = nukes.reduce((a, b) =>
-          (a.timeToLand ?? Infinity) < (b.timeToLand ?? Infinity) ? a : b
+      // Nuke detection is owned by the shared empire observation path. Consume
+      // persisted alerts here instead of scanning FIND_NUKES a second time.
+      const nukeAlerts = (memoryManager.getEmpire().incomingNukes ?? []).filter(
+        alert => alert.roomName === roomName
+          && !alert.evacuationTriggered
+          // impactTick is the persisted deadline. Do not trust a stale
+          // timeToLand value after a global reset or delayed process run.
+          && Number.isFinite(alert.impactTick)
+          && alert.impactTick > Game.time
+          && alert.impactTick - Game.time <= this.config.nukeEvacuationLeadTime
+      );
+      const nearestNuke = nukeAlerts
+        .filter(alert => this.hasCriticalStructures(alert))
+        .sort((a, b) => a.impactTick - b.impactTick)[0];
+
+      if (nearestNuke) {
+        const timeToLand = nearestNuke.impactTick - Game.time;
+        logger.warn(
+          `Triggering evacuation for ${roomName}: ${nukeAlerts.length} nuke(s) detected, impact in ${timeToLand} ticks`,
+          { subsystem: "Evacuation" }
         );
 
-        if ((nearestNuke.timeToLand ?? Infinity) <= this.config.nukeEvacuationLeadTime) {
-          // Set detection flag if not already set (for coordination with nuke manager)
-          if (!swarm.nukeDetected) {
-            swarm.nukeDetected = true;
-          }
-          
-          // Increase urgency based on number of nukes
-          const nukeCount = nukes.length;
-          logger.warn(
-            `Triggering evacuation for ${roomName}: ${nukeCount} nuke(s) detected, impact in ${nearestNuke.timeToLand ?? 0} ticks`,
-            { subsystem: "Evacuation" }
-          );
-          
-          this.startEvacuation(roomName, "nuke", Game.time + (nearestNuke.timeToLand ?? 0));
-          continue;
+        if (this.startEvacuation(roomName, "nuke", nearestNuke.impactTick)) {
+          // The evacuation manager owns this mutation. Mark all same-room alerts
+          // together so stacked nukes remain distinct without repeated side effects.
+          for (const alert of nukeAlerts) alert.evacuationTriggered = true;
         }
+        continue;
       }
 
       // Check for siege (danger level 3)
@@ -273,6 +278,14 @@ export class EvacuationManager {
         }
       }
     }
+  }
+
+  private hasCriticalStructures(alert: IncomingNukeAlert): boolean {
+    return (alert.threatenedStructures ?? []).some(structure =>
+      structure.includes(STRUCTURE_SPAWN)
+      || structure.includes(STRUCTURE_STORAGE)
+      || structure.includes(STRUCTURE_TERMINAL)
+    );
   }
 
   /**

--- a/packages/screeps-defense/src/index.ts
+++ b/packages/screeps-defense/src/index.ts
@@ -99,6 +99,7 @@ export {
   estimateDefenderCost,
   logThreatAnalysis,
   type ThreatAnalysis,
+  type ThreatAssessmentObservations,
 } from "./threat/threatAssessment";
 
 // Tower action policy

--- a/packages/screeps-defense/src/threat/threatAssessment.ts
+++ b/packages/screeps-defense/src/threat/threatAssessment.ts
@@ -66,16 +66,28 @@ export interface ThreatAnalysis {
 }
 
 /**
+ * Optional same-tick observations supplied by the room coordinator.
+ *
+ * Room defense already performs one bounded hostile/nuke observation. Passing the
+ * snapshots through keeps threat analysis pure and avoids repeating FIND_* scans.
+ */
+export interface ThreatAssessmentObservations {
+  hostiles?: Creep[];
+  nukes?: Nuke[];
+}
+
+/**
  * Assess threat level in a room
  * 
  * **IMPORTANT**: Automatically excludes allied entities (permanent allies)
  * 
  * @param room - Room to analyze
+ * @param observations - Optional observations already collected for this room/tick
  * @returns Comprehensive threat analysis
  */
-export function assessThreat(room: Room): ThreatAnalysis {
-  const hostiles = getActualHostileCreeps(room);
-  const nukes = room.find(FIND_NUKES);
+export function assessThreat(room: Room, observations: ThreatAssessmentObservations = {}): ThreatAnalysis {
+  const hostiles = observations.hostiles ?? getActualHostileCreeps(room);
+  const nukes = observations.nukes ?? room.find(FIND_NUKES);
   
   // Incoming nukes are critical even when no hostile creep is visible.
   // Keep the empty-room fast path only for rooms with no nuke threat.

--- a/packages/screeps-defense/test/defenderNeeds.test.ts
+++ b/packages/screeps-defense/test/defenderNeeds.test.ts
@@ -31,7 +31,8 @@ function createRoom(
   friendlyRoles: string[] = [],
   controllerOwned = true,
   criticalStructure = false,
-  incomingNukeCount = 0
+  incomingNukeCount = 0,
+  onNukeFind?: () => void
 ): Room {
   const spawns = Array.from({ length: spawnCount }, () => ({ spawning: false }));
   const friendlyCreeps = friendlyRoles.map(role => ({
@@ -53,7 +54,10 @@ function createRoom(
           ? [{ structureType: STRUCTURE_SPAWN, hits: 10, hitsMax: 100 }]
           : [];
       }
-      if (type === FIND_NUKES) return Array.from({ length: incomingNukeCount }, () => ({}));
+      if (type === FIND_NUKES) {
+        onNukeFind?.();
+        return Array.from({ length: incomingNukeCount }, () => ({}));
+      }
       return [];
     }
   } as unknown as Room;
@@ -278,6 +282,20 @@ describe("defense assistance needs", () => {
 
     expect(state.level).to.equal(EmergencyLevel.CRITICAL);
     expect((Memory as any).boostDefensePriority?.W1N1).to.equal(true);
+  });
+
+  it("uses the room nuke snapshot supplied by the coordinator", () => {
+    let nukeScans = 0;
+    const room = createRoom([], 6, 1, [], true, false, 1, () => nukeScans++);
+    const manager = new EmergencyResponseManager();
+    const state = manager.assess(room, {
+      danger: 0,
+      posture: "eco",
+      pheromones: { defense: 0, war: 0, siege: 0 }
+    } as any, [{} as Nuke]);
+
+    expect(state.level).to.equal(EmergencyLevel.CRITICAL);
+    expect(nukeScans).to.equal(0);
   });
 
   it("records the tick when an existing emergency escalates", () => {

--- a/packages/screeps-defense/test/evacuationManager.test.ts
+++ b/packages/screeps-defense/test/evacuationManager.test.ts
@@ -10,7 +10,13 @@ function createStore() {
   } as unknown as Store<ResourceConstant>;
 }
 
-function createRoom(name: string, creeps: Creep[] = [], hostiles: Creep[] = []): Room {
+function createRoom(
+  name: string,
+  creeps: Creep[] = [],
+  hostiles: Creep[] = [],
+  nukes: Nuke[] = [],
+  onNukeFind?: () => void
+): Room {
   const terminal = { store: createStore(), send: () => OK } as unknown as StructureTerminal;
   const storage = { store: createStore() } as unknown as StructureStorage;
   return {
@@ -21,7 +27,10 @@ function createRoom(name: string, creeps: Creep[] = [], hostiles: Creep[] = []):
     find: (type: FindConstant) => {
       if (type === FIND_MY_CREEPS) return creeps;
       if (type === FIND_HOSTILE_CREEPS) return hostiles;
-      if (type === FIND_NUKES) return [];
+      if (type === FIND_NUKES) {
+        onNukeFind?.();
+        return nukes;
+      }
       return [];
     },
   } as unknown as Room;
@@ -58,6 +67,87 @@ describe("EvacuationManager persistence", () => {
       flags: {},
       powerCreeps: {},
     };
+  });
+
+  it("consumes a persisted critical nuke alert without rescanning the room", () => {
+    let nukeFinds = 0;
+    const source = createRoom("W1N1", [], [], [], () => nukeFinds++);
+    const target = createRoom("W2N1");
+    (Game as any).rooms = { [source.name]: source, [target.name]: target };
+    const swarm = memoryManager.initSwarmState(source.name);
+    const empire = memoryManager.getEmpire();
+    empire.incomingNukes = [{
+      nukeId: "nuke-a",
+      roomName: source.name,
+      landingPos: { x: 25, y: 25 },
+      impactTick: 500,
+      timeToLand: 400,
+      detectedAt: 100,
+      threatenedStructures: [`${STRUCTURE_SPAWN}-25,25`],
+      evacuationTriggered: false,
+      sourceRoom: "W9N9"
+    }];
+
+    const manager = new EvacuationManager();
+    manager.run();
+
+    expect(manager.getEvacuationState(source.name)).to.include({ reason: "nuke" });
+    expect(empire.incomingNukes[0]?.evacuationTriggered).to.equal(true);
+    expect(nukeFinds).to.equal(0);
+    expect(swarm.posture).to.equal("evacuate");
+  });
+
+  it("ignores expired alerts even when timeToLand is stale and positive", () => {
+    let nukeFinds = 0;
+    const source = createRoom("W1N1", [], [], [], () => nukeFinds++);
+    const target = createRoom("W2N1");
+    (Game as any).rooms = { [source.name]: source, [target.name]: target };
+    memoryManager.initSwarmState(source.name);
+    const empire = memoryManager.getEmpire();
+    empire.incomingNukes = [{
+      nukeId: "expired-nuke",
+      roomName: source.name,
+      landingPos: { x: 25, y: 25 },
+      impactTick: 99,
+      // Legacy/stale value must not revive an already-landed alert.
+      timeToLand: 400,
+      detectedAt: 50,
+      threatenedStructures: [`${STRUCTURE_SPAWN}-25,25`],
+      evacuationTriggered: false,
+      sourceRoom: "W9N9"
+    }];
+
+    const manager = new EvacuationManager();
+    manager.run();
+
+    expect(manager.getEvacuationState(source.name)).to.equal(undefined);
+    expect(empire.incomingNukes[0]?.evacuationTriggered).to.equal(false);
+    expect(nukeFinds).to.equal(0);
+  });
+
+  it("uses the persisted impact tick as the evacuation deadline", () => {
+    const source = createRoom("W1N1");
+    const target = createRoom("W2N1");
+    (Game as any).rooms = { [source.name]: source, [target.name]: target };
+    memoryManager.initSwarmState(source.name);
+    const empire = memoryManager.getEmpire();
+    empire.incomingNukes = [{
+      nukeId: "deadline-nuke",
+      roomName: source.name,
+      landingPos: { x: 25, y: 25 },
+      impactTick: 500,
+      // Deliberately stale; impactTick is authoritative.
+      timeToLand: 1,
+      detectedAt: 50,
+      threatenedStructures: [`${STRUCTURE_SPAWN}-25,25`],
+      evacuationTriggered: false,
+      sourceRoom: "W9N9"
+    }];
+
+    const manager = new EvacuationManager();
+    manager.run();
+
+    expect(manager.getEvacuationState(source.name)).to.include({ reason: "nuke", deadline: 500 });
   });
 
   it("starts siege evacuation when nominal defenders are spawning", () => {

--- a/packages/screeps-defense/test/threatAssessment.test.ts
+++ b/packages/screeps-defense/test/threatAssessment.test.ts
@@ -174,6 +174,28 @@ describe('Threat Assessment', () => {
       expect(analysis.recommendedResponse).to.equal('safemode');
     });
 
+    it('should use supplied nuke observations without rescanning FIND_NUKES', () => {
+      const incomingNuke = {
+        id: 'nuke-snapshot',
+        launchRoomName: 'W2N2',
+        timeToLand: 5000
+      } as unknown as Nuke;
+      let nukeScans = 0;
+      mockRoom.find = (type: number) => {
+        if (type === FIND_NUKES) {
+          nukeScans++;
+          throw new Error('unexpected duplicate nuke scan');
+        }
+        return [];
+      };
+
+      const analysis = assessThreat(mockRoom, { nukes: [incomingNuke] });
+
+      expect(analysis.dangerLevel).to.equal(3);
+      expect(analysis.recommendedResponse).to.equal('safemode');
+      expect(nukeScans).to.equal(0);
+    });
+
     it('should detect hostile creeps', () => {
       const mockHostile = {
         id: 'hostile1',


### PR DESCRIPTION
## Summary

Consolidate visible incoming-nuke observation and evacuation ownership across room defense, emergency response, and empire coordination.

## Linked issue

Closes #3371

## Research

- SearXNG was unavailable: configured backend returned HTTP 403; tracked by #3378.
- Local `@types/screeps` confirms `Nuke.id`, `Nuke.launchRoomName`, and `Nuke.timeToLand` are the runtime API fields.
- Repository nuke/pruner code establishes persisted `impactTick` as the durable deadline.

## Changes

- Cache one `FIND_NUKES` result per owned room/tick and reuse it across room defense, threat assessment, emergency response, and the scheduler.
- Persist object-ID keyed incoming-nuke alerts and skip duplicate same-tick empire detection.
- Make `EvacuationManager` consume persisted alerts and own `evacuationTriggered` mutation.
- Use persisted `impactTick` for filtering, ordering, and evacuation deadlines; ignore expired alerts with stale `timeToLand`.
- Update nuke documentation and regression coverage.
- Regenerate the deploy bundle.

## Defense impact

- Threat detection: same-tick room observation; no duplicate nuke scans.
- Defensive response: stacked nukes remain distinct; evacuation is idempotent and deadline-correct after reset/delayed processing.
- Recovery: stale alerts cannot trigger post-impact evacuation.
- Ally safety: existing ally-safe nuke targeting remains unchanged.
- CPU/Memory: bounded room scan cache; compact persisted alert state retained.

## Tests

- `npm run test:defense` — 111 passing
- `npm run test:empire` — 9 passing
- Bot nuke/room unit tests — 66 passing
- Defense/empire/bot typechecks — passed
- Defense/empire/bot lint — passed
- `npm run build` — passed; bundle 1.30 MB / 2 MB limit
- `npm run check:bot-bundle-drift` — passed
- `npm run sync:deps:check` — passed
- `npm run check:alliance-safety` — passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check` — passed
- `npm run check-versions` — blocked by host Node `22.22.2` vs repository requirement Node `>=24 <25`
- Private-server smoke is running separately; final result will be added when complete.

## Live evidence

Sanitized read-only shard1 observation: ticks 72296485–72296985, 500 ticks, 21 samples. No incoming nukes or structure/site loss observed in selected rooms; one transient non-ally hostile sighting; Memory diagnostics returned HTTP 429, so CPU/bucket/task-board claims are unavailable. Permanent allies were excluded from hostile classification.

## Follow-up issues

- #3375 remains P1 pending sustained spawnless recovery evidence.
- #3388 remains a separate structure-loss identity telemetry gap.
- #3378 tracks SearXNG access restoration.
