### PR TITLE
fix(defense): restore nuke helper compatibility

### DIFF
--- a/packages/@ralphschuler/screeps-empire/README.md
+++ b/packages/@ralphschuler/screeps-empire/README.md
@@ -141,6 +141,16 @@ for (const pred of predictions) {
 }
 ```
 
+## Nuke helper compatibility
+
+`hasCriticalStructuresThreatened()` remains exported from the empire package and its previous `nuke/detection` module for compatibility. It is deprecated there and delegates to the canonical defense policy without duplicating the predicate.
+
+New consumers should migrate to:
+
+```typescript
+import { hasCriticalStructuresThreatened } from "@ralphschuler/screeps-defense";
+```
+
 ## Architecture
 
 This package follows the **dependency inversion principle**: 

--- a/packages/@ralphschuler/screeps-empire/src/nuke/detection.ts
+++ b/packages/@ralphschuler/screeps-empire/src/nuke/detection.ts
@@ -5,6 +5,9 @@
  */
 
 import { logger } from "@ralphschuler/screeps-core";
+import {
+  hasCriticalStructuresThreatened as hasCriticalStructuresThreatenedPolicy,
+} from "@ralphschuler/screeps-defense/nuke-threat-policy";
 import { NUKE_DAMAGE } from "./types";
 import type { IncomingNukeAlert } from "../types";
 
@@ -250,4 +253,15 @@ export function identifyThreatenedStructures(room: Room, landingPos: RoomPositio
   }
 
   return threatened;
+}
+
+/**
+ * Check whether an incoming nuke alert threatens evacuation-critical structures.
+ *
+ * @deprecated Import `hasCriticalStructuresThreatened` from
+ * `@ralphschuler/screeps-defense`; this compatibility export delegates to that
+ * canonical policy.
+ */
+export function hasCriticalStructuresThreatened(alert: IncomingNukeAlert): boolean {
+  return hasCriticalStructuresThreatenedPolicy(alert);
 }

--- a/packages/@ralphschuler/screeps-empire/test/fixtures/nukeCompatibilityConsumer.ts
+++ b/packages/@ralphschuler/screeps-empire/test/fixtures/nukeCompatibilityConsumer.ts
@@ -1,0 +1,18 @@
+import {
+  hasCriticalStructuresThreatened as compatibilityPredicate,
+  type IncomingNukeAlert,
+} from "@ralphschuler/screeps-empire";
+import {
+  hasCriticalStructuresThreatened as canonicalPredicate,
+  type NukeStructureThreat,
+} from "@ralphschuler/screeps-defense";
+import {
+  hasCriticalStructuresThreatened as lightweightPredicate,
+} from "@ralphschuler/screeps-defense/nuke-threat-policy";
+
+declare const alert: IncomingNukeAlert;
+const structuralAlert: NukeStructureThreat = alert;
+
+export const compatibilityResult: boolean = compatibilityPredicate(alert);
+export const canonicalResult: boolean = canonicalPredicate(structuralAlert);
+export const lightweightResult: boolean = lightweightPredicate(structuralAlert);

--- a/packages/@ralphschuler/screeps-empire/test/nukeCompatibility.test.ts
+++ b/packages/@ralphschuler/screeps-empire/test/nukeCompatibility.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import ts from "typescript";
+
+const STRUCTURE_TYPES = {
+  STRUCTURE_SPAWN: "spawn",
+  STRUCTURE_TOWER: "tower",
+  STRUCTURE_STORAGE: "storage",
+  STRUCTURE_TERMINAL: "terminal",
+  STRUCTURE_LAB: "lab",
+  STRUCTURE_NUKER: "nuker",
+  STRUCTURE_POWER_SPAWN: "powerSpawn",
+  STRUCTURE_OBSERVER: "observer",
+  STRUCTURE_EXTENSION: "extension",
+  STRUCTURE_LINK: "link",
+};
+
+describe("nuke API compatibility", () => {
+  it("keeps compatible package-root and canonical subpath type contracts", () => {
+    const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+    const configPath = path.join(packageRoot, "tsconfig.json");
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+    const config = ts.parseJsonConfigFileContent(configFile.config, ts.sys, packageRoot);
+    const fixture = path.join(packageRoot, "test/fixtures/nukeCompatibilityConsumer.ts");
+    const program = ts.createProgram([fixture], {
+      ...config.options,
+      noEmit: true,
+      rootDir: packageRoot,
+    });
+    const diagnostics = ts.getPreEmitDiagnostics(program).map(diagnostic =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")
+    );
+
+    expect(diagnostics).to.deep.equal([]);
+  });
+
+  it("exports the deprecated predicate from its previous public module", async () => {
+    const previousGlobals = new Map(
+      Object.keys(STRUCTURE_TYPES).map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)])
+    );
+    Object.assign(globalThis, STRUCTURE_TYPES);
+
+    try {
+      const api = await import("../src/nuke/detection");
+      expect(api).to.have.property("hasCriticalStructuresThreatened").that.is.a("function");
+      const predicate = (api as Record<string, unknown>).hasCriticalStructuresThreatened as
+        (alert: { threatenedStructures?: string[] }) => boolean;
+      expect(predicate({ threatenedStructures: ["spawn-25,25"] })).to.equal(true);
+      expect(predicate({ threatenedStructures: ["tower-25,25"] })).to.equal(false);
+    } finally {
+      for (const [key, descriptor] of previousGlobals) {
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else delete (globalThis as Record<string, unknown>)[key];
+      }
+    }
+  });
+});

--- a/packages/screeps-bot/dist/main.js
+++ b/packages/screeps-bot/dist/main.js
@@ -12654,16 +12654,27 @@ return f.length > 0 && p < 2 * f.length && (U.warn("High-impact siege hostiles d
 subsystem: "Defense"
 }), !0);
 }, e;
-}(), ki = new Oi, Mi = new Set([ "nuke", "siege", "hostile_takeover", "manual" ]), Ai = {
+}(), ki = new Oi, Mi = [ "spawn", "storage", "terminal" ];
+
+function Ai(e) {
+var t;
+return (null !== (t = e.threatenedStructures) && void 0 !== t ? t : []).some(function(e) {
+return Mi.some(function(t) {
+return e.includes(t);
+});
+});
+}
+
+var Ui = new Set([ "nuke", "siege", "hostile_takeover", "manual" ]), _i = {
 triggerDangerLevel: 3,
 nukeEvacuationLeadTime: 5e3,
 minStorageEnergy: 5e4,
 priorityResources: [ RESOURCE_ENERGY, RESOURCE_POWER, RESOURCE_GHODIUM, RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ACID, RESOURCE_CATALYZED_ZYNTHIUM_ACID, RESOURCE_OPS ],
 maxTransfersPerTick: 2
-}, Ui = function() {
+}, Ni = function() {
 function e(e) {
 void 0 === e && (e = {}), this.evacuations = new Map, this.lastTransferTick = 0,
-this.transfersThisTick = 0, this.config = o(o({}, Ai), e);
+this.transfersThisTick = 0, this.config = o(o({}, _i), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o;
@@ -12747,7 +12758,7 @@ delete r.evacuationIntent;
 }, e.prototype.isValidEvacuationIntent = function(e) {
 if (!e || "object" != typeof e) return !1;
 var t = e;
-return Mi.has(String(t.reason)) && "number" == typeof t.startedAt && Number.isFinite(t.startedAt) && "string" == typeof t.targetRoom && t.targetRoom.length > 0 && "number" == typeof t.progress && Number.isFinite(t.progress) && "boolean" == typeof t.complete && "number" == typeof t.updatedAt && Number.isFinite(t.updatedAt) && (void 0 === t.deadline || "number" == typeof t.deadline && Number.isFinite(t.deadline));
+return Ui.has(String(t.reason)) && "number" == typeof t.startedAt && Number.isFinite(t.startedAt) && "string" == typeof t.targetRoom && t.targetRoom.length > 0 && "number" == typeof t.progress && Number.isFinite(t.progress) && "boolean" == typeof t.complete && "number" == typeof t.updatedAt && Number.isFinite(t.updatedAt) && (void 0 === t.deadline || "number" == typeof t.deadline && Number.isFinite(t.deadline));
 }, e.prototype.persistEvacuation = function(e) {
 var t = wr.getSwarmState(e.roomName);
 if (t) {
@@ -12773,9 +12784,7 @@ var u = wr.getSwarmState(o);
 if (!u) return "continue";
 var l = (null !== (t = wr.getEmpire().incomingNukes) && void 0 !== t ? t : []).filter(function(e) {
 return e.roomName === o && !e.evacuationTriggered && Number.isFinite(e.impactTick) && e.impactTick > Game.time && e.impactTick - Game.time <= r.config.nukeEvacuationLeadTime;
-}), m = l.filter(function(e) {
-return r.hasCriticalStructures(e);
-}).sort(function(e, t) {
+}), m = l.filter(Ai).sort(function(e, t) {
 return e.impactTick - t.impactTick;
 })[0];
 if (m) {
@@ -12803,11 +12812,6 @@ if (y.length > 3 * v) return n.startEvacuation(o, "siege"), "continue";
 }
 }, n = this;
 for (var i in Game.rooms) o(i);
-}, e.prototype.hasCriticalStructures = function(e) {
-var t;
-return (null !== (t = e.threatenedStructures) && void 0 !== t ? t : []).some(function(e) {
-return e.includes(STRUCTURE_SPAWN) || e.includes(STRUCTURE_STORAGE) || e.includes(STRUCTURE_TERMINAL);
-});
 }, e.prototype.startEvacuation = function(e, t, r) {
 var o;
 if (this.evacuations.has(e)) return !1;
@@ -12998,9 +13002,9 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), _i = new Ui;
+}(), Pi = new Ni;
 
-function Ni(e) {
+function Ii(e) {
 var t = Math.floor(e.bucketThresholds.lowMode / 2), r = {
 high: 1,
 medium: Math.max(1, Math.min(e.taskFrequencies.clusterLogic, e.taskFrequencies.pheromoneUpdate)),
@@ -13035,21 +13039,21 @@ maxPriorityBoost: 50
 };
 }
 
-var Pi, Ii = null, Gi = new Proxy({}, {
+var Gi, Li = null, Di = new Proxy({}, {
 get: function(e, t) {
-return Ii || (Ii = new Ye(Ni(Mr().cpu))), Ii[t];
+return Li || (Li = new Ye(Ii(Mr().cpu))), Li[t];
 },
 set: function(e, t, r) {
-return Ii || (Ii = new Ye(Ni(Mr().cpu))), Ii[t] = r, !0;
+return Li || (Li = new Ye(Ii(Mr().cpu))), Li[t] = r, !0;
 }
 });
 
-function Li() {
+function Bi() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-ot.apply(void 0, s([ Gi ], i(e), !1));
+ot.apply(void 0, s([ Di ], i(e), !1));
 }
 
-var Di, Bi, Fi = {
+var Fi, Wi, Hi = {
 updateInterval: 200,
 minBucket: 0,
 minCreditsForPixels: 5e5,
@@ -13061,11 +13065,11 @@ targetPixelPrice: 2e3,
 maxPixelsPerTransaction: 10,
 purchaseCooldown: 1e3,
 minBaseMineralReserve: 1e4,
-criticalResourceThresholds: (Pi = {}, Pi[RESOURCE_GHODIUM] = 5e3, Pi),
+criticalResourceThresholds: (Gi = {}, Gi[RESOURCE_GHODIUM] = 5e3, Gi),
 enabled: !0
-}, Wi = function() {
+}, Ki = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Fi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Hi), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13241,15 +13245,15 @@ this.config.enabled = !1, U.info("Pixel buying disabled", {
 subsystem: "PixelBuying"
 });
 }, e;
-}(), Hi = {
+}(), Yi = {
 enabled: !0,
 fullBucketTicksRequired: 25,
 bucketMax: 1e4,
 cpuCostPerPixel: 1e4,
 minBucketAfterGeneration: 0
-}, Ki = function() {
+}, Vi = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.config = o(o({}, Hi), e), this.memoryAccessor = t;
+void 0 === e && (e = {}), this.config = o(o({}, Yi), e), this.memoryAccessor = t;
 }
 return e.prototype.setMemoryAccessor = function(e) {
 this.memoryAccessor = e;
@@ -13311,7 +13315,7 @@ this.config = o(o({}, this.config), e);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e;
-}(), Yi = function(e) {
+}(), qi = function(e) {
 var t = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.map(function(e) {
@@ -13341,18 +13345,18 @@ for (var o = [], n = 1; n < arguments.length; n++) o[n - 1] = arguments[n];
 return console.log.apply(console, s([ "[".concat(e, "] ERROR:"), r ], i(t.apply(void 0, s([], i(o), !1))), !1));
 }
 };
-}("stats"), Vi = function(e) {
+}("stats"), ji = function(e) {
 var t, r, o;
 return (null === (r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e]) || void 0 === r ? void 0 : r.swarm) || (null === (o = Memory.swarm) || void 0 === o ? void 0 : o[e]) || {};
 };
 
 !function(e) {
 e.ACTIVE = "active", e.DECAY = "decay", e.INACTIVE = "inactive";
-}(Di || (Di = {})), function(e) {
+}(Fi || (Fi = {})), function(e) {
 e.PHEROMONES = "pheromones", e.PATHS = "paths", e.TARGETS = "targets", e.DEBUG = "debug";
-}(Bi || (Bi = {}));
+}(Wi || (Wi = {}));
 
-var qi = new (function() {
+var zi = new (function() {
 function e() {
 this.metrics = {
 totalCalls: 0,
@@ -13400,7 +13404,7 @@ moveByPath: 0
 }, e;
 }());
 
-function ji(e, t) {
+function Qi(e, t) {
 var r;
 void 0 === t && (t = {});
 var o = null === (r = t.includeCpuUsage) || void 0 === r || r, n = s([], i(e), !1).sort(function(e, t) {
@@ -13409,15 +13413,15 @@ return t.percentUsed - e.percentUsed;
 var r, n, a = "room:".concat(e.target), i = null === (r = t.processes) || void 0 === r ? void 0 : r[a], s = null !== (n = null == i ? void 0 : i.tickModulo) && void 0 !== n ? n : 1, c = s > 1 ? " [runs every ".concat(s, " ticks]") : "", u = "".concat((100 * e.percentUsed).toFixed(1), "%");
 return o ? "".concat(e.target, ": ").concat(u, " (").concat(e.cpuUsed.toFixed(3), "/").concat(e.budgetLimit.toFixed(3), " CPU)").concat(c) : "".concat(e.target, ": ").concat(u).concat(c);
 });
-return zi(n, e.length);
+return Xi(n, e.length);
 }
 
-function zi(e, t) {
+function Xi(e, t) {
 var r = t - e.length;
 return r > 0 && e.push("... ".concat(r, " more omitted")), e.join(", ");
 }
 
-var Qi = {
+var Zi = {
 enabled: !0,
 smoothingFactor: .1,
 trackNativeCalls: !0,
@@ -13439,9 +13443,9 @@ enabled: !0,
 spikeThreshold: 2,
 minSamples: 10
 }
-}, Xi = 1e-9, Zi = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
+}, Ji = 1e-9, $i = new Set([ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ]);
 
-function Ji() {
+function es() {
 return {
 tasks: 0,
 openTasks: 0,
@@ -13453,28 +13457,28 @@ remainingAmount: 0
 };
 }
 
-function $i(e) {
+function ts(e) {
 return "number" == typeof e && Number.isFinite(e) ? Math.max(0, e) : 0;
 }
 
-function es(e) {
+function rs(e) {
 var t;
 return Object.values(null !== (t = e.reservations) && void 0 !== t ? t : {}).reduce(function(e, t) {
-return e + $i(null == t ? void 0 : t.amount);
+return e + ts(null == t ? void 0 : t.amount);
 }, 0);
 }
 
-var ts = function() {
+var os = function() {
 function e(e) {
 void 0 === e && (e = {}), this.subsystemMeasurements = new Map, this.cpuDetailMeasurements = new Map,
 this.roomMeasurements = new Map, this.lastSegmentUpdate = 0, this.lastBudgetAlertLogTick = -1 / 0,
 this.lastAnomalyLogTick = -1 / 0, this.segmentRequested = !1, this.skippedProcessesThisTick = 0,
-this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Qi), e),
+this.spawnIdleTickState = new Map, this.defenseAssistTelemetry = new Map, this.config = o(o({}, Zi), e),
 this.currentSnapshot = this.createEmptySnapshot(), this.nativeCallsThisTick = this.createEmptyNativeCalls();
 }
 return e.prototype.initialize = function() {
 void 0 === RawMemory.segments[this.config.segmentId] && (RawMemory.setActiveSegments([ this.config.segmentId ]),
-this.segmentRequested = !0), this.installCpuProfilerGlobal(), Yi.info("Unified stats system initialized", {
+this.segmentRequested = !0), this.installCpuProfilerGlobal(), qi.info("Unified stats system initialized", {
 subsystem: "Stats"
 });
 }, e.prototype.preserveRoomStats = function() {
@@ -13511,7 +13515,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-qi.reset();
+zi.reset();
 }
 }, e.prototype.publishIdleTick = function() {
 this.startTick(), this.finalizeTick();
@@ -13547,19 +13551,19 @@ return "critical" === e.severity;
 }), C = R.alerts.filter(function(e) {
 return "warning" === e.severity;
 });
-T.length > 0 && Yi.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(ji(T, {
+T.length > 0 && qi.error("CPU Budget: ".concat(T.length, " critical violations detected - ").concat(Qi(T, {
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
-}), C.length > 0 && Yi.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(ji(C, {
+}), C.length > 0 && qi.warn("CPU Budget: ".concat(C.length, " warnings (≥80% of limit) - ").concat(Qi(C, {
 includeCpuUsage: !1,
 processes: this.currentSnapshot.processes
 })), {
 subsystem: "CPUBudget"
 }), this.lastBudgetAlertLogTick = Game.time;
 }
-E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (Yi.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
-return zi(s([], i(e), !1).sort(function(e, t) {
+E.length > 0 && this.shouldLogCpuAlert(this.lastAnomalyLogTick) && (qi.warn("CPU Anomalies: ".concat(E.length, " detected - ").concat(function(e) {
+return Xi(s([], i(e), !1).sort(function(e, t) {
 return t.multiplier - e.multiplier;
 }).slice(0, 5).map(function(e) {
 return "".concat(e.target, " (").concat(e.type, "): ").concat(e.current.toFixed(3), " CPU (").concat(e.multiplier.toFixed(1), "x baseline)").concat(e.context ? " - ".concat(e.context) : "");
@@ -13659,7 +13663,7 @@ v.staleReservations = null !== (s = null === (i = y.stats) || void 0 === i ? voi
 v.blockedReservations = null !== (u = null === (c = y.stats) || void 0 === c ? void 0 : c.blockedReservations) && void 0 !== u ? u : 0;
 try {
 for (var g = a(Object.values(null !== (l = y.tasks) && void 0 !== l ? l : {})), h = g.next(); !h.done; h = g.next()) {
-var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : Ji(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = $i(R.amount), w = es(R), x = Math.max(0, S - w), b = Zi.has(E);
+var R = h.value, E = null !== (m = R.type) && void 0 !== m ? m : "unknown", T = null !== (d = v.byType[E]) && void 0 !== d ? d : es(), C = Object.keys(null !== (p = R.reservations) && void 0 !== p ? p : {}).length, S = ts(R.amount), w = rs(R), x = Math.max(0, S - w), b = $i.has(E);
 v.tasks++, v.reservations += C, v.amount += S, v.reservedAmount += w, v.remainingAmount += x,
 T.tasks++, T.reservations += C, T.amount += S, T.reservedAmount += w, T.remainingAmount += x,
 "open" === R.status ? (v.openTasks++, T.openTasks++) : "assigned" === R.status && (v.assignedTasks++,
@@ -13883,7 +13887,7 @@ this.defenseAssistTelemetry.set(e, r), (null == o ? void 0 : o.defense) && (o.de
 }, e.prototype.recordRoom = function(e, t) {
 var r, n, s, c, u, l, m, d, p, f, y, v, g, h, R, E, T, C, S, w, x, b, O, k, M;
 if (this.config.enabled) {
-var A = Vi(e.name), U = Object.values(Game.creeps).filter(function(t) {
+var A = ji(e.name), U = Object.values(Game.creeps).filter(function(t) {
 return t.room.name === e.name;
 }).length, _ = Z(e), N = this.getRoomTaskBoardStats(e.name), P = this.getRemoteStats(e.name, A), I = this.getDefenseStats(e, _, A), G = this.defenseAssistTelemetry.get(e.name), L = this.getControllerDowngradeStats(e), D = this.currentSnapshot.rooms[e.name];
 D || (D = {
@@ -13991,7 +13995,7 @@ storageEnergy: W
 };
 }
 }, e.prototype.isWarRoom = function(e) {
-var t = Vi(e);
+var t = ji(e);
 return !!t && ("war" === t.posture || "siege" === t.posture || t.danger >= 2);
 }, e.prototype.validateBudgets = function() {
 var e, t, r, o = {
@@ -14006,8 +14010,8 @@ try {
 for (var n = a(Object.entries(this.currentSnapshot.rooms)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
 o.roomsEvaluated++;
-var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Xi ? h : Math.abs(v - g) <= Xi ? g : v;
-v + Xi >= h ? (o.roomsOverBudget++, o.alerts.push({
+var m = this.isWarRoom(u) ? this.config.budgetLimits.warRoom : this.config.budgetLimits.ecoRoom, d = "room:".concat(u), p = this.currentSnapshot.processes[d], f = m * (null !== (r = null == p ? void 0 : p.tickModulo) && void 0 !== r ? r : 1), y = l.profiler.avgCpu, v = y / f, g = this.config.budgetAlertThresholds.warning, h = this.config.budgetAlertThresholds.critical, R = Math.abs(v - h) <= Ji ? h : Math.abs(v - g) <= Ji ? g : v;
+v + Ji >= h ? (o.roomsOverBudget++, o.alerts.push({
 severity: "critical",
 target: u,
 targetType: "room",
@@ -14015,7 +14019,7 @@ cpuUsed: y,
 budgetLimit: f,
 percentUsed: R,
 tick: Game.time
-})) : v + Xi >= g ? (o.alerts.push({
+})) : v + Ji >= g ? (o.alerts.push({
 severity: "warning",
 target: u,
 targetType: "room",
@@ -14049,7 +14053,7 @@ var v = null !== (n = this.roomMeasurements.get(f)) && void 0 !== n ? n : 0;
 if (!((x = y.profiler.avgCpu) < .01)) {
 var g = v / x;
 if (g >= this.config.anomalyDetection.spikeThreshold) {
-var h = Vi(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
+var h = ji(f), R = h ? "RCL ".concat(null !== (u = null === (c = null === (s = Game.rooms[f]) || void 0 === s ? void 0 : s.controller) || void 0 === c ? void 0 : c.level) && void 0 !== u ? u : 0, ", posture: ").concat(h.posture, ", danger: ").concat(h.danger) : void 0;
 l.push({
 type: "spike",
 target: f,
@@ -14477,7 +14481,7 @@ evictions: 0
 }
 };
 }, e.prototype.finalizePathfindingStats = function() {
-this.currentSnapshot.pathfinding = qi.getMetrics();
+this.currentSnapshot.pathfinding = zi.getMetrics();
 }, e.prototype.formatCpuDetailsForMemory = function() {
 var e, t, r, n, s = this.getCpuDetailsConfig(), c = {};
 try {
@@ -14875,24 +14879,24 @@ var o = JSON.parse(r);
 Array.isArray(o) && (t = o);
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Yi.error("Failed to parse stats segment: ".concat(n), {
+qi.error("Failed to parse stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
 t.push(this.currentSnapshot), t.length > this.config.maxHistoryPoints && (t = t.slice(-this.config.maxHistoryPoints));
 var a = JSON.stringify(t);
 if (a.length > e) {
-for (Yi.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
+for (qi.warn("Stats segment size ".concat(a.length, " exceeds ").concat(e, " bytes, trimming history"), {
 subsystem: "Stats"
 }); a.length > e && t.length > 1; ) t.shift(), a = JSON.stringify(t);
-if (a.length > e) return void Yi.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
+if (a.length > e) return void qi.error("Failed to persist stats segment within ".concat(e, " bytes after trimming"), {
 subsystem: "Stats"
 });
 }
 try {
 RawMemory.segments[this.config.segmentId] = a;
 } catch (e) {
-n = e instanceof Error ? e.message : String(e), Yi.error("Failed to save stats segment: ".concat(n), {
+n = e instanceof Error ? e.message : String(e), qi.error("Failed to save stats segment: ".concat(n), {
 subsystem: "Stats"
 });
 }
@@ -14909,17 +14913,17 @@ lastUpdate: 0
 }), e.stats.profiler;
 }, e.prototype.logSummary = function() {
 var e, t, r, o, n, i, s, c, u, l, m = this.currentSnapshot;
-Yi.info("=== Unified Stats Summary ==="), Yi.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
-Yi.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
+qi.info("=== Unified Stats Summary ==="), qi.info("CPU: ".concat(m.cpu.used.toFixed(2), "/").concat(m.cpu.limit, " (").concat(m.cpu.percent.toFixed(1), "%) | Bucket: ").concat(m.cpu.bucket)),
+qi.info("Empire: ".concat(m.empire.rooms, " rooms, ").concat(m.empire.creeps, " creeps, ").concat(m.empire.credits, " credits"));
 var d = Object.values(m.subsystems).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (d.length > 0) {
-Yi.info("Top Subsystems:");
+qi.info("Top Subsystems:");
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-Yi.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
+qi.info("  ".concat(y.name, ": ").concat(y.avgCpu.toFixed(3), " CPU"));
 }
 } catch (t) {
 e = {
@@ -14937,11 +14941,11 @@ var v = Object.values(m.roles).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (v.length > 0) {
-Yi.info("Top Roles:");
+qi.info("Top Roles:");
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Yi.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
+qi.info("  ".concat(R.name, ": ").concat(R.count, " creeps, ").concat(R.avgCpu.toFixed(3), " CPU"));
 }
 } catch (e) {
 r = {
@@ -14959,11 +14963,11 @@ var E = Object.values(m.processes).sort(function(e, t) {
 return t.avgCpu - e.avgCpu;
 }).slice(0, 5);
 if (E.length > 0) {
-Yi.info("Top Processes:");
+qi.info("Top Processes:");
 try {
 for (var T = a(E), C = T.next(); !C.done; C = T.next()) {
 var S = C.value;
-Yi.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
+qi.info("  ".concat(S.name, ": ").concat(S.avgCpu.toFixed(3), " CPU (runs: ").concat(S.runCount, ", state: ").concat(S.state, ")"));
 }
 } catch (e) {
 n = {
@@ -14981,11 +14985,11 @@ var w = Object.values(m.rooms).sort(function(e, t) {
 return t.profiler.avgCpu - e.profiler.avgCpu;
 }).slice(0, 5);
 if (w.length > 0) {
-Yi.info("Top Rooms by CPU:");
+qi.info("Top Rooms by CPU:");
 try {
 for (var x = a(w), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-Yi.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
+qi.info("  ".concat(O.name, ": ").concat(O.profiler.avgCpu.toFixed(3), " CPU (RCL ").concat(O.rcl, ")"));
 }
 } catch (e) {
 s = {
@@ -15003,11 +15007,11 @@ var k = Object.values(m.creeps).sort(function(e, t) {
 return t.cpu - e.cpu;
 }).slice(0, 5);
 if (k.length > 0) {
-Yi.info("Top Creeps by CPU:");
+qi.info("Top Creeps by CPU:");
 try {
 for (var M = a(k), A = M.next(); !A.done; A = M.next()) {
 var U = A.value;
-Yi.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
+qi.info("  ".concat(U.name, " (").concat(U.role, "): ").concat(U.cpu.toFixed(3), " CPU in ").concat(U.currentRoom));
 }
 } catch (e) {
 u = {
@@ -15021,7 +15025,7 @@ if (u) throw u.error;
 }
 }
 }
-this.config.trackNativeCalls && Yi.info("Native calls: ".concat(m.native.total, " total"));
+this.config.trackNativeCalls && qi.info("Native calls: ".concat(m.native.total, " total"));
 }, e.prototype.postureToCode = function(e) {
 var t;
 return null !== (t = {
@@ -15067,16 +15071,16 @@ lastUpdate: 0
 return o({}, this.currentSnapshot);
 }, e.POSTURE_NAMES = [ "eco", "expand", "defensive", "war", "siege", "evacuate", "nukePrep" ],
 e;
-}(), rs = new ts, os = {
+}(), ns = new os, as = {
 primarySegment: 90,
 backupSegment: 91,
 retentionPeriod: 1e4,
 updateInterval: 50,
 maxDataPoints: 1e3
-}, ns = function() {
+}, is = function() {
 function e(e) {
 void 0 === e && (e = {}), this.statsData = null, this.segmentRequested = !1, this.lastUpdate = 0,
-this.config = o(o({}, os), e);
+this.config = o(o({}, as), e);
 }
 return e.prototype.initialize = function() {
 RawMemory.setActiveSegments([ this.config.primarySegment ]), this.segmentRequested = !0;
@@ -15087,12 +15091,12 @@ this.lastUpdate = Game.time);
 }, e.prototype.loadFromSegment = function() {
 var e = RawMemory.segments[this.config.primarySegment];
 if (e && 0 !== e.length) try {
-this.statsData = JSON.parse(e), Yi.debug("Loaded stats from segment", {
+this.statsData = JSON.parse(e), qi.debug("Loaded stats from segment", {
 subsystem: "Stats"
 });
 } catch (e) {
 var t = e instanceof Error ? e.message : String(e);
-Yi.error("Failed to parse stats segment: ".concat(t), {
+qi.error("Failed to parse stats segment: ".concat(t), {
 subsystem: "Stats"
 }), this.statsData = this.createDefaultStatsData();
 } else this.statsData = this.createDefaultStatsData();
@@ -15144,7 +15148,7 @@ c["".concat(p, ".energy.capacity")] = d.energyCapacity, c["".concat(p, ".storage
 c["".concat(p, ".terminal.energy")] = d.terminalEnergy, c["".concat(p, ".creeps")] = d.creepCount,
 c["".concat(p, ".controller.progress")] = d.controllerProgress, c["".concat(p, ".controller.progress_total")] = d.controllerProgressTotal,
 c["".concat(p, ".controller.progress_percent")] = d.controllerProgressTotal > 0 ? d.controllerProgress / d.controllerProgressTotal * 100 : 0;
-var f = Vi(d.roomName);
+var f = ji(d.roomName);
 if (f) {
 if (c["".concat(p, ".brain.danger")] = f.danger, c["".concat(p, ".brain.posture_code")] = this.postureToCode(f.posture),
 c["".concat(p, ".brain.colony_level_code")] = this.colonyLevelToCode(f.colonyLevel),
@@ -15256,7 +15260,7 @@ try {
 this.statsData.lastUpdate = Game.time;
 var i = JSON.stringify(this.statsData);
 if (i.length > n) {
-for (Yi.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
+for (qi.warn("Stats data exceeds segment limit: ".concat(i.length, " bytes, trimming..."), {
 subsystem: "Stats"
 }); i.length > n && this.statsData.history.length > 10; ) this.statsData.history.shift(),
 i = JSON.stringify(this.statsData);
@@ -15275,7 +15279,7 @@ if (e) throw e.error;
 }
 }
 if (i.length > n) {
-Yi.warn("Stats data still exceeds limit after trimming, clearing history", {
+qi.warn("Stats data still exceeds limit after trimming, clearing history", {
 subsystem: "Stats"
 }), this.statsData.history = this.statsData.history.slice(-5);
 try {
@@ -15298,7 +15302,7 @@ i = JSON.stringify(this.statsData);
 RawMemory.segments[this.config.primarySegment] = i;
 } catch (e) {
 var p = e instanceof Error ? e.message : String(e);
-Yi.error("Failed to save stats segment: ".concat(p), {
+qi.error("Failed to save stats segment: ".concat(p), {
 subsystem: "Stats"
 });
 }
@@ -15402,9 +15406,9 @@ fortifiedHive: 4,
 empireDominance: 5
 }[e]) && void 0 !== t ? t : 0;
 }, e;
-}(), as = new ns;
+}(), ss = new is;
 
-function is(e) {
+function cs(e) {
 e._metrics || (e._metrics = {
 tasksCompleted: 0,
 energyTransferred: 0,
@@ -15417,15 +15421,15 @@ healingDone: 0
 });
 }
 
-function ss(e) {
-return is(e), e._metrics;
+function us(e) {
+return cs(e), e._metrics;
 }
 
-function cs(e, t) {
-ss(e).damageDealt += t;
+function ls(e, t) {
+us(e).damageDealt += t;
 }
 
-var us, ls = {
+var ms, ds = {
 minBucket: 0,
 minSourceLinkEnergy: 400,
 controllerLinkMaxEnergy: 700,
@@ -15437,11 +15441,11 @@ storageEnergyReserveForSpawnLink: 1e4
 !function(e) {
 e.SOURCE = "source", e.CONTROLLER = "controller", e.STORAGE = "storage", e.SPAWN = "spawn",
 e.UNKNOWN = "unknown";
-}(us || (us = {}));
+}(ms || (ms = {}));
 
-var ms, ds, ps = function() {
+var ps, fs, ys = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, ls), e);
+void 0 === e && (e = {}), this.config = o(o({}, ds), e);
 }
 return e.prototype.run = function() {
 var e, t;
@@ -15475,13 +15479,13 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (!(t.length < 2)) {
 var r = this.classifyLinks(e, t), o = r.filter(function(e) {
-return e.role === us.SOURCE;
+return e.role === ms.SOURCE;
 }), n = r.filter(function(e) {
-return e.role === us.CONTROLLER;
+return e.role === ms.CONTROLLER;
 }), a = r.filter(function(e) {
-return e.role === us.STORAGE;
+return e.role === ms.STORAGE;
 }), i = r.filter(function(e) {
-return e.role === us.SPAWN;
+return e.role === ms.SPAWN;
 });
 this.executeTransfers(e, o, n, a, i);
 }
@@ -15518,11 +15522,11 @@ try {
 for (var R = (l = void 0, a(f)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.link.store.getFreeCapacity(RESOURCE_ENERGY) < this.config.transferThreshold)) {
-if (T.role === us.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
+if (T.role === ms.CONTROLLER && T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.controllerLinkMaxEnergy) {
 h = T;
 break;
 }
-if (T.role !== us.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
+if (T.role !== ms.STORAGE) !h && T.link.store.getFreeCapacity(RESOURCE_ENERGY) > this.config.transferThreshold && (h = T); else if (T.link.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.storageLinkReserve) {
 h = T;
 break;
 }
@@ -15602,25 +15606,25 @@ i.transferEnergy(m, l));
 var t = e.room, r = t.controller, o = t.storage, n = t.find(FIND_SOURCES), a = t.find(FIND_MY_SPAWNS);
 return this.classifyLinkRole(e, r, o, n, a);
 }, e.prototype.classifyLinkRole = function(e, t, r, o, n) {
-return t && e.pos.getRangeTo(t) <= 2 ? us.CONTROLLER : o.some(function(t) {
+return t && e.pos.getRangeTo(t) <= 2 ? ms.CONTROLLER : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 1;
-}) ? us.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? us.STORAGE : n.some(function(t) {
+}) ? ms.SOURCE : r && e.pos.getRangeTo(r) <= 2 ? ms.STORAGE : n.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? us.SPAWN : o.some(function(t) {
+}) ? ms.SPAWN : o.some(function(t) {
 return e.pos.getRangeTo(t) <= 2;
-}) ? us.SOURCE : us.UNKNOWN;
+}) ? ms.SOURCE : ms.UNKNOWN;
 }, e.prototype.getRolePriority = function(e) {
 switch (e) {
-case us.CONTROLLER:
+case ms.CONTROLLER:
 return 100;
 
-case us.SPAWN:
+case ms.SPAWN:
 return 75;
 
-case us.STORAGE:
+case ms.STORAGE:
 return 50;
 
-case us.SOURCE:
+case ms.SOURCE:
 return 10;
 
 default:
@@ -15636,9 +15640,9 @@ return e.structureType === STRUCTURE_LINK;
 });
 if (r.length < 2) return !1;
 var o = this.classifyLinks(e, r), n = o.some(function(e) {
-return e.role === us.SOURCE;
+return e.role === ms.SOURCE;
 }), a = o.some(function(e) {
-return e.role === us.CONTROLLER || e.role === us.STORAGE;
+return e.role === ms.CONTROLLER || e.role === ms.STORAGE;
 });
 return n && a;
 }, n([ Xe("link:manager", "Link Manager", {
@@ -15647,23 +15651,23 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), fs = new ps;
+}(), vs = new ys;
 
-function ys(e) {
+function gs(e) {
 return "string" == typeof e.roomName && e.roomName.length > 0;
 }
 
-function vs(e) {
+function hs(e) {
 var t, r;
 return Math.max(0, null !== (r = null !== (t = e.remainingAmount) && void 0 !== t ? t : e.amount) && void 0 !== r ? r : 0);
 }
 
-function gs(e, t) {
+function Rs(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var hs, Rs, Es, Ts, Cs, Ss, ws, xs, bs, Os, ks, Ms = {
+var Es, Ts, Cs, Ss, ws, xs, bs, Os, ks, Ms, As, Us = {
 updateInterval: 100,
 priceUpdateInterval: 500,
 minBucket: 2e3,
@@ -15681,14 +15685,14 @@ highPriceMultiplier: 1.1,
 trendChangeThreshold: .05,
 buyOpportunityAdjustment: 1.02,
 sellOpportunityAdjustment: .98,
-sellThresholds: (ms = {}, ms[RESOURCE_ENERGY] = 5e5, ms[RESOURCE_HYDROGEN] = 2e4,
-ms[RESOURCE_OXYGEN] = 2e4, ms[RESOURCE_UTRIUM] = 2e4, ms[RESOURCE_LEMERGIUM] = 2e4,
-ms[RESOURCE_KEANIUM] = 2e4, ms[RESOURCE_ZYNTHIUM] = 2e4, ms[RESOURCE_CATALYST] = 2e4,
-ms),
-buyThresholds: (ds = {}, ds[RESOURCE_ENERGY] = 1e5, ds[RESOURCE_HYDROGEN] = 5e3,
-ds[RESOURCE_OXYGEN] = 5e3, ds[RESOURCE_UTRIUM] = 5e3, ds[RESOURCE_LEMERGIUM] = 5e3,
-ds[RESOURCE_KEANIUM] = 5e3, ds[RESOURCE_ZYNTHIUM] = 5e3, ds[RESOURCE_CATALYST] = 5e3,
-ds),
+sellThresholds: (ps = {}, ps[RESOURCE_ENERGY] = 5e5, ps[RESOURCE_HYDROGEN] = 2e4,
+ps[RESOURCE_OXYGEN] = 2e4, ps[RESOURCE_UTRIUM] = 2e4, ps[RESOURCE_LEMERGIUM] = 2e4,
+ps[RESOURCE_KEANIUM] = 2e4, ps[RESOURCE_ZYNTHIUM] = 2e4, ps[RESOURCE_CATALYST] = 2e4,
+ps),
+buyThresholds: (fs = {}, fs[RESOURCE_ENERGY] = 1e5, fs[RESOURCE_HYDROGEN] = 5e3,
+fs[RESOURCE_OXYGEN] = 5e3, fs[RESOURCE_UTRIUM] = 5e3, fs[RESOURCE_LEMERGIUM] = 5e3,
+fs[RESOURCE_KEANIUM] = 5e3, fs[RESOURCE_ZYNTHIUM] = 5e3, fs[RESOURCE_CATALYST] = 5e3,
+fs),
 trackedResources: [ RESOURCE_ENERGY, RESOURCE_HYDROGEN, RESOURCE_OXYGEN, RESOURCE_UTRIUM, RESOURCE_LEMERGIUM, RESOURCE_KEANIUM, RESOURCE_ZYNTHIUM, RESOURCE_CATALYST, RESOURCE_GHODIUM, RESOURCE_POWER ],
 criticalResources: [ RESOURCE_ENERGY, RESOURCE_GHODIUM ],
 emergencyBuyThreshold: 5e3,
@@ -15706,41 +15710,41 @@ minArbitrageMargin: .05,
 energyOverflowStorageEnter: 8e5,
 energyOverflowStorageExit: 5e5,
 minOverflowEnergySellAmount: 1e3
-}, As = function() {
+}, _s = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedEmpireTick = -1, this.cachedEmpire = null,
 this.cachedTick = -1, this.cachedMarketOrders = new Map, this.cachedMarketOrderDealAmounts = new Map,
 this.cachedOwnedRooms = null, this.cachedOwnedTerminalRooms = null, this.cachedReadyOwnedTerminalRooms = null,
-this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, Ms), e);
+this.cachedOwnedStorageTerminalRooms = null, this.config = o(o({}, Us), e);
 }
 return e.prototype.run = function() {
 var e = this;
 this.lastRun = Game.time, this.cachedEmpireTick = -1, this.cachedEmpire = null,
-gs("market.ensureMemory", function() {
+Rs("market.ensureMemory", function() {
 return e.ensureMarketMemory();
-}), Game.time % this.config.priceUpdateInterval === 0 && gs("market.updatePriceTracking", function() {
+}), Game.time % this.config.priceUpdateInterval === 0 && Rs("market.updatePriceTracking", function() {
 return e.updatePriceTracking();
-}), gs("market.updateOrderStats", function() {
+}), Rs("market.updateOrderStats", function() {
 return e.updateOrderStats();
-}), gs("market.reconcilePendingArbitrage", function() {
+}), Rs("market.reconcilePendingArbitrage", function() {
 return e.reconcilePendingArbitrage();
-}), gs("market.handleEmergencyBuying", function() {
+}), Rs("market.handleEmergencyBuying", function() {
 return e.handleEmergencyBuying();
-}), gs("market.cancelOldOrders", function() {
+}), Rs("market.cancelOldOrders", function() {
 return e.cancelOldOrders();
-}), gs("market.manageExistingOrders", function() {
+}), Rs("market.manageExistingOrders", function() {
 return e.manageExistingOrders();
-}), this.canRunActiveTrading() && (gs("market.updateBuyOrders", function() {
+}), this.canRunActiveTrading() && (Rs("market.updateBuyOrders", function() {
 return e.updateBuyOrders();
-}), gs("market.handleEnergyOverflowSales", function() {
+}), Rs("market.handleEnergyOverflowSales", function() {
 return e.handleEnergyOverflowSales();
-}), gs("market.updateSellOrders", function() {
+}), Rs("market.updateSellOrders", function() {
 return e.updateSellOrders();
-}), gs("market.checkArbitrageOpportunities", function() {
+}), Rs("market.checkArbitrageOpportunities", function() {
 return e.checkArbitrageOpportunities();
-}), gs("market.executeDeal", function() {
+}), Rs("market.executeDeal", function() {
 return e.executeDeal();
-}), Game.time % 200 == 0 && gs("market.balanceResourcesAcrossRooms", function() {
+}), Game.time % 200 == 0 && Rs("market.balanceResourcesAcrossRooms", function() {
 return e.balanceResourcesAcrossRooms();
 }));
 }, e.prototype.canRunActiveTrading = function() {
@@ -16157,8 +16161,8 @@ energyCreditValue: this.config.energyCreditValue,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}, u.orders.filter(ys).map(function(e) {
-var t = Math.min(u.requestedAmount, vs(e), u.maxDealAmount);
+}, u.orders.filter(gs).map(function(e) {
+var t = Math.min(u.requestedAmount, hs(e), u.maxDealAmount);
 if (!(t <= 0)) {
 var r = u.calcTransactionCost(t, u.sourceRoomName, e.roomName), o = e.price * t - r * u.energyCreditValue;
 return {
@@ -16377,8 +16381,8 @@ maxDealAmount: this.config.maxActiveBuyAmount,
 calcTransactionCost: function(e, t, r) {
 return Game.market.calcTransactionCost(e, t, r);
 }
-}).orders.filter(ys).map(function(e) {
-var t = Math.min(vs(e), m.maxDealAmount, m.requestedAmount);
+}).orders.filter(gs).map(function(e) {
+var t = Math.min(hs(e), m.maxDealAmount, m.requestedAmount);
 if (!(t <= 0)) {
 var r = m.calcTransactionCost(t, e.roomName, m.destinationRoomName);
 return {
@@ -16647,7 +16651,7 @@ interval: 100,
 minBucket: 2e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), Us = new As, _s = function() {
+}(), Ns = new _s, Ps = function() {
 function e() {
 this.costCache = new Map, this.COST_CACHE_TTL = 100, this.MAX_HOPS = 3;
 }
@@ -16774,7 +16778,7 @@ if (e) throw e.error;
 var r = e.path.indexOf(t);
 return -1 === r || r === e.path.length - 1 ? null : e.path[r + 1] || null;
 }, e;
-}(), Ns = new _s, Ps = {
+}(), Is = new Ps, Gs = {
 minBucket: 0,
 minStorageEnergy: 5e4,
 terminalEnergyTarget: 2e4,
@@ -16789,9 +16793,9 @@ emergencyDangerThreshold: 2,
 emergencyEnergyAmount: 2e4,
 energySurplusThreshold: 5e4,
 mineralSurplusThreshold: 5e3
-}, Is = function() {
+}, Ls = function() {
 function e(e) {
-void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, Ps), e);
+void 0 === e && (e = {}), this.transferQueue = [], this.config = o(o({}, Gs), e);
 }
 return e.prototype.requestTransfer = function(e, t, r, o, n) {
 if (void 0 === n && (n = 3), this.transferQueue.some(function(o) {
@@ -16816,7 +16820,7 @@ if (!(Game.cpu.bucket < this.config.minBucket)) {
 var e = Ct().filter(function(e) {
 return e.terminal && e.terminal.my && e.terminal.isActive();
 });
-0 !== e.length && (Ns.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
+0 !== e.length && (Is.clearOldCache(), this.cleanTransferQueue(), this.monitorTerminalCapacity(e),
 e.length < 2 || (this.checkEmergencyTransfers(e), this.balanceEnergy(e), this.balanceMinerals(e),
 this.executeTransfers(e)));
 }
@@ -16844,7 +16848,7 @@ var l = u[0];
 if (!c.transferQueue.some(function(e) {
 return e.toRoom === t.name && e.resourceType === RESOURCE_ENERGY && e.isEmergency;
 })) {
-var m = Ns.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
+var m = Is.findOptimalRoute(l.name, t.name, c.config.emergencyEnergyAmount);
 m && (c.transferQueue.push({
 fromRoom: l.name,
 toRoom: t.name,
@@ -16935,7 +16939,7 @@ var w = C - S;
 if (u && u !== e.name) {
 var x = null === (c = Game.rooms[u]) || void 0 === c ? void 0 : c.terminal;
 if (x && x.store.getFreeCapacity() > w) {
-var b = Ns.findOptimalRoute(e.name, u, w);
+var b = Is.findOptimalRoute(e.name, u, w);
 if (b) {
 this.transferQueue.push({
 fromRoom: e.name,
@@ -16951,7 +16955,7 @@ continue;
 }
 }
 }
-Game.time % 10 == 0 && Us.sellSurplusFromTerminal(e.name, T, w) && U.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
+Game.time % 10 == 0 && Ns.sellSurplusFromTerminal(e.name, T, w) && U.info("Sold ".concat(w, " ").concat(T, " from ").concat(e.name, " terminal via market"), {
 subsystem: "Terminal"
 });
 }
@@ -16996,7 +17000,7 @@ return r.fromRoom === t.room.name && r.toRoom === e.room.name && r.resourceType 
 })) return "continue";
 var r = Math.min(Math.floor((t.totalEnergy - u.config.energySendThreshold) / 2), u.config.energyRequestThreshold - e.totalEnergy, t.terminal.store.getUsedCapacity(RESOURCE_ENERGY));
 if (r < u.config.minTransferAmount) return "continue";
-var o = Ns.findOptimalRoute(t.room.name, e.room.name, r);
+var o = Is.findOptimalRoute(t.room.name, e.room.name, r);
 if (!o) return "continue";
 var n = o.cost / r;
 if (n > u.config.maxTransferCostRatio) return U.debug("Skipping terminal transfer from ".concat(t.room.name, " to ").concat(e.room.name, ": cost ratio ").concat(n.toFixed(2), " too high"), {
@@ -17131,7 +17135,7 @@ var a = r.terminal;
 if (a.cooldown > 0) return "continue";
 var i = t.toRoom;
 if (t.route && !t.route.isDirect) {
-var c = Ns.getNextHop(t.route, t.fromRoom);
+var c = Is.getNextHop(t.route, t.fromRoom);
 c && (i = c);
 }
 var u = null === (o = Game.rooms[i]) || void 0 === o ? void 0 : o.terminal;
@@ -17295,25 +17299,25 @@ interval: 20,
 minBucket: 0,
 cpuBudget: .1
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), Gs = new Is, Ls = {
+}(), Ds = new Ls, Bs = {
 minBucket: 0,
 minStorageEnergy: 8e4,
 inputBufferAmount: 2e3,
 outputBufferAmount: 5e3
-}, Ds = ((hs = {})[RESOURCE_UTRIUM_BAR] = ((Rs = {})[RESOURCE_UTRIUM] = 500, Rs[RESOURCE_ENERGY] = 200,
-Rs), hs[RESOURCE_LEMERGIUM_BAR] = ((Es = {})[RESOURCE_LEMERGIUM] = 500, Es[RESOURCE_ENERGY] = 200,
-Es), hs[RESOURCE_ZYNTHIUM_BAR] = ((Ts = {})[RESOURCE_ZYNTHIUM] = 500, Ts[RESOURCE_ENERGY] = 200,
-Ts), hs[RESOURCE_KEANIUM_BAR] = ((Cs = {})[RESOURCE_KEANIUM] = 500, Cs[RESOURCE_ENERGY] = 200,
-Cs), hs[RESOURCE_GHODIUM_MELT] = ((Ss = {})[RESOURCE_GHODIUM] = 500, Ss[RESOURCE_ENERGY] = 200,
-Ss), hs[RESOURCE_OXIDANT] = ((ws = {})[RESOURCE_OXYGEN] = 500, ws[RESOURCE_ENERGY] = 200,
-ws), hs[RESOURCE_REDUCTANT] = ((xs = {})[RESOURCE_HYDROGEN] = 500, xs[RESOURCE_ENERGY] = 200,
-xs), hs[RESOURCE_PURIFIER] = ((bs = {})[RESOURCE_CATALYST] = 500, bs[RESOURCE_ENERGY] = 200,
-bs), hs[RESOURCE_BATTERY] = ((Os = {})[RESOURCE_ENERGY] = 600, Os), hs), Bs = ((ks = {})[RESOURCE_BATTERY] = 10,
-ks[RESOURCE_UTRIUM_BAR] = 5, ks[RESOURCE_LEMERGIUM_BAR] = 5, ks[RESOURCE_ZYNTHIUM_BAR] = 5,
-ks[RESOURCE_KEANIUM_BAR] = 5, ks[RESOURCE_GHODIUM_MELT] = 4, ks[RESOURCE_OXIDANT] = 3,
-ks[RESOURCE_REDUCTANT] = 3, ks[RESOURCE_PURIFIER] = 3, ks), Fs = function() {
+}, Fs = ((Es = {})[RESOURCE_UTRIUM_BAR] = ((Ts = {})[RESOURCE_UTRIUM] = 500, Ts[RESOURCE_ENERGY] = 200,
+Ts), Es[RESOURCE_LEMERGIUM_BAR] = ((Cs = {})[RESOURCE_LEMERGIUM] = 500, Cs[RESOURCE_ENERGY] = 200,
+Cs), Es[RESOURCE_ZYNTHIUM_BAR] = ((Ss = {})[RESOURCE_ZYNTHIUM] = 500, Ss[RESOURCE_ENERGY] = 200,
+Ss), Es[RESOURCE_KEANIUM_BAR] = ((ws = {})[RESOURCE_KEANIUM] = 500, ws[RESOURCE_ENERGY] = 200,
+ws), Es[RESOURCE_GHODIUM_MELT] = ((xs = {})[RESOURCE_GHODIUM] = 500, xs[RESOURCE_ENERGY] = 200,
+xs), Es[RESOURCE_OXIDANT] = ((bs = {})[RESOURCE_OXYGEN] = 500, bs[RESOURCE_ENERGY] = 200,
+bs), Es[RESOURCE_REDUCTANT] = ((Os = {})[RESOURCE_HYDROGEN] = 500, Os[RESOURCE_ENERGY] = 200,
+Os), Es[RESOURCE_PURIFIER] = ((ks = {})[RESOURCE_CATALYST] = 500, ks[RESOURCE_ENERGY] = 200,
+ks), Es[RESOURCE_BATTERY] = ((Ms = {})[RESOURCE_ENERGY] = 600, Ms), Es), Ws = ((As = {})[RESOURCE_BATTERY] = 10,
+As[RESOURCE_UTRIUM_BAR] = 5, As[RESOURCE_LEMERGIUM_BAR] = 5, As[RESOURCE_ZYNTHIUM_BAR] = 5,
+As[RESOURCE_KEANIUM_BAR] = 5, As[RESOURCE_GHODIUM_MELT] = 4, As[RESOURCE_OXIDANT] = 3,
+As[RESOURCE_REDUCTANT] = 3, As[RESOURCE_PURIFIER] = 3, As), Hs = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, Ls), e);
+void 0 === e && (e = {}), this.config = o(o({}, Bs), e);
 }
 return e.prototype.run = function() {
 var e, t;
@@ -17355,7 +17359,7 @@ var s = e.storage;
 if (s && !(s.store.getUsedCapacity(RESOURCE_ENERGY) < this.config.minStorageEnergy)) {
 var c = this.selectProduction(e, n, s);
 if (c) {
-var u = Ds[c];
+var u = Fs[c];
 if (u) {
 var l = !0;
 try {
@@ -17393,7 +17397,7 @@ subsystem: "Factory"
 }, e.prototype.selectProduction = function(e, t, r) {
 var o, n, s, c, u, l = [];
 try {
-for (var m = a(Object.entries(Ds)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(Object.entries(Fs)), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1], v = f, g = !0, h = 0;
 try {
 for (var R = (s = void 0, a(Object.entries(y))), E = R.next(); !E.done; E = R.next()) {
@@ -17418,7 +17422,7 @@ if (s) throw s.error;
 if (g) {
 var b = t.store.getUsedCapacity(v) + r.store.getUsedCapacity(v);
 if (!(b > this.config.outputBufferAmount)) {
-var O = null !== (u = Bs[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
+var O = null !== (u = Ws[v]) && void 0 !== u ? u : 1, k = O * h * (1 - b / this.config.outputBufferAmount);
 l.push({
 commodity: v,
 priority: O,
@@ -17446,7 +17450,7 @@ var r, o, n = t.storage;
 if (!n) return [];
 var s = this.selectProduction(t, e, n);
 if (!s) return [];
-var c = Ds[s];
+var c = Fs[s];
 if (!c) return [];
 var u = [];
 try {
@@ -17472,7 +17476,7 @@ return u;
 }, e.prototype.hasOutputsToRemove = function(e) {
 var t, r;
 try {
-for (var o = a(Object.keys(Ds)), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(Object.keys(Fs)), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 if (e.store.getUsedCapacity(i) > 0) return !0;
 }
@@ -17504,7 +17508,7 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), Ws = new Fs, Hs = {
+}(), Ks = new Hs, Ys = {
 updateInterval: 500,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -17516,7 +17520,7 @@ opportunityConfidenceThreshold: .7
 !function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.supplyDemandCache = new Map, this.opportunities = [],
-this.config = o(o({}, Hs), e);
+this.config = o(o({}, Ys), e);
 }
 e.prototype.run = function() {
 var e, t, r = Game.cpu.getUsed();
@@ -17681,14 +17685,14 @@ cpuBudget: .02
 }) ], e.prototype, "run", null), e = n([ $e() ], e);
 }();
 
-var Ks, Ys = 5e4;
+var Vs, qs = 5e4;
 
-function Vs(e) {
+function js(e) {
 var t;
 return null !== (t = null == e ? void 0 : e.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== t ? t : 0;
 }
 
-var qs = {
+var zs = {
 updateInterval: 500,
 minGhodium: 5e3,
 minEnergy: 3e5,
@@ -17700,35 +17704,35 @@ donorRoomBuffer: 1e3,
 salvoSyncWindow: 10,
 roiThreshold: 2,
 counterNukeWarThreshold: 60
-}, js = 1e7, zs = 5e6, Qs = ((Ks = {})[STRUCTURE_SPAWN] = 15e3, Ks[STRUCTURE_TOWER] = 5e3,
-Ks[STRUCTURE_STORAGE] = 3e4, Ks[STRUCTURE_TERMINAL] = 1e5, Ks[STRUCTURE_LAB] = 5e4,
-Ks[STRUCTURE_NUKER] = 1e5, Ks[STRUCTURE_POWER_SPAWN] = 1e5, Ks[STRUCTURE_OBSERVER] = 8e3,
-Ks[STRUCTURE_EXTENSION] = 3e3, Ks[STRUCTURE_LINK] = 5e3, Ks), Xs = new Map, Zs = -1, Js = new WeakMap;
+}, Qs = 1e7, Xs = 5e6, Zs = ((Vs = {})[STRUCTURE_SPAWN] = 15e3, Vs[STRUCTURE_TOWER] = 5e3,
+Vs[STRUCTURE_STORAGE] = 3e4, Vs[STRUCTURE_TERMINAL] = 1e5, Vs[STRUCTURE_LAB] = 5e4,
+Vs[STRUCTURE_NUKER] = 1e5, Vs[STRUCTURE_POWER_SPAWN] = 1e5, Vs[STRUCTURE_OBSERVER] = 8e3,
+Vs[STRUCTURE_EXTENSION] = 3e3, Vs[STRUCTURE_LINK] = 5e3, Vs), Js = new Map, $s = -1, ec = new WeakMap;
 
-function $s(e) {
+function tc(e) {
 var t = "undefined" != typeof Game && Number.isFinite(Game.time) ? Game.time : -1;
-t !== Zs && (Xs.clear(), Zs = t);
-var r = Xs.get(e.name);
+t !== $s && (Js.clear(), $s = t);
+var r = Js.get(e.name);
 if ((null == r ? void 0 : r.room) === e && r.tick === t) return r.nukes;
 var o = e.find(FIND_NUKES);
-return Xs.set(e.name, {
+return Js.set(e.name, {
 room: e,
 tick: t,
 nukes: o
 }), o;
 }
 
-function ec(e, t, r, o) {
+function rc(e, t, r, o) {
 var n;
 if (!function(e, t) {
-var r = Js.get(e);
+var r = ec.get(e);
 return (null == r ? void 0 : r.get(t)) === Game.time;
 }(e, t.name)) {
 !function(e, t) {
-var r = Js.get(e);
-r || (r = new Map, Js.set(e, r)), r.set(t, Game.time);
+var r = ec.get(e);
+r || (r = new Map, ec.set(e, r)), r.set(t, Game.time);
 }(e, t.name);
-var i = null != o ? o : $s(t);
+var i = null != o ? o : tc(t);
 if (i.length > 0) {
 var s = null !== (n = e.incomingNukes) && void 0 !== n ? n : e.incomingNukes = [], c = new Map, u = function(e) {
 var r = "".concat(t.name, ":").concat(e.pos.x, ":").concat(e.pos.y), o = c.get(r);
@@ -17739,7 +17743,7 @@ try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value.structure, l = Math.abs(u.pos.x - t.x), m = Math.abs(u.pos.y - t.y), d = Math.max(l, m);
 if (d <= 2) {
-var p = 0 === d ? js : zs;
+var p = 0 === d ? Qs : Xs;
 u.hits <= p && n.push("".concat(u.structureType, "-").concat(u.pos.x, ",").concat(u.pos.y));
 }
 }
@@ -17802,7 +17806,7 @@ subsystem: "Nuke"
 }
 }
 
-function tc(e, t) {
+function oc(e, t) {
 var r = {
 empire: t
 };
@@ -17814,18 +17818,18 @@ return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 });
 }
 
-function rc(e, t) {
+function nc(e, t) {
 var r, o, n;
 if (!e) return !1;
 var a = null === (r = t.knownRooms) || void 0 === r ? void 0 : r[e], i = Game.rooms[e], s = null == i ? void 0 : i.controller, c = {
 empire: t
 };
 return j(e, c) || j(null == a ? void 0 : a.owner, c) || j(null == a ? void 0 : a.reserver, c) || j(null === (o = null == s ? void 0 : s.owner) || void 0 === o ? void 0 : o.username, c) || j(null === (n = null == s ? void 0 : s.reservation) || void 0 === n ? void 0 : n.username, c) || !!i && function(e, t) {
-return tc(e.find(FIND_CREEPS), t) || tc(e.find(FIND_POWER_CREEPS), t) || tc(e.find(FIND_STRUCTURES), t) || tc(e.find(FIND_CONSTRUCTION_SITES), t);
+return oc(e.find(FIND_CREEPS), t) || oc(e.find(FIND_POWER_CREEPS), t) || oc(e.find(FIND_STRUCTURES), t) || oc(e.find(FIND_CONSTRUCTION_SITES), t);
 }(i, t);
 }
 
-function oc() {
+function ac() {
 var e, t = 0, r = 0;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
@@ -17835,14 +17839,14 @@ n.terminal && (t += n.terminal.store.getUsedCapacity(RESOURCE_ENERGY) || 0, r +=
 return t >= 6e5 && r >= 1e4;
 }
 
-function nc(e, t, r, o) {
+function ic(e, t, r, o) {
 var n = 0, a = [], c = t.knownRooms[e];
 if (!c) return {
 roomName: e,
 score: 0,
 reasons: [ "No intel" ]
 };
-if (rc(e, t)) return {
+if (nc(e, t)) return {
 roomName: e,
 score: 0,
 reasons: [ "Allied room" ]
@@ -17869,7 +17873,7 @@ return Game.map.getRoomLinearDistance(e, t.name);
 n -= 2 * d, a.push("".concat(d, " rooms away"));
 }
 t.warTargets.includes(e) && (n += 15, a.push("War target"));
-var p = new RoomPosition(25, 25, e), f = ic(e, p, t);
+var p = new RoomPosition(25, 25, e), f = cc(e, p, t);
 return f >= r.roiThreshold ? (n += Math.min(20, Math.floor(5 * f)), a.push("ROI: ".concat(f.toFixed(1), "x"))) : (n -= 20,
 a.push("Low ROI: ".concat(f.toFixed(1), "x"))), {
 roomName: e,
@@ -17878,7 +17882,7 @@ reasons: a
 };
 }
 
-function ac(e, t, r) {
+function sc(e, t, r) {
 var o, n, i = {
 estimatedDamage: 0,
 estimatedValue: 0,
@@ -17888,16 +17892,16 @@ if (!s) {
 var c = r.knownRooms[e];
 if (c) {
 var u = 5 * (c.towerCount || 0) + 10 * (c.spawnCount || 0) + 5;
-i.estimatedDamage = js + zs * u, i.estimatedValue = .01 * i.estimatedDamage;
+i.estimatedDamage = Qs + Xs * u, i.estimatedValue = .01 * i.estimatedDamage;
 }
 return i;
 }
 var l = s.lookForAtArea(LOOK_STRUCTURES, Math.max(0, t.y - 2), Math.max(0, t.x - 2), Math.min(49, t.y + 2), Math.min(49, t.x + 2), !0);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
-var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? js : zs;
+var p = d.value.structure, f = Math.abs(p.pos.x - t.x), y = Math.abs(p.pos.y - t.y), v = 0 === Math.max(f, y) ? Qs : Xs;
 p.hits <= v ? (i.estimatedDamage += p.hits, i.threatenedStructures.push("".concat(p.structureType, "-").concat(p.pos.x, ",").concat(p.pos.y)),
-i.estimatedValue += sc(p)) : i.estimatedDamage += v;
+i.estimatedValue += uc(p)) : i.estimatedDamage += v;
 }
 } catch (e) {
 o = {
@@ -17913,16 +17917,16 @@ if (o) throw o.error;
 return i;
 }
 
-function ic(e, t, r) {
-var o = ac(e, t, r);
+function cc(e, t, r) {
+var o = sc(e, t, r);
 return 0 === o.estimatedValue ? 0 : o.estimatedValue / 305e3;
 }
 
-function sc(e) {
-return Qs[e.structureType] || 1e3;
+function uc(e) {
+return Zs[e.structureType] || 1e3;
 }
 
-function cc(e) {
+function lc(e) {
 if (e.nukesInFlight && (e.nukesInFlight = e.nukesInFlight.filter(function(e) {
 return e.impactTick > Game.time;
 })), e.incomingNukes) {
@@ -17937,7 +17941,7 @@ subsystem: "Nuke"
 }
 }
 
-function uc(e, t) {
+function mc(e, t) {
 var r, o, n;
 if (e.siegeSquadId) {
 try {
@@ -17965,7 +17969,7 @@ delete e.siegeSquadId;
 }
 }
 
-function lc(e, t, r) {
+function dc(e, t, r) {
 var o, n, i, s = null;
 try {
 for (var c = a(Object.values(t)), u = c.next(); !u.done; u = c.next()) {
@@ -18015,9 +18019,9 @@ subsystem: "Nuke"
 }), !0;
 }
 
-var mc = function() {
+var pc = function() {
 function e(e, t) {
-void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, qs), e),
+void 0 === e && (e = {}), this.nukerReadyLogged = new Set, this.config = o(o({}, zs), e),
 this.getEmpire = t.getEmpire, this.getSwarmState = t.getSwarmState, this.getClusters = t.getClusters;
 }
 return e.prototype.run = function(e) {
@@ -18041,13 +18045,13 @@ for (var o in Game.rooms) {
 var n = Game.rooms[o];
 if (null === (r = n.controller) || void 0 === r ? void 0 : r.my) {
 var a = t(o);
-a && ec(e, n, a);
+a && rc(e, n, a);
 }
 }
 }(r, this.getSwarmState), this.recordCpu("defensiveObservationCpu", n), o) {
 var a = this.getCpuUsed();
 this.runOffensiveCoordination(r), this.recordCpu("offensiveCoordinationCpu", a);
-} else cc(r);
+} else lc(r);
 }, e.prototype.runOffensiveCoordination = function(e) {
 var t = this;
 !function(e, t, r, o) {
@@ -18057,7 +18061,7 @@ for (var c = a(e.incomingNukes), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
 if (l.sourceRoom && !e.warTargets.includes(l.sourceRoom)) {
 var m = e.knownRooms[l.sourceRoom];
-if (m) if (rc(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
+if (m) if (nc(l.sourceRoom, e)) U.warn("Ignoring allied nuke source ".concat(l.sourceRoom, "; no counter-nuke target will be created"), {
 subsystem: "Nuke"
 }); else if (!(m.controllerLevel < 8)) {
 var d = r(l.roomName);
@@ -18086,7 +18090,7 @@ u && !u.done && (i = c.return) && i.call(c);
 if (n) throw n.error;
 }
 }
-}(e, this.config, this.getSwarmState, oc), function(e, t, r, o) {
+}(e, this.config, this.getSwarmState, ac), function(e, t, r, o) {
 var n, a;
 if (e.objectives.warMode) for (var i in Game.rooms) {
 var s = Game.rooms[i];
@@ -18138,10 +18142,10 @@ if (e.nukeCandidates = [], e.objectives.warMode) {
 try {
 for (var i = a(e.warTargets), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-if (rc(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
+if (nc(c, e)) U.warn("Skipping allied nuke target candidate: ".concat(c), {
 subsystem: "Nuke"
 }); else {
-var u = nc(c, e, t, r);
+var u = ic(c, e, t, r);
 u.score >= t.minScore && (e.nukeCandidates.push({
 roomName: c,
 score: u.score,
@@ -18185,11 +18189,11 @@ var d = r();
 try {
 for (var p = a(e.nukesInFlight), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (rc(y.targetRoom, e)) uc(y, d), U.warn("Skipping siege coordination for allied nuke target ".concat(y.targetRoom), {
+if (nc(y.targetRoom, e)) mc(y, d), U.warn("Skipping siege coordination for allied nuke target ".concat(y.targetRoom), {
 subsystem: "Nuke"
 }); else {
 var v = y.impactTick - Game.time;
-y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && lc(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
+y.siegeSquadId || v <= t.siegeCoordinationWindow && v > 0 && dc(y, d, o) && U.info("Siege squad deployment coordinated with nuke on ".concat(y.targetRoom, ", ") + "impact in ".concat(v, " ticks"), {
 subsystem: "Nuke"
 });
 }
@@ -18218,7 +18222,7 @@ if (!r) return "continue";
 var o = null === (m = e.nukesInFlight) || void 0 === m ? void 0 : m.find(function(e) {
 return e.targetRoom === r;
 });
-if (rc(r, e)) return (null == o ? void 0 : o.siegeSquadId) === t.id && (delete o.siegeSquadId,
+if (nc(r, e)) return (null == o ? void 0 : o.siegeSquadId) === t.id && (delete o.siegeSquadId,
 t.state = "dissolving"), "continue";
 o && !o.siegeSquadId && (o.siegeSquadId = t.id, U.info("Linked siege squad ".concat(t.id, " with nuke on ").concat(r), {
 subsystem: "Nuke"
@@ -18328,14 +18332,14 @@ return e.structureType === STRUCTURE_NUKER;
 if (0 !== c.length) try {
 for (var m = a(e.nukeCandidates), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!p.launched) if (rc(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
+if (!p.launched) if (nc(p.roomName, e)) U.warn("Skipping nuke launch on allied candidate: ".concat(p.roomName), {
 subsystem: "Nuke"
 }); else {
 try {
 for (var f = (n = void 0, a(c)), y = f.next(); !y.done; y = f.next()) {
 var v = y.value;
 if (!(Game.map.getRoomLinearDistance(v.room.name, p.roomName) > 10)) {
-var g = new RoomPosition(25, 25, p.roomName), h = ac(p.roomName, g, e), R = ic(p.roomName, g, e);
+var g = new RoomPosition(25, 25, p.roomName), h = sc(p.roomName, g, e), R = cc(p.roomName, g, e);
 if (R < t.roiThreshold) U.warn("Skipping nuke launch on ".concat(p.roomName, ": ROI ").concat(R.toFixed(2), "x below threshold ").concat(t.roiThreshold, "x"), {
 subsystem: "Nuke"
 }); else {
@@ -18402,7 +18406,7 @@ if (r) throw r.error;
 }
 }
 }
-}(e, this.config), cc(e);
+}(e, this.config), lc(e);
 }, e.prototype.getCpuUsed = function() {
 var e;
 return "undefined" != typeof Game && "function" == typeof (null === (e = Game.cpu) || void 0 === e ? void 0 : e.getUsed) ? Game.cpu.getUsed() : void 0;
@@ -18444,13 +18448,13 @@ subsystem: "Nuke"
 }) : U.debug("No donor room found for ".concat(r, " ").concat(t, " to ").concat(e), {
 subsystem: "Nuke"
 });
-}(e, t, r, this.config, Gs);
+}(e, t, r, this.config, Ds);
 }, e.prototype.getConfig = function() {
 return o({}, this.config);
 }, e.prototype.updateConfig = function(e) {
 this.config = o(o({}, this.config), e);
 }, e;
-}(), dc = [ {
+}(), fc = [ {
 carryParts: 4,
 capacity: 200,
 moveParts: 4,
@@ -18472,7 +18476,7 @@ moveParts: 24,
 cost: 2400
 } ];
 
-function pc(e, t, r, o, n) {
+function yc(e, t, r, o, n) {
 var i, s;
 void 0 === n && (n = {});
 var c = n.reserved, u = void 0 !== c && c, l = n.pathLength, m = n.terrainFactor, d = void 0 === m ? 1.2 : m, p = n.safetyBuffer, f = void 0 === p ? 1.2 : p, y = function(e, t) {
@@ -18495,9 +18499,9 @@ var r = 50 * e * t;
 return Math.ceil(2 * r);
 }(y, d), g = function(e, t) {
 return e * (t ? 3e3 : 1500) / 300;
-}(r, u), h = dc[0];
+}(r, u), h = fc[0];
 try {
-for (var R = a(dc), E = R.next(); !E.done; E = R.next()) {
+for (var R = a(fc), E = R.next(); !E.done; E = R.next()) {
 var T = E.value;
 if (!(T.cost <= o)) break;
 h = T;
@@ -18526,7 +18530,7 @@ energyPerTick: g
 };
 }
 
-function fc(e) {
+function vc(e) {
 var t;
 return e ? null !== (t = {
 X: 15,
@@ -18539,12 +18543,12 @@ H: 8
 }[e]) && void 0 !== t ? t : 5 : 0;
 }
 
-function yc(e) {
-var t, r, o = wr.getEmpire(), n = 0, i = Tc(e);
+function gc(e) {
+var t, r, o = wr.getEmpire(), n = 0, i = Sc(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-l && (l.owner && !Cc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
+l && (l.owner && !wc(l.owner) && (n += 30), l.threatLevel >= 2 && (n += 10 * l.threatLevel),
 l.towerCount && l.towerCount > 0 && (n += 5 * l.towerCount));
 }
 } catch (e) {
@@ -18561,12 +18565,12 @@ if (t) throw t.error;
 return n;
 }
 
-function vc(e) {
+function hc(e) {
 return "plains" === e ? 15 : "swamp" === e ? -10 : 0;
 }
 
-function gc(e) {
-var t, r, o = Tc(e);
+function Rc(e) {
+var t, r, o = Sc(e);
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) if (ne(i.value)) return !0;
 } catch (e) {
@@ -18583,7 +18587,7 @@ if (t) throw t.error;
 return !1;
 }
 
-function hc(e) {
+function Ec(e) {
 var t = wr.getEmpire(), r = t.knownRooms[e];
 if (null == r ? void 0 : r.hasPortal) return 20;
 var o = function(e, t) {
@@ -18601,34 +18605,34 @@ return null === r || r > 3 ? null : r;
 return null === o ? 0 : o <= 1 ? 10 : o <= 2 ? 6 : o <= 3 ? 3 : 0;
 }
 
-function Rc(e, t) {
+function Tc(e, t) {
 var r = e < 0 ? "W" : "E", o = t < 0 ? "N" : "S", n = Math.abs(e) - (e < 0 ? 1 : 0), a = Math.abs(t) - (t < 0 ? 1 : 0);
 return "".concat(r).concat(n).concat(o).concat(a);
 }
 
-function Ec(e, t, r) {
+function Cc(e, t, r) {
 return 0 === t.length ? 0 : r <= 2 ? 25 : r <= 3 ? 15 : r <= 5 ? 5 : 0;
 }
 
-function Tc(e) {
+function Sc(e) {
 var t = ee(e);
 if (!t) return [];
-for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(Rc(r + a, o + i));
+for (var r = t.x, o = t.y, n = [], a = -1; a <= 1; a++) for (var i = -1; i <= 1; i++) 0 === a && 0 === i || n.push(Tc(r + a, o + i));
 return n;
 }
 
-function Cc(e) {
+function wc(e) {
 return j(e, {
 empire: wr.getEmpire()
 });
 }
 
-function Sc(e, t, r, o) {
+function xc(e, t, r, o) {
 var n, a = Game.map.getRoomLinearDistance(t, e);
 if (!Number.isFinite(a) || a <= 0) throw new Error("calculateRemoteProfitability: invalid distance ".concat(a, " between ").concat(t, " and ").concat(e));
 if (r.sources <= 0) throw new Error("calculateRemoteProfitability: intel.sources must be positive, got ".concat(r.sources, " for ").concat(e));
 if (void 0 !== r.threatLevel && null !== r.threatLevel && (r.threatLevel < 0 || r.threatLevel > 3)) throw new Error("calculateRemoteProfitability: intel.threatLevel must be in [0, 3], got ".concat(r.threatLevel, " for ").concat(e));
-var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = pc(t, e, r.sources, 800, {
+var i, s, c, u, l, m = Boolean(r.reserver), d = (m ? 3e3 : 1500) / 300 * r.sources, p = yc(t, e, r.sources, 800, {
 reserved: m
 }), f = (650 * r.sources + p.haulerConfig.cost * p.recommendedHaulers) / 1500, y = 5e3 * r.sources + 50 * a * 300, v = y / 5e4, g = d * (null !== (n = [ 0, .1, .3, .6 ][r.threatLevel]) && void 0 !== n ? n : 0), h = d - f - v - g, R = f + v, E = R > 0 ? h / R : 0;
 return {
@@ -18652,9 +18656,9 @@ isProfitable: E > 2 && h > 0
 };
 }
 
-var wc = Mr().cpu.bucketThresholds.highMode + 1e3, xc = {
+var bc = Mr().cpu.bucketThresholds.highMode + 1e3, Oc = {
 updateInterval: 500,
-minBucket: wc,
+minBucket: bc,
 maxRemoteDistance: 2,
 maxRemotesPerRoom: 5,
 minRemoteSources: 1,
@@ -18663,10 +18667,10 @@ minRclForClaiming: 1,
 minGclProgressForClaim: 0,
 clusterExpansionDistance: 5,
 minStableRoomPercentage: 0
-}, bc = function() {
+}, kc = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.cachedUsername = "", this.usernameLastTick = 0,
-this.config = o(o({}, xc), e);
+this.config = o(o({}, Oc), e);
 }
 return e.prototype.run = function() {
 var e = wr.getEmpire();
@@ -18748,7 +18752,7 @@ s > o.config.maxRemoteDistance && (U.info("Removing remote ".concat(e, " - too f
 subsystem: "Expansion"
 }), a = "unreachable");
 }
-return !a || (Gi.emit("remote.lost", {
+return !a || (Di.emit("remote.lost", {
 homeRoom: r,
 remoteRoom: e,
 reason: a,
@@ -18761,7 +18765,7 @@ for (var i in t.knownRooms) if (!r.includes(i) && !this.isRemoteAssignedElsewher
 var s = t.knownRooms[i], c = Game.map.getRoomLinearDistance(e, i);
 if ((s.scouted || !(c > 1)) && !s.owner && !(s.reserver && s.reserver !== a || s.isHighway || s.isSK || s.threatLevel >= 2 || c < 1 || c > this.config.maxRemoteDistance)) if (s.scouted) {
 if (!(s.sources < this.config.minRemoteSources)) {
-var u = Sc(i, e, s);
+var u = xc(i, e, s);
 if (u.isProfitable) {
 var l = this.scoreRemoteCandidate(s, c);
 n.push({
@@ -18793,10 +18797,10 @@ return r += 50 * e.sources, r -= 20 * t, r -= 30 * e.threatLevel, "plains" === e
 r;
 }, e.prototype.scoreClaimCandidate = function(e, t, r) {
 var o = 0;
-return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += fc(e.mineralType),
-o -= 5 * t, o -= yc(e.name), o -= 15 * e.threatLevel, o += vc(e.terrain), gc(e.name) && (o += 10),
-o += hc(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
-o + Ec(e.name, r, t);
+return 2 === e.sources ? o += 40 : 1 === e.sources && (o += 20), o += vc(e.mineralType),
+o -= 5 * t, o -= gc(e.name), o -= 15 * e.threatLevel, o += hc(e.terrain), Rc(e.name) && (o += 10),
+o += Ec(e.name), e.controllerLevel > 0 && !e.owner && (o += 2 * e.controllerLevel),
+o + Cc(e.name, r, t);
 }, e.prototype.isRemoteAssignedElsewhere = function(e, t) {
 var r, o, n, i = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -19144,13 +19148,13 @@ return this.cachedUsername;
 var r, o, n = [], i = function(e) {
 var t = [], r = ee(e);
 if (!r) return [];
-for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(Rc(o + a, n + i));
+for (var o = r.x, n = r.y, a = -2; a <= 2; a++) for (var i = -2; i <= 2; i++) 0 === a && 0 === i || t.push(Tc(o + a, n + i));
 return t;
 }(e);
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = t.knownRooms[u];
-l && (l.owner && !Cc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
+l && (l.owner && !wc(l.owner) && n.push("Hostile player ".concat(l.owner, " in ").concat(u)),
 l.towerCount && l.towerCount > 0 && n.push("".concat(l.towerCount, " towers in ").concat(u)),
 l.spawnCount && l.spawnCount > 0 && n.push("".concat(l.spawnCount, " spawns in ").concat(u)),
 l.threatLevel >= 2 && n.push("Threat level ".concat(l.threatLevel, " in ").concat(u)));
@@ -19167,11 +19171,11 @@ if (r) throw r.error;
 }
 }
 return function(e) {
-var t, r, o = wr.getEmpire(), n = Tc(e), i = new Set;
+var t, r, o = wr.getEmpire(), n = Sc(e), i = new Set;
 try {
 for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = o.knownRooms[u];
-(null == l ? void 0 : l.owner) && !Cc(l.owner) && i.add(l.owner);
+(null == l ? void 0 : l.owner) && !wc(l.owner) && i.add(l.owner);
 }
 } catch (e) {
 t = {
@@ -19286,10 +19290,10 @@ subsystem: "Expansion"
 }, n([ Xe("expansion:manager", "Expansion Manager", {
 priority: Ie.LOW,
 interval: 500,
-minBucket: wc,
+minBucket: bc,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), Oc = new bc, kc = function() {
+}(), Mc = new kc, Ac = function() {
 function e() {}
 return e.prototype.status = function() {
 var e, t, r, o, n, i, s, c, u, l, m = wr.getEmpire(), d = Object.values(Game.rooms).filter(function(e) {
@@ -19381,9 +19385,9 @@ return wr.getEmpire().objectives.expansionPaused = !0, "Expansion paused. Use ex
 }, e.prototype.resume = function() {
 return wr.getEmpire().objectives.expansionPaused = !1, "Expansion resumed.";
 }, e.prototype.addRemote = function(e, t) {
-return Oc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
+return Mc.addRemoteRoom(e, t) ? "Added remote ".concat(t, " to ").concat(e) : "Failed to add remote (check logs for details)";
 }, e.prototype.removeRemote = function(e, t) {
-return Oc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
+return Mc.removeRemoteRoom(e, t) ? "Removed remote ".concat(t, " from ").concat(e) : "Remote ".concat(t, " not found in ").concat(e);
 }, e.prototype.clearQueue = function() {
 var e = wr.getEmpire(), t = e.claimQueue.length;
 return e.claimQueue = [], "Cleared ".concat(t, " candidates from claim queue. Queue will repopulate on next empire tick.");
@@ -19424,21 +19428,21 @@ usage: "expansion.clearQueue()",
 examples: [ "expansion.clearQueue()" ],
 category: "Empire"
 }) ], e.prototype, "clearQueue", null), e;
-}(), Mc = new kc;
+}(), Uc = new Ac;
 
-function Ac(e) {
+function _c(e) {
 return function(e) {
 return "string" == typeof e && e.trimStart().startsWith("{");
 }(e) ? e.trim() : null;
 }
 
-function Uc(e) {
+function Nc(e) {
 var t;
 if (!e.controller) return null;
 var r = e.controller;
 if ("TooAngel" !== (null === (t = r.sign) || void 0 === t ? void 0 : t.username)) return null;
 var o = function(e) {
-var t = Ac(e);
+var t = _c(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19456,12 +19460,12 @@ availableQuests: [ o.id ]
 };
 }
 
-function _c() {
+function Pc() {
 var e;
 return (null === (e = Memory.tooangel) || void 0 === e ? void 0 : e.npcRooms) || {};
 }
 
-function Nc(e) {
+function Ic(e) {
 var t = Memory;
 t.tooangel || (t.tooangel = {}), t.tooangel.npcRooms || (t.tooangel.npcRooms = {});
 var r = t.tooangel.npcRooms[e.roomName];
@@ -19472,7 +19476,7 @@ e.availableQuests = Array.from(o);
 t.tooangel.npcRooms[e.roomName] = e;
 }
 
-function Pc() {
+function Gc() {
 var e = Memory;
 return e.tooangel || (e.tooangel = {
 enabled: !0,
@@ -19494,14 +19498,14 @@ Array.isArray(e.tooangel.recentTransactionIds) || (e.tooangel.recentTransactionI
 e.tooangel;
 }
 
-var Ic = [ "applied", "active" ];
+var Lc = [ "applied", "active" ];
 
-function Gc(e) {
+function Dc(e) {
 var t, r;
 return e.transactionId ? e.transactionId : [ e.time, null !== (r = null === (t = e.sender) || void 0 === t ? void 0 : t.username) && void 0 !== r ? r : "unknown", e.from, e.to, e.description ].join("|");
 }
 
-function Lc(e, t) {
+function Bc(e, t) {
 return !!function(e, t) {
 if (e.sender) return "TooAngel" === e.sender.username;
 var r = function(e) {
@@ -19509,7 +19513,7 @@ var t, r, o = new Set(Object.keys(e.npcRooms || {}));
 try {
 for (var n = a(Object.values(e.activeQuests || {})), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Ic.includes(s.status) && s.originRoom && o.add(s.originRoom);
+Lc.includes(s.status) && s.originRoom && o.add(s.originRoom);
 }
 } catch (e) {
 t = {
@@ -19523,25 +19527,25 @@ if (t) throw t.error;
 }
 }
 return o;
-}(Pc());
+}(Gc());
 return !!r.has(e.from) && (void 0 === t || r.has(t));
 }(e, t) && !function(e) {
-return Pc().recentTransactionIds.includes(Gc(e));
+return Gc().recentTransactionIds.includes(Dc(e));
 }(e) && (function(e) {
-var t = Pc(), r = Gc(e);
+var t = Gc(), r = Dc(e);
 t.recentTransactionIds.includes(r) || (t.recentTransactionIds.push(r), t.recentTransactionIds.length > 100 && t.recentTransactionIds.splice(0, t.recentTransactionIds.length - 100));
 }(e), !0);
 }
 
-var Dc = {
+var Fc = {
 MAX_ACTIVE_QUESTS: 3,
 MIN_APPLICATION_ENERGY: 100,
 DEADLINE_BUFFER: 500,
 SUPPORTED_TYPES: [ "buildcs" ]
 };
 
-function Bc(e) {
-var t = Ac(e);
+function Wc(e) {
+var t = _c(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19552,24 +19556,24 @@ subsystem: "TooAngel"
 return null;
 }
 
-function Fc() {
-return Pc().activeQuests || {};
+function Hc() {
+return Gc().activeQuests || {};
 }
 
-function Wc() {
-var e = Fc();
+function Kc() {
+var e = Hc();
 return Object.values(e).filter(function(e) {
 return "active" === e.status || "applied" === e.status;
-}).length < Dc.MAX_ACTIVE_QUESTS;
+}).length < Fc.MAX_ACTIVE_QUESTS;
 }
 
-function Hc(e) {
-return Dc.SUPPORTED_TYPES.includes(e);
+function Yc(e) {
+return Fc.SUPPORTED_TYPES.includes(e);
 }
 
-function Kc(e, t, r) {
+function Vc(e, t, r) {
 var o, n;
-if (!Wc()) return U.debug("Cannot accept more quests (at max capacity)", {
+if (!Kc()) return U.debug("Cannot accept more quests (at max capacity)", {
 subsystem: "TooAngel"
 }), !1;
 if (r) n = Game.rooms[r]; else {
@@ -19586,17 +19590,17 @@ if (!n || !n.terminal || !n.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var u = n.terminal, l = u.store[RESOURCE_ENERGY];
-if (l < Dc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Dc.MIN_APPLICATION_ENERGY), {
+if (l < Fc.MIN_APPLICATION_ENERGY) return U.warn("Insufficient energy for quest application: ".concat(l, " < ").concat(Fc.MIN_APPLICATION_ENERGY), {
 subsystem: "TooAngel"
 }), !1;
 var m = {
 type: "quest",
 id: e,
 action: "apply"
-}, d = u.send(RESOURCE_ENERGY, Dc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
+}, d = u.send(RESOURCE_ENERGY, Fc.MIN_APPLICATION_ENERGY, t, JSON.stringify(m));
 return d === OK ? (U.info("Applied for quest ".concat(e, " from ").concat(n.name, " to ").concat(t), {
 subsystem: "TooAngel"
-}), Pc().activeQuests[e] = {
+}), Gc().activeQuests[e] = {
 id: e,
 type: "buildcs",
 status: "applied",
@@ -19609,8 +19613,8 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function Yc(e) {
-var t = Pc(), r = t.activeQuests[e.id];
+function qc(e) {
+var t = Gc(), r = t.activeQuests[e.id];
 r ? ("won" === e.result ? (U.info("Quest ".concat(e.id, " completed successfully!"), {
 subsystem: "TooAngel"
 }), r.status = "completed") : (U.warn("Quest ".concat(e.id, " failed"), {
@@ -19620,13 +19624,13 @@ subsystem: "TooAngel"
 });
 }
 
-function Vc() {
+function jc() {
 var e;
-return (null === (e = Pc().reputation) || void 0 === e ? void 0 : e.value) || 0;
+return (null === (e = Gc().reputation) || void 0 === e ? void 0 : e.value) || 0;
 }
 
-function qc(e) {
-var t = Ac(e);
+function zc(e) {
+var t = _c(e);
 if (!t) return null;
 try {
 var r = JSON.parse(t);
@@ -19635,8 +19639,8 @@ if ("reputation" === r.type && "number" == typeof r.reputation) return r.reputat
 return null;
 }
 
-function jc(e) {
-var t, r, o, n = Pc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
+function Qc(e) {
+var t, r, o, n = Gc(), a = (null === (t = n.reputation) || void 0 === t ? void 0 : t.lastRequestedAt) || 0;
 if (Game.time - a < 1e3) return U.debug("Reputation request on cooldown (".concat(1e3 - (Game.time - a), " ticks remaining)"), {
 subsystem: "TooAngel"
 }), !1;
@@ -19651,7 +19655,7 @@ if (!o || !o.terminal || !o.terminal.my) return U.warn("No terminal available to
 subsystem: "TooAngel"
 }), !1;
 var c = function(e) {
-var t = _c(), r = null, o = 1 / 0;
+var t = Pc(), r = null, o = 1 / 0;
 for (var n in t) {
 var a = Game.map.getRoomLinearDistance(e, n);
 a < o && (o = a, r = t[n]);
@@ -19675,7 +19679,7 @@ subsystem: "TooAngel"
 }), !1);
 }
 
-function zc(e) {
+function Xc(e) {
 var t, r, o = Game.rooms[e.targetRoom];
 if (o) {
 var n = o.find(FIND_CONSTRUCTION_SITES);
@@ -19765,7 +19769,7 @@ l.notifyComplete && (U.info("Quest ".concat(e.id, " (buildcs) completed! All con
 subsystem: "TooAngel"
 }), function(e, t) {
 var r, o, n = function(e) {
-return Fc()[e] || null;
+return Hc()[e] || null;
 }(e);
 if (!n) return U.warn("Cannot notify completion for unknown quest: ".concat(e), {
 subsystem: "TooAngel"
@@ -19817,7 +19821,7 @@ subsystem: "TooAngel"
 });
 }
 
-var Qc, Xc, Zc = Mr().cpu.bucketThresholds.highMode + 1e3, Jc = Zc, $c = /^tooangel_error_\d+$/, eu = function() {
+var Zc, Jc, $c = Mr().cpu.bucketThresholds.highMode + 1e3, eu = $c, tu = /^tooangel_error_\d+$/, ru = function() {
 function e() {
 this.lastScanTick = 0, this.lastReputationRequestTick = 0, this.lastQuestDiscoveryTick = 0;
 }
@@ -19835,19 +19839,19 @@ e.tooangel || (e.tooangel = {}), e.tooangel.enabled = !1, U.info("TooAngel integ
 subsystem: "TooAngel"
 });
 }, e.prototype.run = function() {
-if (this.isEnabled() && !(Game.cpu.bucket < Jc)) try {
+if (this.isEnabled() && !(Game.cpu.bucket < eu)) try {
 !function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Pc();
+var r = Gc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
 try {
 if (i.order) continue;
 if (!i.description) continue;
-var s = qc(i.description);
-null !== s && Lc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
+var s = zc(i.description);
+null !== s && Bc(i) && (U.info("Received reputation update from TooAngel: ".concat(s), {
 subsystem: "TooAngel"
 }), r.reputation = {
 value: s,
@@ -19874,7 +19878,7 @@ if (e) throw e.error;
 }(), function() {
 var e, t;
 if (Game.market.incomingTransactions) {
-var r = Pc();
+var r = Gc();
 try {
 for (var o = a(Game.market.incomingTransactions), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
@@ -19882,12 +19886,12 @@ try {
 if (i.time <= r.lastProcessedTick) continue;
 if (i.order) continue;
 if (!i.description) continue;
-var s = Bc(i.description);
-if (s && Lc(i, s.origin)) {
+var s = Wc(i.description);
+if (s && Bc(i, s.origin)) {
 if (U.info("Received quest ".concat(s.id, ": ").concat(s.quest, " in ").concat(s.room, " (deadline: ").concat(s.end, ")"), {
 subsystem: "TooAngel"
 }), s.result) {
-Yc(s);
+qc(s);
 continue;
 }
 var c = r.activeQuests[s.id];
@@ -19901,7 +19905,7 @@ deadline: s.end,
 appliedAt: null == c ? void 0 : c.appliedAt,
 receivedAt: Game.time,
 assignedCreeps: []
-}, Hc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
+}, Yc(s.quest) || (U.warn("Received unsupported quest type: ".concat(s.quest), {
 subsystem: "TooAngel"
 }), r.activeQuests[s.id].status = "failed");
 }
@@ -19938,15 +19942,15 @@ for (var r in t) {
 var o = t[r];
 "active" === o.status && (o.deadline > 0 && Game.time > o.deadline ? (U.warn("Quest ".concat(r, " missed deadline (").concat(o.deadline, ")"), {
 subsystem: "TooAngel"
-}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? zc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
+}), o.status = "failed", o.completedAt = Game.time) : "buildcs" === o.type ? Xc(o) : (U.warn("Unsupported quest type for execution: ".concat(o.type), {
 subsystem: "TooAngel"
 }), o.status = "failed", o.completedAt = Game.time));
 }
 }(), function() {
-var e = Pc().activeQuests || {};
+var e = Gc().activeQuests || {};
 for (var t in e) {
 var r = e[t];
-r.deadline > 0 && Game.time >= r.deadline - Dc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
+r.deadline > 0 && Game.time >= r.deadline - Fc.DEADLINE_BUFFER && ("active" !== r.status && "applied" !== r.status || (U.warn("Quest ".concat(t, " expired (deadline: ").concat(r.deadline, ", current: ").concat(Game.time, ")"), {
 subsystem: "TooAngel"
 }), r.status = "failed", r.completedAt = Game.time)), ("completed" === r.status || "failed" === r.status) && r.completedAt && Game.time - r.completedAt > 1e4 && delete e[t];
 }
@@ -19958,9 +19962,9 @@ var e = String(t);
 (function(e) {
 !function() {
 var e = Memory;
-for (var t in e) $c.test(t) && delete e[t];
+for (var t in e) tu.test(t) && delete e[t];
 }();
-var t = Pc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
+var t = Gc(), r = t.errorThrottle, o = "number" == typeof (null == r ? void 0 : r.lastErrorTick) ? r.lastErrorTick : void 0, n = "number" == typeof (null == r ? void 0 : r.count) ? r.count : 0, a = void 0 === o ? Number.POSITIVE_INFINITY : Game.time - o, i = void 0 === o || a < 0 || a >= 100;
 return t.errorThrottle = {
 lastErrorTick: i ? Game.time : o,
 count: i ? 1 : n + 1,
@@ -19974,7 +19978,7 @@ subsystem: "TooAngel"
 var e, t, r = function() {
 var e = [];
 for (var t in Game.rooms) {
-var r = Uc(Game.rooms[t]);
+var r = Nc(Game.rooms[t]);
 r && (U.info("Detected TooAngel NPC room: ".concat(t), {
 subsystem: "TooAngel"
 }), e.push(r));
@@ -19982,7 +19986,7 @@ subsystem: "TooAngel"
 return e;
 }();
 try {
-for (var o = a(r), n = o.next(); !n.done; n = o.next()) Nc(n.value);
+for (var o = a(r), n = o.next(); !n.done; n = o.next()) Ic(n.value);
 } catch (t) {
 e = {
 error: t
@@ -19998,12 +20002,12 @@ r.length > 0 && U.info("Scanned ".concat(r.length, " TooAngel NPC rooms"), {
 subsystem: "TooAngel"
 });
 }, e.prototype.updateReputation = function() {
-jc();
+Qc();
 }, e.prototype.discoverQuests = function() {
 !function() {
 var e, t;
-if (Wc()) {
-var r = _c(), o = Fc();
+if (Kc()) {
+var r = Pc(), o = Hc();
 for (var n in r) {
 var i = r[n];
 try {
@@ -20011,7 +20015,7 @@ for (var s = (e = void 0, a(i.availableQuests)), c = s.next(); !c.done; c = s.ne
 var u = c.value;
 if (!o[u]) return U.info("Auto-applying for quest ".concat(u, " from ").concat(n), {
 subsystem: "TooAngel"
-}), void Kc(u, n);
+}), void Vc(u, n);
 }
 } catch (t) {
 e = {
@@ -20028,11 +20032,11 @@ if (e) throw e.error;
 }
 }();
 }, e.prototype.getReputation = function() {
-return Vc();
+return jc();
 }, e.prototype.getActiveQuests = function() {
-return Fc();
+return Hc();
 }, e.prototype.applyForQuest = function(e, t, r) {
-return Kc(e, t, r);
+return Vc(e, t, r);
 }, e.prototype.getStatus = function() {
 var e = this.getReputation(), t = this.getActiveQuests(), r = Object.values(t).filter(function(e) {
 return "active" === e.status;
@@ -20049,27 +20053,27 @@ return n.join("\n");
 }, n([ Ze("empire:tooangel", "TooAngel Manager", {
 priority: Ie.LOW,
 interval: 100,
-minBucket: Zc
+minBucket: $c
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), tu = new eu, ru = {
+}(), ou = new ru, nu = {
 status: function() {
-return tu.getStatus();
+return ou.getStatus();
 },
 enable: function() {
-return tu.enable(), "TooAngel integration enabled";
+return ou.enable(), "TooAngel integration enabled";
 },
 disable: function() {
-return tu.disable(), "TooAngel integration disabled";
+return ou.disable(), "TooAngel integration disabled";
 },
 reputation: function() {
-var e = Vc();
+var e = jc();
 return "Current TooAngel reputation: ".concat(e);
 },
 requestReputation: function(e) {
-return jc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
+return Qc(e) ? "Reputation request sent".concat(e ? " from ".concat(e) : "") : "Failed to send reputation request (check logs for details)";
 },
 quests: function() {
-var e, t = Fc(), r = [ "Active Quests:" ];
+var e, t = Hc(), r = [ "Active Quests:" ];
 if (0 === Object.keys(t).length) r.push("  No active quests"); else for (var o in t) {
 var n = t[o], a = n.deadline - Game.time, i = (null === (e = n.assignedCreeps) || void 0 === e ? void 0 : e.length) || 0;
 r.push("  ".concat(o, ":")), r.push("    Type: ".concat(n.type)), r.push("    Target: ".concat(n.targetRoom)),
@@ -20079,7 +20083,7 @@ r.push("    Assigned creeps: ".concat(i));
 return r.join("\n");
 },
 npcs: function() {
-var e = _c(), t = [ "TooAngel NPC Rooms:" ];
+var e = Pc(), t = [ "TooAngel NPC Rooms:" ];
 if (0 === Object.keys(e).length) t.push("  No NPC rooms discovered"); else for (var r in e) {
 var o = e[r];
 t.push("  ".concat(r, ":")), t.push("    Has terminal: ".concat(o.hasTerminal)),
@@ -20088,12 +20092,12 @@ t.push("    Available quests: ".concat(o.availableQuests.length)), t.push("    L
 return t.join("\n");
 },
 apply: function(e, t, r) {
-return Kc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
+return Vc(e, t, r) ? "Applied for quest ".concat(e).concat(r ? " from ".concat(r) : "") : "Failed to apply for quest (check logs for details)";
 },
 help: function() {
 return [ "TooAngel Console Commands:", "", "  tooangel.status()                    - Show current status", "  tooangel.enable()                    - Enable integration", "  tooangel.disable()                   - Disable integration", "  tooangel.reputation()                - Get current reputation", "  tooangel.requestReputation(fromRoom) - Request reputation update", "  tooangel.quests()                    - List active quests", "  tooangel.npcs()                      - List discovered NPC rooms", "  tooangel.apply(id, origin, fromRoom) - Apply for a quest", "  tooangel.help()                      - Show this help" ].join("\n");
 }
-}, ou = function() {
+}, au = function() {
 function e() {}
 return e.prototype.status = function() {
 return function(e, t) {
@@ -20261,16 +20265,16 @@ usage: "memory.reset('CONFIRM')",
 examples: [ "memory.reset('CONFIRM')" ],
 category: "Memory"
 }) ], e.prototype, "reset", null), e;
-}(), nu = new ou, au = {
+}(), iu = new au, su = {
 minPower: 1e3,
 maxDistance: 5,
 minTicksRemaining: 3e3,
 healerRatio: .5,
 minBucket: 2e3,
 maxConcurrentOps: 2
-}, iu = function() {
+}, cu = function() {
 function e(e) {
-void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, au), e);
+void 0 === e && (e = {}), this.operations = new Map, this.lastScan = 0, this.config = o(o({}, su), e);
 }
 return e.prototype.run = function() {
 Game.time - this.lastScan >= 50 && (this.scanForPowerBanks(), this.lastScan = Game.time),
@@ -20634,16 +20638,16 @@ interval: 50,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), su = new iu, cu = {
+}(), uu = new cu, lu = {
 minGPL: 1,
 minPowerReserve: 1e4,
 energyPerPower: 50,
 minEnergyReserve: 1e5,
 gplMilestones: [ 1, 2, 5, 10, 15, 20 ]
-}, uu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], lu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], mu = function() {
+}, mu = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_OPERATE_EXTENSION, PWR_OPERATE_TOWER, PWR_OPERATE_LAB, PWR_OPERATE_STORAGE, PWR_REGEN_SOURCE, PWR_OPERATE_FACTORY ], du = [ PWR_GENERATE_OPS, PWR_OPERATE_SPAWN, PWR_SHIELD, PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_FORTIFY, PWR_OPERATE_TOWER, PWR_DISRUPT_TERMINAL ], pu = function() {
 function e(e) {
 void 0 === e && (e = {}), this.assignments = new Map, this.gplState = null, this.lastGPLUpdate = 0,
-this.config = o(o({}, cu), e);
+this.config = o(o({}, lu), e);
 }
 return e.prototype.run = function() {
 this.updateGPLState(), this.managePowerProcessing(), this.manageAssignments(), this.checkPowerUpgrades(),
@@ -20797,7 +20801,7 @@ return l.homeRoom = a, l.role = o, U.info("Power creep ".concat(e.name, " assign
 subsystem: "PowerCreep"
 }), u;
 }, e.prototype.generatePowerPath = function(e) {
-var t = this, r = ("powerQueen" === e ? uu : lu).filter(function(e) {
+var t = this, r = ("powerQueen" === e ? mu : du).filter(function(e) {
 var r, o, n = POWER_INFO[e];
 return n && void 0 !== n.level && n.level[0] <= (null !== (o = null === (r = t.gplState) || void 0 === r ? void 0 : r.currentLevel) && void 0 !== o ? o : 0);
 });
@@ -20941,211 +20945,211 @@ interval: 20,
 minBucket: 6e3,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), du = new mu, pu = {
+}(), fu = new pu, yu = {
 info: function() {},
 warn: function() {},
 error: function() {},
 debug: function() {}
-}, fu = ((Qc = {})[RESOURCE_HYDROXIDE] = {
+}, vu = ((Zc = {})[RESOURCE_HYDROXIDE] = {
 product: RESOURCE_HYDROXIDE,
 input1: RESOURCE_HYDROGEN,
 input2: RESOURCE_OXYGEN,
 priority: 10
-}, Qc[RESOURCE_ZYNTHIUM_KEANITE] = {
+}, Zc[RESOURCE_ZYNTHIUM_KEANITE] = {
 product: RESOURCE_ZYNTHIUM_KEANITE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_KEANIUM,
 priority: 10
-}, Qc[RESOURCE_UTRIUM_LEMERGITE] = {
+}, Zc[RESOURCE_UTRIUM_LEMERGITE] = {
 product: RESOURCE_UTRIUM_LEMERGITE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_LEMERGIUM,
 priority: 10
-}, Qc[RESOURCE_GHODIUM] = {
+}, Zc[RESOURCE_GHODIUM] = {
 product: RESOURCE_GHODIUM,
 input1: RESOURCE_ZYNTHIUM_KEANITE,
 input2: RESOURCE_UTRIUM_LEMERGITE,
 priority: 15
-}, Qc[RESOURCE_UTRIUM_HYDRIDE] = {
+}, Zc[RESOURCE_UTRIUM_HYDRIDE] = {
 product: RESOURCE_UTRIUM_HYDRIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Qc[RESOURCE_UTRIUM_OXIDE] = {
+}, Zc[RESOURCE_UTRIUM_OXIDE] = {
 product: RESOURCE_UTRIUM_OXIDE,
 input1: RESOURCE_UTRIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Qc[RESOURCE_KEANIUM_HYDRIDE] = {
+}, Zc[RESOURCE_KEANIUM_HYDRIDE] = {
 product: RESOURCE_KEANIUM_HYDRIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Qc[RESOURCE_KEANIUM_OXIDE] = {
+}, Zc[RESOURCE_KEANIUM_OXIDE] = {
 product: RESOURCE_KEANIUM_OXIDE,
 input1: RESOURCE_KEANIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Qc[RESOURCE_LEMERGIUM_HYDRIDE] = {
+}, Zc[RESOURCE_LEMERGIUM_HYDRIDE] = {
 product: RESOURCE_LEMERGIUM_HYDRIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Qc[RESOURCE_LEMERGIUM_OXIDE] = {
+}, Zc[RESOURCE_LEMERGIUM_OXIDE] = {
 product: RESOURCE_LEMERGIUM_OXIDE,
 input1: RESOURCE_LEMERGIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Qc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
+}, Zc[RESOURCE_ZYNTHIUM_HYDRIDE] = {
 product: RESOURCE_ZYNTHIUM_HYDRIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Qc[RESOURCE_ZYNTHIUM_OXIDE] = {
+}, Zc[RESOURCE_ZYNTHIUM_OXIDE] = {
 product: RESOURCE_ZYNTHIUM_OXIDE,
 input1: RESOURCE_ZYNTHIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Qc[RESOURCE_GHODIUM_HYDRIDE] = {
+}, Zc[RESOURCE_GHODIUM_HYDRIDE] = {
 product: RESOURCE_GHODIUM_HYDRIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_HYDROGEN,
 priority: 20
-}, Qc[RESOURCE_GHODIUM_OXIDE] = {
+}, Zc[RESOURCE_GHODIUM_OXIDE] = {
 product: RESOURCE_GHODIUM_OXIDE,
 input1: RESOURCE_GHODIUM,
 input2: RESOURCE_OXYGEN,
 priority: 20
-}, Qc[RESOURCE_UTRIUM_ACID] = {
+}, Zc[RESOURCE_UTRIUM_ACID] = {
 product: RESOURCE_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_UTRIUM_ALKALIDE] = {
+}, Zc[RESOURCE_UTRIUM_ALKALIDE] = {
 product: RESOURCE_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_KEANIUM_ACID] = {
+}, Zc[RESOURCE_KEANIUM_ACID] = {
 product: RESOURCE_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_KEANIUM_ALKALIDE] = {
+}, Zc[RESOURCE_KEANIUM_ALKALIDE] = {
 product: RESOURCE_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_LEMERGIUM_ACID] = {
+}, Zc[RESOURCE_LEMERGIUM_ACID] = {
 product: RESOURCE_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_LEMERGIUM_ALKALIDE] = {
+}, Zc[RESOURCE_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_ZYNTHIUM_ACID] = {
+}, Zc[RESOURCE_ZYNTHIUM_ACID] = {
 product: RESOURCE_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
+}, Zc[RESOURCE_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_GHODIUM_ACID] = {
+}, Zc[RESOURCE_GHODIUM_ACID] = {
 product: RESOURCE_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_HYDRIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_GHODIUM_ALKALIDE] = {
+}, Zc[RESOURCE_GHODIUM_ALKALIDE] = {
 product: RESOURCE_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_OXIDE,
 input2: RESOURCE_HYDROXIDE,
 priority: 30
-}, Qc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_UTRIUM_ACID] = {
 product: RESOURCE_CATALYZED_UTRIUM_ACID,
 input1: RESOURCE_UTRIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_UTRIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
 input1: RESOURCE_UTRIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_KEANIUM_ACID] = {
 product: RESOURCE_CATALYZED_KEANIUM_ACID,
 input1: RESOURCE_KEANIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
 input1: RESOURCE_KEANIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_LEMERGIUM_ACID] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ACID,
 input1: RESOURCE_LEMERGIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
 input1: RESOURCE_LEMERGIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ACID,
 input1: RESOURCE_ZYNTHIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
 input1: RESOURCE_ZYNTHIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
+}, Zc[RESOURCE_CATALYZED_GHODIUM_ACID] = {
 product: RESOURCE_CATALYZED_GHODIUM_ACID,
 input1: RESOURCE_GHODIUM_ACID,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
+}, Zc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = {
 product: RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
 input1: RESOURCE_GHODIUM_ALKALIDE,
 input2: RESOURCE_CATALYST,
 priority: 40
-}, Qc), yu = ((Xc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Xc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
-Xc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Xc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
-Xc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Xc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
-Xc[RESOURCE_GHODIUM] = 5e3, Xc[RESOURCE_HYDROXIDE] = 5e3, Xc);
+}, Zc), gu = ((Jc = {})[RESOURCE_CATALYZED_UTRIUM_ACID] = 3e3, Jc[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 3e3,
+Jc[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 3e3, Jc[RESOURCE_CATALYZED_GHODIUM_ACID] = 3e3,
+Jc[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 2e3, Jc[RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE] = 2e3,
+Jc[RESOURCE_GHODIUM] = 5e3, Jc[RESOURCE_HYDROXIDE] = 5e3, Jc);
 
-function vu(e, t) {
-var r, o, n, a = null !== (r = yu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
+function hu(e, t) {
+var r, o, n, a = null !== (r = gu[e]) && void 0 !== r ? r : 1e3, i = null !== (o = t.pheromones.war) && void 0 !== o ? o : 0, s = null !== (n = t.pheromones.siege) && void 0 !== n ? n : 0, c = Math.max(i, s), u = c > 50 ? 1 + c / 100 * .5 : 1;
 return !("war" === t.posture || "siege" === t.posture || c > 50) || e !== RESOURCE_CATALYZED_UTRIUM_ACID && e !== RESOURCE_CATALYZED_KEANIUM_ALKALIDE && e !== RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE && e !== RESOURCE_CATALYZED_GHODIUM_ACID ? "war" !== t.posture && "siege" !== t.posture || e !== RESOURCE_CATALYZED_GHODIUM_ALKALIDE && e !== RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE ? a : .5 * a : a * Math.min(1.5 * u, 1.75);
 }
 
-function gu(e) {
+function Ru(e) {
 var t = [];
 return t.push(RESOURCE_GHODIUM, RESOURCE_HYDROXIDE), "war" === e.posture || "siege" === e.posture || e.danger >= 2 ? t.push(RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_KEANIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, RESOURCE_CATALYZED_GHODIUM_ACID) : t.push(RESOURCE_CATALYZED_GHODIUM_ALKALIDE, RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE),
 t;
 }
 
-var hu = function() {
+var Eu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : pu;
+void 0 === e && (e = {}), this.logger = null !== (t = e.logger) && void 0 !== t ? t : yu;
 }
 return e.prototype.getReaction = function(e) {
-return fu[e];
+return vu[e];
 }, e.prototype.calculateReactionChain = function(e, t) {
 return function(e, t) {
 var r = [], o = new Set, n = function(e) {
 var a, i, s;
 if (o.has(e)) return !0;
 o.add(e);
-var c = fu[e];
+var c = vu[e];
 return c ? !((null !== (i = t[c.input1]) && void 0 !== i ? i : 0) < 100 && !n(c.input1) || (null !== (s = t[c.input2]) && void 0 !== s ? s : 0) < 100 && !n(c.input2) || (r.push(c),
 0)) : (null !== (a = t[e]) && void 0 !== a ? a : 0) > 0;
 };
@@ -21167,11 +21171,11 @@ return e.structureType === STRUCTURE_LAB;
 }).length < 3) return null;
 var m = e.terminal;
 if (!m) return null;
-var d = gu(t);
+var d = Ru(t);
 try {
 for (var p = a(d), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-if (fu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < vu(y, t)) {
+if (vu[y] && (null !== (l = m.store[y]) && void 0 !== l ? l : 0) < hu(y, t)) {
 var v = {};
 try {
 for (var g = (n = void 0, a(Object.entries(m.store))), h = g.next(); !h.done; h = g.next()) {
@@ -21230,12 +21234,12 @@ try {
 for (var f = a(e), y = f.next(); !y.done; y = f.next()) {
 var v = y.value, g = v.terminal;
 if (g) {
-var h = gu(t);
+var h = Ru(t);
 try {
 for (var R = (n = void 0, a(h)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = fu[T];
+var T = E.value, C = vu[T];
 if (C) {
-var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = vu(T, t), x = w - S;
+var S = null !== (d = g.store[T]) && void 0 !== d ? d : 0, w = hu(T, t), x = w - S;
 if (x > 0) {
 var b = x / w, O = C.priority * (1 + Math.min(b, .5)), k = {};
 try {
@@ -21351,7 +21355,7 @@ if (r) throw r.error;
 }
 }
 }, e;
-}(), Ru = [ {
+}(), Tu = [ {
 role: "soldier",
 boosts: [ RESOURCE_CATALYZED_UTRIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE ],
 minDanger: 2
@@ -21369,13 +21373,13 @@ boosts: [ RESOURCE_CATALYZED_GHODIUM_ACID, RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE
 minDanger: 1
 } ];
 
-function Eu(e) {
-return Ru.find(function(t) {
+function Cu(e) {
+return Tu.find(function(t) {
 return t.role === e;
 });
 }
 
-function Tu(e, t) {
+function Su(e, t) {
 switch (e) {
 case "input1":
 return t.input1;
@@ -21392,29 +21396,29 @@ return;
 }
 }
 
-function Cu(e, t) {
+function wu(e, t) {
 return t.outputCount - e.outputCount || t.combinedReach - e.combinedReach || e.input1Index - t.input1Index || e.input2Index - t.input2Index;
 }
 
-function Su(e, t, r) {
-return e.id === t.id ? "input1" : e.id === r.id ? "input2" : xu(e, t) && xu(e, r) ? "output" : "boost";
+function xu(e, t, r) {
+return e.id === t.id ? "input1" : e.id === r.id ? "input2" : Ou(e, t) && Ou(e, r) ? "output" : "boost";
 }
 
-function wu(e, t) {
+function bu(e, t) {
 return t.filter(function(t) {
-return e.id !== t.id && xu(e, t);
+return e.id !== t.id && Ou(e, t);
 }).length;
 }
 
-function xu(e, t) {
+function Ou(e, t) {
 return r = e.pos, o = t.pos, Math.max(Math.abs(r.x - o.x), Math.abs(r.y - o.y)) <= 2;
 var r, o;
 }
 
-var bu, Ou = function() {
+var ku, Mu = function() {
 function e(e) {
 var t;
-void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : pu;
+void 0 === e && (e = {}), this.configs = new Map, this.logger = null !== (t = e.logger) && void 0 !== t ? t : yu;
 }
 return e.prototype.initialize = function(e) {
 var t, r = Game.rooms[e];
@@ -21530,7 +21534,7 @@ return !0;
 var t, r, o = e.activeReaction;
 if (o) try {
 for (var n = a(e.labs), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = Tu(s.role, o);
+var s = i.value, c = Su(s.role, o);
 c && (s.resourceType = c);
 }
 } catch (e) {
@@ -21552,13 +21556,13 @@ reason: "too-few-labs"
 };
 var t = function(e) {
 for (var t, r, o = new Map(e.map(function(t) {
-return [ t.id, wu(t, e) ];
+return [ t.id, bu(t, e) ];
 })), n = [], a = function(a) {
 for (var i = function(i) {
 var s = e[a], c = e[i];
 if (!s || !c) return "continue";
 var u = e.filter(function(e, t) {
-return t !== a && t !== i && xu(e, s) && xu(e, c);
+return t !== a && t !== i && Ou(e, s) && Ou(e, c);
 }).length;
 if (0 === u) return "continue";
 n.push({
@@ -21571,19 +21575,19 @@ combinedReach: (null !== (t = o.get(s.id)) && void 0 !== t ? t : 0) + (null !== 
 });
 }, s = a + 1; s < e.length; s++) i(s);
 }, i = 0; i < e.length - 1; i++) a(i);
-return n.sort(Cu)[0];
+return n.sort(wu)[0];
 }(e);
 return t ? {
 isValid: !0,
 roles: e.map(function(e) {
 return {
 labId: e.id,
-role: Su(e, t.input1, t.input2)
+role: xu(e, t.input1, t.input2)
 };
 })
 } : function(e) {
 return e.reduce(function(t, r) {
-return Math.max(t, wu(r, e));
+return Math.max(t, bu(r, e));
 }, 0);
 }(e) < 2 ? {
 isValid: !1,
@@ -21727,17 +21731,17 @@ return this.configs.get(e);
 }, e.prototype.importConfig = function(e) {
 this.configs.set(e.roomName, e);
 }, e;
-}(), ku = function() {
+}(), Au = function() {
 function e() {}
 return e.prototype.shouldBoost = function(e, t) {
 var r, o = e.memory;
 if (o.boosted) return !1;
-var n = Eu(o.role);
+var n = Cu(o.role);
 if (!n) return !1;
 var a = !0 === (null !== (r = Memory.boostDefensePriority) && void 0 !== r ? r : {})[e.room.name] ? Math.max(1, n.minDanger - 1) : n.minDanger;
 return !(t.danger < a || t.missingStructures.labs);
 }, e.prototype.boostCreep = function(e, t) {
-var r, o, n = e.memory, i = Eu(n.role);
+var r, o, n = e.memory, i = Cu(n.role);
 if (!i) return !1;
 var s = t.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21815,7 +21819,7 @@ return 0 === c.length && (n.boosted = !0, U.info("".concat(e.name, " fully boost
 subsystem: "Boost"
 }), !0);
 }, e.prototype.areBoostLabsReady = function(e, t) {
-var r, o, n = Eu(t);
+var r, o, n = Cu(t);
 if (!n) return !0;
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21846,7 +21850,7 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.getMissingBoosts = function(e, t) {
-var r, o, n = Eu(t);
+var r, o, n = Cu(t);
 if (!n) return [];
 var i = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
@@ -21880,7 +21884,7 @@ return e.structureType === STRUCTURE_LAB;
 }
 });
 if (!(u.length < 3)) {
-var l = u.slice(2), m = new Set, d = [ Eu("soldier"), Eu("ranger"), Eu("healer"), Eu("siegeUnit") ].filter(function(e) {
+var l = u.slice(2), m = new Set, d = [ Cu("soldier"), Cu("ranger"), Cu("healer"), Cu("siegeUnit") ].filter(function(e) {
 return void 0 !== e && t.danger >= e.minDanger;
 });
 try {
@@ -21937,7 +21941,7 @@ if (s) throw s.error;
 }
 }, e.prototype.calculateBoostCost = function(e, t) {
 return function(e, t) {
-var r = Eu(e);
+var r = Cu(e);
 return r ? {
 mineral: 30 * t * r.boosts.length,
 energy: 20 * t * r.boosts.length
@@ -21947,7 +21951,7 @@ energy: 0
 };
 }(e, t);
 }, e.prototype.analyzeBoostROI = function(e, t, r, o) {
-var n = Eu(e);
+var n = Cu(e);
 if (!n) return {
 worthwhile: !1,
 roi: 0,
@@ -21981,7 +21985,7 @@ roi: u,
 reasoning: m
 };
 }, e;
-}(), Mu = new ku, Au = {
+}(), Uu = new Au, _u = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -21994,10 +21998,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, Uu = function() {
+}, Nu = function() {
 function e() {
-this.manager = new Ou({
-logger: Au
+this.manager = new Mu({
+logger: _u
 });
 }
 return e.prototype.initialize = function(e) {
@@ -22067,14 +22071,14 @@ return this.manager.getConfiguredRooms();
 }, e.prototype.hasValidConfig = function(e) {
 return this.manager.hasValidConfig(e);
 }, e;
-}(), _u = new Uu, Nu = function() {
+}(), Pu = new Nu, Iu = function() {
 function e() {}
 return e.prototype.getLabResourceNeeds = function(e) {
 var t, r, o, n, i;
 if (!Game.rooms[e]) return [];
-var s = _u.getConfig(e);
+var s = Pu.getConfig(e);
 if (!s || !s.isValid) return [];
-var c, u = [], l = _u.getInputLabs(e), m = l.input1, d = l.input2;
+var c, u = [], l = Pu.getInputLabs(e), m = l.input1, d = l.input2;
 m && s.activeReaction && (c = null !== (o = m.store[s.activeReaction.input1]) && void 0 !== o ? o : 0) < 1e3 && u.push({
 labId: m.id,
 resourceType: s.activeReaction.input1,
@@ -22086,7 +22090,7 @@ resourceType: s.activeReaction.input2,
 amount: 2e3 - c,
 priority: 10
 });
-var p = _u.getBoostLabs(e), f = function(e) {
+var p = Pu.getBoostLabs(e), f = function(e) {
 var t = s.labs.find(function(t) {
 return t.labId === e.id;
 });
@@ -22117,9 +22121,9 @@ return u;
 }, e.prototype.getLabOverflow = function(e) {
 var t, r, o, n, i, s;
 if (!Game.rooms[e]) return [];
-var c = _u.getConfig(e);
+var c = Pu.getConfig(e);
 if (!c) return [];
-var u = [], l = _u.getOutputLabs(e);
+var u = [], l = Pu.getOutputLabs(e);
 try {
 for (var m = a(l), d = m.next(); !d.done; d = m.next()) {
 var p = (T = d.value).mineralType;
@@ -22144,7 +22148,7 @@ d && !d.done && (r = m.return) && r.call(m);
 if (t) throw t.error;
 }
 }
-var v = _u.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
+var v = Pu.getInputLabs(e), g = [ v.input1, v.input2 ].filter(function(e) {
 return void 0 !== e;
 }), h = function(e) {
 var t = e.mineralType;
@@ -22180,15 +22184,15 @@ if (o) throw o.error;
 }
 return u;
 }, e.prototype.areLabsReady = function(e, t) {
-var r, o, n, i, s = _u.getConfig(e);
+var r, o, n, i, s = Pu.getConfig(e);
 if (!s || !s.isValid) return !1;
-var c = _u.getInputLabs(e), u = c.input1, l = c.input2;
+var c = Pu.getInputLabs(e), u = c.input1, l = c.input2;
 if (!u || !l) return !1;
 if (u.mineralType && u.mineralType !== t.input1) return !1;
 if (l.mineralType && l.mineralType !== t.input2) return !1;
 if ((null !== (n = u.store[t.input1]) && void 0 !== n ? n : 0) < 500) return !1;
 if ((null !== (i = l.store[t.input2]) && void 0 !== i ? i : 0) < 500) return !1;
-var m = _u.getOutputLabs(e);
+var m = Pu.getOutputLabs(e);
 if (0 === m.length) return !1;
 try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
@@ -22210,23 +22214,23 @@ if (r) throw r.error;
 }
 return !0;
 }, e.prototype.clearReactions = function(e) {
-_u.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
+Pu.clearActiveReaction(e), U.info("Cleared active reactions in ".concat(e), {
 subsystem: "Labs"
 });
 }, e.prototype.setActiveReaction = function(e, t, r, o) {
-var n = _u.setActiveReaction(e, t, r, o);
+var n = Pu.setActiveReaction(e, t, r, o);
 return n && U.info("Set active reaction: ".concat(t, " + ").concat(r, " -> ").concat(o), {
 subsystem: "Labs",
 room: e
 }), n;
 }, e.prototype.runReactions = function(e) {
-return _u.runReactions(e);
+return Pu.runReactions(e);
 }, e.prototype.hasAvailableBoostLabs = function(e) {
-return _u.getBoostLabs(e).length > 0;
+return Pu.getBoostLabs(e).length > 0;
 }, e.prototype.prepareBoostLab = function(e, t) {
-var r, o, n, i, s, c = _u.getConfig(e);
+var r, o, n, i, s, c = Pu.getConfig(e);
 if (!c) return null;
-var u = _u.getBoostLabs(e);
+var u = Pu.getBoostLabs(e);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) if ((y = m.value).mineralType === t && (null !== (s = y.store[t]) && void 0 !== s ? s : 0) >= 30) return y.id;
 } catch (e) {
@@ -22330,17 +22334,17 @@ if (r) throw r.error;
 }
 return !1;
 }, e.prototype.getLabTaskStatus = function(e) {
-var t = _u.getConfig(e);
+var t = Pu.getConfig(e);
 return t && t.isValid ? t.activeReaction ? "reacting" : this.getLabResourceNeeds(e).length > 0 ? "loading" : this.getLabOverflow(e).length > 0 ? "unloading" : "idle" : "idle";
 }, e.prototype.initialize = function(e) {
-_u.loadFromMemory(e), _u.initialize(e);
+Pu.loadFromMemory(e), Pu.initialize(e);
 }, e.prototype.save = function(e) {
-_u.saveToMemory(e);
+Pu.saveToMemory(e);
 }, e;
-}(), Pu = new Nu, Iu = function() {
+}(), Gu = new Iu, Lu = function() {
 function e() {}
 return e.prototype.status = function(e) {
-var t, r, o, n, i, s, c, u, l = _u.getConfig(e);
+var t, r, o, n, i, s, c, u, l = Pu.getConfig(e);
 if (!l) return "No lab configuration for ".concat(e);
 var m = "=== Lab Status: ".concat(e, " ===\n");
 m += "Valid: ".concat(l.isValid, "\n"), m += "Labs: ".concat(l.labs.length, "\n"),
@@ -22363,7 +22367,7 @@ p && !p.done && (r = d.return) && r.call(d);
 if (t) throw t.error;
 }
 }
-var h = Pu.getLabResourceNeeds(e);
+var h = Gu.getLabResourceNeeds(e);
 if (h.length > 0) {
 m += "\nResource Needs:\n";
 try {
@@ -22383,7 +22387,7 @@ if (o) throw o.error;
 }
 }
 }
-var C = Pu.getLabOverflow(e);
+var C = Gu.getLabOverflow(e);
 if (C.length > 0) {
 m += "\nOverflow (needs emptying):\n";
 try {
@@ -22405,13 +22409,13 @@ if (i) throw i.error;
 }
 return m;
 }, e.prototype.setReaction = function(e, t, r, o) {
-return Pu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
+return Gu.setActiveReaction(e, t, r, o) ? "Set active reaction: ".concat(t, " + ").concat(r, " → ").concat(o) : "Failed to set reaction (check lab configuration)";
 }, e.prototype.clear = function(e) {
-return Pu.clearReactions(e), "Cleared active reactions in ".concat(e);
+return Gu.clearReactions(e), "Cleared active reactions in ".concat(e);
 }, e.prototype.boost = function(e, t) {
 var r, o, n = Game.rooms[e];
 if (!n) return "Room ".concat(e, " not visible");
-var i = Mu.areBoostLabsReady(n, t), s = Mu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
+var i = Uu.areBoostLabsReady(n, t), s = Uu.getMissingBoosts(n, t), c = "=== Boost Status: ".concat(e, " / ").concat(t, " ===\n");
 if (c += "Ready: ".concat(i, "\n"), s.length > 0) {
 c += "\nMissing Boosts:\n";
 try {
@@ -22457,7 +22461,7 @@ usage: "labs.boost(roomName, role)",
 examples: [ "labs.boost('E1S1', 'soldier')" ],
 category: "Labs"
 }) ], e.prototype, "boost", null), e;
-}(), Gu = function() {
+}(), Du = function() {
 function e() {}
 return e.prototype.data = function(e) {
 var t = Game.market.getHistory(e);
@@ -22514,10 +22518,10 @@ usage: "market.profit()",
 examples: [ "market.profit()" ],
 category: "Market"
 }) ], e.prototype, "profit", null), e;
-}(), Lu = function() {
+}(), Bu = function() {
 function e() {}
 return e.prototype.gpl = function() {
-var e = du.getGPLState();
+var e = fu.getGPLState();
 if (!e) return "GPL tracking not available (no power unlocked)";
 var t = "=== GPL Status ===\n";
 t += "Level: ".concat(e.currentLevel, "\n"), t += "Progress: ".concat(e.currentProgress, " / ").concat(e.progressNeeded, "\n"),
@@ -22526,7 +22530,7 @@ t += "Target Milestone: ".concat(e.targetMilestone, "\n");
 var r = e.ticksToNextLevel === 1 / 0 ? "N/A (no progress yet)" : "".concat(e.ticksToNextLevel.toLocaleString(), " ticks");
 return (t += "Estimated Time: ".concat(r, "\n")) + "\nTotal Power Processed: ".concat(e.totalPowerProcessed.toLocaleString(), "\n");
 }, e.prototype.creeps = function() {
-var e, t, r = du.getAssignments();
+var e, t, r = fu.getAssignments();
 if (0 === r.length) return "No power creeps created yet";
 var o = "=== Power Creeps (".concat(r.length, ") ===\n");
 o += "Name | Role | Room | Level | Spawned\n", o += "-".repeat(70) + "\n";
@@ -22548,7 +22552,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.operations = function() {
-var e, t, r = su.getActiveOperations();
+var e, t, r = uu.getActiveOperations();
 if (0 === r.length) return "No active power bank operations";
 var o = "=== Power Bank Operations (".concat(r.length, ") ===\n");
 try {
@@ -22573,7 +22577,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.assign = function(e, t) {
-return du.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
+return fu.reassignPowerCreep(e, t) ? "Reassigned ".concat(e, " to ").concat(t) : "Failed to reassign ".concat(e, " (not found)");
 }, e.prototype.create = function(e, t) {
 var r = "string" == typeof t && "operator" === t.toLowerCase() ? POWER_CLASS.OPERATOR : t;
 if (Game.powerCreeps[e]) return 'Power creep "'.concat(e, '" already exists');
@@ -22647,31 +22651,31 @@ usage: "power.upgrade(powerCreepName, power)",
 examples: [ "power.upgrade('operator_eco', PWR_OPERATE_SPAWN)", "power.upgrade('operator_eco', PWR_OPERATE_TOWER)" ],
 category: "Power"
 }) ], e.prototype, "upgrade", null), e;
-}(), Du = new Iu, Bu = new Gu, Fu = new Lu;
+}(), Fu = new Lu, Wu = new Du, Hu = new Bu;
 
 !function(e) {
 e[e.DEBUG = 0] = "DEBUG", e[e.INFO = 1] = "INFO", e[e.WARN = 2] = "WARN", e[e.ERROR = 3] = "ERROR",
 e[e.NONE = 4] = "NONE";
-}(bu || (bu = {}));
+}(ku || (ku = {}));
 
-var Wu = {
-level: bu.INFO,
+var Ku = {
+level: ku.INFO,
 cpuLogging: !1,
 enableBatching: !0,
 maxBatchSize: 50,
 debugSampleRate: 1,
 maxEntriesPerSubsystemPerTick: 0,
 maxEntriesPerTick: 0
-}, Hu = o({}, Wu), Ku = [], Yu = {
+}, Yu = o({}, Ku), Vu = [], qu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
 debugSampleCounter: 0
 };
 
-function Vu() {
+function ju() {
 var e = "undefined" != typeof Game && "number" == typeof Game.time ? Game.time : 0;
-Yu.tick !== e && (Yu = {
+qu.tick !== e && (qu = {
 tick: e,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22679,47 +22683,47 @@ debugSampleCounter: 0
 });
 }
 
-function qu(e, t) {
+function zu(e, t) {
 return !!function(e) {
-if (e !== bu.DEBUG) return !0;
-Vu();
-var t, r = (t = Hu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
+if (e !== ku.DEBUG) return !0;
+ju();
+var t, r = (t = Yu.debugSampleRate, Number.isFinite(t) ? Math.min(1, Math.max(0, t)) : 1);
 if (r >= 1) return !0;
 if (r <= 0) return !1;
-Yu.debugSampleCounter += 1;
+qu.debugSampleCounter += 1;
 var o = Math.max(1, Math.ceil(1 / r));
-return Yu.debugSampleCounter % o === 0;
+return qu.debugSampleCounter % o === 0;
 }(e) && function(e) {
-var t, r, o = ju(Hu.maxEntriesPerTick), n = ju(Hu.maxEntriesPerSubsystemPerTick);
+var t, r, o = Qu(Yu.maxEntriesPerTick), n = Qu(Yu.maxEntriesPerSubsystemPerTick);
 if (0 === o && 0 === n) return !0;
-if (Vu(), o > 0 && Yu.totalCount >= o) return !1;
+if (ju(), o > 0 && qu.totalCount >= o) return !1;
 if (n > 0) {
 var a = null != e ? e : "global";
-if ((null !== (t = Yu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
+if ((null !== (t = qu.perSubsystemCounts.get(a)) && void 0 !== t ? t : 0) >= n) return !1;
 }
-Yu.totalCount += 1;
+qu.totalCount += 1;
 var i = null != e ? e : "global";
-return Yu.perSubsystemCounts.set(i, (null !== (r = Yu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
+return qu.perSubsystemCounts.set(i, (null !== (r = qu.perSubsystemCounts.get(i)) && void 0 !== r ? r : 0) + 1),
 !0;
 }(null == t ? void 0 : t.subsystem);
 }
 
-function ju(e) {
+function Qu(e) {
 return Number.isFinite(e) && e > 0 ? Math.floor(e) : 0;
 }
 
-function zu(e) {
-Ku.length > 0 && Zu();
-var t = Hu;
-Hu = o(o(o({}, Wu), e), {
+function Xu(e) {
+Vu.length > 0 && $u();
+var t = Yu;
+Yu = o(o(o({}, Ku), e), {
 level: "level" in e ? e.level : t.level,
 cpuLogging: "cpuLogging" in e ? e.cpuLogging : t.cpuLogging,
 enableBatching: "enableBatching" in e ? e.enableBatching : t.enableBatching,
 maxBatchSize: "maxBatchSize" in e ? e.maxBatchSize : t.maxBatchSize,
 debugSampleRate: "debugSampleRate" in e ? e.debugSampleRate : t.debugSampleRate,
-maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Wu.maxEntriesPerSubsystemPerTick,
-maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Wu.maxEntriesPerTick
-}), Ku = [], Yu = {
+maxEntriesPerSubsystemPerTick: "maxEntriesPerSubsystemPerTick" in e ? e.maxEntriesPerSubsystemPerTick : Ku.maxEntriesPerSubsystemPerTick,
+maxEntriesPerTick: "maxEntriesPerTick" in e ? e.maxEntriesPerTick : Ku.maxEntriesPerTick
+}), Vu = [], qu = {
 tick: -1,
 totalCount: 0,
 perSubsystemCounts: new Map,
@@ -22727,21 +22731,21 @@ debugSampleCounter: 0
 };
 }
 
-function Qu() {
-return o({}, Hu);
-}
-
-function Xu(e) {
-Hu.enableBatching ? (Ku.push(e), Ku.length >= Hu.maxBatchSize && Zu()) : console.log(e);
-}
-
 function Zu() {
-0 !== Ku.length && (console.log(Ku.join("\n")), Ku = []);
+return o({}, Yu);
 }
 
-var Ju = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
+function Ju(e) {
+Yu.enableBatching ? (Vu.push(e), Vu.length >= Yu.maxBatchSize && $u()) : console.log(e);
+}
 
-function $u(e) {
+function $u() {
+0 !== Vu.length && (console.log(Vu.join("\n")), Vu = []);
+}
+
+var el = new Set([ "type", "level", "message", "tick", "subsystem", "room", "creep", "processId", "shard" ]);
+
+function tl(e) {
 return JSON.stringify(e, (t = new WeakSet, function(e, r) {
 return "bigint" == typeof r ? r.toString() : "object" != typeof r || null === r ? r : t.has(r) ? "[Circular]" : (t.add(r),
 r);
@@ -22749,7 +22753,7 @@ r);
 var t;
 }
 
-function el(e, t, r, o) {
+function rl(e, t, r, o) {
 void 0 === o && (o = "log");
 var n = {
 type: o,
@@ -22760,35 +22764,35 @@ shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (r.shard && (n.shard = r.shard), r.subsystem && (n.subsystem = r.subsystem),
 r.room && (n.room = r.room), r.creep && (n.creep = r.creep), r.processId && (n.processId = r.processId),
-r.meta)) for (var a in r.meta) Ju.has(a) || (n[a] = r.meta[a]);
-return $u(n);
-}
-
-function tl(e, t) {
-Hu.level <= bu.DEBUG && qu(bu.DEBUG, t) && Xu(el("DEBUG", e, t));
-}
-
-function rl(e, t) {
-Hu.level <= bu.INFO && qu(bu.INFO, t) && Xu(el("INFO", e, t));
+r.meta)) for (var a in r.meta) el.has(a) || (n[a] = r.meta[a]);
+return tl(n);
 }
 
 function ol(e, t) {
-Hu.level <= bu.WARN && qu(bu.WARN, t) && Xu(el("WARN", e, t));
+Yu.level <= ku.DEBUG && zu(ku.DEBUG, t) && Ju(rl("DEBUG", e, t));
 }
 
 function nl(e, t) {
-Hu.level <= bu.ERROR && qu(bu.ERROR, t) && Xu(el("ERROR", e, t));
+Yu.level <= ku.INFO && zu(ku.INFO, t) && Ju(rl("INFO", e, t));
 }
 
-function al(e, t, r) {
-if (!Hu.cpuLogging) return t();
+function al(e, t) {
+Yu.level <= ku.WARN && zu(ku.WARN, t) && Ju(rl("WARN", e, t));
+}
+
+function il(e, t) {
+Yu.level <= ku.ERROR && zu(ku.ERROR, t) && Ju(rl("ERROR", e, t));
+}
+
+function sl(e, t, r) {
+if (!Yu.cpuLogging) return t();
 var o = Game.cpu.getUsed(), n = t(), a = Game.cpu.getUsed() - o;
-return tl("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
+return ol("".concat(e, ": ").concat(a.toFixed(3), " CPU"), r), n;
 }
 
-var il = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
+var cl = new Set([ "type", "key", "value", "tick", "unit", "subsystem", "room", "shard" ]);
 
-function sl(e, t, r, o) {
+function ul(e, t, r, o) {
 var n = {
 type: "stat",
 key: e,
@@ -22797,29 +22801,13 @@ tick: "undefined" != typeof Game ? Game.time : 0,
 shard: "undefined" != typeof Game && Game.shard ? Game.shard.name : "shard0"
 };
 if (r && (n.unit = r), o && (o.shard && (n.shard = o.shard), o.subsystem && (n.subsystem = o.subsystem),
-o.room && (n.room = o.room), o.meta)) for (var a in o.meta) il.has(a) || (n[a] = o.meta[a]);
-qu(bu.INFO, o) && Xu($u(n));
+o.room && (n.room = o.room), o.meta)) for (var a in o.meta) cl.has(a) || (n[a] = o.meta[a]);
+zu(ku.INFO, o) && Ju(tl(n));
 }
 
-function cl(e) {
+function ll(e) {
 return {
 debug: function(t, r) {
-tl(t, "string" == typeof r ? {
-subsystem: e,
-room: r
-} : o({
-subsystem: e
-}, r));
-},
-info: function(t, r) {
-rl(t, "string" == typeof r ? {
-subsystem: e,
-room: r
-} : o({
-subsystem: e
-}, r));
-},
-warn: function(t, r) {
 ol(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22827,7 +22815,7 @@ room: r
 subsystem: e
 }, r));
 },
-error: function(t, r) {
+info: function(t, r) {
 nl(t, "string" == typeof r ? {
 subsystem: e,
 room: r
@@ -22835,8 +22823,24 @@ room: r
 subsystem: e
 }, r));
 },
+warn: function(t, r) {
+al(t, "string" == typeof r ? {
+subsystem: e,
+room: r
+} : o({
+subsystem: e
+}, r));
+},
+error: function(t, r) {
+il(t, "string" == typeof r ? {
+subsystem: e,
+room: r
+} : o({
+subsystem: e
+}, r));
+},
 stat: function(t, r, n, a) {
-sl(t, r, n, "string" == typeof a ? {
+ul(t, r, n, "string" == typeof a ? {
 subsystem: e,
 room: a
 } : o({
@@ -22844,7 +22848,7 @@ subsystem: e
 }, a));
 },
 measureCpu: function(t, r, n) {
-return al(t, r, "string" == typeof n ? {
+return sl(t, r, "string" == typeof n ? {
 subsystem: e,
 room: n
 } : o({
@@ -22854,22 +22858,22 @@ subsystem: e
 };
 }
 
-var ul, ll = {
-debug: tl,
-info: rl,
-warn: ol,
-error: nl,
-stat: sl,
-measureCpu: al,
-configure: zu,
-getConfig: Qu,
-createLogger: cl,
-flush: Zu
-}, ml = function() {
+var ml, dl = {
+debug: ol,
+info: nl,
+warn: al,
+error: il,
+stat: ul,
+measureCpu: sl,
+configure: Xu,
+getConfig: Zu,
+createLogger: ll,
+flush: $u
+}, pl = function() {
 function e() {}
 return e.prototype.showConfig = function() {
-var e = Mr(), t = Qu();
-return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(bu[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
+var e = Mr(), t = Zu();
+return "=== SwarmBot Config ===\nDebug: ".concat(String(e.debug), "\nProfiling: ").concat(String(e.profiling), "\nVisualizations: ").concat(String(e.visualizations), "\nLogger Level: ").concat(ku[t.level], "\nCPU Logging: ").concat(String(t.cpuLogging));
 }, n([ Zr({
 name: "showConfig",
 description: "Show current bot configuration",
@@ -22877,13 +22881,13 @@ usage: "showConfig()",
 examples: [ "showConfig()" ],
 category: "Configuration"
 }) ], e.prototype, "showConfig", null), e;
-}(), dl = new Map, pl = ((ul = {})[STRUCTURE_SPAWN] = 100, ul[STRUCTURE_TOWER] = 95,
-ul[STRUCTURE_STORAGE] = 90, ul[STRUCTURE_EXTENSION] = 80, ul[STRUCTURE_TERMINAL] = 75,
-ul[STRUCTURE_LINK] = 70, ul[STRUCTURE_CONTAINER] = 65, ul[STRUCTURE_RAMPART] = 55,
-ul[STRUCTURE_WALL] = 50, ul[STRUCTURE_ROAD] = 30, ul);
+}(), fl = new Map, yl = ((ml = {})[STRUCTURE_SPAWN] = 100, ml[STRUCTURE_TOWER] = 95,
+ml[STRUCTURE_STORAGE] = 90, ml[STRUCTURE_EXTENSION] = 80, ml[STRUCTURE_TERMINAL] = 75,
+ml[STRUCTURE_LINK] = 70, ml[STRUCTURE_CONTAINER] = 65, ml[STRUCTURE_RAMPART] = 55,
+ml[STRUCTURE_WALL] = 50, ml[STRUCTURE_ROAD] = 30, ml);
 
-function fl(e) {
-var t, r, o, n, i, s = dl.get(e.name);
+function vl(e) {
+var t, r, o, n, i, s = fl.get(e.name);
 if (s && s.tick === Game.time) return s;
 var c = e.find(FIND_MY_STRUCTURES), u = {
 tick: Game.time,
@@ -22908,55 +22912,55 @@ m && !m.done && (r = l.return) && r.call(l);
 if (t) throw t.error;
 }
 }
-return dl.set(e.name, u), u;
+return fl.set(e.name, u), u;
 }
 
-function yl(e) {
+function gl(e) {
 return !e.hasStorage && e.builtTowerCount > 0;
 }
 
-function vl(e, t) {
+function hl(e, t) {
 var r;
 return function(e, t) {
 if (!t || e.structureType !== STRUCTURE_EXTENSION) return !1;
-var r = fl(t);
-return r.controllerLevel >= 4 && yl(r) && r.energyCapacityAvailable < 650;
+var r = vl(t);
+return r.controllerLevel >= 4 && gl(r) && r.energyCapacityAvailable < 650;
 }(e, t) ? 98 : function(e, t) {
 if (!t || e.structureType !== STRUCTURE_STORAGE) return !1;
-var r = fl(t);
-return r.controllerLevel >= 4 && yl(r);
-}(e, t) ? 97 : null !== (r = pl[e.structureType]) && void 0 !== r ? r : 50;
+var r = vl(t);
+return r.controllerLevel >= 4 && gl(r);
+}(e, t) ? 97 : null !== (r = yl[e.structureType]) && void 0 !== r ? r : 50;
 }
 
-var gl = M("CreepContext"), hl = new Map;
+var Rl = M("CreepContext"), El = new Map;
 
-function Rl(e) {
+function Tl(e) {
 e._allStructuresLoaded || (e.allStructures = e.room.find(FIND_STRUCTURES), e._allStructuresLoaded = !0);
 }
 
-function El(e) {
-return void 0 === e._containers && (Rl(e), e._containers = e.allStructures.filter(function(e) {
+function Cl(e) {
+return void 0 === e._containers && (Tl(e), e._containers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._containers;
 }
 
-function Tl(e) {
+function Sl(e) {
 return void 0 === e._prioritizedSites && (e._prioritizedSites = e.room.find(FIND_MY_CONSTRUCTION_SITES).sort(function(t, r) {
 return function(e, t, r) {
-return vl(t, r) - vl(e, r);
+return hl(t, r) - hl(e, r);
 }(t, r, e.room);
 })), e._prioritizedSites;
 }
 
-function Cl(e) {
-return void 0 === e._repairTargets && (Rl(e), e._repairTargets = e.allStructures.filter(function(e) {
+function wl(e) {
+return void 0 === e._repairTargets && (Tl(e), e._repairTargets = e.allStructures.filter(function(e) {
 return e.hits < .75 * e.hitsMax && e.structureType !== STRUCTURE_WALL;
 })), e._repairTargets;
 }
 
-function Sl(e) {
+function xl(e) {
 var t, r, o = e.room, n = e.memory, i = function(e) {
-var t = hl.get(e.name);
+var t = El.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = {
 tick: Game.time,
@@ -22965,9 +22969,9 @@ hostiles: Z(e),
 myStructures: e.find(FIND_MY_STRUCTURES),
 allStructures: []
 };
-return hl.set(e.name, r), r;
+return El.set(e.name, r), r;
 }(o);
-void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, gl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
+void 0 === n.working && (n.working = e.store.getUsedCapacity() > 0, Rl.debug("".concat(e.name, " initialized working=").concat(n.working, " from carry state"), {
 creep: e.name
 }));
 var s = null !== (t = n.homeRoom) && void 0 !== t ? t : o.name;
@@ -23032,10 +23036,10 @@ return !1;
 }(e.pos, i.hostiles);
 },
 get constructionSiteCount() {
-return Tl(i).length;
+return Sl(i).length;
 },
 get damagedStructureCount() {
-return Cl(i).length;
+return wl(i).length;
 },
 get droppedResources() {
 return void 0 === (e = i)._droppedResources && (e._droppedResources = e.room.find(FIND_DROPPED_RESOURCES, {
@@ -23046,7 +23050,7 @@ return e.resourceType === RESOURCE_ENERGY && e.amount > 50 || e.resourceType !==
 var e;
 },
 get containers() {
-return El(i);
+return Cl(i);
 },
 get sourceContainers() {
 return function(e) {
@@ -23054,7 +23058,7 @@ if (void 0 === e._sourceContainers) {
 var t = function(e) {
 return void 0 === e._sources && (e._sources = e.room.find(FIND_SOURCES)), e._sources;
 }(e);
-0 === t.length ? e._sourceContainers = [] : e._sourceContainers = El(e).filter(function(e) {
+0 === t.length ? e._sourceContainers = [] : e._sourceContainers = Cl(e).filter(function(e) {
 return t.some(function(t) {
 return t.pos.getRangeTo(e.pos) <= 2;
 });
@@ -23064,7 +23068,7 @@ return e._sourceContainers;
 }(i);
 },
 get depositContainers() {
-return void 0 === (e = i)._depositContainers && (Rl(e), e._depositContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._depositContainers && (Tl(e), e._depositContainers = e.allStructures.filter(function(e) {
 return e.structureType === STRUCTURE_CONTAINER;
 })), e._depositContainers;
 var e;
@@ -23093,10 +23097,10 @@ return e.hits < e.hitsMax;
 var e;
 },
 get prioritizedSites() {
-return Tl(i);
+return Sl(i);
 },
 get repairTargets() {
-return Cl(i);
+return wl(i);
 },
 get labs() {
 return void 0 === (e = i)._labs && (e._labs = e.myStructures.filter(function(e) {
@@ -23116,7 +23120,7 @@ e._tombstones;
 var e;
 },
 get mineralContainers() {
-return void 0 === (e = i)._mineralContainers && (Rl(e), e._mineralContainers = e.allStructures.filter(function(e) {
+return void 0 === (e = i)._mineralContainers && (Tl(e), e._mineralContainers = e.allStructures.filter(function(e) {
 if (e.structureType !== STRUCTURE_CONTAINER) return !1;
 var t = e;
 return Object.keys(t.store).some(function(e) {
@@ -23128,9 +23132,9 @@ var e;
 };
 }
 
-var wl, xl = {}, bl = function() {
-if (wl) return xl;
-wl = 1, Object.defineProperty(xl, "__esModule", {
+var bl, Ol = {}, kl = function() {
+if (bl) return Ol;
+bl = 1, Object.defineProperty(Ol, "__esModule", {
 value: !0
 });
 var e = "undefined" != typeof globalThis ? globalThis : "undefined" != typeof window ? window : void 0 !== ar ? ar : "undefined" != typeof self ? self : {}, t = function(e) {
@@ -24807,14 +24811,14 @@ reverse: !1,
 cache: u
 }))), T;
 }, As = "_rsi";
-return xl.CachingStrategies = vi, xl.CoordListSerializer = fi, xl.CoordSerializer = pi,
-xl.Keys = ji, xl.MoveTargetListSerializer = li, xl.MoveTargetSerializer = ui, xl.NumberSerializer = Oa,
-xl.PositionListSerializer = di, xl.PositionSerializer = mi, xl.adjacentWalkablePositions = xi,
-xl.blockSquare = function(e) {
+return Ol.CachingStrategies = vi, Ol.CoordListSerializer = fi, Ol.CoordSerializer = pi,
+Ol.Keys = ji, Ol.MoveTargetListSerializer = li, Ol.MoveTargetSerializer = ui, Ol.NumberSerializer = Oa,
+Ol.PositionListSerializer = di, Ol.PositionSerializer = mi, Ol.adjacentWalkablePositions = xi,
+Ol.blockSquare = function(e) {
 ns(e.roomName).blockedSquares.add(Ya(e));
-}, xl.cachePath = ys, xl.cachedPathKey = ps, xl.calculateAdjacencyMatrix = Ti, xl.calculateAdjacentPositions = Ci,
-xl.calculateNearbyPositions = Si, xl.calculatePositionsAtRange = wi, xl.cleanAllCaches = yi,
-xl.clearCachedPath = ks, xl.compressPath = e => {
+}, Ol.cachePath = ys, Ol.cachedPathKey = ps, Ol.calculateAdjacencyMatrix = Ti, Ol.calculateAdjacentPositions = Ci,
+Ol.calculateNearbyPositions = Si, Ol.calculatePositionsAtRange = wi, Ol.cleanAllCaches = yi,
+Ol.clearCachedPath = ks, Ol.compressPath = e => {
 const t = [], r = e[0];
 if (!r) return "";
 let o = r;
@@ -24823,19 +24827,19 @@ if (1 !== ri(o, r)) throw new Error("Cannot compress path unless each RoomPositi
 t.push(o.getDirectionTo(r)), o = r;
 }
 return Ya(r) + Wa.encode(t);
-}, xl.config = Ta, xl.decompressPath = e => {
+}, Ol.config = Ta, Ol.decompressPath = e => {
 let t = Va(e.slice(0, 2));
 const r = [ t ], o = Wa.decode(e.slice(2));
 for (const e of o) t = oi(t, e), r.push(t);
 return r;
-}, xl.fastRoomPosition = Ga, xl.fixEdgePosition = Ei, xl.follow = function(e, t) {
+}, Ol.fastRoomPosition = Ga, Ol.fixEdgePosition = Ei, Ol.follow = function(e, t) {
 e.move(t), t.pull(e), function(e, t) {
 const r = ns(e.pos.roomName);
 r.pullers.add(e.id), r.pullees.add(t.id);
 }(t, e);
-}, xl.followPath = hs, xl.fromGlobalPosition = ti, xl.generatePath = ts, xl.getCachedPath = vs,
-xl.getMoveIntents = ns, xl.getRangeTo = ri, xl.globalPosition = ei, xl.isExit = hi,
-xl.isPositionWalkable = bi, xl.move = ds, xl.moveByPath = function(e, t, r) {
+}, Ol.followPath = hs, Ol.fromGlobalPosition = ti, Ol.generatePath = ts, Ol.getCachedPath = vs,
+Ol.getMoveIntents = ns, Ol.getRangeTo = ri, Ol.globalPosition = ei, Ol.isExit = hi,
+Ol.isPositionWalkable = bi, Ol.move = ds, Ol.moveByPath = function(e, t, r) {
 var o, n, a, i;
 const s = null !== (o = null == r ? void 0 : r.repathIfStuck) && void 0 !== o ? o : Ta.DEFAULT_MOVE_OPTS.repathIfStuck, c = null !== (i = null === (a = null !== (n = null == r ? void 0 : r.avoidTargets) && void 0 !== n ? n : Ta.DEFAULT_MOVE_OPTS.avoidTargets) || void 0 === a ? void 0 : a(e.pos.roomName)) && void 0 !== i ? i : [];
 let u = wa.get(qi(e, As));
@@ -24864,9 +24868,9 @@ void 0 !== t && (u = (null == r ? void 0 : r.reverse) ? t - 1 : t + 2, wa.set(qi
 }
 let d = vs(t, r);
 return d ? (void 0 !== u && (d = Mi(d, u, null == r ? void 0 : r.reverse)), 0 === d.length ? ERR_NO_PATH : Ms(e, d, r)) : ERR_NO_PATH;
-}, xl.moveTo = Ms, xl.normalizeTargets = Ri, xl.offsetRoomPosition = Da, xl.packCoord = qa,
-xl.packCoordList = za, xl.packPos = Ya, xl.packPosList = Xa, xl.packRoomName = ii,
-xl.packRoomNames = ni, xl.posAtDirection = oi, xl.preTick = function() {
+}, Ol.moveTo = Ms, Ol.normalizeTargets = Ri, Ol.offsetRoomPosition = Da, Ol.packCoord = qa,
+Ol.packCoordList = za, Ol.packPos = Ya, Ol.packPosList = Xa, Ol.packRoomName = ii,
+Ol.packRoomNames = ni, Ol.posAtDirection = oi, Ol.preTick = function() {
 yi(), function() {
 for (const e in Game.rooms) Ui(e), Fi(e);
 !function() {
@@ -24878,34 +24882,34 @@ n.expires && n.expires < Game.time ? (null === (e = Bi.get(n.room1)) || void 0 =
 null === (t = Bi.get(n.room2)) || void 0 === t || t.delete(n.room1)) : Memory[Ta.MEMORY_PORTAL_PATH].push(Wi(n)));
 }();
 }();
-}, xl.reconcileTraffic = function(e) {
+}, Ol.reconcileTraffic = function(e) {
 for (const t of [ ...rs.keys() ]) Game.rooms[t] && ms(t, e);
 _a.with(Oa).set(cs, Game.time);
-}, xl.reconciledRecently = us, xl.resetCachedPath = gs, xl.roomNameFromCoords = $a,
-xl.roomNameToCoords = Ja, xl.sameRoomPosition = La, xl.unpackCoord = ja, xl.unpackCoordList = Qa,
-xl.unpackPos = Va, xl.unpackPosList = Za, xl.unpackRoomName = si, xl.unpackRoomNames = ai,
-xl;
+}, Ol.reconciledRecently = us, Ol.resetCachedPath = gs, Ol.roomNameFromCoords = $a,
+Ol.roomNameToCoords = Ja, Ol.sameRoomPosition = La, Ol.unpackCoord = ja, Ol.unpackCoordList = Qa,
+Ol.unpackPos = Va, Ol.unpackPosList = Za, Ol.unpackRoomName = si, Ol.unpackRoomNames = ai,
+Ol;
 }();
 
-function Ol(e) {
+function Ml(e) {
 var t = Game.rooms[e];
 if (!t) return null;
 var r = t.find(FIND_MY_SPAWNS);
 return r.length > 0 ? r[0].pos : new RoomPosition(25, 25, e);
 }
 
-var kl, Ml = 5e5;
+var Al, Ul = 5e5;
 
-function Al(e) {
+function _l(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || !e.storage || !e.terminal) return null;
 if (!function(e) {
 var t, r, o, n = null !== (r = null === (t = e.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, a = (o = e.name,
 Memory.rooms || (Memory.rooms = {}), Memory.rooms[o] || (Memory.rooms[o] = {}),
-Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Ml;
+Memory.rooms[o]), i = !0 === a.energyExportActive, s = n >= 8e5 || i && n > Ul;
 return a.energyExportActive = s, s;
 }(e)) return null;
-var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Ml), u = Math.min(i, s, c);
+var r = e.storage, o = e.terminal, n = r.store.getUsedCapacity(RESOURCE_ENERGY), a = o.store.getUsedCapacity(RESOURCE_ENERGY), i = o.store.getFreeCapacity(RESOURCE_ENERGY), s = Math.max(0, 25e4 - a), c = Math.max(0, n - Ul), u = Math.min(i, s, c);
 return u <= 0 ? null : {
 storage: r,
 terminal: o,
@@ -24917,21 +24921,21 @@ amount: u
 
 !function(e) {
 e[e.LOW = 10] = "LOW", e[e.NORMAL = 50] = "NORMAL", e[e.HIGH = 100] = "HIGH", e[e.CRITICAL = 200] = "CRITICAL";
-}(kl || (kl = {}));
+}(Al || (Al = {}));
 
-var Ul = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], _l = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Nl = new Set([ "build", "repair", "upgrade" ]), Pl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
+var Nl = [ "larvaWorker", "hauler", "queenCarrier", "remoteHauler", "builder", "upgrader", "engineer", "interRoomCarrier" ], Pl = [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ], Il = new Set([ "build", "repair", "upgrade" ]), Gl = [ "guard", "remoteGuard", "healer", "soldier", "siegeUnit", "harasser", "ranger" ];
 
-function Il(e, t) {
+function Ll(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-function Gl() {
+function Dl() {
 var e = globalThis.Game;
 return e && "object" == typeof e ? e : null;
 }
 
-function Ll() {
+function Bl() {
 var e = function() {
 var e = globalThis.Memory;
 return e && "object" == typeof e ? e : null;
@@ -24946,8 +24950,8 @@ rooms: {}
 };
 }
 
-function Dl(e) {
-var t = Ll();
+function Fl(e) {
+var t = Bl();
 return t.rooms[e] || (t.rooms[e] = function(e) {
 return {
 roomName: e,
@@ -24966,42 +24970,42 @@ preemptions: 0
 }(e)), t.rooms[e];
 }
 
-function Bl(e, t, r) {
+function Wl(e, t, r) {
 return "".concat(e, ":").concat(t, ":").concat(null != r ? r : "room");
 }
 
-function Fl(e) {
+function Hl(e) {
 return Math.max(0, e.amount - e.reservedAmount);
 }
 
-function Wl(e) {
-return _l.includes(e);
-}
-
-function Hl(e) {
-return Nl.has(e);
-}
-
 function Kl(e) {
-return e.store.getUsedCapacity(RESOURCE_ENERGY);
+return Pl.includes(e);
 }
 
 function Yl(e) {
+return Il.has(e);
+}
+
+function Vl(e) {
+return e.store.getUsedCapacity(RESOURCE_ENERGY);
+}
+
+function ql(e) {
 return Math.max(0, e.store.getCapacity(RESOURCE_ENERGY));
 }
 
-function Vl(e, t, r) {
-if (void 0 === r && (r = {}), "harvest" === t.type) return Yl(e);
-var o = Kl(e);
-return r.reserveEmptyEnergyDelivery && Wl(t.type) ? Yl(e) : Math.max(1, o);
+function jl(e, t, r) {
+if (void 0 === r && (r = {}), "harvest" === t.type) return ql(e);
+var o = Vl(e);
+return r.reserveEmptyEnergyDelivery && Kl(t.type) ? ql(e) : Math.max(1, o);
 }
 
-function ql(e, t) {
+function zl(e, t) {
 var r, o = null === (r = e.reservations[t]) || void 0 === r ? void 0 : r.amount;
 return "number" == typeof o && Number.isFinite(o) && o > 0 ? o : void 0;
 }
 
-function jl(e, t, r) {
+function Ql(e, t, r) {
 if (void 0 === r && (r = {}), !t.allowedRoles.includes(e.memory.role)) return !1;
 switch (t.type) {
 case "refillSpawn":
@@ -25009,12 +25013,12 @@ case "refillExtension":
 case "refillTower":
 case "fillTerminalEnergy":
 case "storeEnergy":
-return Kl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && Yl(e.creep) > 0;
+return Vl(e.creep) > 0 || !0 === r.reserveEmptyEnergyDelivery && ql(e.creep) > 0;
 
 case "build":
 case "repair":
 case "upgrade":
-return Kl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
+return Vl(e.creep) > 0 && e.creep.getActiveBodyparts(WORK) > 0;
 
 case "harvest":
 return !e.isFull && e.creep.getActiveBodyparts(WORK) > 0;
@@ -25033,7 +25037,7 @@ return !1;
 }
 }
 
-function zl(e, t) {
+function Xl(e, t) {
 var r = e.tasks[t.id];
 if (r) return r.priority = t.priority, r.targetId = t.targetId, r.targetPos = t.targetPos,
 r.resourceType = t.resourceType, r.amount = t.amount, r.maxAssignments = t.maxAssignments,
@@ -25050,7 +25054,7 @@ updatedTick: Game.time
 return e.tasks[n.id] = n, e.stats.generated++, n;
 }
 
-function Ql(e) {
+function Zl(e) {
 if (e) return {
 x: e.x,
 y: e.y,
@@ -25058,36 +25062,36 @@ roomName: e.roomName
 };
 }
 
-function Xl(e, t, r, o, n) {
+function Jl(e, t, r, o, n) {
 return {
-id: Bl(e, t, r.id),
+id: Wl(e, t, r.id),
 roomName: e,
 type: t,
 priority: n,
 targetId: r.id,
-targetPos: Ql(r.pos),
+targetPos: Zl(r.pos),
 resourceType: RESOURCE_ENERGY,
 amount: o,
 maxAssignments: Math.max(1, Math.ceil(o / 50)),
-allowedRoles: Ul,
+allowedRoles: Nl,
 expiresTick: Game.time + 50
 };
 }
 
-function Zl(e, t) {
+function $l(e, t) {
 var r, o, n, i, s, c, u, l, m, d, p = function() {
 var e, t, r;
-return null !== (r = null === (t = null === (e = Gl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
+return null !== (r = null === (t = null === (e = Dl()) || void 0 === e ? void 0 : e.cpu) || void 0 === t ? void 0 : t.bucket) && void 0 !== r ? r : 1e4;
 }() < 4e3 ? 5 : 3;
 if (!(Game.time - t.lastGeneratedTick < p)) {
 t.lastGeneratedTick = Game.time;
-var f = Il("taskBoard.findMyStructures", function() {
+var f = Ll("taskBoard.findMyStructures", function() {
 return e.find(FIND_MY_STRUCTURES);
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
 var g, h = v.value;
-h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && zl(t, Xl(e.name, "refillTower", h, g, kl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && zl(t, Xl(e.name, "refillExtension", h, g, kl.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && zl(t, Xl(e.name, "refillSpawn", h, g, kl.CRITICAL));
+h.structureType !== STRUCTURE_SPAWN ? h.structureType !== STRUCTURE_EXTENSION ? h.structureType === STRUCTURE_TOWER && (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) >= 100 && Xl(t, Jl(e.name, "refillTower", h, g, Al.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Xl(t, Jl(e.name, "refillExtension", h, g, Al.HIGH)) : (g = h.store.getFreeCapacity(RESOURCE_ENERGY)) > 0 && Xl(t, Jl(e.name, "refillSpawn", h, g, Al.CRITICAL));
 }
 } catch (e) {
 r = {
@@ -25100,29 +25104,29 @@ v && !v.done && (o = y.return) && o.call(y);
 if (r) throw r.error;
 }
 }
-var R = Al(e);
-R && zl(t, Xl(e.name, "fillTerminalEnergy", R.terminal, R.amount, kl.NORMAL));
+var R = _l(e);
+R && Xl(t, Jl(e.name, "fillTerminalEnergy", R.terminal, R.amount, Al.NORMAL));
 var E = null !== (l = null === (u = e.storage) || void 0 === u ? void 0 : u.store.getFreeCapacity(RESOURCE_ENERGY)) && void 0 !== l ? l : 0;
 if (e.storage && E > 0) {
-var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < Ys ? kl.NORMAL : kl.LOW, S = Math.min(E, 1e3);
-zl(t, Xl(e.name, "storeEnergy", e.storage, S, C));
+var T = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), C = (null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : 0) >= 4 && T < qs ? Al.NORMAL : Al.LOW, S = Math.min(E, 1e3);
+Xl(t, Jl(e.name, "storeEnergy", e.storage, S, C));
 }
-var w = Il("taskBoard.findHostiles", function() {
+var w = Ll("taskBoard.findHostiles", function() {
 return Z(e);
 });
 try {
 for (var x = a(w.slice(0, 5)), b = x.next(); !b.done; b = x.next()) {
 var O = b.value;
-zl(t, {
-id: Bl(e.name, "defend", O.id),
+Xl(t, {
+id: Wl(e.name, "defend", O.id),
 roomName: e.name,
 type: "defend",
-priority: kl.CRITICAL,
+priority: Al.CRITICAL,
 targetId: O.id,
-targetPos: Ql(O.pos),
+targetPos: Zl(O.pos),
 amount: O.hits,
 maxAssignments: 3,
-allowedRoles: Pl,
+allowedRoles: Gl,
 expiresTick: Game.time + 50
 });
 }
@@ -25137,7 +25141,7 @@ b && !b.done && (i = x.return) && i.call(x);
 if (n) throw n.error;
 }
 }
-var k = Il("taskBoard.findInjuredAllies", function() {
+var k = Ll("taskBoard.findInjuredAllies", function() {
 return e.find(FIND_MY_CREEPS, {
 filter: function(e) {
 return e.hits < e.hitsMax;
@@ -25147,13 +25151,13 @@ return e.hits < e.hitsMax;
 try {
 for (var M = a(k.slice(0, 5)), A = M.next(); !A.done; A = M.next()) {
 var U = A.value;
-zl(t, {
-id: Bl(e.name, "heal", U.id),
+Xl(t, {
+id: Wl(e.name, "heal", U.id),
 roomName: e.name,
 type: "heal",
-priority: kl.HIGH,
+priority: Al.HIGH,
 targetId: U.id,
-targetPos: Ql(U.pos),
+targetPos: Zl(U.pos),
 amount: U.hitsMax - U.hits,
 maxAssignments: 1,
 allowedRoles: [ "healer" ],
@@ -25174,17 +25178,17 @@ if (s) throw s.error;
 }
 }
 
-function Jl(e) {
+function em(e) {
 e.assignedCreeps = Object.keys(e.reservations), e.reservedAmount = Object.values(e.reservations).reduce(function(e, t) {
 return e + t.amount;
 }, 0), e.status = e.assignedCreeps.length > 0 ? "assigned" : "open";
 }
 
-function $l(e) {
+function tm(e) {
 return Boolean(e && "object" == typeof e && "owner" in e && z(e));
 }
 
-function em(e) {
+function rm(e) {
 if (!e.targetId) return !0;
 var t = Game.getObjectById(e.targetId);
 if (!t) return !1;
@@ -25196,7 +25200,7 @@ case "storeEnergy":
 return "store" in t && t.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 
 case "fillTerminalEnergy":
-var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? Al(r) : null;
+var r = "room" in t ? t.room : Game.rooms[e.roomName], o = r ? _l(r) : null;
 return Boolean(o && o.terminal.id === e.targetId);
 
 case "build":
@@ -25209,11 +25213,11 @@ case "heal":
 return "hits" in t && t.hits < t.hitsMax;
 
 case "defend":
-return !$l(t);
+return !tm(t);
 }
 }
 
-function tm(e, t) {
+function om(e, t) {
 t.status = "invalid", function(e) {
 var t, r;
 try {
@@ -25235,7 +25239,7 @@ if (t) throw t.error;
 }(t), e.stats.invalidated++, delete e.tasks[t.id];
 }
 
-function rm(e, t) {
+function nm(e, t) {
 var r, o, n, s;
 if (void 0 === t && (t = !1), t || e.lastCleanedTick !== Game.time) {
 e.lastCleanedTick = Game.time;
@@ -25243,7 +25247,7 @@ var c = 0;
 try {
 for (var u = a(Object.values(e.tasks)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-if (Hl(m.type)) tm(e, m); else {
+if (Yl(m.type)) om(e, m); else {
 try {
 for (var d = (n = void 0, a(Object.entries(m.reservations))), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
@@ -25260,7 +25264,7 @@ p && !p.done && (s = d.return) && s.call(d);
 if (n) throw n.error;
 }
 }
-Jl(m), Game.time > m.expiresTick || !em(m) ? tm(e, m) : (Fl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Wl(m.type)) && (m.status = "assigned");
+em(m), Game.time > m.expiresTick || !rm(m) ? om(e, m) : (Hl(m) <= 0 || m.assignedCreeps.length >= m.maxAssignments && !Kl(m.type)) && (m.status = "assigned");
 }
 }
 } catch (e) {
@@ -25278,7 +25282,7 @@ e.stats.staleReservations = c;
 }
 }
 
-function om(e, t, r) {
+function am(e, t, r) {
 if (t.reservations[r]) {
 delete t.reservations[r];
 var o = Game.creeps[r];
@@ -25286,15 +25290,15 @@ if (o) {
 var n = o.memory;
 "assignedTaskId" in n && delete n.assignedTaskId;
 }
-Jl(t);
+em(t);
 }
 }
 
-function nm(e, t) {
+function im(e, t) {
 return !t.allowedTypes || t.allowedTypes.includes(e.type);
 }
 
-function am(e, t, r) {
+function sm(e, t, r) {
 var o, n, a, i;
 void 0 === r && (r = {});
 var s = function(e, t, r) {
@@ -25308,37 +25312,37 @@ return e.reservations[t];
 }(e, t.creep.name, t.memory.assignedTaskId);
 s && t.memory.assignedTaskId !== s.id ? t.memory.assignedTaskId = s.id : !s && t.memory.assignedTaskId && delete t.memory.assignedTaskId;
 var c = null;
-if (s && nm(s, r) && em(s) && jl(t, s, r)) {
+if (s && im(s, r) && rm(s) && Ql(t, s, r)) {
 if (!function(e, t) {
-var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= kl.CRITICAL ? 6 : 3;
+var r, o = e.memory, n = null !== (r = o.assignedTaskPreemptCheckTick) && void 0 !== r ? r : 0, a = t.priority >= Al.CRITICAL ? 6 : 3;
 return !(Game.time - n < a || (o.assignedTaskPreemptCheckTick = Game.time, 0));
 }(t, s)) return s;
-var u = im(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : kl.CRITICAL);
+var u = cm(e, t, r), l = (null !== (o = null == u ? void 0 : u.priority) && void 0 !== o ? o : 0) - s.priority, m = null !== (n = r.priorityStickinessDelta) && void 0 !== n ? n : 75, d = (null !== (a = null == u ? void 0 : u.priority) && void 0 !== a ? a : 0) >= (null !== (i = r.preemptPriority) && void 0 !== i ? i : Al.CRITICAL);
 if (!u || l < m || !d) return s;
-c = u, om(0, s, t.creep.name), e.stats.preemptions++;
-} else if (s && (c = im(e, t, r), om(0, s, t.creep.name), e.stats.preemptions++,
+c = u, am(0, s, t.creep.name), e.stats.preemptions++;
+} else if (s && (c = cm(e, t, r), am(0, s, t.creep.name), e.stats.preemptions++,
 !c)) return null;
-if (null != c || (c = im(e, t, r)), !c) return null;
-var p = Vl(t.creep, c, r);
+if (null != c || (c = cm(e, t, r)), !c) return null;
+var p = jl(t.creep, c, r);
 if (p <= 0) return null;
-var f = Math.min(Math.max(1, Fl(c)), p);
+var f = Math.min(Math.max(1, Hl(c)), p);
 return t.memory.assignedTaskId = c.id, c.reservations[t.creep.name] = {
 creepName: t.creep.name,
 amount: f,
 assignedTick: Game.time,
 expiresTick: Game.time + 15
-}, c.updatedTick = Game.time, Jl(c), e.stats.assigned++, c;
+}, c.updatedTick = Game.time, em(c), e.stats.assigned++, c;
 }
 
-function im(e, t, r) {
+function cm(e, t, r) {
 var o, n;
 void 0 === r && (r = {});
 var i = null, s = -1 / 0;
 try {
 for (var c = a(Object.values(e.tasks)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (nm(l, r) && jl(t, l, r) && em(l) && !(Fl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Wl(l.type))) {
-var m = sm(t.creep, l), d = 1e3 * l.priority - m;
+if (im(l, r) && Ql(t, l, r) && rm(l) && !(Hl(l) <= 0) && (!(l.assignedCreeps.length >= l.maxAssignments) || Kl(l.type))) {
+var m = um(t.creep, l), d = 1e3 * l.priority - m;
 d > s && (i = l, s = d);
 }
 }
@@ -25356,7 +25360,7 @@ if (o) throw o.error;
 return i;
 }
 
-function sm(e, t) {
+function um(e, t) {
 if (t.targetId) {
 var r = Game.getObjectById(t.targetId);
 if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
@@ -25364,7 +25368,7 @@ if (r && "pos" in r) return e.pos.getRangeTo(r.pos);
 return t.targetPos ? e.pos.getRangeTo(new RoomPosition(t.targetPos.x, t.targetPos.y, t.targetPos.roomName)) : 50;
 }
 
-function cm(e, t) {
+function lm(e, t) {
 if (!e.targetId) return null;
 var r = Game.getObjectById(e.targetId);
 if (!r) return null;
@@ -25378,7 +25382,7 @@ return {
 type: "transfer",
 target: r,
 resourceType: RESOURCE_ENERGY,
-amount: ql(e, t.creep.name)
+amount: zl(e, t.creep.name)
 };
 
 case "build":
@@ -25407,7 +25411,7 @@ target: r
 
 case "defend":
 return function(e, t) {
-if ($l(t)) return null;
+if (tm(t)) return null;
 var r = e.creep.getActiveBodyparts(ATTACK) > 0, o = e.creep.getActiveBodyparts(RANGED_ATTACK) > 0;
 return "ranger" === e.memory.role && o ? {
 type: "rangedAttack",
@@ -25426,83 +25430,83 @@ return null;
 }
 }
 
-var um = function() {
+var mm = function() {
 function e() {}
 return e.prototype.isEnabled = function() {
-return !1 !== Ll().enabled;
+return !1 !== Bl().enabled;
 }, e.prototype.setEnabled = function(e) {
-Ll().enabled = e;
+Bl().enabled = e;
 }, e.prototype.getAssignedAction = function(e, t) {
-if (!this.isEnabled() || !Gl()) return null;
-var r = Dl(e.room.name);
-Il("taskBoard.cleanup", function() {
-return rm(r);
-}), Il("taskBoard.generate", function() {
-return Zl(e.room, r);
+if (!this.isEnabled() || !Dl()) return null;
+var r = Fl(e.room.name);
+Ll("taskBoard.cleanup", function() {
+return nm(r);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, r);
 });
-var o = am(r, e, {
+var o = sm(r, e, {
 allowedTypes: t
 });
-return o ? cm(o, e) : null;
+return o ? lm(o, e) : null;
 }, e.prototype.getAssignedDeliveryAction = function(e) {
-if (!this.isEnabled() || !Gl()) return null;
-var t = Dl(e.room.name);
-Il("taskBoard.cleanup", function() {
-return rm(t);
-}), Il("taskBoard.generate", function() {
-return Zl(e.room, t);
+if (!this.isEnabled() || !Dl()) return null;
+var t = Fl(e.room.name);
+Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, t);
 });
-var r = am(t, e, {
+var r = sm(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: kl.NORMAL,
+preemptPriority: Al.NORMAL,
 priorityStickinessDelta: 25
 });
 if (!r) return null;
-var o = cm(r, e);
+var o = lm(r, e);
 return "transfer" === (null == o ? void 0 : o.type) ? o : null;
 }, e.prototype.reserveDeliveryWork = function(e) {
-if (!this.isEnabled() || !Gl()) return !1;
-var t = Dl(e.room.name);
-return Il("taskBoard.cleanup", function() {
-return rm(t);
-}), Il("taskBoard.generate", function() {
-return Zl(e.room, t);
-}), Boolean(am(t, e, {
+if (!this.isEnabled() || !Dl()) return !1;
+var t = Fl(e.room.name);
+return Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, t);
+}), Boolean(sm(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower", "fillTerminalEnergy", "storeEnergy" ],
-preemptPriority: kl.NORMAL,
+preemptPriority: Al.NORMAL,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.reserveCriticalDeliveryWork = function(e) {
-if (!this.isEnabled() || !Gl()) return !1;
-var t = Dl(e.room.name);
-return Il("taskBoard.cleanup", function() {
-return rm(t);
-}), Il("taskBoard.generate", function() {
-return Zl(e.room, t);
-}), Boolean(am(t, e, {
+if (!this.isEnabled() || !Dl()) return !1;
+var t = Fl(e.room.name);
+return Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e.room, t);
+}), Boolean(sm(t, e, {
 allowedTypes: [ "refillSpawn", "refillExtension", "refillTower" ],
-preemptPriority: kl.HIGH,
+preemptPriority: Al.HIGH,
 priorityStickinessDelta: 25,
 reserveEmptyEnergyDelivery: !0
 }));
 }, e.prototype.hasActiveTask = function(e, t) {
-var r, o = Gl();
+var r, o = Dl();
 if (!this.isEnabled() || !o) return !1;
-var n = Dl(e);
-Il("taskBoard.cleanup", function() {
-return rm(n);
+var n = Fl(e);
+Ll("taskBoard.cleanup", function() {
+return nm(n);
 });
 var a = null === (r = o.rooms) || void 0 === r ? void 0 : r[e];
-return a && Il("taskBoard.generate", function() {
-return Zl(a, n);
+return a && Ll("taskBoard.generate", function() {
+return $l(a, n);
 }), Object.values(n.tasks).some(function(e) {
-return t.includes(e.type) && em(e);
+return t.includes(e.type) && rm(e);
 });
 }, e.prototype.refreshRoom = function(e) {
-if (this.isEnabled() && Gl()) {
+if (this.isEnabled() && Dl()) {
 !function(e) {
-var t, r, o, n, s = Ll();
+var t, r, o, n, s = Bl();
 try {
 for (var c = a(Object.entries(s.rooms)), u = c.next(); !u.done; u = c.next()) {
 var l = i(u.value, 2), m = l[0], d = l[1];
@@ -25523,20 +25527,20 @@ if (t) throw t.error;
 }
 }
 }(e.name);
-var t = Dl(e.name);
-Il("taskBoard.cleanup", function() {
-return rm(t);
-}), Il("taskBoard.generate", function() {
-return Zl(e, t);
+var t = Fl(e.name);
+Ll("taskBoard.cleanup", function() {
+return nm(t);
+}), Ll("taskBoard.generate", function() {
+return $l(e, t);
 });
 }
 }, e.prototype.releaseCreep = function(e, t) {
-var r, o, n, i, s = Ll(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
+var r, o, n, i, s = Bl(), c = t ? [ s.rooms[t] ].filter(Boolean) : Object.values(s.rooms);
 try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) om(0, p.value, e);
+for (var d = (n = void 0, a(Object.values(m.tasks))), p = d.next(); !p.done; p = d.next()) am(0, p.value, e);
 } catch (e) {
 n = {
 error: e
@@ -25563,37 +25567,37 @@ if (r) throw r.error;
 }, e.prototype.refreshCreepReservation = function(e, t) {
 var r, o, n = e.memory.assignedTaskId;
 if (!n) return null;
-var a = Ll(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
-if (!(s && c && u && c.targetId === t.target.id && Wl(c.type) && em(c))) return delete e.memory.assignedTaskId,
+var a = Bl(), i = t.target.pos.roomName, s = null !== (r = a.rooms[i]) && void 0 !== r ? r : a.rooms[e.room.name], c = null == s ? void 0 : s.tasks[n], u = null == c ? void 0 : c.reservations[e.creep.name];
+if (!(s && c && u && c.targetId === t.target.id && Kl(c.type) && rm(c))) return delete e.memory.assignedTaskId,
 null;
-var l = null !== (o = ql(c, e.creep.name)) && void 0 !== o ? o : t.amount;
+var l = null !== (o = zl(c, e.creep.name)) && void 0 !== o ? o : t.amount;
 return "number" != typeof l || !Number.isFinite(l) || l <= 0 ? (delete e.memory.assignedTaskId,
 null) : (u.amount = l, u.expiresTick = Game.time + 15, c.updatedTick = Game.time,
-Jl(c), u.amount);
+em(c), u.amount);
 }, e.prototype.refreshAssignedDeliveryReservation = function(e) {
 var t, r = e.memory.assignedTaskId;
 if (!r) return !1;
-var o = Ll(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
-if (!(a && i && s && Wl(i.type) && em(i))) return delete e.memory.assignedTaskId,
+var o = Bl(), n = r.split(":", 1)[0], a = null !== (t = o.rooms[n]) && void 0 !== t ? t : o.rooms[e.room.name], i = null == a ? void 0 : a.tasks[r], s = null == i ? void 0 : i.reservations[e.creep.name];
+if (!(a && i && s && Kl(i.type) && rm(i))) return delete e.memory.assignedTaskId,
 !1;
-var c = Vl(e.creep, i, {
+var c = jl(e.creep, i, {
 reserveEmptyEnergyDelivery: !0
 });
-return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Fl(i) + s.amount), c),
-s.expiresTick = Game.time + 15, i.updatedTick = Game.time, Jl(i), !0);
+return c <= 0 ? (delete e.memory.assignedTaskId, !1) : (s.amount = Math.min(Math.max(1, Hl(i) + s.amount), c),
+s.expiresTick = Game.time + 15, i.updatedTick = Game.time, em(i), !0);
 }, e.prototype.clear = function(e) {
-var t = Ll();
+var t = Bl();
 e ? delete t.rooms[e] : t.rooms = {};
 }, e.prototype.getStats = function(e) {
-var t, r = Gl();
+var t, r = Dl();
 if (!r) return null;
 var o = null === (t = r.rooms) || void 0 === t ? void 0 : t[e];
 if (!o) return null;
-var n = Dl(e);
-Il("taskBoard.cleanup", function() {
-return rm(n, !0);
-}), Il("taskBoard.generate", function() {
-return Zl(o, n);
+var n = Fl(e);
+Ll("taskBoard.cleanup", function() {
+return nm(n, !0);
+}), Ll("taskBoard.generate", function() {
+return $l(o, n);
 });
 var a = Object.values(n.tasks);
 return {
@@ -25618,10 +25622,10 @@ staleReservations: n.stats.staleReservations,
 preemptions: n.stats.preemptions
 };
 }, e.prototype.describe = function(e) {
-var t, r, o = Gl(), n = null == o ? void 0 : o.rooms[e];
+var t, r, o = Dl(), n = null == o ? void 0 : o.rooms[e];
 if (!n) return "Room ".concat(e, " is not visible");
-var i = Dl(e);
-rm(i, !0), Zl(n, i);
+var i = Fl(e);
+nm(i, !0), $l(n, i);
 var s = [ "Tasks for ".concat(e, " (enabled=").concat(this.isEnabled(), ")") ];
 try {
 for (var c = a(Object.values(i.tasks).sort(function(e, t) {
@@ -25643,8 +25647,8 @@ if (t) throw t.error;
 }
 return s.join("\n");
 }, e.prototype.describeAssignments = function(e) {
-var t, r, o, n, i, s = Dl(e);
-rm(s, !0);
+var t, r, o, n, i, s = Fl(e);
+nm(s, !0);
 var c = [ "Task assignments for ".concat(e) ];
 try {
 for (var u = a(Object.values(s.tasks)), l = u.next(); !l.done; l = u.next()) {
@@ -25679,15 +25683,15 @@ if (t) throw t.error;
 }
 return c.join("\n");
 }, e;
-}(), lm = new um;
+}(), dm = new mm;
 
-function mm(e) {
+function pm(e) {
 return e === ERR_NO_PATH;
 }
 
-function dm(e) {
+function fm(e) {
 return e.actionResult === ERR_NOT_IN_RANGE ? {
-clearState: void 0 !== e.moveResult && mm(e.moveResult),
+clearState: void 0 !== e.moveResult && pm(e.moveResult),
 moved: !0,
 trackMetrics: !1
 } : {
@@ -25698,11 +25702,11 @@ trackMetrics: e.actionResult === OK
 var t;
 }
 
-var pm, fm = M("ActionExecutor");
+var ym, vm = M("ActionExecutor");
 
-function ym(e, t, r) {
+function gm(e, t, r) {
 var o;
-return !!z(r) && (fm.warn("Refusing harmful action against known ally target", {
+return !!z(r) && (vm.warn("Refusing harmful action against known ally target", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -25710,37 +25714,37 @@ action: t,
 target: r.id,
 owner: null === (o = r.owner) || void 0 === o ? void 0 : o.username
 }
-}), delete e.memory.state, e.creep.id && (bl.clearCachedPath(e.creep), Rt(e.creep)),
-lm.releaseCreep(e.creep.name, e.creep.room.name), !0);
+}), delete e.memory.state, e.creep.id && (kl.clearCachedPath(e.creep), Rt(e.creep)),
+dm.releaseCreep(e.creep.name, e.creep.room.name), !0);
 }
 
-function vm(e, t, r) {
+function hm(e, t, r) {
 var o, n;
-if (!t || !t.type) return fm.warn("".concat(e.name, " received invalid action, clearing state")),
+if (!t || !t.type) return vm.warn("".concat(e.name, " received invalid action, clearing state")),
 void delete r.memory.state;
 var a = function(e, t) {
 return t;
 }(0, t);
-t.type !== a.type && fm.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
-fm.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
+t.type !== a.type && vm.debug("".concat(e.name, " opportunistic action: ").concat(t.type, " → ").concat(a.type)),
+vm.debug("".concat(e.name, " (").concat(r.memory.role, ") executing ").concat(a.type));
 var i = !1;
 switch (a.type) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.harvest(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "pickup":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.pickup(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "withdraw":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.withdraw(a.target, a.resourceType);
 }, a.target, 0, a.type);
 break;
@@ -25764,7 +25768,7 @@ amount: s
 error: ERR_INVALID_ARGS
 };
 }(e, a.target, a.resourceType, a.amount);
-i = hm(e, function() {
+i = Em(e, function() {
 var t;
 return null !== (t = s.error) && void 0 !== t ? t : e.transfer(a.target, a.resourceType, s.amount);
 }, a.target, 0, a.type, {
@@ -25778,92 +25782,92 @@ e.drop(a.resourceType);
 break;
 
 case "build":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.build(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "repair":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.repair(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "upgrade":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.upgradeController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "dismantle":
-if (ym(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = hm(e, function() {
+i = Em(e, function() {
 return e.dismantle(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attack":
-if (ym(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-hm(e, function() {
+Em(e, function() {
 return e.attack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedAttack":
-if (ym(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-hm(e, function() {
+Em(e, function() {
 return e.rangedAttack(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "heal":
-hm(e, function() {
+Em(e, function() {
 return e.heal(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "rangedHeal":
-e.rangedHeal(a.target), mm(bl.moveTo(e, a.target)) && (i = !0);
+e.rangedHeal(a.target), pm(kl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "claim":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.claimController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "reserve":
-i = hm(e, function() {
+i = Em(e, function() {
 return e.reserveController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "attackController":
-if (ym(r, a.type, a.target)) {
+if (gm(r, a.type, a.target)) {
 i = !0;
 break;
 }
-i = hm(e, function() {
+i = Em(e, function() {
 return e.attackController(a.target);
 }, a.target, 0, a.type);
 break;
 
 case "moveTo":
-mm(bl.moveTo(e, a.target)) && (i = !0);
+pm(kl.moveTo(e, a.target)) && (i = !0);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, a.roomName);
-mm(bl.moveTo(e, {
+pm(kl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -25872,11 +25876,11 @@ maxRooms: 16
 break;
 
 case "remoteMoveTo":
-mm(gm(e, a.target, a.routeType)) && (i = !0);
+pm(Rm(e, a.target, a.routeType)) && (i = !0);
 break;
 
 case "remoteMoveToRoom":
-c = new RoomPosition(25, 25, a.roomName), mm(gm(e, {
+c = new RoomPosition(25, 25, a.roomName), pm(Rm(e, {
 pos: c,
 range: 20
 }, a.routeType, {
@@ -25891,44 +25895,44 @@ pos: e,
 range: 10
 };
 });
-mm(bl.moveTo(e, u, {
+pm(kl.moveTo(e, u, {
 flee: !0
 })) && (i = !0);
 break;
 
 case "wait":
-if (bl.isExit(e.pos)) {
+if (kl.isExit(e.pos)) {
 var l = new RoomPosition(25, 25, e.pos.roomName);
-bl.moveTo(e, l, {
+kl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
-e.pos.isEqualTo(a.position) || mm(bl.moveTo(e, a.position)) && (i = !0);
+e.pos.isEqualTo(a.position) || pm(kl.moveTo(e, a.position)) && (i = !0);
 break;
 
 case "requestMove":
-mm(bl.moveTo(e, a.target, {
+pm(kl.moveTo(e, a.target, {
 priority: 5
 })) && (i = !0);
 break;
 
 case "idle":
-if (bl.isExit(e.pos)) {
-l = new RoomPosition(25, 25, e.pos.roomName), bl.moveTo(e, l, {
+if (kl.isExit(e.pos)) {
+l = new RoomPosition(25, 25, e.pos.roomName), kl.moveTo(e, l, {
 priority: 2
 });
 break;
 }
 var m = Game.rooms[e.pos.roomName];
 if (m && (null === (o = m.controller) || void 0 === o ? void 0 : o.my)) {
-var d = Ol(m.name);
+var d = Ml(m.name);
 if (d && !e.pos.isEqualTo(d) && function(e) {
 return "scout" !== e.role;
 }({
 role: r.memory.role
 })) {
-mm(bl.moveTo(e, d, {
+pm(kl.moveTo(e, d, {
 priority: 2
 })) && (i = !0);
 break;
@@ -25937,7 +25941,7 @@ break;
 var p = ((null === (n = Game.rooms[e.pos.roomName]) || void 0 === n ? void 0 : n.find(FIND_MY_SPAWNS)) || []).find(function(t) {
 return e.pos.inRangeTo(t.pos, 1);
 });
-p && bl.moveTo(e, {
+p && kl.moveTo(e, {
 pos: p.pos,
 range: 3
 }, {
@@ -25945,8 +25949,8 @@ flee: !0,
 priority: 2
 });
 }
-i && (delete r.memory.state, bl.clearCachedPath(e), Rt(e), lm.releaseCreep(e.name, e.room.name)),
-"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || lm.releaseCreep(e.name, e.room.name),
+i && (delete r.memory.state, kl.clearCachedPath(e), Rt(e), dm.releaseCreep(e.name, e.room.name)),
+"transfer" !== a.type && "build" !== a.type && "repair" !== a.type && "upgrade" !== a.type || 0 !== e.store.getUsedCapacity(RESOURCE_ENERGY) || dm.releaseCreep(e.name, e.room.name),
 function(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t), t && (e.memory.working = !1),
@@ -25954,27 +25958,27 @@ r && (e.memory.working = !0);
 }(r);
 }
 
-function gm(e, t, r, o) {
-if (!pm) return bl.moveTo(e, t, o);
+function Rm(e, t, r, o) {
+if (!ym) return kl.moveTo(e, t, o);
 try {
-return pm(e, t, r, o);
+return ym(e, t, r, o);
 } catch (n) {
-return fm.warn("Remote movement handler failed; falling back to default movement", {
+return vm.warn("Remote movement handler failed; falling back to default movement", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
 routeType: r,
 error: n instanceof Error ? n.message : String(n)
 }
-}), bl.moveTo(e, t, o);
+}), kl.moveTo(e, t, o);
 }
 }
 
-function hm(e, t, r, o, n, a) {
+function Em(e, t, r, o, n, a) {
 var i = t();
 if (i === ERR_NOT_IN_RANGE) {
-var s = bl.moveTo(e, r);
-return s !== OK && fm.info("Movement attempt returned non-OK result", {
+var s = kl.moveTo(e, r);
+return s !== OK && vm.info("Movement attempt returned non-OK result", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -25982,49 +25986,49 @@ action: null != n ? n : "rangeAction",
 moveResult: s,
 target: r.pos.toString()
 }
-}), dm({
+}), fm({
 actionResult: i,
 moveResult: s
 }).clearState;
 }
-var c = dm({
+var c = fm({
 actionResult: i
 });
 return c.trackMetrics && n && function(e, t, r, o) {
 var n, a, i, s, c, u, l, m = e.memory;
-switch (is(m), t) {
+switch (cs(m), t) {
 case "harvest":
 case "harvestMineral":
 case "harvestDeposit":
 var d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length;
-l = 2 * d, ss(m).energyHarvested += l;
+l = 2 * d, us(m).energyHarvested += l;
 break;
 
 case "transfer":
 var p = null !== (n = null == o ? void 0 : o.resourceType) && void 0 !== n ? n : RESOURCE_ENERGY, f = Math.min(null !== (a = null == o ? void 0 : o.amount) && void 0 !== a ? a : e.store.getUsedCapacity(p), e.store.getUsedCapacity(p), null !== (s = null === (i = r.store) || void 0 === i ? void 0 : i.getFreeCapacity(p)) && void 0 !== s ? s : 1 / 0);
 f > 0 && function(e, t) {
-ss(e).energyTransferred += t;
+us(e).energyTransferred += t;
 }(m, f);
 break;
 
 case "build":
 c = m, u = 5 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
-}).length), ss(c).buildProgress += u;
+}).length), us(c).buildProgress += u;
 break;
 
 case "repair":
 !function(e, t) {
-ss(e).repairProgress += t;
+us(e).repairProgress += t;
 }(m, 100 * (d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length));
 break;
 
 case "attack":
-cs(m, g = 30 * e.body.filter(function(e) {
+ls(m, g = 30 * e.body.filter(function(e) {
 return e.type === ATTACK && e.hits > 0;
 }).length);
 break;
@@ -26033,7 +26037,7 @@ case "rangedAttack":
 var y = e.body.filter(function(e) {
 return e.type === RANGED_ATTACK && e.hits > 0;
 }).length, v = e.pos.getRangeTo(r), g = 0;
-v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), cs(m, g);
+v <= 1 ? g = 10 * y : v <= 2 ? g = 4 * y : v <= 3 && (g = 1 * y), ls(m, g);
 break;
 
 case "heal":
@@ -26042,18 +26046,18 @@ var h = e.body.filter(function(e) {
 return e.type === HEAL && e.hits > 0;
 }).length;
 !function(e, t) {
-ss(e).healingDone += t;
+us(e).healingDone += t;
 }(m, "heal" === t ? 12 * h : 4 * h);
 break;
 
 case "upgrade":
 !function(e, t) {
-ss(e).upgradeProgress += t;
+us(e).upgradeProgress += t;
 }(m, d = e.body.filter(function(e) {
 return e.type === WORK && e.hits > 0;
 }).length);
 }
-}(e, n, r, a), !!c.clearState && (fm.info("Clearing state after action error", {
+}(e, n, r, a), !!c.clearState && (vm.info("Clearing state after action error", {
 room: e.pos.roomName,
 creep: e.name,
 meta: {
@@ -26064,13 +26068,13 @@ target: r.pos.toString()
 }), !0);
 }
 
-var Rm, Em = M("StateMachine");
+var Tm, Cm = M("StateMachine");
 
-function Tm(e) {
+function Sm(e) {
 return "number" == typeof e && Number.isFinite(e) && e > 0 ? e : void 0;
 }
 
-function Cm(e, t, r) {
+function wm(e, t, r) {
 var n;
 return t && t.type ? ("idle" !== t.type ? (e.memory.state = function(e) {
 var t, r = {
@@ -26092,12 +26096,12 @@ return "withdraw" === e.type && (r.data = {
 resourceType: e.resourceType
 }), "transfer" === e.type && (r.data = o({
 resourceType: e.resourceType
-}, void 0 !== Tm(e.amount) ? {
+}, void 0 !== Sm(e.amount) ? {
 amount: e.amount
 } : {})), "remoteMoveTo" !== e.type && "remoteMoveToRoom" !== e.type || (r.data = o(o({}, null !== (t = r.data) && void 0 !== t ? t : {}), {
 routeType: e.routeType
 })), r;
-}(t), Em.info(r, {
+}(t), Cm.info(r, {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26105,13 +26109,13 @@ action: t.type,
 role: e.memory.role,
 targetId: null === (n = e.memory.state) || void 0 === n ? void 0 : n.targetId
 }
-})) : Em.info("Behavior returned idle action", {
+})) : Cm.info("Behavior returned idle action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
 role: e.memory.role
 }
-}), t) : (Em.warn("Behavior returned invalid action, defaulting to idle", {
+}), t) : (Cm.warn("Behavior returned invalid action, defaulting to idle", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26122,11 +26126,11 @@ type: "idle"
 });
 }
 
-function Sm(e, t, r) {
+function xm(e, t, r) {
 var n;
 void 0 === r && (r = {});
 var a = e.memory.state, i = a ? null === (n = r.interrupt) || void 0 === n ? void 0 : n.call(r, e, a) : null;
-if (i) return delete e.memory.state, Cm(e, i, "State interrupted, committed safety action");
+if (i) return delete e.memory.state, wm(e, i, "State interrupted, committed safety action");
 var s = function(e) {
 if (!e) return {
 valid: !1,
@@ -26206,7 +26210,7 @@ return !0;
 default:
 return !1;
 }
-}(a, e)) Em.info("State completed, evaluating new action", {
+}(a, e)) Cm.info("State completed, evaluating new action", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26256,7 +26260,7 @@ resourceType: e.data.resourceType
 
 case "transfer":
 if (i && (null === (r = e.data) || void 0 === r ? void 0 : r.resourceType)) {
-var c = Tm(e.data.amount);
+var c = Sm(e.data.amount);
 return o({
 type: "transfer",
 target: i,
@@ -26339,12 +26343,12 @@ return null;
 if (c) {
 if ("transfer" !== c.type || !e.memory.assignedTaskId) return e.memory.assignedTaskId && function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(c) && lm.refreshAssignedDeliveryReservation(e), c;
-var u = e.memory.assignedTaskId, l = lm.refreshCreepReservation(e, c);
+}(c) && dm.refreshAssignedDeliveryReservation(e), c;
+var u = e.memory.assignedTaskId, l = dm.refreshCreepReservation(e, c);
 if (null !== l) return o(o({}, c), {
 amount: l
 });
-Em.info("Task-board delivery reservation missing, re-evaluating behavior", {
+Cm.info("Task-board delivery reservation missing, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26354,7 +26358,7 @@ assignedTaskId: u
 }
 }), delete e.memory.state;
 }
-Em.info("State reconstruction failed, re-evaluating behavior", {
+Cm.info("State reconstruction failed, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: {
@@ -26362,7 +26366,7 @@ action: a.action,
 role: e.memory.role
 }
 }), delete e.memory.state;
-} else a && (Em.info("State invalid, re-evaluating behavior", {
+} else a && (Cm.info("State invalid, re-evaluating behavior", {
 room: e.creep.pos.roomName,
 creep: e.creep.name,
 meta: o({
@@ -26371,33 +26375,33 @@ role: e.memory.role,
 invalidReason: s.reason
 }, s.meta)
 }), delete e.memory.state);
-return Cm(e, t(e), "Committed new state action");
+return wm(e, t(e), "Committed new state action");
 }
 
-(Rm = {})[FIND_SOURCES] = 5e3, Rm[FIND_MINERALS] = 5e3, Rm[FIND_DEPOSITS] = 100,
-Rm[FIND_STRUCTURES] = 50, Rm[FIND_MY_STRUCTURES] = 50, Rm[FIND_HOSTILE_STRUCTURES] = 20,
-Rm[FIND_MY_SPAWNS] = 100, Rm[FIND_MY_CONSTRUCTION_SITES] = 20, Rm[FIND_CONSTRUCTION_SITES] = 20,
-Rm[FIND_CREEPS] = 5, Rm[FIND_MY_CREEPS] = 5, Rm[FIND_HOSTILE_CREEPS] = 3, Rm[FIND_DROPPED_RESOURCES] = 5,
-Rm[FIND_TOMBSTONES] = 10, Rm[FIND_RUINS] = 10, Rm[FIND_FLAGS] = 50, Rm[FIND_NUKES] = 20,
-Rm[FIND_POWER_CREEPS] = 10, Rm[FIND_MY_POWER_CREEPS] = 10;
+(Tm = {})[FIND_SOURCES] = 5e3, Tm[FIND_MINERALS] = 5e3, Tm[FIND_DEPOSITS] = 100,
+Tm[FIND_STRUCTURES] = 50, Tm[FIND_MY_STRUCTURES] = 50, Tm[FIND_HOSTILE_STRUCTURES] = 20,
+Tm[FIND_MY_SPAWNS] = 100, Tm[FIND_MY_CONSTRUCTION_SITES] = 20, Tm[FIND_CONSTRUCTION_SITES] = 20,
+Tm[FIND_CREEPS] = 5, Tm[FIND_MY_CREEPS] = 5, Tm[FIND_HOSTILE_CREEPS] = 3, Tm[FIND_DROPPED_RESOURCES] = 5,
+Tm[FIND_TOMBSTONES] = 10, Tm[FIND_RUINS] = 10, Tm[FIND_FLAGS] = 50, Tm[FIND_NUKES] = 20,
+Tm[FIND_POWER_CREEPS] = 10, Tm[FIND_MY_POWER_CREEPS] = 10;
 
-var wm, xm, bm = {}, Om = {}, km = {}, Mm = {};
+var bm, Om, km = {}, Mm = {}, Am = {}, Um = {};
 
-function Am() {
-if (wm) return Mm;
-wm = 1;
+function _m() {
+if (bm) return Um;
+bm = 1;
 const e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-return Mm.encode = function(t) {
+return Um.encode = function(t) {
 if (0 <= t && t < e.length) return e[t];
 throw new TypeError("Must be between 0 and 63: " + t);
-}, Mm;
+}, Um;
 }
 
-function Um() {
-if (xm) return km;
-xm = 1;
-const e = Am();
-return km.encode = function(t) {
+function Nm() {
+if (Om) return Am;
+Om = 1;
+const e = _m();
+return Am.encode = function(t) {
 let r, o = "", n = function(e) {
 return e < 0 ? 1 + (-e << 1) : 0 + (e << 1);
 }(t);
@@ -26405,23 +26409,23 @@ do {
 r = 31 & n, n >>>= 5, n > 0 && (r |= 32), o += e.encode(r);
 } while (n > 0);
 return o;
-}, km;
+}, Am;
 }
 
-var _m, Nm, Pm, Im = {}, Gm = ir(Object.freeze({
+var Pm, Im, Gm, Lm = {}, Dm = ir(Object.freeze({
 __proto__: null,
 default: {}
 }));
 
-function Lm() {
-return Nm ? _m : (Nm = 1, _m = "function" == typeof URL ? URL : Gm.URL);
+function Bm() {
+return Im ? Pm : (Im = 1, Pm = "function" == typeof URL ? URL : Dm.URL);
 }
 
-function Dm() {
-if (Pm) return Im;
-Pm = 1;
-const e = Lm();
-Im.getArg = function(e, t, r) {
+function Fm() {
+if (Gm) return Lm;
+Gm = 1;
+const e = Bm();
+Lm.getArg = function(e, t, r) {
 if (t in e) return e[t];
 if (3 === arguments.length) return r;
 throw new Error('"' + t + '" is a required argument.');
@@ -26441,16 +26445,16 @@ return !0;
 function n(e, t) {
 return e === t ? 0 : null === e ? 1 : null === t ? -1 : e > t ? 1 : -1;
 }
-Im.toSetString = t ? r : function(e) {
+Lm.toSetString = t ? r : function(e) {
 return o(e) ? "$" + e : e;
-}, Im.fromSetString = t ? r : function(e) {
+}, Lm.fromSetString = t ? r : function(e) {
 return o(e) ? e.slice(1) : e;
-}, Im.compareByGeneratedPositionsInflated = function(e, t) {
+}, Lm.compareByGeneratedPositionsInflated = function(e, t) {
 let r = e.generatedLine - t.generatedLine;
 return 0 !== r ? r : (r = e.generatedColumn - t.generatedColumn, 0 !== r ? r : (r = n(e.source, t.source),
 0 !== r ? r : (r = e.originalLine - t.originalLine, 0 !== r ? r : (r = e.originalColumn - t.originalColumn,
 0 !== r ? r : n(e.name, t.name)))));
-}, Im.parseSourceMapInput = function(e) {
+}, Lm.parseSourceMapInput = function(e) {
 return JSON.parse(e.replace(/^\)]}'[^\n]*\n/, ""));
 };
 const a = "http://host";
@@ -26504,7 +26508,7 @@ if ("path-absolute" === o) return s(t, s(e, a)).slice(11);
 const n = c(t + e);
 return m(n, s(t, s(e, n)));
 }
-return Im.normalize = f, Im.join = y, Im.relative = function(t, r) {
+return Lm.normalize = f, Lm.join = y, Lm.relative = function(t, r) {
 const o = function(t, r) {
 if (l(t) !== l(r)) return null;
 const o = c(t + r), n = new e(t, o), a = new e(r, o);
@@ -26516,18 +26520,18 @@ return null;
 return a.protocol !== n.protocol || a.user !== n.user || a.password !== n.password || a.hostname !== n.hostname || a.port !== n.port ? null : m(n, a);
 }(t, r);
 return "string" == typeof o ? o : f(r);
-}, Im.computeSourceURL = function(e, t, r) {
+}, Lm.computeSourceURL = function(e, t, r) {
 e && "path-absolute" === l(t) && (t = t.replace(/^\//, ""));
 let o = f(t || "");
 return e && (o = y(e, o)), r && (o = y(p(r), o)), o;
-}, Im;
+}, Lm;
 }
 
-var Bm, Fm = {};
+var Wm, Hm = {};
 
-function Wm() {
-if (Bm) return Fm;
-Bm = 1;
+function Km() {
+if (Wm) return Hm;
+Wm = 1;
 class e {
 constructor() {
 this._array = [], this._set = new Map;
@@ -26560,19 +26564,19 @@ toArray() {
 return this._array.slice();
 }
 }
-return Fm.ArraySet = e, Fm;
+return Hm.ArraySet = e, Hm;
 }
 
-var Hm, Km, Ym = {};
+var Ym, Vm, qm = {};
 
-function Vm() {
-if (Km) return Om;
-Km = 1;
-const e = Um(), t = Dm(), r = Wm().ArraySet, o = function() {
-if (Hm) return Ym;
-Hm = 1;
-const e = Dm();
-return Ym.MappingList = class {
+function jm() {
+if (Vm) return Mm;
+Vm = 1;
+const e = Nm(), t = Fm(), r = Km().ArraySet, o = function() {
+if (Ym) return qm;
+Ym = 1;
+const e = Fm();
+return qm.MappingList = class {
 constructor() {
 this._array = [], this._sorted = !0, this._last = {
 generatedLine: -1,
@@ -26592,7 +26596,7 @@ toArray() {
 return this._sorted || (this._array.sort(e.compareByGeneratedPositionsInflated),
 this._sorted = !0), this._array;
 }
-}, Ym;
+}, qm;
 }().MappingList;
 class n {
 constructor(e) {
@@ -26721,13 +26725,13 @@ toString() {
 return JSON.stringify(this.toJSON());
 }
 }
-return n.prototype._version = 3, Om.SourceMapGenerator = n, Om;
+return n.prototype._version = 3, Mm.SourceMapGenerator = n, Mm;
 }
 
-var qm, jm = {}, zm = {};
+var zm, Qm = {}, Xm = {};
 
-function Qm() {
-return qm || (qm = 1, function(e) {
+function Zm() {
+return zm || (zm = 1, function(e) {
 function t(r, o, n, a, i, s) {
 const c = Math.floor((o - r) / 2) + r, u = i(n, a[c], !0);
 return 0 === u ? c : u > 0 ? o - c > 1 ? t(c, o, n, a, i, s) : s === e.LEAST_UPPER_BOUND ? o < a.length ? o : -1 : c : c - r > 1 ? t(r, c, n, a, i, s) : s == e.LEAST_UPPER_BOUND ? c : r < 0 ? -1 : r;
@@ -26739,36 +26743,36 @@ if (i < 0) return -1;
 for (;i - 1 >= 0 && 0 === n(o[i], o[i - 1], !0); ) --i;
 return i;
 };
-}(zm)), zm;
+}(Xm)), Xm;
 }
 
-var Xm, Zm, Jm, $m, ed = {
+var Jm, $m, ed, td, rd = {
 exports: {}
 };
 
-function td() {
-if (Xm) return ed.exports;
-Xm = 1;
+function od() {
+if (Jm) return rd.exports;
+Jm = 1;
 let e = null;
-return ed.exports = function() {
+return rd.exports = function() {
 if ("string" == typeof e) return fetch(e).then(e => e.arrayBuffer());
 if (e instanceof ArrayBuffer) return Promise.resolve(e);
 throw new Error("You must provide the string URL or ArrayBuffer contents of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer");
-}, ed.exports.initialize = t => {
+}, rd.exports.initialize = t => {
 e = t;
-}, ed.exports;
+}, rd.exports;
 }
 
-function rd() {
-if (Jm) return Zm;
-Jm = 1;
-const e = td();
+function nd() {
+if (ed) return $m;
+ed = 1;
+const e = od();
 function t() {
 this.generatedLine = 0, this.generatedColumn = 0, this.lastGeneratedColumn = null,
 this.source = null, this.originalLine = null, this.originalColumn = null, this.name = null;
 }
 let r = null;
-return Zm = function() {
+return $m = function() {
 if (r) return r;
 const o = [];
 return r = e().then(e => WebAssembly.instantiate(e, {
@@ -26835,28 +26839,28 @@ o.pop();
 })).then(null, e => {
 throw r = null, e;
 }), r;
-}, Zm;
+}, $m;
 }
 
-var od, nd, ad, id, sd = {};
+var ad, id, sd, cd, ud = {};
 
-function cd(e, t, r) {
+function ld(e, t, r) {
 return e - t >= r;
 }
 
-function ud(e, t) {
+function md(e, t) {
 return e.priority - t.priority;
 }
 
-function ld(e, t, r, o) {
+function dd(e, t, r, o) {
 return e !== o && t < r[e];
 }
 
-function md(e, t, r, o) {
+function pd(e, t, r, o) {
 return Boolean(o) && e + t > r;
 }
 
-function dd(e) {
+function fd(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value] = 0;
@@ -26874,12 +26878,12 @@ if (t) throw t.error;
 return o;
 }
 
-nd || (nd = 1, bm.SourceMapGenerator = Vm().SourceMapGenerator, bm.SourceMapConsumer = function() {
-if ($m) return jm;
-$m = 1;
-const e = Dm(), t = Qm(), r = Wm().ArraySet;
-Um();
-const o = td(), n = rd(), a = Symbol("smcInternal");
+id || (id = 1, km.SourceMapGenerator = jm().SourceMapGenerator, km.SourceMapConsumer = function() {
+if (td) return Qm;
+td = 1;
+const e = Fm(), t = Zm(), r = Km().ArraySet;
+Nm();
+const o = od(), n = nd(), a = Symbol("smcInternal");
 class i {
 constructor(t, r) {
 return t == a ? Promise.resolve(this) : function(t, r) {
@@ -26916,7 +26920,7 @@ throw new Error("Subclasses must implement destroy");
 }
 }
 i.prototype._version = 3, i.GENERATED_ORDER = 1, i.ORIGINAL_ORDER = 2, i.GREATEST_LOWER_BOUND = 1,
-i.LEAST_UPPER_BOUND = 2, jm.SourceMapConsumer = i;
+i.LEAST_UPPER_BOUND = 2, Qm.SourceMapConsumer = i;
 class s extends i {
 constructor(t, o) {
 return super(a).then(a => {
@@ -27106,7 +27110,7 @@ lastColumn: null
 };
 }
 }
-s.prototype.consumer = i, jm.BasicSourceMapConsumer = s;
+s.prototype.consumer = i, Qm.BasicSourceMapConsumer = s;
 class c extends i {
 constructor(t, r) {
 return super(a).then(o => {
@@ -27215,11 +27219,11 @@ destroy() {
 for (let e = 0; e < this._sections.length; e++) this._sections[e].consumer.destroy();
 }
 }
-return jm.IndexedSourceMapConsumer = c, jm;
-}().SourceMapConsumer, bm.SourceNode = function() {
-if (od) return sd;
-od = 1;
-const e = Vm().SourceMapGenerator, t = Dm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
+return Qm.IndexedSourceMapConsumer = c, Qm;
+}().SourceMapConsumer, km.SourceNode = function() {
+if (ad) return ud;
+ad = 1;
+const e = jm().SourceMapGenerator, t = Fm(), r = /(\r?\n)/, o = "$$$isSourceNode$$$";
 class n {
 constructor(e, t, r, n, a) {
 this.children = [], this.sourceContents = {}, this.line = null == e ? null : e,
@@ -27358,27 +27362,27 @@ map: o
 };
 }
 }
-return sd.SourceNode = n, sd;
+return ud.SourceNode = n, ud;
 }().SourceNode), function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(id || (id = {}));
+}(cd || (cd = {}));
 
-var pd, fd = [ id.CRITICAL, id.HIGH, id.MEDIUM, id.LOW ], yd = {
-bucketThresholds: (ad = {}, ad[id.CRITICAL] = 0, ad[id.HIGH] = 2e3, ad[id.MEDIUM] = 5e3,
-ad[id.LOW] = 8e3, ad),
+var yd, vd = [ cd.CRITICAL, cd.HIGH, cd.MEDIUM, cd.LOW ], gd = {
+bucketThresholds: (sd = {}, sd[cd.CRITICAL] = 0, sd[cd.HIGH] = 2e3, sd[cd.MEDIUM] = 5e3,
+sd[cd.LOW] = 8e3, sd),
 defaultMaxCpu: 5,
 logExecution: !1
-}, vd = function() {
+}, hd = function() {
 function e(e) {
 this.tasks = new Map, this.stats = {
 totalTasks: 0,
-tasksByPriority: dd(fd),
+tasksByPriority: fd(vd),
 executedThisTick: 0,
 skippedThisTick: 0,
 deferredThisTick: 0,
 cpuUsed: 0
-}, this.config = o(o({}, yd), e);
+}, this.config = o(o({}, gd), e);
 }
 return e.prototype.register = function(e) {
 var t, r, n = o(o({}, e), {
@@ -27392,13 +27396,13 @@ this.tasks.delete(e), this.updateStats();
 }, e.prototype.run = function(e) {
 var t, r, n, i = Game.cpu.getUsed(), s = Game.cpu.bucket, c = null != e ? e : 1 / 0;
 this.stats.executedThisTick = 0, this.stats.skippedThisTick = 0, this.stats.deferredThisTick = 0;
-var u = Array.from(this.tasks.values()).sort(ud), l = 0;
+var u = Array.from(this.tasks.values()).sort(md), l = 0;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (cd(Game.time, p.lastRun, p.interval)) if (ld(p.priority, s, this.config.bucketThresholds, id.CRITICAL)) this.stats.skippedThisTick++; else {
+if (ld(Game.time, p.lastRun, p.interval)) if (dd(p.priority, s, this.config.bucketThresholds, cd.CRITICAL)) this.stats.skippedThisTick++; else {
 var f = null !== (n = p.maxCpu) && void 0 !== n ? n : this.config.defaultMaxCpu;
-if (md(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
+if (pd(l, f, c, p.skippable)) this.stats.deferredThisTick++; else {
 var y = Game.cpu.getUsed();
 try {
 p.execute(), p.lastRun = Game.time, this.stats.executedThisTick++;
@@ -27446,7 +27450,7 @@ return this.tasks.has(e);
 this.tasks.clear(), this.updateStats();
 }, e.prototype.updateStats = function() {
 this.stats.totalTasks = this.tasks.size, this.stats.tasksByPriority = function(e) {
-var t, r, o = dd(fd);
+var t, r, o = fd(vd);
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) o[i.value.priority]++;
 } catch (e) {
@@ -27463,22 +27467,22 @@ if (t) throw t.error;
 return o;
 }(this.tasks.values());
 }, e;
-}(), gd = ((pd = global)._computationScheduler || (pd._computationScheduler = new vd),
-pd._computationScheduler), hd = new Map;
+}(), Rd = ((yd = global)._computationScheduler || (yd._computationScheduler = new hd),
+yd._computationScheduler), Ed = new Map;
 
-function Rd(e) {
-var t = hd.get(e);
+function Td(e) {
+var t = Ed.get(e);
 return t && t.tick === Game.time || (t = {
 assignments: new Map,
 tick: Game.time
-}, hd.set(e, t)), t;
+}, Ed.set(e, t)), t;
 }
 
-function Ed(e, t, r) {
+function Cd(e, t, r) {
 var o, n;
 if (0 === t.length) return null;
-if (1 === t.length) return Td(e, t[0], r), t[0];
-var i = Rd(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
+if (1 === t.length) return Sd(e, t[0], r), t[0];
+var i = Td(e.room.name), s = null, c = 1 / 0, u = 1 / 0;
 try {
 for (var l = a(t), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = "".concat(r, ":").concat(d.id), f = (i.assignments.get(p) || []).length, y = e.pos.getRangeTo(d.pos);
@@ -27495,32 +27499,32 @@ m && !m.done && (n = l.return) && n.call(l);
 if (o) throw o.error;
 }
 }
-return s && Td(e, s, r), s;
+return s && Sd(e, s, r), s;
 }
 
-function Td(e, t, r) {
-var o = Rd(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
+function Sd(e, t, r) {
+var o = Td(e.room.name), n = "".concat(r, ":").concat(t.id), a = o.assignments.get(n) || [];
 a.includes(e.name) || (a.push(e.name), o.assignments.set(n, a));
 }
 
-var Cd = {
+var wd = {
 red: "#ef9a9a",
 green: "#6b9955",
 yellow: "#c5c599",
 blue: "#8dc5e3"
 };
 
-function Sd(e, t, r) {
+function xd(e, t, r) {
 void 0 === t && (t = null), void 0 === r && (r = !1);
-var o = t ? "color: ".concat(Cd[t], ";") : "";
+var o = t ? "color: ".concat(wd[t], ";") : "";
 return '<text style="'.concat([ o, r ? "font-weight: bolder;" : "" ].join(" "), '">').concat(e, "</text>");
 }
 
-function wd(e) {
+function bd(e) {
 return e.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var xd = {
+var Od = {
 customStyle: function() {
 return "<style>\n      input {\n        background-color: #2b2b2b;\n        border: none;\n        border-bottom: 1px solid #888;\n        padding: 3px;\n        color: #ccc;\n      }\n      select {\n        border: none;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n      button {\n        border: 1px solid #888;\n        cursor: pointer;\n        background-color: #2b2b2b;\n        color: #ccc;\n      }\n    </style>".replace(/\n/g, "");
 },
@@ -27534,7 +27538,7 @@ return ' <option value="'.concat(e.value, '">').concat(e.label, "</option>");
 })), !1)), t.push("</select>"), t.join("");
 },
 button: function(e) {
-return '<button onclick="'.concat(wd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
+return '<button onclick="'.concat(bd((t = e.command, "angular.element(document.body).injector().get('Console').sendCommand(".concat(JSON.stringify("(".concat(t, ")()")), ", 1)"))), '">').concat(e.content, "</button>");
 var t;
 },
 form: function(e, t, r) {
@@ -27551,44 +27555,44 @@ return o.select(e) + "    ";
 var c = "(() => {\n      const form = document.forms['".concat(n, "']\n      let formDatas = {}\n      [").concat(t.map(function(e) {
 return "'".concat(e.name, "'");
 }).toString(), "].map(eleName => formDatas[eleName] = form[eleName].value)\n      angular.element(document.body).injector().get('Console').sendCommand(`(").concat(r.command, ")(${JSON.stringify(formDatas)})`, 1)\n    })()");
-return a.push('<button type="button" onclick="'.concat(wd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
+return a.push('<button type="button" onclick="'.concat(bd(c.replace(/\n/g, ";")), '">').concat(r.content, "</button>")),
 a.push("</form>"), a.join("");
 }
 };
 
-function bd() {
+function kd() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return Md() + Ad() + '<div class="module-help">'.concat(e.map(Od).join(""), "</div>");
+return Ud() + _d() + '<div class="module-help">'.concat(e.map(Md).join(""), "</div>");
 }
 
-var Od = function(e) {
-var t = e.api.map(kd).join("");
-return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(Sd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(Sd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
-}, kd = function(e) {
+var Md = function(e) {
+var t = e.api.map(Ad).join("");
+return '<div class="module-container">\n    <div class="module-info">\n      <span class="module-title">'.concat(xd(e.name, "yellow"), '</span>\n      <span class="module-describe">').concat(xd(e.describe, "green"), '</span>\n    </div>\n    <div class="module-api-list">').concat(t, "</div>\n  </div>").replace(/\n/g, "");
+}, Ad = function(e) {
 var t = [];
-e.describe && t.push(Sd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
-return "  - ".concat(Sd(e.name, "blue"), ": ").concat(Sd(e.desc, "green"));
+e.describe && t.push(xd(e.describe, "green")), e.params && t.push(e.params.map(function(e) {
+return "  - ".concat(xd(e.name, "blue"), ": ").concat(xd(e.desc, "green"));
 }).map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""));
 var r = e.params ? e.params.map(function(e) {
-return Sd(e.name, "blue");
-}).join(", ") : "", o = Sd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
+return xd(e.name, "blue");
+}).join(", ") : "", o = xd(e.functionName, "yellow") + (e.commandType ? "" : "(".concat(r, ")"));
 t.push(o);
 var n = t.map(function(e) {
 return '<div class="api-content-line">'.concat(e, "</div>");
 }).join(""), a = "".concat(e.functionName).concat(Game.time);
-return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(Sd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
-}, Md = function() {
+return '\n  <div class="api-container">\n    <label for="'.concat(a, '">').concat(e.title, " ").concat(xd(e.functionName, "yellow", !0), '</label>\n    <input id="').concat(a, '" type="checkbox" />\n    <div class="api-content">').concat(n, "</div>\n  </div>\n  ").replace(/\n/g, "");
+}, Ud = function() {
 return "\n  <style>\n  .module-help {\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-container {\n    padding: 0px 10px 10px 10px;\n    display: flex;\n    flex-flow: column nowrap;\n  }\n  .module-info {\n    margin: 5px;\n    display: flex;\n    flex-flow: row nowrap;\n    align-items: baseline;\n  }\n  .module-title {\n    font-size: 19px;\n    font-weight: bolder;\n    margin-left: -15px;\n  }\n  .module-api-list {\n    display: flex;\n    flex-flow: row wrap;\n  }\n  </style>".replace(/\n/g, "");
-}, Ad = function() {
+}, _d = function() {
 return "\n  <style>\n  .api-content-line {\n    width: max-content;\n    padding-right: 15px;\n  }\n  .api-container {\n    margin: 5px;\n    width: 250px;\n    background-color: #2b2b2b;\n    overflow: hidden;\n    display: flex;\n    flex-flow: column;\n  }\n\n  .api-container label {\n    transition: all 0.1s;\n    min-width: 300px;\n  }\n\n  /* Hide checkbox */\n  .api-container input {\n    display: none;\n  }\n\n  .api-container label {\n    cursor: pointer;\n    display: block;\n    padding: 10px;\n    background-color: #3b3b3b;\n    white-space: nowrap;\n    overflow: hidden;\n    text-overflow: ellipsis;\n  }\n\n  .api-container label:hover, label:focus {\n    background-color: #525252;\n  }\n\n  /* Collapsed state */\n  .api-container input + .api-content {\n    overflow: hidden;\n    transition: all 0.1s;\n    width: auto;\n    max-height: 0px;\n    padding: 0px 10px;\n  }\n\n  /* Expanded state when checkbox is checked */\n  .api-container input:checked + .api-content {\n    max-height: 200px;\n    padding: 10px;\n    background-color: #1c1c1c;\n    overflow-x: auto;\n  }\n  </style>".replace(/\n/g, "");
-}, Ud = M("EnergyCollection"), _d = [ "refillSpawn", "refillExtension", "refillTower" ], Nd = new Set([ "builder", "pioneer", "interShardPioneer" ]);
+}, Nd = M("EnergyCollection"), Pd = [ "refillSpawn", "refillExtension", "refillTower" ], Id = new Set([ "builder", "pioneer", "interShardPioneer" ]);
 
-function Pd(e) {
+function Gd(e) {
 if (e.droppedResources.length > 0) {
 var t = ht(e.creep, e.droppedResources, "energy_drop", 5);
-if (t) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
+if (t) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting dropped resource at ").concat(t.pos)),
 {
 type: "pickup",
 target: t
@@ -27598,15 +27602,15 @@ var r = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (r.length > 0) {
-var o = Ed(e.creep, r, "energy_container");
-if (o) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+var o = Cd(e.creep, r, "energy_container");
+if (o) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting container ").concat(o.id, " at ").concat(o.pos, " with ").concat(o.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
 {
 type: "withdraw",
 target: o,
 resourceType: RESOURCE_ENERGY
 };
-if (Ud.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(r)) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
+if (Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(r.length, " containers but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(r)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback container ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "withdraw",
 target: i,
@@ -27617,8 +27621,8 @@ if (e.storage) {
 var n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
 if (n > 0 && !function(e, t) {
 var r, o;
-return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= Ys && Nd.has(e.memory.role);
-}(e, n)) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
+return (null !== (o = null === (r = e.room.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0) >= 4 && t <= qs && Id.has(e.memory.role);
+}(e, n)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting storage at ").concat(e.storage.pos)),
 {
 type: "withdraw",
 target: e.storage,
@@ -27629,41 +27633,41 @@ var a = ft(e.room).filter(function(e) {
 return e.energy > 0;
 });
 if (a.length > 0) {
-var i, s = Ed(e.creep, a, "energy_source");
-if (s) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
+var i, s = Cd(e.creep, a, "energy_source");
+if (s) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") selecting source ").concat(s.id, " at ").concat(s.pos)),
 {
 type: "harvest",
 target: s
 };
-if (Ud.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
-i = e.creep.pos.findClosestByRange(a)) return Ud.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
+if (Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") found ").concat(a.length, " sources but distribution returned null, falling back to closest")),
+i = e.creep.pos.findClosestByRange(a)) return Nd.debug("".concat(e.creep.name, " (").concat(e.memory.role, ") using fallback source ").concat(i.id, " at ").concat(i.pos)),
 {
 type: "harvest",
 target: i
 };
 }
-return Ud.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
+return Nd.warn("".concat(e.creep.name, " (").concat(e.memory.role, ") findEnergy returning idle - no energy sources available")),
 {
 type: "idle"
 };
 }
 
-function Id(e) {
-var t = lm.getAssignedAction(e, _d);
+function Ld(e) {
+var t = dm.getAssignedAction(e, Pd);
 return "transfer" === (null == t ? void 0 : t.type) ? t : null;
 }
 
-function Gd(e) {
-return lm.hasActiveTask(e.room.name, _d);
+function Dd(e) {
+return dm.hasActiveTask(e.room.name, Pd);
 }
 
-function Ld(e, t) {
+function Bd(e, t) {
 return function(e) {
 return "harvest" === e.type || "withdraw" === e.type && e.resourceType === RESOURCE_ENERGY || "pickup" === e.type && e.target.resourceType === RESOURCE_ENERGY;
-}(t) && lm.reserveCriticalDeliveryWork(e), t;
+}(t) && dm.reserveCriticalDeliveryWork(e), t;
 }
 
-function Dd(e, t) {
+function Fd(e, t) {
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -27690,11 +27694,11 @@ resourceType: RESOURCE_ENERGY
 } : null;
 }
 
-function Bd(e) {
-var t = lm.getAssignedDeliveryAction(e);
+function Wd(e) {
+var t = dm.getAssignedDeliveryAction(e);
 if (t) return t;
-if (!Gd(e)) {
-var r = Dd(e, "deliver");
+if (!Dd(e)) {
+var r = Fd(e, "deliver");
 if (r) return r;
 }
 if (e.storage && e.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) return {
@@ -27716,9 +27720,9 @@ resourceType: RESOURCE_ENERGY
 return null;
 }
 
-var Fd = /^[WE]\d+[NS]\d+$/;
+var Hd = /^[WE]\d+[NS]\d+$/;
 
-function Wd(e) {
+function Kd(e) {
 return function(e) {
 delete e.memory.questId, delete e.memory.questTarget, delete e.memory.questAction;
 }(e), e.room.name !== e.homeRoom ? {
@@ -27728,28 +27732,28 @@ routeType: "hauler"
 } : null;
 }
 
-function Hd(e) {
-return Fd.test(e);
+function Yd(e) {
+return Hd.test(e);
 }
 
-function Kd(e) {
+function Vd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-if (!n || !Hd(n)) return Wd(e);
+if (!n || !Yd(n)) return Kd(e);
 var a = null !== (t = Game.rooms[n]) && void 0 !== t ? t : e.room.name === n ? e.room : void 0;
 return a ? a.find(FIND_CONSTRUCTION_SITES).length > 0 ? e.room.name === n && e.room.name !== e.homeRoom && e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
-} : null : Wd(e) : null;
+} : null : Kd(e) : null;
 }
 
-function Yd(e) {
+function qd(e) {
 var t, r = e.memory, o = r.questAction, n = r.questTarget;
 if ("build" !== o) return null;
-var a = Kd(e);
+var a = Vd(e);
 if (a || "build" !== e.memory.questAction) return a;
-if (!n || !Hd(n)) return null;
+if (!n || !Yd(n)) return null;
 if (e.room.name !== n) return {
 type: "remoteMoveToRoom",
 roomName: n,
@@ -27762,7 +27766,7 @@ target: null != s ? s : i[0]
 };
 }
 
-function Vd(e) {
+function jd(e) {
 var t = 0 === e.creep.store.getUsedCapacity(), r = 0 === e.creep.store.getFreeCapacity();
 void 0 === e.memory.working && (e.memory.working = !t);
 var o = e.memory.working;
@@ -27771,11 +27775,11 @@ var n = e.memory.working;
 return o !== n && Et(e.creep), n;
 }
 
-function qd(e) {
+function zd(e) {
 e.memory.working = !1, Et(e.creep);
 }
 
-var jd = function() {
+var Qd = function() {
 function e() {}
 return e.prototype.getRoomIntel = function(e) {
 var t, r = Memory;
@@ -27870,20 +27874,20 @@ expansionPaused: !1
 lastUpdate: Game.time
 }), e.empire;
 }, e;
-}(), zd = new jd, Qd = M("LarvaWorkerBehavior");
+}(), Xd = new Qd, Zd = M("LarvaWorkerBehavior");
 
-function Xd(e) {
-var t = Vd(e), r = Kd(e);
+function Jd(e) {
+var t = jd(e), r = Vd(e);
 if (r) return r;
 if (t) {
-Qd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
-var o = Yd(e);
+Zd.debug("".concat(e.creep.name, " larvaWorker working with ").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), " energy"));
+var o = qd(e);
 if (o) return o;
-var n = Bd(e);
-if (n) return Qd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
+var n = Wd(e);
+if (n) return Zd.debug("".concat(e.creep.name, " larvaWorker delivering via ").concat(n.type)),
 n;
 var a = function(e) {
-var t, r = zd.getSwarmState(e.room.name);
+var t, r = Xd.getSwarmState(e.room.name);
 return null !== (t = null == r ? void 0 : r.pheromones) && void 0 !== t ? t : null;
 }(e.creep);
 if (a) {
@@ -27900,7 +27904,7 @@ type: "upgrade",
 target: e.room.controller
 };
 }
-if (e.prioritizedSites.length > 0) return Qd.debug("".concat(e.creep.name, " larvaWorker building site")),
+if (e.prioritizedSites.length > 0) return Zd.debug("".concat(e.creep.name, " larvaWorker building site")),
 {
 type: "build",
 target: e.prioritizedSites[0]
@@ -27909,54 +27913,54 @@ if (e.room.controller) return {
 type: "upgrade",
 target: e.room.controller
 };
-if (e.isEmpty) return Qd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
+if (e.isEmpty) return Zd.warn("".concat(e.creep.name, " larvaWorker idle (empty, working=true, no targets) - this indicates a bug")),
 {
 type: "idle"
 };
-Qd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
-qd(e);
+Zd.debug("".concat(e.creep.name, " larvaWorker has energy but no targets, switching to collection mode")),
+zd(e);
 }
-return Ld(e, Pd(e));
+return Bd(e, Gd(e));
 }
 
-function Zd(e) {
+function $d(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-var Jd = new Map;
+var ep = new Map;
 
-function $d(e) {
+function tp(e) {
 var t, r, o, n = null !== (r = null === (t = e.room) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "", a = e, i = null !== (o = a.memory) && void 0 !== o ? o : {};
 return a.memory || (a.memory = i), null == i.role && (i.role = "unknown"), null == i.homeRoom && (i.homeRoom = n),
 null == i.working && (i.working = !1), null == i.room && (i.room = n), i;
 }
 
-var ep = M("HarvesterBehavior"), tp = M("HaulerBehavior"), rp = Ys, op = [ "refillSpawn", "refillExtension" ];
+var rp = M("HarvesterBehavior"), op = M("HaulerBehavior"), np = qs, ap = [ "refillSpawn", "refillExtension" ];
 
-function np(e, t) {
-return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && lm.reserveDeliveryWork(e),
-"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && lm.reserveDeliveryWork(e),
+function ip(e, t) {
+return "withdraw" === t.type && t.resourceType === RESOURCE_ENERGY && dm.reserveDeliveryWork(e),
+"pickup" === t.type && t.target.resourceType === RESOURCE_ENERGY && dm.reserveDeliveryWork(e),
 t;
 }
 
-function ap(e, t, r) {
+function sp(e, t, r) {
 var o, n, a = null !== (o = e.memory) && void 0 !== o ? o : e.memory = {}, i = null !== (n = a.haulerTargetCache) && void 0 !== n ? n : a.haulerTargetCache = {}, s = i[r];
 if (s && Game.time - s.tick <= 5) {
 var c = t.find(function(e) {
 return e.id === s.id;
 });
-if (c) return Td(e, c, r), c;
+if (c) return Sd(e, c, r), c;
 }
-var u = Ed(e, t, r);
+var u = Cd(e, t, r);
 return u ? i[r] = {
 id: u.id,
 tick: Game.time
 } : delete i[r], u;
 }
 
-function ip(e) {
+function cp(e) {
 return !function(e) {
 var t = globalThis.Game;
 return !!(null == t ? void 0 : t.creeps) && Object.values(t.creeps).some(function(t) {
@@ -27970,9 +27974,9 @@ return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_E
 }(e);
 }
 
-function sp(e) {
+function up(e) {
 if (e.creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
-var t = Bd(e);
+var t = Wd(e);
 if (t) return t;
 }
 var r, o = (r = e.creep, Object.keys(r.store).find(function(e) {
@@ -27990,7 +27994,7 @@ resourceType: o
 } : null;
 }
 
-var cp = {
+var lp = {
 getLabResourceNeeds: function() {
 return [];
 },
@@ -28000,11 +28004,11 @@ return [];
 getLabOverflow: function() {
 return [];
 }
-}, up = cp, lp = function(e) {
-return up.getLabResourceNeeds(e);
+}, mp = lp, dp = function(e) {
+return mp.getLabResourceNeeds(e);
 };
 
-function mp(e) {
+function pp(e) {
 var t = function(e) {
 var t, r, o = null !== (t = e.memory.working) && void 0 !== t && t;
 e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0);
@@ -28026,7 +28030,7 @@ resourceType: o
 }
 delete e.memory.targetId;
 }
-var n = lp(e.room.name);
+var n = dp(e.room.name);
 if (0 === n.length) return {
 type: "idle"
 };
@@ -28054,7 +28058,7 @@ resourceType: a.resourceType
 type: "idle"
 };
 }(e) : function(e) {
-var t, r, o = (r = e.room.name, up.getLabOverflow(r));
+var t, r, o = (r = e.room.name, mp.getLabOverflow(r));
 if (o.length > 0) {
 o.sort(function(e, t) {
 return t.priority - e.priority;
@@ -28069,7 +28073,7 @@ resourceType: n.resourceType
 };
 }
 }
-var i = lp(e.room.name);
+var i = dp(e.room.name);
 if (i.length > 0 && e.terminal) {
 i.sort(function(e, t) {
 return t.priority - e.priority;
@@ -28088,8 +28092,8 @@ type: "idle"
 }(e);
 }
 
-var dp = {
-larvaWorker: Xd,
+var fp = {
+larvaWorker: Jd,
 pioneer: function(e) {
 var t, r = e.memory.targetRoom;
 if (!r) return {
@@ -28106,7 +28110,7 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-if (Vd(e)) {
+if (jd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28125,7 +28129,7 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Pd(e);
+return Gd(e);
 },
 interShardPioneer: function(e) {
 var t, r, o = e.memory;
@@ -28162,10 +28166,10 @@ if (o.targetRoom || (o.targetRoom = e.room.name), e.room.name !== o.targetRoom) 
 type: "moveToRoom",
 roomName: o.targetRoom
 };
-if (e.hostiles.some(Zd)) return {
+if (e.hostiles.some($d)) return {
 type: "idle"
 };
-if (Vd(e)) {
+if (jd(e)) {
 var n = function(e) {
 return e.prioritizedSites.find(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
@@ -28184,10 +28188,10 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Pd(e);
+return Gd(e);
 },
 harvester: function(e) {
-var t, r = (t = $d(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
+var t, r = (t = tp(e.creep)).sourceId ? Game.getObjectById(t.sourceId) : null;
 if (r || (r = e.assignedSource), r || (r = function(e) {
 var t, r, o, n, i, s, c, u = e.room.find(FIND_SOURCES);
 if (0 === u.length) return null;
@@ -28236,8 +28240,8 @@ if (o) throw o.error;
 }
 return T && (e.memory.sourceId = T.id, l.set(T.id, (null !== (c = l.get(T.id)) && void 0 !== c ? c : 0) + 1)),
 T;
-}(e), ep.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
-!r) return ep.warn("".concat(e.creep.name, " harvester has no source to harvest")),
+}(e), rp.debug("".concat(e.creep.name, " harvester assigned to source ").concat(null == r ? void 0 : r.id))),
+!r) return rp.warn("".concat(e.creep.name, " harvester has no source to harvest")),
 {
 type: "idle"
 };
@@ -28265,7 +28269,7 @@ return e.structureType === STRUCTURE_LINK;
 return n ? (r.nearbyLinkId = n.id, r.nearbyLinkTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyLinkId,
 void delete r.nearbyLinkTick);
 }(e.creep);
-if (i) return ep.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
+if (i) return rp.debug("".concat(e.creep.name, " harvester transferring to link ").concat(i.id)),
 {
 type: "transfer",
 target: i,
@@ -28286,12 +28290,12 @@ return e.structureType === STRUCTURE_CONTAINER;
 return n ? (r.nearbyContainerId = n.id, r.nearbyContainerTick = Game.time, n.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? n : void 0) : (delete r.nearbyContainerId,
 void delete r.nearbyContainerTick);
 }(e.creep);
-return s ? (ep.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
+return s ? (rp.debug("".concat(e.creep.name, " harvester transferring to container ").concat(s.id)),
 {
 type: "transfer",
 target: s,
 resourceType: RESOURCE_ENERGY
-}) : (ep.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
+}) : (rp.debug("".concat(e.creep.name, " harvester dropping energy on ground")),
 {
 type: "drop",
 resourceType: RESOURCE_ENERGY
@@ -28304,8 +28308,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
 };
-var r = Vd(e), o = "defenseRefuel" === e.memory.task;
-if (tp.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
+var r = jd(e), o = "defenseRefuel" === e.memory.task;
+if (op.debug("".concat(e.creep.name, " hauler state: working=").concat(r, ", energy=").concat(e.creep.store.getUsedCapacity(RESOURCE_ENERGY), "/").concat(e.creep.store.getCapacity())),
 r) {
 var n = Object.keys(e.creep.store)[0];
 if (0 === e.creep.store.getUsedCapacity(RESOURCE_ENERGY) && n && n !== RESOURCE_ENERGY) {
@@ -28318,9 +28322,9 @@ resourceType: n
 }
 if (o) {
 var s = function(e) {
-var t = lm.getAssignedAction(e, op);
+var t = dm.getAssignedAction(e, ap);
 if ("transfer" === (null == t ? void 0 : t.type)) return t;
-if (lm.hasActiveTask(e.room.name, op)) return null;
+if (dm.hasActiveTask(e.room.name, ap)) return null;
 var r = e.spawnStructures.filter(function(e) {
 return e.structureType === STRUCTURE_SPAWN && e.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 });
@@ -28340,17 +28344,17 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (s) return s;
 }
-var c = lm.getAssignedDeliveryAction(e);
+var c = dm.getAssignedDeliveryAction(e);
 if (c) return c;
-if (!Gd(e)) {
-var u = Dd(e, "hauler");
+if (!Dd(e)) {
+var u = Fd(e, "hauler");
 if (u) return u;
 }
 var l = function(e, t) {
 if (!t || !e.terminal || !e.storage) return null;
 if (t === RESOURCE_ENERGY) {
-var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = Al(e.room);
-return r < 2e4 && o > rp && n > 0 || Boolean(a) ? {
+var r = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), o = e.storage.store.getUsedCapacity(RESOURCE_ENERGY), n = e.terminal.store.getFreeCapacity(RESOURCE_ENERGY), a = _l(e.room);
+return r < 2e4 && o > np && n > 0 || Boolean(a) ? {
 type: "transfer",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28376,12 +28380,12 @@ type: "transfer",
 target: m,
 resourceType: RESOURCE_ENERGY
 };
-if (e.isEmpty) return tp.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
+if (e.isEmpty) return op.warn("".concat(e.creep.name, " hauler idle (empty, working=true, no targets)")),
 {
 type: "idle"
 };
-tp.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
-qd(e);
+op.debug("".concat(e.creep.name, " hauler has energy but no targets, switching to collection mode")),
+zd(e);
 }
 if (o) {
 var p = function(e) {
@@ -28389,7 +28393,7 @@ var t = e.sourceContainers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (t.length > 0) {
-var r = ap(e.creep, t, "energy_container");
+var r = sp(e.creep, t, "energy_container");
 if (r) return {
 type: "withdraw",
 target: r,
@@ -28410,7 +28414,7 @@ resourceType: RESOURCE_ENERGY
 }(e);
 if (p) return p;
 }
-if (e.droppedResources.length > 0 && (m = ht(e.creep, e.droppedResources, "hauler_drop", 5))) return np(e, {
+if (e.droppedResources.length > 0 && (m = ht(e.creep, e.droppedResources, "hauler_drop", 5))) return ip(e, {
 type: "pickup",
 target: m
 });
@@ -28420,7 +28424,7 @@ return e.store.getUsedCapacity() > 0;
 if (f.length > 0) {
 var y = ht(e.creep, f, "hauler_tomb", 10);
 if (y) {
-if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return np(e, {
+if (y.store.getUsedCapacity(RESOURCE_ENERGY) > 0) return ip(e, {
 type: "withdraw",
 target: y,
 resourceType: RESOURCE_ENERGY
@@ -28439,24 +28443,24 @@ var g = e.containers.filter(function(e) {
 return e.store.getUsedCapacity(RESOURCE_ENERGY) > 100;
 });
 if (g.length > 0) {
-var h = ap(e.creep, g, "energy_container");
-if (h) return tp.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
-np(e, {
+var h = sp(e.creep, g, "energy_container");
+if (h) return op.debug("".concat(e.creep.name, " hauler withdrawing from container ").concat(h.id, " with ").concat(h.store.getUsedCapacity(RESOURCE_ENERGY), " energy")),
+ip(e, {
 type: "withdraw",
 target: h,
 resourceType: RESOURCE_ENERGY
 });
-tp.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
+op.warn("".concat(e.creep.name, " hauler found ").concat(g.length, " containers but distribution returned null, falling back to closest"));
 var R = e.creep.pos.findClosestByRange(g);
-if (R) return tp.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
-np(e, {
+if (R) return op.debug("".concat(e.creep.name, " hauler using fallback container ").concat(R.id)),
+ip(e, {
 type: "withdraw",
 target: R,
 resourceType: RESOURCE_ENERGY
 });
 }
 if (e.mineralContainers.length > 0) {
-var E = ap(e.creep, e.mineralContainers, "mineral_container");
+var E = sp(e.creep, e.mineralContainers, "mineral_container");
 if (E) {
 if (T = Object.keys(E.store).find(function(e) {
 return e !== RESOURCE_ENERGY && E.store.getUsedCapacity(e) > 0;
@@ -28466,11 +28470,11 @@ target: E,
 resourceType: T
 };
 } else {
-tp.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
+op.warn("".concat(e.creep.name, " hauler found ").concat(e.mineralContainers.length, " mineral containers but distribution returned null, falling back to closest"));
 var T, C = e.creep.pos.findClosestByRange(e.mineralContainers);
 if (C && (T = Object.keys(C.store).find(function(e) {
 return e !== RESOURCE_ENERGY && C.store.getUsedCapacity(e) > 0;
-}))) return tp.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
+}))) return op.debug("".concat(e.creep.name, " hauler using fallback mineral container ").concat(C.id)),
 {
 type: "withdraw",
 target: C,
@@ -28484,7 +28488,7 @@ if (!e.storage || !e.terminal) return null;
 if (e.terminal.cooldown > 0) return null;
 if (e.terminal.store.getFreeCapacity() <= 0) return null;
 var o = e.terminal.store.getUsedCapacity(RESOURCE_ENERGY), n = e.storage.store.getUsedCapacity(RESOURCE_ENERGY);
-if (o < 2e4 && n > rp || Al(e.room)) return {
+if (o < 2e4 && n > np || _l(e.room)) return {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28515,53 +28519,53 @@ if (t) throw t.error;
 }
 return null;
 }(e);
-return S ? np(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (tp.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
-np(e, {
+return S ? ip(e, S) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? (op.debug("".concat(e.creep.name, " hauler withdrawing from storage")),
+ip(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-})) : (tp.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
+})) : (op.warn("".concat(e.creep.name, " hauler idle (no energy sources found)")),
 {
 type: "idle"
 });
 },
 builder: function(e) {
-var t = Vd(e), r = Kd(e);
+var t = jd(e), r = Vd(e);
 if (r) return r;
 if (t) {
-var o = Yd(e);
+var o = qd(e);
 if (o) return o;
-var n = Id(e);
+var n = Ld(e);
 if (n) return n;
-if (!Gd(e)) {
-var a = Dd(e, "builder");
+if (!Dd(e)) {
+var a = Fd(e, "builder");
 if (a) return a;
 }
 var i = function(e) {
 if (!e.room) return null;
-var t = $d(e), r = function(e) {
-var t = Jd.get(e.name);
+var t = tp(e), r = function(e) {
+var t = ep.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_CONSTRUCTION_SITES), o = r.reduce(function(t, r) {
-return Math.max(t, vl(r, e));
+return Math.max(t, hl(r, e));
 }, Number.NEGATIVE_INFINITY), n = {
 tick: Game.time,
 sites: r,
 highestPriority: o
 };
-return Jd.set(e.name, n), n;
+return ep.set(e.name, n), n;
 }(e.room);
 if (0 === r.sites.length) return delete t.targetId, null;
 if (t.targetId) {
 var o = Game.getObjectById(t.targetId);
 if (o && function(e, t) {
 return e.pos.roomName === t.name;
-}(o, e.room) && vl(o, e.room) >= r.highestPriority) return o;
+}(o, e.room) && hl(o, e.room) >= r.highestPriority) return o;
 delete t.targetId;
 }
 var n = function(e, t) {
 var r, o, n = t.sites.filter(function(r) {
-return vl(r, e.room) === t.highestPriority;
+return hl(r, e.room) === t.highestPriority;
 });
 return null !== (o = null !== (r = e.pos.findClosestByRange(n)) && void 0 !== r ? r : n[0]) && void 0 !== o ? o : null;
 }(e, r);
@@ -28580,15 +28584,15 @@ target: e.room.controller
 type: "idle"
 };
 }
-return Ld(e, Pd(e));
+return Bd(e, Gd(e));
 },
 upgrader: function(e) {
-if (Vd(e)) {
-if (ip(e)) {
-var t = Id(e);
+if (jd(e)) {
+if (cp(e)) {
+var t = Ld(e);
 if (t) return t;
-if (!Gd(e)) {
-var r = Dd(e, "upgrader");
+if (!Dd(e)) {
+var r = Fd(e, "upgrader");
 if (r) return r;
 }
 }
@@ -28599,8 +28603,8 @@ target: e.room.controller
 type: "idle"
 };
 }
-var o = ip(e), n = function(t) {
-return o ? Ld(e, t) : t;
+var o = cp(e), n = function(t) {
+return o ? Bd(e, t) : t;
 }, a = e.room.controller;
 if (a) {
 var i = a.pos.findInRange(FIND_MY_STRUCTURES, 2, {
@@ -28635,7 +28639,7 @@ type: "withdraw",
 target: m,
 resourceType: RESOURCE_ENERGY
 });
-if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > Ys) return n({
+if (e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > qs) return n({
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
@@ -28663,7 +28667,7 @@ type: "idle"
 };
 },
 queenCarrier: function(e) {
-if (Vd(e)) {
+if (jd(e)) {
 var t = function(e, t) {
 if (t && !(e.energyAvailable >= e.energyCapacityAvailable)) {
 var r = e.find(FIND_MY_SPAWNS);
@@ -28687,7 +28691,7 @@ return t ? {
 type: "transfer",
 target: t,
 resourceType: RESOURCE_ENERGY
-} : Bd(e) || (e.storage ? {
+} : Wd(e) || (e.storage ? {
 type: "moveTo",
 target: e.storage
 } : {
@@ -28706,15 +28710,15 @@ return e.pos.getRangeTo(t) <= 2;
 })[0];
 }
 }(e.room);
-return r ? Ld(e, {
+return r ? Bd(e, {
 type: "withdraw",
 target: r,
 resourceType: RESOURCE_ENERGY
-}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Ld(e, {
+}) : e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Bd(e, {
 type: "withdraw",
 target: e.storage,
 resourceType: RESOURCE_ENERGY
-}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Ld(e, {
+}) : e.terminal && e.terminal.store.getUsedCapacity(RESOURCE_ENERGY) > 0 ? Bd(e, {
 type: "withdraw",
 target: e.terminal,
 resourceType: RESOURCE_ENERGY
@@ -28807,15 +28811,15 @@ target: i
 labTech: function(e) {
 return 0 === e.labs.length ? {
 type: "idle"
-} : mp(e);
+} : pp(e);
 },
-labSupply: mp,
+labSupply: pp,
 factoryWorker: function(e) {
 var t, r, o, n, i;
 if (!e.factory) return {
 type: "idle"
 };
-if (Vd(e)) {
+if (jd(e)) {
 var s = Object.keys(e.creep.store)[0];
 return {
 type: "transfer",
@@ -28995,11 +28999,11 @@ resourceType: RESOURCE_ENERGY
 };
 },
 remoteHauler: function(e) {
-var t, r = Vd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
+var t, r = jd(e), o = e.memory.targetRoom, n = e.memory.homeRoom, a = e.creep.store.getUsedCapacity() > 0;
 if (!o || o === n) return {
 type: "idle"
 };
-if (a && e.room.name === n && (t = sp(e))) return t;
+if (a && e.room.name === n && (t = up(e))) return t;
 if (e.nearbyEnemies && e.hostiles.length > 0) {
 var i = e.hostiles.filter(function(t) {
 return e.creep.pos.getRangeTo(t) <= 5 && (t.getActiveBodyparts(ATTACK) > 0 || t.getActiveBodyparts(RANGED_ATTACK) > 0);
@@ -29019,7 +29023,7 @@ if (r || a && e.room.name === n) return e.room.name !== n ? {
 type: "remoteMoveToRoom",
 roomName: n,
 routeType: "hauler"
-} : (t = sp(e)) || (a && e.room.name === n ? (qd(e), {
+} : (t = up(e)) || (a && e.room.name === n ? (zd(e), {
 type: "remoteMoveToRoom",
 roomName: o,
 routeType: "hauler"
@@ -29120,16 +29124,16 @@ roomName: o
 }
 };
 
-function pp(e) {
+function yp(e) {
 var t;
-return (null !== (t = dp[e.memory.role]) && void 0 !== t ? t : Xd)(e);
+return (null !== (t = fp[e.memory.role]) && void 0 !== t ? t : Jd)(e);
 }
 
-var fp = new Set([ "build", "repair", "upgrade" ]);
+var vp = new Set([ "build", "repair", "upgrade" ]);
 
-function yp(e, t) {
+function gp(e, t) {
 var r = function(e, t) {
-return "build" !== e.memory.questAction || e.memory.questTarget && Hd(e.memory.questTarget) && (function(e, t) {
+return "build" !== e.memory.questAction || e.memory.questTarget && Yd(e.memory.questTarget) && (function(e, t) {
 var r = e.memory.questTarget;
 if (!r) return !1;
 if (("moveToRoom" === t.action || "remoteMoveToRoom" === t.action) && t.targetRoom === r && e.room.name !== r) return !0;
@@ -29138,12 +29142,12 @@ var o = Game.getObjectById(t.targetId);
 return function(e) {
 return "object" == typeof e && null !== e && "progress" in e && "progressTotal" in e && "pos" in e;
 }(o) && o.pos.roomName === r;
-}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : Yd(e);
+}(e, t) || e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) ? null : qd(e);
 }(e, t);
-return r || (fp.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || ip(e) ? Id(e) : null : null);
+return r || (vp.has(t.action) ? e.creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0 ? null : "upgrader" !== e.memory.role || cp(e) ? Ld(e) : null : null);
 }
 
-var vp = "patrol", gp = [ {
+var hp = "patrol", Rp = [ {
 x: 10,
 y: 5
 }, {
@@ -29179,7 +29183,7 @@ y: 25
 }, {
 x: 44,
 y: 39
-} ], hp = [ {
+} ], Ep = [ {
 x: 10,
 y: 10
 }, {
@@ -29196,7 +29200,7 @@ x: 25,
 y: 25
 } ];
 
-function Rp(e) {
+function Tp(e) {
 var t = e.x, r = e.y;
 return {
 x: Math.max(2, Math.min(47, t)),
@@ -29204,7 +29208,7 @@ y: Math.max(2, Math.min(47, r))
 };
 }
 
-function Ep(e) {
+function Cp(e) {
 return e.map(function(e) {
 return {
 x: e.x,
@@ -29214,9 +29218,9 @@ roomName: e.roomName
 });
 }
 
-function Tp(e) {
+function Sp(e) {
 var t = e.find(FIND_MY_SPAWNS), r = t.length, o = Ee.get(e.name, {
-namespace: vp
+namespace: hp
 });
 if (o && o.metadata.spawnCount === r) return function(e) {
 return e.map(function(e) {
@@ -29236,25 +29240,25 @@ x: e.pos.x - 3,
 y: e.pos.y - 3
 } ];
 });
-}(e)), !1), i(gp), !1), i(hp), !1);
-}(t).map(Rp).filter(function(e) {
+}(e)), !1), i(Rp), !1), i(Ep), !1);
+}(t).map(Tp).filter(function(e) {
 return r.get(e.x, e.y) !== TERRAIN_MASK_WALL;
 }).map(function(t) {
 return new RoomPosition(t.x, t.y, e.name);
 });
 }(e, t);
 return Ee.set(e.name, {
-waypoints: Ep(n),
+waypoints: Cp(n),
 metadata: {
 spawnCount: r
 }
 }, {
-namespace: vp,
+namespace: hp,
 ttl: 1e3
 }), n;
 }
 
-function Cp(e, t) {
+function wp(e, t) {
 var r;
 if (0 === t.length) return null;
 var o = e.memory;
@@ -29264,89 +29268,89 @@ return n && e.pos.getRangeTo(n) <= 2 && (o.patrolIndex = (o.patrolIndex + 1) % t
 null !== (r = t[o.patrolIndex % t.length]) && void 0 !== r ? r : null;
 }
 
-var Sp = M("MilitaryBehaviors");
+var xp = M("MilitaryBehaviors");
 
-function wp(e) {
+function bp(e) {
 delete e.assistTarget, delete e.defenseSquadId, delete e.defenseSquadSize, delete e.defenseSquadCreatedAt,
 delete e.defenseAssistReleasedAt, delete e.defenseAssistReleaseReason, e.task === vi && (delete e.task,
 delete e.targetRoom);
 }
 
-function xp(e, t) {
+function Op(e, t) {
 var r;
 null !== (r = e.defenseAssistReleasedAt) && void 0 !== r || (e.defenseAssistReleasedAt = Game.time),
 e.defenseAssistReleaseReason = t;
 }
 
-function bp(e) {
+function kp(e) {
 return Po(Mo(e));
 }
 
-function Op(e) {
+function Mp(e) {
 return e.creep.room.name === e.homeRoom && Z(e.room).length > 0;
 }
 
-function kp(e) {
+function Ap(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Mp(e, t) {
+function Up(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Ap(e) {
-return Mp(e, "guard") + Mp(e, "ranger") + Mp(e, "healer");
+function _p(e) {
+return Up(e, "guard") + Up(e, "ranger") + Up(e, "healer");
 }
 
-function Up(e, t, r) {
+function Np(e, t, r) {
 var o = e.memory;
 return Ri(o) === t && o.homeRoom === r && e.room.name === r && !e.spawning;
 }
 
-function _p(e, t) {
+function Pp(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
-return Up(r, e, t);
+return Np(r, e, t);
 });
 }
 
-function Np(e) {
+function Ip(e) {
 return "number" == typeof e.createdAt && Number.isFinite(e.createdAt) ? e.createdAt : Game.time;
 }
 
-function Pp(e, t, r) {
-return Mp(e, t) > function(e, t) {
+function Gp(e, t, r) {
+return Up(e, t) > function(e, t) {
 return Object.values(Game.creeps).filter(function(r) {
 var o = r.memory;
 return !r.spawning && o.role === t && Ri(o) === e;
 }).length;
-}(e.roomName, t) || Ap(e) > 0 && bp(e.roomName) && function(e, t) {
-return _p(e, t).length;
+}(e.roomName, t) || _p(e) > 0 && kp(e.roomName) && function(e, t) {
+return Pp(e, t).length;
 }(e.roomName, r) < 5;
 }
 
-function Ip(e, t) {
+function Lp(e, t) {
 var r, o, n, i;
 if ("guard" !== (n = t.role) && "ranger" !== n && "healer" !== n) return null;
 if (e.creep.spawning || e.creep.room.name !== e.homeRoom) return null;
 if (t.squadId || t.targetRoom || t.assistTarget || t.assignedTaskId) return null;
 if (t.task && t.task !== vi) return null;
-if (Op(e)) return null;
+if (Mp(e)) return null;
 try {
-for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(kp).sort(function(e, t) {
+for (var s = a((i = Memory.defenseRequests, (Array.isArray(i) ? i : Object.values(null != i ? i : {})).filter(Ap).sort(function(e, t) {
 var r, o, n, a, i = (null !== (r = t.urgency) && void 0 !== r ? r : 0) - (null !== (o = e.urgency) && void 0 !== o ? o : 0);
 return 0 !== i ? i : (null !== (n = e.createdAt) && void 0 !== n ? n : 0) - (null !== (a = t.createdAt) && void 0 !== a ? a : 0);
 }))), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u.roomName];
-if (l && 0 !== Z(l).length && Pp(u, t.role, e.homeRoom)) {
-var m = Np(u);
+if (l && 0 !== Z(l).length && Gp(u, t.role, e.homeRoom)) {
+var m = Ip(u);
 return hi(e.creep, {
 homeRoom: e.homeRoom,
 targetRoom: u.roomName,
 now: Game.time,
 createdAt: m,
 squadId: gi(e.homeRoom, u.roomName, m),
-squadSize: bp(u.roomName) ? Math.max(5, Ap(u)) : Math.max(1, Ap(u))
+squadSize: kp(u.roomName) ? Math.max(5, _p(u)) : Math.max(1, _p(u))
 }), u.roomName;
 }
 }
@@ -29364,7 +29368,7 @@ if (r) throw r.error;
 return null;
 }
 
-function Gp(e) {
+function Dp(e) {
 return e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK);
 }) ? 0 : e.body.some(function(e) {
@@ -29372,7 +29376,7 @@ return e.hits > 0 && e.type === HEAL;
 }) ? 1 : 2;
 }
 
-function Lp(e, t) {
+function Bp(e, t) {
 if (!function(e) {
 return Boolean(Ri(e) && e.defenseSquadId && e.defenseSquadSize && e.defenseSquadSize > 0);
 }(t)) return null;
@@ -29380,11 +29384,11 @@ if (e.creep.room.name !== e.homeRoom) return null;
 var r = Ri(t);
 if (!r) return null;
 if (void 0 !== t.defenseAssistReleasedAt) return null;
-var o = Mo(r), n = Po(o), a = n ? _p(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
+var o = Mo(r), n = Po(o), a = n ? Pp(r, e.homeRoom) : [], c = n ? a.length : function(e, t) {
 var r = Ri(e);
 return e.defenseSquadId && r ? Object.values(Game.creeps).filter(function(o) {
 return function(e, t, r, o) {
-return e.memory.defenseSquadId === t && Up(e, r, o);
+return e.memory.defenseSquadId === t && Np(e, r, o);
 }(o, e.defenseSquadId, r, t);
 }).length : 0;
 }(t, e.homeRoom), u = function(e, t) {
@@ -29398,7 +29402,7 @@ return Game.time - e.defenseSquadCreatedAt >= r;
 if (o) {
 if (function(e, t, r) {
 var o = function(e, t) {
-return _p(e, t).reduce(function(e, t) {
+return Pp(e, t).reduce(function(e, t) {
 var r, o;
 return r = e, o = wo(t.body.filter(function(e) {
 return e.hits > 0;
@@ -29420,16 +29424,16 @@ score: 0
 });
 }(e, t);
 return o.attack + o.ranged + o.dismantle > 0 && o.score >= r.total.score && o.partCount >= r.total.partCount;
-}(r, e.homeRoom, o)) return xp(t, "parity-ready"), null;
-if (c >= u) return xp(t, "squad-quorum"), null;
+}(r, e.homeRoom, o)) return Op(t, "parity-ready"), null;
+if (c >= u) return Op(t, "squad-quorum"), null;
 if (l) {
-if (!n) return xp(t, "expired-staging"), null;
+if (!n) return Op(t, "expired-staging"), null;
 if (function(e, t, r, o) {
 var n, a;
 if ((null === (n = function(e) {
 var t;
 return null !== (t = s([], i(e), !1).sort(function(e, t) {
-var r = Gp(e) - Gp(t);
+var r = Dp(e) - Dp(t);
 return 0 !== r ? r : e.name.localeCompare(t.name);
 })[0]) && void 0 !== t ? t : null;
 }(o)) || void 0 === n ? void 0 : n.name) !== e.name) return !1;
@@ -29437,20 +29441,20 @@ var c = Memory, u = null !== (a = c.defenseAssistTrickleReleases) && void 0 !== 
 return "".concat(e, ":").concat(t);
 }(t, r), m = u[l];
 return !(void 0 !== m && Game.time - m < 50 || (u[l] = Game.time, 0));
-}(e.creep, e.homeRoom, r, a)) return xp(t, "hard-threat-trickle"), null;
+}(e.creep, e.homeRoom, r, a)) return Op(t, "hard-threat-trickle"), null;
 }
 } else {
-if (c >= u) return xp(t, "squad-quorum"), null;
-if (l) return xp(t, "expired-staging"), null;
+if (c >= u) return Op(t, "squad-quorum"), null;
+if (l) return Op(t, "expired-staging"), null;
 }
-var m = Ol(e.room.name);
+var m = Ml(e.room.name);
 return {
 type: "wait",
 position: null != m ? m : e.creep.pos
 };
 }
 
-function Dp(e) {
+function Fp(e) {
 var t, r;
 if (0 === e.hostiles.length) return null;
 var o = e.hostiles.map(function(e) {
@@ -29482,21 +29486,21 @@ return t.score - e.score;
 }), null !== (r = null === (t = o[0]) || void 0 === t ? void 0 : t.hostile) && void 0 !== r ? r : null;
 }
 
-function Bp(e, t) {
+function Wp(e, t) {
 return e.getActiveBodyparts(t) > 0;
 }
 
-function Fp(e, t) {
+function Hp(e, t) {
 if (!e.swarmState) return null;
-var r = Ol(e.room.name);
-return r && e.creep.pos.getRangeTo(r) > 2 ? (Sp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
+var r = Ml(e.room.name);
+return r && e.creep.pos.getRangeTo(r) > 2 ? (xp.debug("".concat(e.creep.name, " ").concat(t, " moving to collection point at ").concat(r.x, ",").concat(r.y)),
 {
 type: "moveTo",
 target: r
 }) : null;
 }
 
-function Wp(e) {
+function Kp(e) {
 var t, r, o, n, i = Memory;
 try {
 for (var s = a(Object.values(null !== (o = i.clusters) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
@@ -29520,7 +29524,7 @@ if (t) throw t.error;
 }
 }
 
-function Hp(e) {
+function Yp(e) {
 return e.members.map(function(e) {
 return Game.creeps[e];
 }).filter(function(e) {
@@ -29528,23 +29532,23 @@ return Boolean(e);
 });
 }
 
-function Kp(e) {
+function Vp(e) {
 var t, r, o = e.rallyFlag ? null === (t = Game.flags) || void 0 === t ? void 0 : t[e.rallyFlag] : void 0;
 return null !== (r = null == o ? void 0 : o.pos) && void 0 !== r ? r : new RoomPosition(25, 25, e.rallyRoom);
 }
 
-function Yp(e) {
+function qp(e) {
 var t, r = e.creep.memory;
 if (Ei(e.creep)) return {
 type: "idle"
 };
 if (e.memory.squadId) {
-var o = Wp(e.memory.squadId);
-if (o) return Vp(e, o);
+var o = Kp(e.memory.squadId);
+if (o) return jp(e, o);
 }
-var n = null !== (t = Ip(e, r)) && void 0 !== t ? t : Ri(r);
-if (n && !Op(e)) {
-var a = Lp(e, r);
+var n = null !== (t = Lp(e, r)) && void 0 !== t ? t : Ri(r);
+if (n && !Mp(e)) {
+var a = Bp(e, r);
 if (a) return a;
 if (e.creep.room.name !== n) return {
 type: "moveToRoom",
@@ -29557,9 +29561,9 @@ return e.structureType !== STRUCTURE_CONTROLLER;
 return 0 === o.length ? null : null !== (r = null !== (t = e.creep.pos.findClosestByRange(o)) && void 0 !== t ? t : o[0]) && void 0 !== r ? r : null;
 }(e);
 if (0 !== e.hostiles.length || i) {
-var s = Dp(e);
+var s = Fp(e);
 if (s) {
-var c = e.creep.pos.getRangeTo(s), u = Bp(e.creep, RANGED_ATTACK), l = Bp(e.creep, ATTACK);
+var c = e.creep.pos.getRangeTo(s), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK);
 return u && c <= 3 ? {
 type: "rangedAttack",
 target: s
@@ -29571,7 +29575,7 @@ type: "moveTo",
 target: s
 };
 }
-if (i) return c = e.creep.pos.getRangeTo(i), u = Bp(e.creep, RANGED_ATTACK), l = Bp(e.creep, ATTACK),
+if (i) return c = e.creep.pos.getRangeTo(i), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29582,7 +29586,7 @@ target: i
 type: "moveTo",
 target: i
 };
-} else if (wp(r), e.creep.room.name !== e.homeRoom) return {
+} else if (bp(r), e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -29591,8 +29595,8 @@ if (e.creep.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var m = Dp(e);
-if (m) return c = e.creep.pos.getRangeTo(m), u = Bp(e.creep, RANGED_ATTACK), l = Bp(e.creep, ATTACK),
+var m = Fp(e);
+if (m) return c = e.creep.pos.getRangeTo(m), u = Wp(e.creep, RANGED_ATTACK), l = Wp(e.creep, ATTACK),
 u && c <= 3 ? {
 type: "rangedAttack",
 target: m
@@ -29603,7 +29607,7 @@ target: m
 type: "moveTo",
 target: m
 };
-var d = Tp(e.room), p = Cp(e.creep, d);
+var d = Sp(e.room), p = wp(e.creep, d);
 if (p) return {
 type: "moveTo",
 target: p
@@ -29617,7 +29621,7 @@ type: "idle"
 };
 }
 
-function Vp(e, t) {
+function jp(e, t) {
 var r, o;
 switch (t.members.includes(e.creep.name) || t.members.push(e.creep.name), t.state) {
 case "gathering":
@@ -29625,7 +29629,7 @@ if (e.room.name !== t.rallyRoom) return {
 type: "moveToRoom",
 roomName: t.rallyRoom
 };
-var n = Kp(t);
+var n = Vp(t);
 return e.creep.pos.getRangeTo(n) > 3 ? {
 type: "moveTo",
 target: n
@@ -29633,7 +29637,7 @@ target: n
 return !!function(e) {
 var t, r, o, n, s = null !== (o = e.targetComposition) && void 0 !== o ? o : {}, c = {};
 try {
-for (var u = a(Hp(e)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(Yp(e)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 if (m.room.name === e.rallyRoom && !m.spawning) {
 var d = m.memory.role;
@@ -29656,7 +29660,7 @@ var t, r = i(e, 2), o = r[0], n = r[1];
 return (null !== (t = c[o]) && void 0 !== t ? t : 0) >= (null != n ? n : 0);
 });
 }(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
-var t, r, o = Hp(e).filter(function(t) {
+var t, r, o = Yp(e).filter(function(t) {
 return t.room.name === e.rallyRoom && !t.spawning;
 }), n = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
@@ -29685,7 +29689,7 @@ if (!s) return {
 type: "idle"
 };
 if (e.room.name !== s) return function(e, t) {
-var r = Hp(t).filter(function(t) {
+var r = Yp(t).filter(function(t) {
 return t.room.name === e.room.name && !t.spawning;
 });
 return !(r.length <= 1) && r.reduce(function(t, r) {
@@ -29701,7 +29705,7 @@ roomName: s
 var c = function(e, t) {
 var r, o, n;
 if ("siege" !== t.type) return null;
-var a = Hp(t).sort(function(e, t) {
+var a = Yp(t).sort(function(e, t) {
 return e.name.localeCompare(t.name);
 }), i = a.findIndex(function(t) {
 return t.name === e.creep.name;
@@ -29738,7 +29742,7 @@ roomName: t.rallyRoom
 };
 var u = e.memory.role;
 if ("healer" === u) {
-var l = Hp(t).filter(function(e) {
+var l = Yp(t).filter(function(e) {
 return e.hits < e.hitsMax;
 }).sort(function(e, t) {
 return e.hits / e.hitsMax - t.hits / t.hitsMax;
@@ -29755,7 +29759,7 @@ target: l
 };
 var m = function(e) {
 var t;
-return null !== (t = Hp(e).find(function(e) {
+return null !== (t = Yp(e).find(function(e) {
 return "healer" !== e.memory.role;
 })) && void 0 !== t ? t : null;
 }(t);
@@ -29766,7 +29770,7 @@ target: m
 type: "idle"
 };
 }
-var d = Dp(e);
+var d = Fp(e);
 if (d) {
 var p = e.creep.pos.getRangeTo(d);
 return "ranger" === u ? p < 3 ? {
@@ -29778,10 +29782,10 @@ target: d
 } : {
 type: "moveTo",
 target: d
-} : Bp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: d
-} : Bp(e.creep, ATTACK) && p <= 1 ? {
+} : Wp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: d
 } : {
@@ -29797,10 +29801,10 @@ return e.structureType === STRUCTURE_TOWER || e.structureType === STRUCTURE_SPAW
 return y ? (p = e.creep.pos.getRangeTo(y), "siegeUnit" === u && p <= 1 ? {
 type: "dismantle",
 target: y
-} : Bp(e.creep, RANGED_ATTACK) && p <= 3 ? {
+} : Wp(e.creep, RANGED_ATTACK) && p <= 3 ? {
 type: "rangedAttack",
 target: y
-} : Bp(e.creep, ATTACK) && p <= 1 ? {
+} : Wp(e.creep, ATTACK) && p <= 1 ? {
 type: "attack",
 target: y
 } : {
@@ -29816,7 +29820,7 @@ type: "moveToRoom",
 roomName: t.rallyRoom
 } : {
 type: "moveTo",
-target: Kp(t)
+target: Vp(t)
 };
 
 case "dissolving":
@@ -29834,8 +29838,8 @@ type: "idle"
 }
 }
 
-var qp = {
-guard: Yp,
+var zp = {
+guard: qp,
 remoteGuard: function(e) {
 var t = e.creep.memory;
 if (!t.targetRoom) {
@@ -29844,8 +29848,8 @@ type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
 };
-var r = Tp(e.room);
-return (o = Cp(e.creep, r)) ? {
+var r = Sp(e.room);
+return (o = wp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29862,7 +29866,7 @@ if (0 === n.length) return e.creep.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "guard"
-} : (r = Tp(e.room), (o = Cp(e.creep, r)) ? {
+} : (r = Sp(e.room), (o = wp(e.creep, r)) ? {
 type: "moveTo",
 target: o
 } : {
@@ -29876,11 +29880,11 @@ return e.body.some(function(e) {
 return e.boost;
 });
 }), t.filter(function(e) {
-return Bp(e, HEAL);
+return Wp(e, HEAL);
 }), t.filter(function(e) {
-return Bp(e, RANGED_ATTACK);
+return Wp(e, RANGED_ATTACK);
 }), t.filter(function(e) {
-return Bp(e, ATTACK);
+return Wp(e, ATTACK);
 }), t ];
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
@@ -29901,7 +29905,7 @@ if (r) throw r.error;
 return null;
 }(e, n);
 if (i) {
-var s = e.creep.pos.getRangeTo(i), c = Bp(e.creep, RANGED_ATTACK), u = Bp(e.creep, ATTACK);
+var s = e.creep.pos.getRangeTo(i), c = Wp(e.creep, RANGED_ATTACK), u = Wp(e.creep, ATTACK);
 return c && s <= 3 ? {
 type: "rangedAttack",
 target: i
@@ -29932,19 +29936,19 @@ type: "heal",
 target: e.creep
 };
 if (e.memory.squadId) {
-var o = Wp(e.memory.squadId);
-if (o) return Vp(e, o);
+var o = Kp(e.memory.squadId);
+if (o) return jp(e, o);
 }
-var n = null !== (t = Ip(e, r)) && void 0 !== t ? t : Ri(r);
-if (n && !Op(e)) {
-var a = Lp(e, r);
+var n = null !== (t = Lp(e, r)) && void 0 !== t ? t : Ri(r);
+if (n && !Mp(e)) {
+var a = Bp(e, r);
 if (a) return a;
 var i = Game.rooms[n];
 if (!i) return {
 type: "moveToRoom",
 roomName: n
 };
-if (0 === Z(i).length) return wp(r), {
+if (0 === Z(i).length) return bp(r), {
 type: "idle"
 };
 if (e.creep.room.name !== n) return {
@@ -30038,7 +30042,7 @@ type: "moveTo",
 target: f
 };
 }
-var y = Tp(e.room), v = Cp(e.creep, y);
+var y = Sp(e.room), v = wp(e.creep, y);
 return v ? {
 type: "moveTo",
 target: v
@@ -30049,8 +30053,8 @@ type: "idle"
 soldier: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Wp(e.memory.squadId);
-if (r) return Vp(e, r);
+var r = Kp(e.memory.squadId);
+if (r) return jp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30072,9 +30076,9 @@ if (e.room.name !== n) return {
 type: "moveToRoom",
 roomName: n
 };
-var a = Dp(e);
+var a = Fp(e);
 if (a) {
-var i = e.creep.pos.getRangeTo(a), s = Bp(e.creep, RANGED_ATTACK), c = Bp(e.creep, ATTACK);
+var i = e.creep.pos.getRangeTo(a), s = Wp(e.creep, RANGED_ATTACK), c = Wp(e.creep, ATTACK);
 return s && i <= 3 ? {
 type: "rangedAttack",
 target: a
@@ -30093,7 +30097,7 @@ if (u) return {
 type: "attack",
 target: u
 };
-var l = Tp(e.room), m = Cp(e.creep, l);
+var l = Sp(e.room), m = wp(e.creep, l);
 if (m) return {
 type: "moveTo",
 target: m
@@ -30115,8 +30119,8 @@ type: "idle"
 siegeUnit: function(e) {
 var t;
 if (e.memory.squadId) {
-var r = Wp(e.memory.squadId);
-if (r) return Vp(e, r);
+var r = Kp(e.memory.squadId);
+if (r) return jp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .3) {
 if (e.room.name !== e.homeRoom) return {
@@ -30177,9 +30181,9 @@ if (d) return {
 type: "dismantle",
 target: d
 };
-var p = Fp(e, "siegeUnit");
+var p = Hp(e, "siegeUnit");
 if (p) return p;
-var f = Tp(e.room), y = Cp(e.creep, f);
+var f = Sp(e.room), y = wp(e.creep, f);
 return y ? {
 type: "moveTo",
 target: y
@@ -30190,8 +30194,8 @@ type: "idle"
 harasser: function(e) {
 var t = e.memory.targetRoom;
 if (e.memory.squadId) {
-var r = Wp(e.memory.squadId);
-if (r) return Vp(e, r);
+var r = Kp(e.memory.squadId);
+if (r) return jp(e, r);
 }
 if (e.creep.hits / e.creep.hitsMax < .4) {
 if (e.room.name !== e.homeRoom) return {
@@ -30208,7 +30212,7 @@ target: o[0]
 type: "idle"
 };
 }
-if (!t) return Fp(e, "harasser (no target)") || {
+if (!t) return Hp(e, "harasser (no target)") || {
 type: "idle"
 };
 if (e.room.name !== t) return {
@@ -30250,9 +30254,9 @@ if (e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
-var c = Fp(e, "harasser (no targets)");
+var c = Hp(e, "harasser (no targets)");
 if (c) return c;
-var u = Tp(e.room), l = Cp(e.creep, u);
+var u = Sp(e.room), l = wp(e.creep, u);
 return l ? {
 type: "moveTo",
 target: l
@@ -30265,9 +30269,9 @@ var t, r, o = e.creep.memory;
 if (Ei(e.creep)) return {
 type: "idle"
 };
-if (e.memory.squadId && (a = Wp(e.memory.squadId))) return Vp(e, a);
+if (e.memory.squadId && (a = Kp(e.memory.squadId))) return jp(e, a);
 if (e.creep.hits / e.creep.hitsMax < .3) {
-if (Ri(o) && wp(o), e.room.name !== e.homeRoom) return {
+if (Ri(o) && bp(o), e.room.name !== e.homeRoom) return {
 type: "moveToRoom",
 roomName: e.homeRoom
 };
@@ -30281,9 +30285,9 @@ target: n[0]
 type: "idle"
 };
 }
-var a, i = null !== (t = Ip(e, o)) && void 0 !== t ? t : Ri(o);
-if (i && !Op(e)) {
-var s = Lp(e, o);
+var a, i = null !== (t = Lp(e, o)) && void 0 !== t ? t : Ri(o);
+if (i && !Mp(e)) {
+var s = Bp(e, o);
 if (s) return s;
 var c = Game.rooms[i];
 if (!c) return {
@@ -30293,14 +30297,14 @@ roomName: i
 var u = Z(c), l = J(c).filter(function(e) {
 return e.structureType !== STRUCTURE_CONTROLLER;
 });
-if (0 === u.length && 0 === l.length) return wp(o), {
+if (0 === u.length && 0 === l.length) return bp(o), {
 type: "idle"
 };
 if (e.creep.room.name !== i) return {
 type: "moveToRoom",
 roomName: i
 };
-var m = Dp(e);
+var m = Fp(e);
 if (m) return (p = e.creep.pos.getRangeTo(m)) < 3 ? {
 type: "flee",
 from: [ m.pos ]
@@ -30320,8 +30324,8 @@ type: "moveTo",
 target: d
 };
 }
-if (e.memory.squadId && (a = Wp(e.memory.squadId))) return Vp(e, a);
-var p, f = Dp(e);
+if (e.memory.squadId && (a = Kp(e.memory.squadId))) return jp(e, a);
+var p, f = Fp(e);
 if (f) return (p = e.creep.pos.getRangeTo(f)) < 3 ? {
 type: "flee",
 from: [ f.pos ]
@@ -30332,7 +30336,7 @@ target: f
 type: "moveTo",
 target: f
 };
-var y = Tp(e.room), v = Cp(e.creep, y);
+var y = Sp(e.room), v = wp(e.creep, y);
 if (v) return {
 type: "moveTo",
 target: v
@@ -30353,21 +30357,21 @@ type: "idle"
 }
 };
 
-function jp(e) {
+function Qp(e) {
 var t;
-return lm.getAssignedAction(e) || (null !== (t = qp[e.memory.role]) && void 0 !== t ? t : Yp)(e);
+return dm.getAssignedAction(e) || (null !== (t = zp[e.memory.role]) && void 0 !== t ? t : qp)(e);
 }
 
-var zp = M("PowerExecutor");
+var Xp = M("PowerExecutor");
 
-function Qp(e, t) {
+function Zp(e, t) {
 var r = e.effects;
 return void 0 !== r && Array.isArray(r) && r.some(function(e) {
 return e.effect === t;
 });
 }
 
-function Xp(e) {
+function Jp(e) {
 var t = e.memory.targetRoom;
 if (!t) return {
 type: "idle"
@@ -30409,8 +30413,8 @@ type: "idle"
 };
 }
 
-var Zp = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), Jp = {
-powerHarvester: Xp,
+var $p = new Set([ PWR_DISRUPT_SPAWN, PWR_DISRUPT_TOWER, PWR_DISRUPT_TERMINAL ]), ef = {
+powerHarvester: Jp,
 powerCarrier: function(e) {
 var t = e.memory.targetRoom;
 if (e.creep.store.getUsedCapacity(RESOURCE_POWER) > 0) {
@@ -30482,65 +30486,65 @@ roomName: e.homeRoom
 }
 };
 
-function $p(e) {
+function tf(e) {
 var t;
-return (null !== (t = Jp[e.memory.role]) && void 0 !== t ? t : Xp)(e);
+return (null !== (t = ef[e.memory.role]) && void 0 !== t ? t : Jp)(e);
 }
 
-function ef(e) {
+function rf(e) {
 for (var t = 0, r = 0; r < e.length; r++) t = (t << 5) - t + e.charCodeAt(r), t &= t;
 return Math.abs(t);
 }
 
-var tf = {
+var of = {
 core: "c",
 frontier: "f",
 resource: "r",
 backup: "b",
 war: "w"
-}, rf = {
+}, nf = {
 c: "core",
 f: "frontier",
 r: "resource",
 b: "backup",
 w: "war"
-}, of = {
+}, af = {
 low: "l",
 medium: "m",
 high: "h",
 critical: "c"
-}, nf = {
+}, sf = {
 l: "low",
 m: "medium",
 h: "high",
 c: "critical"
-}, af = {
+}, cf = {
 colonize: "c",
 reinforce: "r",
 transfer: "t",
 evacuate: "e"
-}, sf = {
+}, uf = {
 c: "colonize",
 r: "reinforce",
 t: "transfer",
 e: "evacuate"
-}, cf = {
+}, lf = {
 pending: "p",
 active: "a",
 complete: "c",
 failed: "f"
-}, uf = {
+}, mf = {
 p: "pending",
 a: "active",
 c: "complete",
 f: "failed"
 };
 
-function lf(e) {
+function df(e) {
 return "".concat(e.x, ",").concat(e.y);
 }
 
-function mf(e) {
+function pf(e) {
 var t = i(e.split(","), 2), r = t[0], o = t[1];
 return {
 x: parseInt(null != r ? r : "0", 10),
@@ -30548,7 +30552,7 @@ y: parseInt(null != o ? o : "0", 10)
 };
 }
 
-function df(e) {
+function ff(e) {
 var t, r = i(null !== (t = null == e ? void 0 : e.split(",")) && void 0 !== t ? t : [], 2), o = r[0], n = r[1];
 if (void 0 !== o && void 0 !== n) return {
 x: parseInt(o, 10),
@@ -30556,12 +30560,12 @@ y: parseInt(n, 10)
 };
 }
 
-function pf(e) {
+function yf(e) {
 var t, r, o = {};
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-o[s.n] = ff(s);
+o[s.n] = vf(s);
 }
 } catch (e) {
 t = {
@@ -30577,23 +30581,23 @@ if (t) throw t.error;
 return o;
 }
 
-function ff(e) {
+function vf(e) {
 var t, r;
 return {
 name: e.n,
-role: null !== (t = rf[e.r]) && void 0 !== t ? t : "core",
-health: yf(e.h),
+role: null !== (t = nf[e.r]) && void 0 !== t ? t : "core",
+health: gf(e.h),
 activeTasks: e.t,
-portals: e.p.map(vf),
+portals: e.p.map(hf),
 cpuLimit: e.cl,
-cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(gf)
+cpuHistory: (null !== (r = e.ch) && void 0 !== r ? r : []).map(Rf)
 };
 }
 
-function yf(e) {
+function gf(e) {
 var t, r, o;
 return {
-cpuCategory: null !== (t = nf[e.c]) && void 0 !== t ? t : "low",
+cpuCategory: null !== (t = sf[e.c]) && void 0 !== t ? t : "low",
 cpuUsage: null !== (r = e.cu) && void 0 !== r ? r : 0,
 bucketLevel: null !== (o = e.b) && void 0 !== o ? o : 1e4,
 economyIndex: e.e,
@@ -30606,11 +30610,11 @@ lastUpdate: e.u
 };
 }
 
-function vf(e) {
+function hf(e) {
 var t;
 return {
 sourceRoom: e.sr,
-sourcePos: mf(e.sp),
+sourcePos: pf(e.sp),
 targetShard: e.ts,
 targetRoom: e.tr,
 threatRating: e.th,
@@ -30620,7 +30624,7 @@ traversalCount: null !== (t = e.tc) && void 0 !== t ? t : 0
 };
 }
 
-function gf(e) {
+function Rf(e) {
 return {
 tick: e.t,
 cpuLimit: e.l,
@@ -30629,7 +30633,7 @@ bucketLevel: e.b
 };
 }
 
-function hf(e) {
+function Ef(e) {
 return {
 username: e.u,
 rooms: e.r,
@@ -30639,12 +30643,12 @@ isAlly: 1 === e.a
 };
 }
 
-function Rf(e) {
+function Tf(e) {
 var t, r, o, n, i = {};
 try {
 for (var s = a(null !== (o = e.t) && void 0 !== o ? o : []), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-i[u.n] = Ef(u);
+i[u.n] = Cf(u);
 }
 } catch (e) {
 t = {
@@ -30667,13 +30671,13 @@ updatedAt: e.u
 };
 }
 
-function Ef(e) {
+function Cf(e) {
 var t;
 return {
 shard: e.n,
 status: e.st,
 portalRoom: e.pr,
-portalPos: df(e.pp),
+portalPos: ff(e.pp),
 destinationRoom: e.dr,
 claimTargetRoom: e.cr,
 arrivedAt: e.ar,
@@ -30684,46 +30688,46 @@ lastUpdate: e.u
 };
 }
 
-function Tf(e) {
+function Sf(e) {
 var t, r, o = {
 id: e.i,
-type: null !== (t = sf[e.y]) && void 0 !== t ? t : "colonize",
+type: null !== (t = uf[e.y]) && void 0 !== t ? t : "colonize",
 sourceShard: e.ss,
 targetShard: e.ts,
 priority: e.p,
-status: null !== (r = uf[e.st]) && void 0 !== r ? r : "pending",
+status: null !== (r = mf[e.st]) && void 0 !== r ? r : "pending",
 createdAt: 0
 };
 return e.tr && (o.targetRoom = e.tr), e.rt && (o.resourceType = e.rt), void 0 !== e.ra && (o.resourceAmount = e.ra),
 void 0 !== e.pr && (o.progress = e.pr), o;
 }
 
-function Cf(e, t) {
+function wf(e, t) {
 var r = Math.pow(10, t);
 return Math.round(e * r) / r;
 }
 
-function Sf(e) {
+function xf(e) {
 var t;
 return {
-c: null !== (t = of[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
-cu: Cf(e.cpuUsage, 2),
+c: null !== (t = af[e.cpuCategory]) && void 0 !== t ? t : e.cpuCategory[0],
+cu: wf(e.cpuUsage, 2),
 b: e.bucketLevel,
 e: Math.round(e.economyIndex),
 w: Math.round(e.warIndex),
 m: Math.round(e.commodityIndex),
 rc: e.roomCount,
-rl: Cf(e.avgRCL, 1),
+rl: wf(e.avgRCL, 1),
 cc: e.creepCount,
 u: e.lastUpdate
 };
 }
 
-function wf(e) {
+function bf(e) {
 var t;
 return {
 sr: e.sourceRoom,
-sp: lf(e.sourcePos),
+sp: df(e.sourcePos),
 ts: e.targetShard,
 tr: e.targetRoom,
 th: e.threatRating,
@@ -30732,27 +30736,27 @@ tc: null !== (t = e.traversalCount) && void 0 !== t ? t : 0
 };
 }
 
-function xf(e) {
+function Of(e) {
 return {
 t: e.tick,
 l: e.cpuLimit,
-u: Cf(e.cpuUsed, 2),
+u: wf(e.cpuUsed, 2),
 b: e.bucketLevel
 };
 }
 
-function bf(e) {
+function kf(e) {
 var t;
 return {
 pl: e.targetPowerLevel,
 ws: e.mainWarShard,
 es: e.primaryEcoShard,
 ct: e.colonizationTarget,
-en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Of)
+en: (null !== (t = e.enemies) && void 0 !== t ? t : []).map(Mf)
 };
 }
 
-function Of(e) {
+function Mf(e) {
 return {
 u: e.username,
 r: e.rooms,
@@ -30762,23 +30766,23 @@ a: e.isAlly ? 1 : 0
 };
 }
 
-function kf(e) {
+function Af(e) {
 var t, r;
 return {
 i: e.id,
-y: null !== (t = af[e.type]) && void 0 !== t ? t : e.type[0],
+y: null !== (t = cf[e.type]) && void 0 !== t ? t : e.type[0],
 ss: e.sourceShard,
 ts: e.targetShard,
 tr: e.targetRoom,
 rt: e.resourceType,
 ra: e.resourceAmount,
 p: e.priority,
-st: null !== (r = cf[e.status]) && void 0 !== r ? r : e.status[0],
+st: null !== (r = lf[e.status]) && void 0 !== r ? r : e.status[0],
 pr: e.progress
 };
 }
 
-function Mf(e) {
+function Uf(e) {
 return {
 name: e,
 role: "core",
@@ -30801,7 +30805,7 @@ cpuLimit: 0
 };
 }
 
-function Af(e) {
+function _f(e) {
 var t = function(e) {
 return {
 v: e.version,
@@ -30811,16 +30815,16 @@ return function(e, t) {
 var r, o;
 return {
 n: e,
-r: null !== (r = tf[t.role]) && void 0 !== r ? r : t.role[0],
-h: Sf(t.health),
+r: null !== (r = of[t.role]) && void 0 !== r ? r : t.role[0],
+h: xf(t.health),
 t: t.activeTasks,
-p: t.portals.map(wf),
+p: t.portals.map(bf),
 cl: t.cpuLimit,
-ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(xf)
+ch: (null !== (o = t.cpuHistory) && void 0 !== o ? o : []).slice(-5).map(Of)
 };
 }(t[0], t[1]);
 }),
-g: bf(e.globalTargets),
+g: kf(e.globalTargets),
 o: e.footprintOperation ? (t = e.footprintOperation, {
 i: t.id,
 e: t.enabled ? 1 : 0,
@@ -30834,7 +30838,7 @@ return {
 n: e,
 st: t.status,
 pr: t.portalRoom,
-pp: t.portalPos ? lf(t.portalPos) : void 0,
+pp: t.portalPos ? df(t.portalPos) : void 0,
 dr: t.destinationRoom,
 cr: t.claimTargetRoom,
 ar: t.arrivedAt,
@@ -30846,20 +30850,20 @@ u: t.lastUpdate
 }(t[0], t[1]);
 })
 }) : void 0,
-k: e.tasks.map(kf),
+k: e.tasks.map(Af),
 ls: e.lastSync
 };
 var t;
-}(e), r = ef(JSON.stringify(t));
+}(e), r = rf(JSON.stringify(t));
 return JSON.stringify({
 d: t,
 c: r
 });
 }
 
-function Uf(e) {
+function Nf(e) {
 try {
-var t = JSON.parse(e), r = ef(JSON.stringify(t.d));
+var t = JSON.parse(e), r = rf(JSON.stringify(t.d));
 return t.c !== r ? (Ne.warn("InterShardMemory checksum mismatch", {
 subsystem: "InterShard",
 meta: {
@@ -30868,13 +30872,13 @@ actual: t.c
 }
 }), null) : (a = t.d, i = t.c, {
 version: a.v,
-shards: pf(a.s),
+shards: yf(a.s),
 globalTargets: (o = a.g, n = {
 targetPowerLevel: o.pl
 }, o.ws && (n.mainWarShard = o.ws), o.es && (n.primaryEcoShard = o.es), o.ct && (n.colonizationTarget = o.ct),
-o.en && (n.enemies = o.en.map(hf)), n),
-footprintOperation: a.o ? Rf(a.o) : void 0,
-tasks: a.k.map(Tf),
+o.en && (n.enemies = o.en.map(Ef)), n),
+footprintOperation: a.o ? Tf(a.o) : void 0,
+tasks: a.k.map(Sf),
 lastSync: a.ls,
 checksum: i
 });
@@ -30886,12 +30890,12 @@ subsystem: "InterShard"
 var o, n, a, i;
 }
 
-var _f, Nf, Pf = 102400, If = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
+var Pf, If, Gf = 102400, Lf = [ "shards", "globalTargets", "tasks", "footprintOperation", "lastSync" ];
 
-function Gf(e, t, r) {
+function Df(e, t, r) {
 var n, a;
 void 0 === t && (t = ""), void 0 === r && (r = {});
-var i = Ff(t), s = function(e, t, r) {
+var i = Hf(t), s = function(e, t, r) {
 if (!e) return t;
 var n, a, i = new Set(r);
 return {
@@ -30904,11 +30908,11 @@ n ? a && a.updatedAt >= n.updatedAt ? a : n : a) : e.footprintOperation,
 lastSync: i.has("lastSync") ? t.lastSync : e.lastSync,
 checksum: t.checksum
 };
-}(Bf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : If), c = null !== (a = Ff(Af(s))) && void 0 !== a ? a : {};
+}(Wf(t, i), e, null !== (n = r.updatedSections) && void 0 !== n ? n : Lf), c = null !== (a = Hf(_f(s))) && void 0 !== a ? a : {};
 return JSON.stringify(o(o({}, null != i ? i : {}), c));
 }
 
-function Lf(e) {
+function Bf(e) {
 var t;
 void 0 === e && (e = {
 version: 1,
@@ -30924,69 +30928,69 @@ checksum: 0
 try {
 if ("undefined" == typeof InterShardMemory) return e;
 var r = InterShardMemory.getLocal();
-return r && null !== (t = Bf(r, Ff(r))) && void 0 !== t ? t : e;
+return r && null !== (t = Wf(r, Hf(r))) && void 0 !== t ? t : e;
 } catch (t) {
 return e;
 }
 }
 
-function Df(e, t) {
+function Ff(e, t) {
 void 0 === t && (t = {});
 try {
 if ("undefined" == typeof InterShardMemory) return !1;
 var r = InterShardMemory.getLocal();
-return InterShardMemory.setLocal(Gf(e, r, t)), !0;
+return InterShardMemory.setLocal(Df(e, r, t)), !0;
 } catch (e) {
 return !1;
 }
 }
 
-function Bf(e, t) {
+function Wf(e, t) {
 return t && function(e) {
-return Wf(e.d) && "number" == typeof e.c;
-}(t) ? Uf(e) : null;
+return Kf(e.d) && "number" == typeof e.c;
+}(t) ? Nf(e) : null;
 }
 
-function Ff(e) {
+function Hf(e) {
 if (!e) return {};
 try {
 var t = JSON.parse(e);
-return Wf(t) ? t : null;
+return Kf(t) ? t : null;
 } catch (e) {
 return null;
 }
 }
 
-function Wf(e) {
+function Kf(e) {
 return "object" == typeof e && null !== e && !Array.isArray(e);
 }
 
 !function(e) {
 e[e.LOW = 0] = "LOW", e[e.MEDIUM = 1] = "MEDIUM", e[e.HIGH = 2] = "HIGH", e[e.CRITICAL = 3] = "CRITICAL";
-}(_f || (_f = {})), function(e) {
+}(Pf || (Pf = {})), function(e) {
 e[e.LOW = 0] = "LOW", e[e.NORMAL = 1] = "NORMAL", e[e.MEDIUM = 2] = "MEDIUM", e[e.HIGH = 3] = "HIGH",
 e[e.CRITICAL = 4] = "CRITICAL", e[e.EMERGENCY = 5] = "EMERGENCY";
-}(Nf || (Nf = {}));
+}(If || (If = {}));
 
-var Hf = null != Ne ? Ne : {
+var Yf = null != Ne ? Ne : {
 debug: function() {},
 info: function() {},
 warn: function() {},
 error: function() {}
-}, Kf = {
+}, Vf = {
 updateInterval: 100,
 minBucket: 0,
 maxCpuBudget: .02,
 defaultCpuLimit: 20
-}, Yf = {
+}, qf = {
 core: 1.5,
 frontier: .8,
 resource: 1,
 backup: .5,
 war: 1.2
-}, Vf = function() {
+}, jf = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Kf), e), this.interShardMemory = {
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, Vf), e), this.interShardMemory = {
 version: 1,
 shards: {},
 globalTargets: {
@@ -31003,19 +31007,19 @@ var e, t;
 try {
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Uf(r);
-o && (this.interShardMemory = o, Hf.debug("Loaded InterShardMemory", {
+var o = Nf(r);
+o && (this.interShardMemory = o, Yf.debug("Loaded InterShardMemory", {
 subsystem: "Shard"
 }));
 }
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Hf.error("Failed to load InterShardMemory: ".concat(n), {
+Yf.error("Failed to load InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 });
 }
 var a = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Mf(a));
+this.interShardMemory.shards[a] || (this.interShardMemory.shards[a] = Uf(a));
 }, e.prototype.run = function() {
 this.lastRun = Game.time, this.updateCurrentShardHealth(), this.processInterShardTasks(),
 this.scanForPortals(), this.autoAssignShardRole(), Object.keys(this.interShardMemory.shards).length > 1 && this.distributeCpuLimits(),
@@ -31176,25 +31180,25 @@ return "pending" === e.status || "active" === e.status || Game.time - e.createdA
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Hf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
+Yf.info("Processing colonize task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleReinforceTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Hf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
+Yf.info("Processing reinforce task: ".concat(r, " from ").concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleTransferTask = function(e) {
-e.status = "active", Hf.info("Processing transfer task from ".concat(e.sourceShard), {
+e.status = "active", Yf.info("Processing transfer task from ".concat(e.sourceShard), {
 subsystem: "Shard"
 });
 }, e.prototype.handleEvacuateTask = function(e) {
 var t;
 e.status = "active";
 var r = null !== (t = e.targetRoom) && void 0 !== t ? t : "unknown";
-Hf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
+Yf.info("Processing evacuate task: ".concat(r, " to ").concat(e.targetShard), {
 subsystem: "Shard"
 });
 }, e.prototype.scanForPortals = function() {
@@ -31227,7 +31231,7 @@ isStable: void 0 === t.ticksToDecay,
 traversalCount: 0
 };
 void 0 !== t.ticksToDecay && (s.decayTick = Game.time + t.ticksToDecay), o.portals.push(s),
-Hf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
+Yf.info("Discovered portal in ".concat(e, " to ").concat(n, "/").concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31257,12 +31261,12 @@ var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 :
 if (o) {
 var n = o.health, a = Object.values(this.interShardMemory.shards), i = o.role;
 n.warIndex > 50 ? i = "war" : n.roomCount < 3 && n.avgRCL < 4 ? i = "frontier" : n.economyIndex > 70 && n.roomCount >= 3 && n.avgRCL >= 6 ? i = "resource" : a.length > 1 && n.roomCount < 2 && n.avgRCL < 3 ? i = "backup" : n.roomCount >= 2 && n.avgRCL >= 4 && (i = "core"),
-"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Hf.info("Transitioning from frontier to core shard", {
+"frontier" === o.role && n.roomCount >= 3 && n.avgRCL >= 5 && (i = "core", Yf.info("Transitioning from frontier to core shard", {
 subsystem: "Shard"
 })), "war" === o.role && n.warIndex < 20 && (i = n.economyIndex > 70 && n.roomCount >= 3 ? "resource" : n.roomCount >= 2 ? "core" : "frontier",
-Hf.info("War ended, transitioning to ".concat(i), {
+Yf.info("War ended, transitioning to ".concat(i), {
 subsystem: "Shard"
-})), i !== o.role && (o.role = i, Hf.info("Auto-assigned shard role: ".concat(i), {
+})), i !== o.role && (o.role = i, Yf.info("Auto-assigned shard role: ".concat(i), {
 subsystem: "Shard"
 }));
 }
@@ -31288,7 +31292,7 @@ if (t) throw t.error;
 }
 return o / e.cpuHistory.length;
 }, e.prototype.calculateShardWeight = function(e, t, r) {
-var o = Yf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
+var o = qf[e.role], n = t === r ? Game.cpu.bucket : e.health.bucketLevel;
 n < 2e3 ? o *= .8 : n < 5e3 ? o *= .9 : n > 9e3 && (o *= 1.1);
 var a = this.calculateCpuEfficiency(e);
 return a > .95 ? o *= 1.15 : a < .6 && (o *= .85), "war" === e.role && e.health.warIndex > 50 && (o *= 1.2),
@@ -31340,13 +31344,13 @@ var T = Game.cpu.shardLimits, C = c.some(function(e) {
 var t, r;
 return Math.abs((null !== (t = T[e]) && void 0 !== t ? t : 0) - (null !== (r = g[e]) && void 0 !== r ? r : 0)) > 1;
 });
-C && Game.cpu.setShardLimits(g) === OK && Hf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
+C && Game.cpu.setShardLimits(g) === OK && Yf.info("Updated shard CPU limits: ".concat(JSON.stringify(g)), {
 subsystem: "Shard"
 });
 }
 } catch (e) {
 var S = e instanceof Error ? e.message : String(e);
-Hf.debug("Could not set shard limits: ".concat(S), {
+Yf.debug("Could not set shard limits: ".concat(S), {
 subsystem: "Shard"
 });
 }
@@ -31354,27 +31358,27 @@ subsystem: "Shard"
 try {
 this.interShardMemory.lastSync = Game.time;
 var e = this.validateInterShardMemory();
-e.valid || (Hf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
+e.valid || (Yf.warn("InterShardMemory validation failed: ".concat(e.errors.join(", ")), {
 subsystem: "Shard"
 }), this.repairInterShardMemory());
-var t = InterShardMemory.getLocal(), r = Gf(this.interShardMemory, t, {
+var t = InterShardMemory.getLocal(), r = Df(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-if (r.length > Pf) {
-Hf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(Pf), {
+if (r.length > Gf) {
+Yf.warn("InterShardMemory size exceeds limit: ".concat(r.length, "/").concat(Gf), {
 subsystem: "Shard"
 }), this.trimInterShardMemory();
-var o = Gf(this.interShardMemory, t, {
+var o = Df(this.interShardMemory, t, {
 updatedSections: [ "shards", "tasks", "lastSync" ]
 });
-return o.length > Pf ? (Hf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(Pf), {
+return o.length > Gf ? (Yf.error("InterShardMemory still too large after trim: ".concat(o.length, "/").concat(Gf), {
 subsystem: "Shard"
 }), void this.emergencyTrim()) : void InterShardMemory.setLocal(o);
 }
 InterShardMemory.setLocal(r), Game.time % 50 == 0 && this.verifySyncIntegrity();
 } catch (e) {
 var n = e instanceof Error ? e.message : String(e);
-Hf.error("Failed to sync InterShardMemory: ".concat(n), {
+Yf.error("Failed to sync InterShardMemory: ".concat(n), {
 subsystem: "Shard"
 }), this.attemptSyncRecovery();
 }
@@ -31412,7 +31416,7 @@ var e, t;
 try {
 for (var r = a(Object.entries(this.interShardMemory.shards)), o = r.next(); !o.done; o = r.next()) {
 var n = i(o.value, 2), s = n[0], c = n[1];
-c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Mf(s)),
+c.health && "number" == typeof c.health.lastUpdate || (this.interShardMemory.shards[s] = Uf(s)),
 Array.isArray(c.portals) || (c.portals = []), Array.isArray(c.activeTasks) || (c.activeTasks = []);
 }
 } catch (t) {
@@ -31430,40 +31434,40 @@ Array.isArray(this.interShardMemory.tasks) || (this.interShardMemory.tasks = [])
 this.interShardMemory.globalTargets || (this.interShardMemory.globalTargets = {
 targetPowerLevel: 0
 }), "number" != typeof this.interShardMemory.lastSync && (this.interShardMemory.lastSync = Game.time),
-Hf.info("Repaired InterShardMemory structure", {
+Yf.info("Repaired InterShardMemory structure", {
 subsystem: "Shard"
 });
 }, e.prototype.verifySyncIntegrity = function() {
 var e, t;
 try {
 var r = InterShardMemory.getLocal();
-if (!r) return void Hf.warn("InterShardMemory verification failed: no data present", {
+if (!r) return void Yf.warn("InterShardMemory verification failed: no data present", {
 subsystem: "Shard"
 });
-var o = Uf(r);
-if (!o) return void Hf.warn("InterShardMemory verification failed: deserialization failed", {
+var o = Nf(r);
+if (!o) return void Yf.warn("InterShardMemory verification failed: deserialization failed", {
 subsystem: "Shard"
 });
 var n = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
-o.shards[n] || Hf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
+o.shards[n] || Yf.warn("InterShardMemory verification failed: current shard ".concat(n, " not found"), {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Hf.warn("InterShardMemory verification failed: ".concat(a), {
+Yf.warn("InterShardMemory verification failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
 }, e.prototype.attemptSyncRecovery = function() {
 var e, t;
 try {
-Hf.info("Attempting InterShardMemory recovery", {
+Yf.info("Attempting InterShardMemory recovery", {
 subsystem: "Shard"
 });
 var r = InterShardMemory.getLocal();
 if (r) {
-var o = Uf(r);
-if (o) return this.interShardMemory = o, void Hf.info("Recovered InterShardMemory from storage", {
+var o = Nf(r);
+if (o) return this.interShardMemory = o, void Yf.info("Recovered InterShardMemory from storage", {
 subsystem: "Shard"
 });
 }
@@ -31478,12 +31482,12 @@ tasks: [],
 footprintOperation: void 0,
 lastSync: 0,
 checksum: 0
-}, this.interShardMemory.shards[n] = Mf(n), Hf.info("Recreated InterShardMemory with current shard only", {
+}, this.interShardMemory.shards[n] = Uf(n), Yf.info("Recreated InterShardMemory with current shard only", {
 subsystem: "Shard"
 });
 } catch (e) {
 var a = e instanceof Error ? e.message : String(e);
-Hf.error("InterShardMemory recovery failed: ".concat(a), {
+Yf.error("InterShardMemory recovery failed: ".concat(a), {
 subsystem: "Shard"
 });
 }
@@ -31493,7 +31497,7 @@ n && (this.interShardMemory.shards = ((e = {})[o] = n, e), this.interShardMemory
 return e.sourceShard === o || e.targetShard === o;
 }), n.portals = n.portals.sort(function(e, t) {
 return t.lastScouted - e.lastScouted;
-}).slice(0, 10), Hf.warn("Emergency trim applied to InterShardMemory", {
+}).slice(0, 10), Yf.warn("Emergency trim applied to InterShardMemory", {
 subsystem: "Shard"
 }));
 }, e.prototype.trimInterShardMemory = function() {
@@ -31509,7 +31513,7 @@ return Game.time - e.lastScouted < 1e4;
 var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = this.interShardMemory.shards[r];
 if (o) {
 var n = o.health;
-Hf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
+Yf.info("Shard ".concat(r, " (").concat(o.role, "): ") + "".concat(n.roomCount, " rooms, RCL ").concat(n.avgRCL, ", ") + "CPU: ".concat(n.cpuCategory, ", Eco: ").concat(n.economyIndex, "%, War: ").concat(n.warIndex, "%"), {
 subsystem: "Shard"
 });
 }
@@ -31525,7 +31529,7 @@ priority: o,
 status: "pending",
 createdAt: Game.time
 };
-r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Hf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
+r && (s.targetRoom = r), this.interShardMemory.tasks.push(s), Yf.info("Created inter-shard task: ".concat(e, " to ").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getCurrentShardState = function() {
@@ -31540,7 +31544,7 @@ return t.targetShard === e;
 }) : [];
 }, e.prototype.setShardRole = function(e) {
 var t, r, o = null !== (r = null === (t = Game.shard) || void 0 === t ? void 0 : t.name) && void 0 !== r ? r : "shard0", n = this.interShardMemory.shards[o];
-n && (n.role = e, Hf.info("Set shard role to: ".concat(e), {
+n && (n.role = e, Yf.info("Set shard role to: ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.createResourceTransferTask = function(e, t, r, o, n) {
@@ -31559,7 +31563,7 @@ status: "pending",
 createdAt: Game.time,
 progress: 0
 };
-this.interShardMemory.tasks.push(c), Hf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
+this.interShardMemory.tasks.push(c), Yf.info("Created resource transfer task: ".concat(o, " ").concat(r, " to ").concat(e, "/").concat(t), {
 subsystem: "Shard"
 });
 }, e.prototype.getOptimalPortalRoute = function(e, t) {
@@ -31605,11 +31609,11 @@ return !("transfer" !== e.type || e.sourceShard !== r && e.targetShard !== r || 
 var t = this.interShardMemory.tasks.find(function(t) {
 return t.id === e;
 });
-t && (t.status = "failed", t.updatedAt = Game.time, Hf.info("Cancelled task ".concat(e), {
+t && (t.status = "failed", t.updatedAt = Game.time, Yf.info("Cancelled task ".concat(e), {
 subsystem: "Shard"
 }));
 }, e.prototype.getSyncStatus = function() {
-var e, t, r = Af(this.interShardMemory).length, o = r / Pf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
+var e, t, r = _f(this.interShardMemory).length, o = r / Gf * 100, n = Game.time - this.interShardMemory.lastSync, i = r < 92160 && n < 500, s = 0;
 try {
 for (var c = a(Object.values(this.interShardMemory.shards)), u = c.next(); !u.done; u = c.next()) s += u.value.portals.length;
 } catch (t) {
@@ -31636,11 +31640,11 @@ totalPortals: s,
 isHealthy: i
 };
 }, e.prototype.forceSync = function() {
-Hf.info("Forcing InterShardMemory sync with validation", {
+Yf.info("Forcing InterShardMemory sync with validation", {
 subsystem: "Shard"
 }), this.syncInterShardMemory();
 }, e.prototype.getMemoryStats = function() {
-var e, t, r = Af(this.interShardMemory).length, n = Af(o(o({}, this.interShardMemory), {
+var e, t, r = _f(this.interShardMemory).length, n = _f(o(o({}, this.interShardMemory), {
 tasks: [],
 globalTargets: {
 targetPowerLevel: 0
@@ -31664,8 +31668,8 @@ if (e) throw e.error;
 }
 return {
 size: r,
-limit: Pf,
-percent: Math.round(r / Pf * 1e4) / 100,
+limit: Gf,
+percent: Math.round(r / Gf * 1e4) / 100,
 breakdown: {
 shards: n,
 tasks: i,
@@ -31673,10 +31677,10 @@ portals: s,
 other: r - n - i
 }
 };
-}, n([ (_f.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
+}, n([ (Pf.LOW, function(e, t, r) {}) ], e.prototype, "run", null), n([ function(e) {
 return e;
 } ], e);
-}(), qf = new Vf, jf = {
+}(), zf = new jf, Qf = {
 optimizeBody: function(e, t) {
 return {
 parts: [ WORK, CARRY, MOVE ]
@@ -31687,11 +31691,11 @@ add: function(e, t) {},
 addRequest: function(e) {}
 },
 spawnPriorities: {
-LOW: Nf.LOW,
-NORMAL: Nf.NORMAL,
-HIGH: Nf.HIGH
+LOW: If.LOW,
+NORMAL: If.NORMAL,
+HIGH: If.HIGH
 }
-}, zf = function() {
+}, Xf = function() {
 function e() {
 Memory.crossShardTransfers || (Memory.crossShardTransfers = {
 requests: {},
@@ -31701,7 +31705,7 @@ lastUpdate: Game.time
 return e.prototype.run = function() {
 var e, t, r, o;
 this.cleanupOldRequests();
-var n = qf.getActiveTransferTasks();
+var n = zf.getActiveTransferTasks();
 try {
 for (var i = a(n), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
@@ -31728,7 +31732,7 @@ m && this.processTransferRequest(m);
 this.memory.lastUpdate = Game.time;
 }, e.prototype.createTransferRequest = function(e) {
 if (e.resourceType && e.resourceAmount && e.targetRoom) {
-var t = qf.getOptimalPortalRoute(e.targetShard);
+var t = zf.getOptimalPortalRoute(e.targetShard);
 if (t) {
 var r = this.findSourceRoom(e.resourceType, e.resourceAmount);
 if (r) {
@@ -31796,7 +31800,7 @@ case "transferring":
 this.handleTransferringRequest(e);
 }
 var t = Math.round(e.transferred / e.amount * 100);
-qf.updateTaskProgress(e.taskId, t);
+zf.updateTaskProgress(e.taskId, t);
 }, e.prototype.handleQueuedRequest = function(e) {
 var t, r = e.amount - e.transferred, o = e.assignedCreeps.map(function(e) {
 return Game.creeps[e];
@@ -31812,7 +31816,7 @@ var a = Game.rooms[e.sourceRoom];
 if (a && (null === (t = a.controller) || void 0 === t ? void 0 : t.my)) {
 var i, s = r - n, c = a.energyCapacityAvailable;
 try {
-i = jf.optimizeBody({
+i = Qf.optimizeBody({
 maxEnergy: c,
 role: "crossShardCarrier"
 });
@@ -31823,8 +31827,8 @@ subsystem: "CrossShardTransfer"
 }
 var u = 50 * i.parts.filter(function(e) {
 return e === CARRY;
-}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = jf.spawnPriorities.LOW;
-e.priority >= 80 ? d = jf.spawnPriorities.HIGH : e.priority >= 50 && (d = jf.spawnPriorities.NORMAL);
+}).length, l = Math.ceil(s / u), m = Math.min(l, 3), d = Qf.spawnPriorities.LOW;
+e.priority >= 80 ? d = Qf.spawnPriorities.HIGH : e.priority >= 50 && (d = Qf.spawnPriorities.NORMAL);
 for (var p = 0; p < m; p++) {
 var f = {
 transferRequestId: e.taskId,
@@ -31842,7 +31846,7 @@ createdAt: Game.time,
 targetRoom: e.targetRoom,
 additionalMemory: f
 };
-jf.spawnQueue.addRequest(y), Ne.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
+Qf.spawnQueue.addRequest(y), Ne.info("Requested spawn of crossShardCarrier for transfer ".concat(e.taskId, " (").concat(p + 1, "/").concat(m, ")"), {
 subsystem: "CrossShardTransfer"
 });
 }
@@ -31869,7 +31873,7 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-if (0 === t.length) return e.status = "failed", void qf.updateTaskProgress(e.taskId, e.transferred, "failed");
+if (0 === t.length) return e.status = "failed", void zf.updateTaskProgress(e.taskId, e.transferred, "failed");
 t.filter(function(t) {
 return t.room.name === e.portalRoom;
 }).length > 0 && (e.status = "transferring", Ne.info("Transfer request ".concat(e.taskId, " reached portal, transferring"), {
@@ -31881,8 +31885,8 @@ return Game.creeps[e];
 }).filter(function(e) {
 return void 0 !== e;
 });
-0 === t.length && (e.status = "complete", e.transferred = e.amount, qf.updateTaskProgress(e.taskId, 100, "complete"),
-qf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ne.info("Transfer request ".concat(e.taskId, " completed"), {
+0 === t.length && (e.status = "complete", e.transferred = e.amount, zf.updateTaskProgress(e.taskId, 100, "complete"),
+zf.recordPortalTraversal(e.portalRoom, e.targetShard, !0), Ne.info("Transfer request ".concat(e.taskId, " completed"), {
 subsystem: "CrossShardTransfer"
 }));
 }, e.prototype.cleanupOldRequests = function() {
@@ -31912,12 +31916,12 @@ return "queued" === e.status;
 return t.priority - e.priority;
 });
 }, e;
-}(), Qf = new zf;
+}(), Zf = new Xf;
 
-function Xf(e, t, r) {
+function Jf(e, t, r) {
 var o, n, a;
 try {
-var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Lf({
+var i = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", s = Bf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -31932,13 +31936,13 @@ if (!(null == c ? void 0 : c.targets[i])) return;
 var u = c.targets[i];
 u.status = e, null !== (a = u.arrivedAt) && void 0 !== a || (u.arrivedAt = Game.time),
 u.claimTargetRoom = null != t ? t : u.claimTargetRoom, u.blockedReason = r, u.lastUpdate = Game.time,
-"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Df(s, {
+"claimed" === e && (u.claimedAt = Game.time), c.updatedAt = Game.time, Ff(s, {
 updatedSections: [ "footprintOperation" ]
 });
 } catch (e) {}
 }
 
-function Zf(e) {
+function $f(e) {
 var t, r, o, n, a, i = e.memory;
 if (!i.targetShard) return e.creep.suicide(), {
 type: "idle"
@@ -31969,15 +31973,15 @@ range: 0
 type: "idle"
 };
 }(e, i);
-if (Xf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
+if (Jf("reached"), i.targetRoom && e.room.name !== i.targetRoom) return {
 type: "moveToRoom",
 roomName: i.targetRoom
 };
 if ((a = (n = e.room).controller) && (a.my || !(a.owner || a.reservation || Z(n).length > 0))) return i.targetRoom = e.room.name,
-"interShardScout" === e.memory.role ? (Xf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
+"interShardScout" === e.memory.role ? (Jf("reached", e.room.name, "Safe neutral claim target found; waiting for free GCL slot"),
 {
 type: "idle"
-}) : (Xf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
+}) : (Jf((null === (r = e.room.controller) || void 0 === r ? void 0 : r.my) ? "claimed" : "claimTargetSelected", e.room.name),
 (null === (o = e.room.controller) || void 0 === o ? void 0 : o.my) ? {
 type: "idle"
 } : {
@@ -31994,24 +31998,24 @@ return [ "".concat(o).concat(a).concat(n).concat(i + 1), "".concat(o).concat(a +
 }(e.room.name).find(function(e) {
 return e !== i.homeRoom;
 });
-return s ? (i.targetRoom = s, Xf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
+return s ? (i.targetRoom = s, Jf("reached", void 0, "Searching adjacent rooms for safe neutral controller"),
 {
 type: "moveToRoom",
 roomName: s
-}) : (Xf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
+}) : (Jf("blocked", void 0, "No safe neutral claim target visible near arrival room"),
 {
 type: "idle"
 });
 }
 
-function Jf(e) {
+function ey(e) {
 return {
 type: "moveTo",
 target: new RoomPosition(25, 25, e)
 };
 }
 
-function $f(e, t) {
+function ty(e, t) {
 var r, o, n, a, i, s, c, u = t.knownRooms, l = u[e.name], m = null !== (r = null == l ? void 0 : l.lastSeen) && void 0 !== r ? r : 0, d = Game.time - m;
 if ((null == l ? void 0 : l.scouted) && d < 2e3) {
 l.lastSeen = Game.time;
@@ -32045,12 +32049,12 @@ isSK: O
 (null == y ? void 0 : y.mineralType) && (k.mineralType = y.mineralType), u[e.name] = k;
 }
 
-function ey(e, t) {
+function ry(e, t) {
 var r = e >= 0 ? "E".concat(e) : "W".concat(-e - 1), o = t >= 0 ? "S".concat(t) : "N".concat(-t - 1);
 return "".concat(r).concat(o);
 }
 
-function ty(e) {
+function oy(e) {
 var t = Game.map.describeExits(e), r = t ? Object.values(t) : [], o = function(e) {
 var t = function(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
@@ -32061,20 +32065,20 @@ x: "E" === r ? o : -o - 1,
 y: "S" === n ? a : -a - 1
 };
 }(e);
-return t ? [ ey(t.x, t.y - 1), ey(t.x + 1, t.y), ey(t.x, t.y + 1), ey(t.x - 1, t.y) ] : [];
+return t ? [ ry(t.x, t.y - 1), ry(t.x + 1, t.y), ry(t.x, t.y + 1), ry(t.x - 1, t.y) ] : [];
 }(e);
 return Array.from(new Set(s(s([], i(r), !1), i(o), !1)));
 }
 
-function ry(e) {
-var t = zd.getEmpire();
-if (bl.isExit(e.creep.pos)) return Jf(e.room.name);
+function ny(e) {
+var t = Xd.getEmpire();
+if (kl.isExit(e.creep.pos)) return ey(e.room.name);
 var r = e.memory.lastExploredRoom, o = e.memory.targetRoom;
 if (o && !function(e, t) {
-return t === e || ty(e).includes(t);
+return t === e || oy(e).includes(t);
 }(e.room.name, o) && (delete e.memory.targetRoom, o = void 0), !o) {
 if (o = function(e, t, r) {
-var o, n, i, s, c = t.knownRooms, u = ty(e);
+var o, n, i, s, c = t.knownRooms, u = oy(e);
 if (0 !== u.length) {
 var l = [];
 try {
@@ -32134,13 +32138,13 @@ if (t) throw t.error;
 }
 return null;
 }(e.room);
-return n ? e.creep.pos.getRangeTo(n) <= 3 ? ($f(e.room, t), e.memory.lastExploredRoom = e.room.name,
+return n ? e.creep.pos.getRangeTo(n) <= 3 ? (ty(e.room, t), e.memory.lastExploredRoom = e.room.name,
 delete e.memory.targetRoom, {
 type: "idle"
 }) : {
 type: "moveTo",
 target: n
-} : ($f(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
+} : (ty(e.room, t), e.memory.lastExploredRoom = e.room.name, delete e.memory.targetRoom,
 {
 type: "idle"
 });
@@ -32150,19 +32154,19 @@ type: "idle"
 };
 }
 
-function oy(e) {
+function ay(e) {
 return e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0 || e.getActiveBodyparts(WORK) > 0;
 }
 
-function ny(e) {
-return e.hostiles.some(oy);
+function iy(e) {
+return e.hostiles.some(ay);
 }
 
-function ay(e) {
+function sy(e) {
 return e.structureType === STRUCTURE_CONTAINER ? 100 : e.structureType === STRUCTURE_ROAD ? 80 : 50;
 }
 
-function iy(e) {
+function cy(e) {
 if (!e.isEmpty && e.room.name !== e.homeRoom) return {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32185,8 +32189,8 @@ type: "idle"
 };
 }
 
-var sy = {
-scout: ry,
+var uy = {
+scout: ny,
 claimer: function(e) {
 if (0 === e.creep.getActiveBodyparts(CLAIM)) return function(e) {
 delete e.memory.state, delete e.memory.task;
@@ -32220,7 +32224,7 @@ return {
 type: "idle"
 };
 }
-if (bl.isExit(e.creep.pos)) return Jf(e.room.name);
+if (kl.isExit(e.creep.pos)) return ey(e.room.name);
 if (e.room.name !== t) return {
 type: "remoteMoveToRoom",
 roomName: t,
@@ -32242,8 +32246,8 @@ type: "reserve",
 target: n
 };
 },
-interShardClaimer: Zf,
-interShardScout: Zf,
+interShardClaimer: $f,
+interShardScout: $f,
 engineer: function(e) {
 var t, r;
 if (e.isEmpty && (e.memory.working = !1), e.isFull && (e.memory.working = !0), e.memory.working) {
@@ -32319,8 +32323,8 @@ var t, r = e.memory.targetRoom;
 if (!r || r === e.homeRoom) return {
 type: "idle"
 };
-if (e.room.name === e.homeRoom && !e.isEmpty) return iy(e);
-if (ny(e)) return function(e) {
+if (e.room.name === e.homeRoom && !e.isEmpty) return cy(e);
+if (iy(e)) return function(e) {
 return e.room.name !== e.homeRoom ? {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
@@ -32361,7 +32365,7 @@ type: "idle"
 var o = function(e) {
 var t;
 return null !== (t = e.find(FIND_MY_CONSTRUCTION_SITES).sort(function(e, t) {
-return ay(t) - ay(e);
+return sy(t) - sy(e);
 })[0]) && void 0 !== t ? t : null;
 }(e.room);
 if (o) return {
@@ -32381,7 +32385,7 @@ return e.hits - t.hits;
 return n ? {
 type: "repair",
 target: n
-} : iy(e);
+} : cy(e);
 },
 linkManager: function(e) {
 var t = e.room.find(FIND_MY_STRUCTURES, {
@@ -32470,9 +32474,9 @@ type: "idle"
 }
 };
 
-function cy(e, t) {
+function ly(e, t) {
 return "remoteWorker" === e.memory.role ? function(e, t) {
-return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : ny(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
+return "remoteWorker" !== e.memory.role || e.room.name === e.homeRoom ? null : iy(e) ? "remoteMoveToRoom" === t.action && t.targetRoom === e.homeRoom ? null : {
 type: "remoteMoveToRoom",
 roomName: e.homeRoom,
 routeType: "hauler"
@@ -32480,26 +32484,26 @@ routeType: "hauler"
 }(e, t) : null;
 }
 
-function uy(e) {
-var t;
-return (null !== (t = sy[e.memory.role]) && void 0 !== t ? t : ry)(e);
-}
-
-function ly(e) {
-var t = Sl(e);
-vm(e, Sm(t, pp, {
-interrupt: yp
-}), t);
-}
-
 function my(e) {
-var t = Sl(e);
-vm(e, Sm(t, uy, {
-interrupt: cy
-}), t);
+var t;
+return (null !== (t = uy[e.memory.role]) && void 0 !== t ? t : ny)(e);
 }
 
 function dy(e) {
+var t = xl(e);
+hm(e, xm(t, yp, {
+interrupt: gp
+}), t);
+}
+
+function py(e) {
+var t = xl(e);
+hm(e, xm(t, my, {
+interrupt: ly
+}), t);
+}
+
+function fy(e) {
 var t = function(e) {
 var t, r, o;
 if (!e.room) return null;
@@ -32540,8 +32544,8 @@ t && function(e, t) {
 var r, o, n, a, i, s;
 switch (t.type) {
 case "usePower":
-if (i = t.power, s = t.target, Boolean(s && Zp.has(i) && z(s))) {
-zp.warn("Refusing disruptive power action against known ally target", {
+if (i = t.power, s = t.target, Boolean(s && $p.has(i) && z(s))) {
+Xp.warn("Refusing disruptive power action against known ally target", {
 creep: e.name,
 room: null === (r = e.pos) || void 0 === r ? void 0 : r.roomName,
 meta: {
@@ -32552,16 +32556,16 @@ owner: null === (n = null === (o = t.target) || void 0 === o ? void 0 : o.owner)
 });
 break;
 }
-(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && bl.moveTo(e, t.target);
+(t.target ? e.usePower(t.power, t.target) : e.usePower(t.power)) === ERR_NOT_IN_RANGE && t.target && kl.moveTo(e, t.target);
 break;
 
 case "moveTo":
-bl.moveTo(e, t.target);
+kl.moveTo(e, t.target);
 break;
 
 case "moveToRoom":
 var c = new RoomPosition(25, 25, t.roomName);
-bl.moveTo(e, {
+kl.moveTo(e, {
 pos: c,
 range: 20
 }, {
@@ -32570,11 +32574,11 @@ maxRooms: 16
 break;
 
 case "renewSelf":
-e.renew(t.spawn) === ERR_NOT_IN_RANGE && bl.moveTo(e, t.spawn);
+e.renew(t.spawn) === ERR_NOT_IN_RANGE && kl.moveTo(e, t.spawn);
 break;
 
 case "enableRoom":
-(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && bl.moveTo(e, e.room.controller);
+(null === (a = e.room) || void 0 === a ? void 0 : a.controller) && e.enableRoom(e.room.controller) === ERR_NOT_IN_RANGE && kl.moveTo(e, e.room.controller);
 }
 }(e, function(e) {
 return "powerWarrior" === e.powerCreep.memory.role ? function(e) {
@@ -32606,7 +32610,7 @@ target: u
 }
 if (o.includes(PWR_DISRUPT_SPAWN) && e.ops >= 10) {
 var l = c.filter(function(e) {
-return e.structureType === STRUCTURE_SPAWN && !Qp(e, PWR_DISRUPT_SPAWN);
+return e.structureType === STRUCTURE_SPAWN && !Zp(e, PWR_DISRUPT_SPAWN);
 })[0];
 if (l) return {
 type: "usePower",
@@ -32616,7 +32620,7 @@ target: l
 }
 if (o.includes(PWR_DISRUPT_TOWER) && e.ops >= 10) {
 var m = c.filter(function(e) {
-return e.structureType === STRUCTURE_TOWER && !Qp(e, PWR_DISRUPT_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_DISRUPT_TOWER);
 })[0];
 if (m) return {
 type: "usePower",
@@ -32627,7 +32631,7 @@ target: m
 if (o.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && n.length > 0) {
 var d = pt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Qp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 })[0];
@@ -32680,7 +32684,7 @@ target: h
 }
 if (o.includes(PWR_DISRUPT_TERMINAL) && e.ops >= 50) {
 var R = c.find(function(e) {
-return e.structureType === STRUCTURE_TERMINAL && !Qp(e, PWR_DISRUPT_TERMINAL);
+return e.structureType === STRUCTURE_TERMINAL && !Zp(e, PWR_DISRUPT_TERMINAL);
 });
 if (R) return {
 type: "usePower",
@@ -32722,7 +32726,7 @@ power: PWR_GENERATE_OPS
 if (t.includes(PWR_OPERATE_SPAWN) && e.ops >= 100) {
 var r = e.spawns.find(function(e) {
 var t = e;
-return null !== t.spawning && !Qp(t, PWR_OPERATE_SPAWN);
+return null !== t.spawning && !Zp(t, PWR_OPERATE_SPAWN);
 });
 if (r) return {
 type: "usePower",
@@ -32732,7 +32736,7 @@ target: r
 }
 if (t.includes(PWR_OPERATE_EXTENSION) && e.ops >= 2 && e.extensions.reduce(function(e, t) {
 return e + t.store.getFreeCapacity(RESOURCE_ENERGY);
-}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Qp(e.storage, PWR_OPERATE_EXTENSION)) return {
+}, 0) > 1e3 && e.storage && e.storage.store.getUsedCapacity(RESOURCE_ENERGY) > 1e4 && !Zp(e.storage, PWR_OPERATE_EXTENSION)) return {
 type: "usePower",
 power: PWR_OPERATE_EXTENSION,
 target: e.storage
@@ -32740,7 +32744,7 @@ target: e.storage
 if (t.includes(PWR_OPERATE_TOWER) && e.ops >= 10 && Z(e.room).length > 0) {
 var o = pt(e.room, FIND_MY_STRUCTURES, {
 filter: function(e) {
-return e.structureType === STRUCTURE_TOWER && !Qp(e, PWR_OPERATE_TOWER);
+return e.structureType === STRUCTURE_TOWER && !Zp(e, PWR_OPERATE_TOWER);
 },
 filterKey: "towerNoEffect"
 });
@@ -32752,7 +32756,7 @@ target: o[0]
 }
 if (t.includes(PWR_OPERATE_LAB) && e.ops >= 10) {
 var n = e.labs.find(function(e) {
-return 0 === e.cooldown && e.mineralType && !Qp(e, PWR_OPERATE_LAB);
+return 0 === e.cooldown && e.mineralType && !Zp(e, PWR_OPERATE_LAB);
 });
 if (n) return {
 type: "usePower",
@@ -32760,12 +32764,12 @@ power: PWR_OPERATE_LAB,
 target: n
 };
 }
-if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Qp(e.factory, PWR_OPERATE_FACTORY)) return {
+if (t.includes(PWR_OPERATE_FACTORY) && e.ops >= 100 && e.factory && 0 === e.factory.cooldown && !Zp(e.factory, PWR_OPERATE_FACTORY)) return {
 type: "usePower",
 power: PWR_OPERATE_FACTORY,
 target: e.factory
 };
-if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Qp(e.storage, PWR_OPERATE_STORAGE)) return {
+if (t.includes(PWR_OPERATE_STORAGE) && e.ops >= 100 && e.storage && e.storage.store.getUsedCapacity() > .85 * e.storage.store.getCapacity() && !Zp(e.storage, PWR_OPERATE_STORAGE)) return {
 type: "usePower",
 power: PWR_OPERATE_STORAGE,
 target: e.storage
@@ -32799,18 +32803,18 @@ roomName: e.homeRoom
 }(t));
 }
 
-function py(e) {
+function yy(e) {
 return null !== e && "object" == typeof e && "pos" in e && e.pos instanceof RoomPosition && "room" in e && e.room instanceof Room;
 }
 
-var fy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), yy = -1, vy = Object.create(null);
+var vy = new Set([ "harvester", "upgrader", "mineralHarvester", "depositHarvester", "factoryWorker", "labTech", "builder", "queenCarrier" ]), gy = -1, hy = Object.create(null);
 
-function gy(e) {
+function Ry(e) {
 var t = e.memory;
 return "string" == typeof t.homeRoom && t.homeRoom.length > 0 ? t.homeRoom : void 0;
 }
 
-var hy = {
+var Ey = {
 harvester: Ie.CRITICAL,
 queenCarrier: Ie.CRITICAL,
 hauler: Ie.HIGH,
@@ -32845,12 +32849,12 @@ labTech: Ie.IDLE,
 factoryWorker: Ie.IDLE
 };
 
-function Ry(e) {
+function Ty(e) {
 var t;
-return null !== (t = hy[e]) && void 0 !== t ? t : Ie.MEDIUM;
+return null !== (t = Ey[e]) && void 0 !== t ? t : Ie.MEDIUM;
 }
 
-function Ey(e) {
+function Cy(e) {
 var t = e.memory;
 if (!e.spawning) {
 if ("string" == typeof t.role && t.role.startsWith("interShard") && !t.targetShard) return e.suicide(),
@@ -32866,30 +32870,30 @@ return void 0 === t && (t = {}), !1 === t.useCache ? function(e) {
 var t = 0;
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
-o && gy(o) === e && t++;
+o && Ry(o) === e && t++;
 }
 return t;
-}(e) : null !== (r = (yy !== Game.time && (yy = Game.time, vy = function() {
+}(e) : null !== (r = (gy !== Game.time && (gy = Game.time, hy = function() {
 var e, t = Object.create(null);
 for (var r in Game.creeps) {
 var o = Game.creeps[r];
 if (o) {
-var n = gy(o);
+var n = Ry(o);
 n && (t[n] = (null !== (e = t[n]) && void 0 !== e ? e : 0) + 1);
 }
 }
 return t;
-}()), vy)[e]) && void 0 !== r ? r : 0;
+}()), hy)[e]) && void 0 !== r ? r : 0;
 }(e.name, t) < o;
 }(r, {
 useCache: !0 !== Mr().cpu.disableCreepBootstrapCountCache
 });
-if (o && Game.time % 50 == 0 && ll.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
+if (o && Game.time % 50 == 0 && dl.info("Executing role for creep ".concat(e.name, " (").concat(t.role, ")"), {
 subsystem: "CreepProcessManager",
 creep: e.name
 }), function(e) {
 var t = e.memory;
-if (!fy.has(t.role)) return !1;
+if (!vy.has(t.role)) return !1;
 var r = t.state;
 if (!r || !r.startTick) return !1;
 if (Game.time - r.startTick < 3) return !1;
@@ -32899,7 +32903,7 @@ return function(e, t) {
 if ("harvest" !== t.action && "transfer" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !py(r)) return !1;
+if (!r || !yy(r)) return !1;
 if (!e.pos.isNearTo(r.pos)) return !1;
 if ("harvest" === t.action) {
 var o = e.store.getCapacity();
@@ -32913,7 +32917,7 @@ return function(e, t) {
 if ("upgrade" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !py(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
+return !(!r || !yy(r) || !e.pos.inRangeTo(r.pos, 3) || "upgrade" === t.action && 0 === e.store.getUsedCapacity(RESOURCE_ENERGY) || "withdraw" === t.action && 0 === e.store.getFreeCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "mineralHarvester":
@@ -32921,7 +32925,7 @@ return function(e, t) {
 if ("harvestMineral" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !py(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
+return !(!r || !yy(r) || !e.pos.isNearTo(r.pos) || 0 === e.store.getFreeCapacity());
 }(e, r);
 
 case "builder":
@@ -32929,7 +32933,7 @@ return function(e, t) {
 if ("build" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !(!r || !py(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
+return !(!r || !yy(r) || !e.pos.inRangeTo(r.pos, 3) || 0 === e.store.getUsedCapacity(RESOURCE_ENERGY));
 }(e, r);
 
 case "queenCarrier":
@@ -32937,7 +32941,7 @@ return function(e, t) {
 if ("transfer" !== t.action && "withdraw" !== t.action) return !1;
 if (!t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-return !!(r && py(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+return !!(r && yy(r) && "store" in r) && !!e.pos.isNearTo(r.pos) && ("transfer" === t.action ? e.store.getUsedCapacity(RESOURCE_ENERGY) > 0 : e.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
 }(e, r);
 
 case "depositHarvester":
@@ -32953,7 +32957,7 @@ var n = function(e) {
 var t = e.memory.state;
 if (!t || !t.targetId) return !1;
 var r = Game.getObjectById(t.targetId);
-if (!r || !py(r)) return !1;
+if (!r || !yy(r)) return !1;
 switch (t.action) {
 case "harvest":
 return "energy" in r && "energyCapacity" in r && "ticksToRegeneration" in r && e.harvest(r) === OK;
@@ -32988,41 +32992,41 @@ var t;
 return null !== (t = e.memory.family) && void 0 !== t ? t : "economy";
 }(e), i = t.role;
 try {
-rs.measureSubsystem("role:".concat(i), function() {
+ns.measureSubsystem("role:".concat(i), function() {
 switch (a) {
 case "economy":
 default:
 !function(e) {
-var t = Sl(e);
-vm(e, Sm(t, pp, {
-interrupt: yp
+var t = xl(e);
+hm(e, xm(t, yp, {
+interrupt: gp
 }), t);
 }(e);
 break;
 
 case "military":
 !function(e) {
-var t = Sl(e);
-vm(e, Sm(t, jp), t);
+var t = xl(e);
+hm(e, xm(t, Qp), t);
 }(e);
 break;
 
 case "utility":
 !function(e) {
-var t = Sl(e);
-vm(e, Sm(t, uy), t);
+var t = xl(e);
+hm(e, xm(t, my), t);
 }(e);
 break;
 
 case "power":
 !function(e) {
-var t = Sl(e);
-vm(e, Sm(t, $p), t);
+var t = xl(e);
+hm(e, xm(t, tf), t);
 }(e);
 }
 });
 } catch (t) {
-ll.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
+dl.error("EXCEPTION in role execution for ".concat(e.name, " (").concat(i, "/").concat(a, "): ").concat(t), {
 subsystem: "CreepProcessManager",
 creep: e.name,
 meta: {
@@ -33038,7 +33042,7 @@ pos: "".concat(e.pos.x, ",").concat(e.pos.y, " in ").concat(e.room.name)
 }
 }
 
-var Ty = function() {
+var Sy = function() {
 function e() {
 this.registeredCreeps = new Set, this.lastSyncTick = -1;
 }
@@ -33067,7 +33071,7 @@ if (e) throw e.error;
 }
 }
 var d = s < 5;
-(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && ll.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
+(o > 0 || n > 0 || Game.time % 100 == 0 || d && Game.time % 25 == 0) && dl.info("CreepProcessManager: ".concat(r.size, " active, ").concat(i, " spawning, ").concat(s, " total (registered: ").concat(o, ", unregistered: ").concat(n, ")"), {
 subsystem: "CreepProcessManager",
 meta: {
 activeCreeps: r.size,
@@ -33079,8 +33083,8 @@ unregisteredThisTick: n
 });
 }
 }, e.prototype.registerCreepProcess = function(e) {
-var t = e.memory, r = t.role, o = Ry(r), n = "creep:".concat(e.name);
-Gi.registerProcess({
+var t = e.memory, r = t.role, o = Ty(r), n = "creep:".concat(e.name);
+Di.registerProcess({
 id: n,
 name: "Creep ".concat(e.name, " (").concat(r, ")"),
 priority: o,
@@ -33095,14 +33099,14 @@ layer: "creep"
 },
 execute: function() {
 var t = Game.creeps[e.name];
-t && !t.spawning && Ey(t);
+t && !t.spawning && Cy(t);
 }
-}), this.registeredCreeps.add(e.name), ll.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
+}), this.registeredCreeps.add(e.name), dl.info("Registered creep process: ".concat(e.name, " (").concat(r, ") with priority ").concat(o), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.unregisterCreepProcess = function(e) {
 var t = "creep:".concat(e);
-Gi.unregisterProcess(t), this.registeredCreeps.delete(e), ll.info("Unregistered creep process: ".concat(e), {
+Di.unregisterProcess(t), this.registeredCreeps.delete(e), dl.info("Unregistered creep process: ".concat(e), {
 subsystem: "CreepProcessManager"
 });
 }, e.prototype.getMinBucketForRole = function(e, t) {
@@ -33120,7 +33124,7 @@ try {
 for (var i = a(this.registeredCreeps), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.creeps[c];
 if (u) {
-var l = Ry(u.memory.role), m = null !== (r = Ie[l]) && void 0 !== r ? r : "UNKNOWN";
+var l = Ty(u.memory.role), m = null !== (r = Ie[l]) && void 0 !== r ? r : "UNKNOWN";
 n[m] = (null !== (o = n[m]) && void 0 !== o ? o : 0) + 1;
 }
 }
@@ -33145,20 +33149,20 @@ this.lastSyncTick = -1, this.syncCreepProcesses();
 }, e.prototype.reset = function() {
 this.registeredCreeps.clear(), this.lastSyncTick = -1;
 }, e;
-}(), Cy = new Ty;
+}(), wy = new Sy;
 
-function Sy(e) {
+function xy(e) {
 var t, r, o;
-return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, wy(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
+return [ e.id, null !== (t = e.parentId) && void 0 !== t ? t : "root", null !== (r = e.layer) && void 0 !== r ? r : "-", null !== (o = e.group) && void 0 !== o ? o : "-", e.priority, e.frequency, by(e), e.state, "runs=".concat(e.runCount, " avg=").concat(e.avgCpu.toFixed(4), " max=").concat(e.maxCpu.toFixed(4), " last=").concat(e.lastRunTick, " skipped=").concat(e.skippedCount, " cpuSkips=").concat(e.consecutiveCpuSkips, " errors=").concat(e.errorCount, " consecutiveErrors=").concat(e.consecutiveErrors, " health=").concat(e.healthScore.toFixed(0)) ].join(" | ");
 }
 
-function wy(e) {
+function by(e) {
 var t = [ "interval=".concat(e.interval) ];
 return void 0 !== e.tickModulo && t.push("modulo=".concat(e.tickModulo)), void 0 !== e.tickOffset && t.push("offset=".concat(e.tickOffset)),
 e.minBucket > 0 && t.push("minBucket=".concat(e.minBucket)), t.join(" ");
 }
 
-function xy(e) {
+function Oy(e) {
 var t = Object.entries(e).filter(function(e) {
 return i(e, 2)[1] > 0;
 }).sort(function(e, t) {
@@ -33171,14 +33175,14 @@ return "".concat(r, "=").concat(o);
 }).join(", ");
 }
 
-function by(e, t) {
+function ky(e, t) {
 var r, o, n = (null !== (r = e.layer) && void 0 !== r ? r : "").localeCompare(null !== (o = t.layer) && void 0 !== o ? o : "");
 if (0 !== n) return n;
 var a = t.priority - e.priority;
 return 0 !== a ? a : e.id.localeCompare(t.id);
 }
 
-var Oy = {
+var My = {
 updateInterval: 5,
 decayFactors: {
 expand: .95,
@@ -33206,11 +33210,11 @@ maxValue: 100,
 minValue: 0
 };
 
-function ky(e, t) {
+function Ay(e, t) {
 return Math.max(t.minValue, Math.min(t.maxValue, e));
 }
 
-function My(e) {
+function Uy(e) {
 var t, r = global, o = (t = e.name, "sources_".concat(t)), n = r[o];
 if ((null == n ? void 0 : n.tick) === Game.time) return n.sources;
 var a = e.find(FIND_SOURCES);
@@ -33220,9 +33224,9 @@ tick: Game.time
 }, a;
 }
 
-var Ay = [ "defense", "war", "expand", "siege" ];
+var _y = [ "defense", "war", "expand", "siege" ];
 
-function Uy(e) {
+function Ny(e) {
 var t = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!t) return [];
 var r = i(t, 5), o = r[1], n = r[2], a = r[3], s = r[4];
@@ -33235,11 +33239,11 @@ return "N" === a ? l.push("".concat(o).concat(c, "N").concat(u + 1)) : u > 0 ? l
 l;
 }
 
-function _y(e, t, r) {
-t >= 2 && (e.pheromones.war = ky(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = ky(e.pheromones.siege + 20, r));
+function Py(e, t, r) {
+t >= 2 && (e.pheromones.war = Ay(e.pheromones.war + 10 * t, r)), t >= 3 && (e.pheromones.siege = Ay(e.pheromones.siege + 20, r));
 }
 
-var Ny = function() {
+var Iy = function() {
 function e(e) {
 void 0 === e && (e = 10), this.maxSamples = e, this.values = [], this.sum = 0;
 }
@@ -33254,27 +33258,27 @@ return this.values.length > 0 ? this.sum / this.values.length : 0;
 }, e.prototype.reset = function() {
 this.values = [], this.sum = 0;
 }, e;
-}(), Py = function() {
+}(), Gy = function() {
 function e(e) {
-void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, Oy), e);
+void 0 === e && (e = {}), this.trackers = new Map, this.config = o(o({}, My), e);
 }
 return e.prototype.getTracker = function(e) {
 var t = this.trackers.get(e);
 return t || (t = {
-energyHarvested: new Ny(10),
-energySpawning: new Ny(10),
-energyConstruction: new Ny(10),
-energyRepair: new Ny(10),
-energyTower: new Ny(10),
-controllerProgress: new Ny(10),
-hostileCount: new Ny(5),
-damageReceived: new Ny(5),
-idleWorkers: new Ny(10),
+energyHarvested: new Iy(10),
+energySpawning: new Iy(10),
+energyConstruction: new Iy(10),
+energyRepair: new Iy(10),
+energyTower: new Iy(10),
+controllerProgress: new Iy(10),
+hostileCount: new Iy(5),
+damageReceived: new Iy(5),
+idleWorkers: new Iy(10),
 lastControllerProgress: 0
 }, this.trackers.set(e, t)), t;
 }, e.prototype.updateMetrics = function(e, t) {
 !function(e, t, r) {
-var o = My(e);
+var o = Uy(e);
 r.energyHarvested.add(function(e) {
 var t, r, o = 0, n = 0;
 try {
@@ -33347,7 +33351,7 @@ var r, o;
 try {
 for (var n = a(Object.keys(e)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = t.decayFactors[s];
-e[s] = ky(e[s] * c, t);
+e[s] = Ay(e[s] * c, t);
 }
 } catch (e) {
 r = {
@@ -33363,43 +33367,43 @@ if (r) throw r.error;
 }(e.pheromones, this.config), function(e, t, r, o) {
 var n = e.pheromones;
 !function(e, t, r) {
-var o = My(t);
+var o = Uy(t);
 if (0 !== o.length) {
 var n = o.reduce(function(e, t) {
 return e + t.energy;
 }, 0) / o.length;
-e.harvest = ky(e.harvest + n / 3e3 * 10, r);
+e.harvest = Ay(e.harvest + n / 3e3 * 10, r);
 }
 }(n, t, o), function(e, t, r) {
 var o = t.find(FIND_MY_CONSTRUCTION_SITES);
-0 !== o.length && (e.build = ky(e.build + Math.min(2 * o.length, 20), r));
+0 !== o.length && (e.build = Ay(e.build + Math.min(2 * o.length, 20), r));
 }(n, t, o), function(e, t, r) {
 var o;
 if (null === (o = t.controller) || void 0 === o ? void 0 : o.my) {
 var n = t.controller.progress / t.controller.progressTotal;
-n < .5 && (e.upgrade = ky(e.upgrade + 15 * (1 - n), r));
+n < .5 && (e.upgrade = Ay(e.upgrade + 15 * (1 - n), r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.hostileCount.get();
-o > 0 && (e.defense = ky(e.defense + 10 * o, r));
+o > 0 && (e.defense = Ay(e.defense + 10 * o, r));
 }(n, r, o), function(e, t) {
-e.danger >= 2 && (e.pheromones.war = ky(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = ky(e.pheromones.siege + 20, t));
+e.danger >= 2 && (e.pheromones.war = Ay(e.pheromones.war + 10 * e.danger, t)), e.danger >= 3 && (e.pheromones.siege = Ay(e.pheromones.siege + 20, t));
 }(e, o), function(e, t, r) {
 if (t.storage) {
 var o = t.find(FIND_MY_SPAWNS);
 o.reduce(function(e, t) {
 return e + t.store.getUsedCapacity(RESOURCE_ENERGY);
-}, 0) < 300 * o.length * .5 && (e.logistics = ky(e.logistics + 10, r));
+}, 0) < 300 * o.length * .5 && (e.logistics = Ay(e.logistics + 10, r));
 }
 }(n, t, o), function(e, t, r) {
 var o = t.energyHarvested.get() - e.metrics.energySpawning;
-o > 0 && 0 === e.danger && (e.pheromones.expand = ky(e.pheromones.expand + Math.min(o / 100, 10), r));
+o > 0 && 0 === e.danger && (e.pheromones.expand = Ay(e.pheromones.expand + Math.min(o / 100, 10), r));
 }(e, r, o);
 }(e, t, this.getTracker(t.name), this.config), e.nextUpdateTick = Game.time + this.config.updateInterval,
 e.lastUpdate = Game.time);
 }, e.prototype.onHostileDetected = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = ky(e.pheromones.defense + 5 * t, o), _y(e, r, o),
+e.danger = r, e.pheromones.defense = Ay(e.pheromones.defense + 5 * t, o), Py(e, r, o),
 U.info("Hostile detected: ".concat(t, " hostiles, danger=").concat(r), {
 room: e.role,
 subsystem: "Pheromone"
@@ -33407,7 +33411,7 @@ subsystem: "Pheromone"
 }(e, t, r, this.config);
 }, e.prototype.updateDangerFromThreat = function(e, t, r) {
 !function(e, t, r, o) {
-e.danger = r, e.pheromones.defense = ky(t / 10, o), _y(e, r, o);
+e.danger = r, e.pheromones.defense = Ay(t / 10, o), Py(e, r, o);
 }(e, t, r, this.config);
 }, e.prototype.diffuseDangerToCluster = function(e, t, r) {
 !function(e, t, r, o) {
@@ -33420,8 +33424,8 @@ var m = Game.rooms[l];
 if (null === (s = null == m ? void 0 : m.controller) || void 0 === s ? void 0 : s.my) {
 var d = m.memory.swarm;
 if (d) {
-var p = ky(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
-d.pheromones.defense = ky(f + y, o);
+var p = Ay(t / 10, o), f = d.pheromones.defense, y = .05 * Math.max(0, p - f);
+d.pheromones.defense = Ay(f + y, o);
 }
 }
 }
@@ -33440,18 +33444,18 @@ if (n) throw n.error;
 }(e, t, r, this.config);
 }, e.prototype.onStructureDestroyed = function(e, t) {
 !function(e, t, r) {
-e.pheromones.defense = ky(e.pheromones.defense + 5, r), e.pheromones.build = ky(e.pheromones.build + 10, r),
+e.pheromones.defense = Ay(e.pheromones.defense + 5, r), e.pheromones.build = Ay(e.pheromones.build + 10, r),
 function(e) {
 return e === STRUCTURE_SPAWN || e === STRUCTURE_STORAGE || e === STRUCTURE_TOWER;
-}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = ky(e.pheromones.siege + 15, r));
+}(t) && (e.danger = Math.min(3, e.danger + 1), e.pheromones.siege = Ay(e.pheromones.siege + 15, r));
 }(e, t, this.config);
 }, e.prototype.onNukeDetected = function(e) {
 !function(e, t) {
-e.danger = 3, e.pheromones.siege = ky(e.pheromones.siege + 50, t), e.pheromones.defense = ky(e.pheromones.defense + 30, t);
+e.danger = 3, e.pheromones.siege = Ay(e.pheromones.siege + 50, t), e.pheromones.defense = Ay(e.pheromones.defense + 30, t);
 }(e, this.config);
 }, e.prototype.onRemoteSourceLost = function(e) {
 !function(e, t) {
-e.pheromones.expand = ky(e.pheromones.expand - 10, t), e.pheromones.defense = ky(e.pheromones.defense + 5, t);
+e.pheromones.expand = Ay(e.pheromones.expand - 10, t), e.pheromones.defense = Ay(e.pheromones.defense + 5, t);
 }(e, this.config);
 }, e.prototype.applyDiffusion = function(e) {
 !function(e, t) {
@@ -33461,10 +33465,10 @@ try {
 for (var m = a(e), d = m.next(); !d.done; d = m.next()) {
 var p = i(d.value, 2), f = p[0], y = p[1];
 try {
-for (var v = (n = void 0, a(Uy(f))), g = v.next(); !g.done; g = v.next()) {
+for (var v = (n = void 0, a(Ny(f))), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 if (e.has(h)) try {
-for (var R = (c = void 0, a(Ay)), E = R.next(); !E.done; E = R.next()) {
+for (var R = (c = void 0, a(_y)), E = R.next(); !E.done; E = R.next()) {
 var T = E.value, C = y.pheromones[T];
 if (!(C <= 1)) {
 var S = t.diffusionRates[T];
@@ -33518,7 +33522,7 @@ for (var s = a(n), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = e.get(u.target);
 if (l) {
 var m = l.pheromones[u.type] + u.amount;
-l.pheromones[u.type] = ky(Math.min(m, u.sourceIntensity), t);
+l.pheromones[u.type] = Ay(Math.min(m, u.sourceIntensity), t);
 }
 }
 } catch (e) {
@@ -33553,7 +33557,7 @@ if (t) throw t.error;
 }
 return o;
 }, e;
-}(), Iy = new Py, Gy = {
+}(), Ly = new Gy, Dy = {
 seedNest: {
 rcl: 1
 },
@@ -33594,7 +33598,7 @@ minRooms: 3,
 minRemoteRooms: 2,
 minTowerCount: 6
 }
-}, Ly = {
+}, By = {
 eco: {
 economy: .75,
 military: .05,
@@ -33637,7 +33641,7 @@ military: .3,
 utility: .2,
 power: .1
 }
-}, Dy = {
+}, Fy = {
 eco: {
 upgrade: 80,
 build: 60,
@@ -33694,13 +33698,13 @@ spawn: 80,
 terminal: 30,
 labs: 70
 }
-}, By = function() {
+}, Wy = function() {
 function e() {
 this.STRUCTURE_CACHE_NAMESPACE = "evolution:structures", this.structureCacheTtl = 20;
 }
 return e.prototype.determineEvolutionStage = function(e, t, r) {
 var o, n, a, i, s = null !== (n = null === (o = t.controller) || void 0 === o ? void 0 : o.level) && void 0 !== n ? n : 0, c = Game.gcl.level;
-return s >= 8 && c >= (null !== (a = Gy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Gy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Gy.fortifiedHive.rcl ? "fortifiedHive" : s >= Gy.matureColony.rcl ? "matureColony" : s >= Gy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
+return s >= 8 && c >= (null !== (a = Dy.empireDominance.minGcl) && void 0 !== a ? a : 0) && r >= (null !== (i = Dy.empireDominance.minRooms) && void 0 !== i ? i : 0) ? "empireDominance" : s >= Dy.fortifiedHive.rcl ? "fortifiedHive" : s >= Dy.matureColony.rcl ? "matureColony" : s >= Dy.foragingExpansion.rcl ? "foragingExpansion" : "seedNest";
 }, e.prototype.getStructureCounts = function(e) {
 var t, r, o, n = Ee.get(e.name, {
 namespace: this.STRUCTURE_CACHE_NAMESPACE,
@@ -33735,7 +33739,7 @@ room: t.name,
 subsystem: "Evolution"
 }), e.colonyLevel = o, !0);
 }, e.prototype.updateMissingStructures = function(e, t) {
-var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Gy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
+var r, o, n, a, i, s, c, u, l, m, d, p, f = this.getStructureCounts(t), y = null !== (o = null === (r = t.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, v = Dy[e.colonyLevel], g = v.requiresLabs && y >= 6, h = g ? null !== (n = v.minLabCount) && void 0 !== n ? n : 3 : 0, R = v.requiresFactory && y >= 7, E = v.requiresTerminal && y >= 6, T = v.requiresStorage && y >= 4, C = v.requiresPowerSpawn && y >= 7, S = v.requiresObserver && y >= 8, w = v.requiresNuker && y >= 8;
 e.missingStructures = {
 spawn: 0 === (null !== (a = f[STRUCTURE_SPAWN]) && void 0 !== a ? a : 0),
 storage: !!T && 0 === (null !== (i = f[STRUCTURE_STORAGE]) && void 0 !== i ? i : 0),
@@ -33748,7 +33752,7 @@ powerSpawn: !!C && 0 === (null !== (d = f[STRUCTURE_POWER_SPAWN]) && void 0 !== 
 observer: !!S && 0 === (null !== (p = f[STRUCTURE_OBSERVER]) && void 0 !== p ? p : 0)
 };
 }, e;
-}(), Fy = function() {
+}(), Hy = function() {
 function e() {}
 return e.prototype.determinePosture = function(e, t) {
 if (t) return t;
@@ -33761,7 +33765,7 @@ var n = e.posture, a = null != r ? r : e.role;
 return U.info("Posture change: ".concat(n, " -> ").concat(o), {
 room: a,
 subsystem: "Posture"
-}), e.posture = o, Gi.emit("posture.change", {
+}), e.posture = o, Di.emit("posture.change", {
 roomName: a,
 oldPosture: n,
 newPosture: o,
@@ -33770,9 +33774,9 @@ source: "PostureManager"
 }
 return !1;
 }, e.prototype.getSpawnProfile = function(e) {
-return Ly[e];
+return By[e];
 }, e.prototype.getResourcePriorities = function(e) {
-return Dy[e];
+return Fy[e];
 }, e.prototype.allowsBuilding = function(e) {
 return "evacuate" !== e && "siege" !== e;
 }, e.prototype.allowsUpgrading = function(e) {
@@ -33782,15 +33786,15 @@ return "defensive" === e || "war" === e || "siege" === e;
 }, e.prototype.allowsExpansion = function(e) {
 return "eco" === e || "expand" === e;
 }, e;
-}(), Wy = new By, Hy = new Fy;
+}(), Ky = new Wy, Yy = new Hy;
 
-function Ky(e) {
+function Vy(e) {
 return !j(e.owner.username) && e.body.some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK || e.type === WORK || e.type === HEAL);
 });
 }
 
-function Yy(e, t, r) {
+function qy(e, t, r) {
 if (!e) return null;
 var o = wr.getEmpire();
 if (j(e, {
@@ -33829,18 +33833,18 @@ room: t
 })), n.players[e] = s, s;
 }
 
-function Vy() {
+function jy() {
 if ("undefined" != typeof Memory) return Memory.defenseSettings;
 }
 
-var qy = new Map, jy = function() {
+var zy = new Map, Qy = function() {
 function e() {}
 return e.prototype.updateThreatAssessment = function(e, t, r) {
-var o = Z(e), n = $s(e), a = this.getDefensePostureIntent(e, t, r, o, n);
-return this.executeDefensePostureIntent(e, t, o, a), ec(wr.getEmpire(), e, t, n),
+var o = Z(e), n = tc(e), a = this.getDefensePostureIntent(e, t, r, o, n);
+return this.executeDefensePostureIntent(e, t, o, a), rc(wr.getEmpire(), e, t, n),
 n;
 }, e.prototype.getDefensePostureIntent = function(e, t, r, o, n) {
-return void 0 === o && (o = Z(e)), void 0 === n && (n = $s(e)), function(e, t) {
+return void 0 === o && (o = Z(e)), void 0 === n && (n = tc(e)), function(e, t) {
 var r = e.currentStructures.spawns.length + e.currentStructures.towers.length, o = e.previousStructures;
 o && o.lastTick < e.time && (e.currentStructures.spawns.length < o.spawns.length && t.kernelEvents.push({
 type: "structure.destroyed",
@@ -33983,7 +33987,7 @@ nukeDetected: null !== (a = t.nukeDetected) && void 0 !== a && a,
 nukeScanPerformed: !0,
 clusterId: t.clusterId,
 clusterMemberRooms: null == i ? void 0 : i.memberRooms,
-previousStructures: qy.get(e.name),
+previousStructures: zy.get(e.name),
 currentStructures: {
 spawns: r.spawns.map(function(e) {
 return e.id;
@@ -34013,7 +34017,7 @@ launchRoomName: e.launchRoomName
 };
 }, e.prototype.executeDefensePostureIntent = function(e, t, r, o) {
 var n, c, u, l, m, d;
-o.nextStructureTracking && qy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
+o.nextStructureTracking && zy.set(e.name, o.nextStructureTracking), r.length > 0 && (t.lastHostileTick = Game.time),
 o.recordAttackers && function(e, t) {
 var r, o;
 try {
@@ -34022,7 +34026,7 @@ var t, r, o = new Set;
 try {
 for (var n = a(e), c = n.next(); !c.done; c = n.next()) {
 var u = c.value;
-Ky(u) && o.add(u.owner.username);
+Vy(u) && o.add(u.owner.username);
 }
 } catch (e) {
 t = {
@@ -34036,7 +34040,7 @@ if (t) throw t.error;
 }
 }
 return s([], i(o), !1);
-}(t)), c = n.next(); !c.done; c = n.next()) Yy(c.value, e, "hostileCombat");
+}(t)), c = n.next(); !c.done; c = n.next()) qy(c.value, e, "hostileCombat");
 } catch (e) {
 r = {
 error: e
@@ -34052,7 +34056,7 @@ if (r) throw r.error;
 try {
 for (var p = a(o.pheromoneEffects), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
-"danger" === y.type ? Iy.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Iy.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Iy.onNukeDetected(t);
+"danger" === y.type ? Ly.updateDangerFromThreat(t, y.threatScore, y.dangerLevel) : "diffuseDanger" === y.type ? Ly.diffuseDangerToCluster(y.roomName, y.threatScore, y.memberRooms) : "nukeDetected" === y.type && Ly.onNukeDetected(t);
 }
 } catch (e) {
 n = {
@@ -34102,7 +34106,7 @@ case "hostile.detected":
 case "hostile.cleared":
 case "structure.destroyed":
 case "nuke.detected":
-Gi.emit(e.type, e.payload);
+Di.emit(e.type, e.payload);
 }
 }, e.prototype.runTowerControl = function(e, t, r) {
 var o, n, i, s;
@@ -34112,10 +34116,10 @@ var t, r, o, n, i, s, c, u, l, m, d, p;
 if (0 === e.towers.length) return [];
 var f = null !== (o = e.hostiles) && void 0 !== o ? o : [], y = null !== (n = e.posture) && void 0 !== n ? n : "eco", v = null !== (i = e.rcl) && void 0 !== i ? i : 1, g = null !== (s = e.danger) && void 0 !== s ? s : 0, h = null !== (c = e.isCombatPosture) && void 0 !== c && c, R = null !== (u = e.wallRepairTarget) && void 0 !== u ? u : 0, E = null !== (l = e.preferWoundedTargets) && void 0 !== l ? l : function() {
 var e;
-return !1 !== (null === (e = Vy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
+return !1 !== (null === (e = jy()) || void 0 === e ? void 0 : e.towerPreferWoundedTargets);
 }(), T = null !== (m = e.allowSiegeHealing) && void 0 !== m ? m : function() {
 var e;
-return !1 !== (null === (e = Vy()) || void 0 === e ? void 0 : e.towerHealInSiege);
+return !1 !== (null === (e = jy()) || void 0 === e ? void 0 : e.towerHealInSiege);
 }(), C = null !== (d = e.bucket) && void 0 !== d ? d : "undefined" != typeof Game && Number.isFinite(null === (p = Game.cpu) || void 0 === p ? void 0 : p.bucket) ? Game.cpu.bucket : 1e4, S = C >= 1500, w = [];
 try {
 for (var x = a(e.towers), b = x.next(); !b.done; b = x.next()) {
@@ -34158,7 +34162,7 @@ hostiles: c,
 posture: t.posture,
 rcl: u,
 danger: t.danger,
-isCombatPosture: Hy.isCombatPosture(t.posture),
+isCombatPosture: Yy.isCombatPosture(t.posture),
 wallRepairTarget: an(u, t.danger),
 bucket: Game.cpu.bucket
 });
@@ -34182,27 +34186,27 @@ if (o) throw o.error;
 }, e.prototype.executeTowerDefenseAction = function(e) {
 "attack" === e.type ? e.tower.attack(e.target) : "heal" === e.type ? e.tower.heal(e.target) : "repair" === e.type && e.tower.repair(e.target);
 }, e;
-}(), zy = new jy, Qy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
+}(), Xy = new Qy, Zy = new Set([ STRUCTURE_WALL, STRUCTURE_RAMPART ]);
 
-function Xy() {
+function Jy() {
 return "undefined" == typeof Game ? 0 : Game.time;
 }
 
-function Zy(e, t, r, o) {
+function $y(e, t, r, o) {
 e.layoutAnchor || (e.layoutAnchor = {
 x: t.x,
 y: t.y,
 blueprintName: r,
 rclSelectedAt: o,
-selectedAt: Xy()
+selectedAt: Jy()
 });
 }
 
-function Jy(e) {
+function ev(e) {
 return e >= 2 && e <= 3;
 }
 
-function $y(e, t, r) {
+function tv(e, t, r) {
 var o, n = e.find(FIND_MY_STRUCTURES, {
 filter: function(e) {
 return e.structureType === t;
@@ -34215,7 +34219,7 @@ return e.structureType === t;
 return n.length + a.length + (null !== (o = null == r ? void 0 : r.getPlacedCount(t)) && void 0 !== o ? o : 0);
 }
 
-function ev(e, t) {
+function rv(e, t) {
 var r, o, n;
 return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES ? ((r = {})[STRUCTURE_TOWER] = {
 1: 0,
@@ -34229,10 +34233,10 @@ return null !== (n = null === (o = ("undefined" == typeof CONTROLLER_STRUCTURES 
 }, r) : CONTROLLER_STRUCTURES)[e]) || void 0 === o ? void 0 : o[t]) && void 0 !== n ? n : 0;
 }
 
-var tv = function() {
+var ov = function() {
 function e() {}
 return e.prototype.getConstructionInterval = function(e) {
-return Jy(e) ? 5 : 10;
+return ev(e) ? 5 : 10;
 }, e.prototype.runConstruction = function(e, t, r, n, c) {
 var u, l, m, d;
 void 0 === c && (c = {});
@@ -34641,10 +34645,10 @@ y: e.y - C.anchor.y
 type: "dynamic",
 minSpaceRadius: 3
 });
-Zy(t, R, S.name, f);
+$y(t, R, S.name, f);
 var w = f >= 3 && (t.danger >= 1 || function(e, t, r) {
-var o = ev(STRUCTURE_TOWER, t);
-return o > 0 && $y(e, STRUCTURE_TOWER, r) < o;
+var o = rv(STRUCTURE_TOWER, t);
+return o > 0 && tv(e, STRUCTURE_TOWER, r) < o;
 }(e, f, y));
 if (w) {
 var x = y.capRequested(t.danger >= 2 ? 3 : 1, {
@@ -34655,7 +34659,7 @@ var o, n, i, s, c, u, l, m, d, p, f;
 if (r <= 0) return 0;
 var y = "undefined" == typeof MAX_CONSTRUCTION_SITES ? 100 : MAX_CONSTRUCTION_SITES, v = "undefined" == typeof Game ? 0 : Object.keys(null !== (l = Game.constructionSites) && void 0 !== l ? l : {}).length;
 if (v >= y) return 0;
-var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = ev(STRUCTURE_TOWER, g), R = $y(e, STRUCTURE_TOWER), E = new Set, T = new Set;
+var g = null !== (d = null === (m = e.controller) || void 0 === m ? void 0 : m.level) && void 0 !== d ? d : t.rcl, h = rv(STRUCTURE_TOWER, g), R = tv(e, STRUCTURE_TOWER), E = new Set, T = new Set;
 try {
 for (var C = a(e.find(FIND_STRUCTURES)), S = C.next(); !S.done; S = C.next()) {
 var w = S.value;
@@ -35058,7 +35062,7 @@ var o, n, i, s = jn(t);
 try {
 for (var c = a(Object.keys(s)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = null !== (i = s[l]) && void 0 !== i ? i : 0;
-if (!(m <= 0) && $y(e, l, r) < m) return !0;
+if (!(m <= 0) && tv(e, l, r) < m) return !0;
 }
 } catch (e) {
 o = {
@@ -35074,8 +35078,8 @@ if (o) throw o.error;
 return !1;
 }(e, f, y);
 if (y.canPlace() || k) {
-if (!Hy.isCombatPosture(t.posture) && function(e, t) {
-return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Xy());
+if (!Yy.isCombatPosture(t.posture) && function(e, t) {
+return Boolean(e.layoutAnchor && e.layoutAnchor.x === t.x && e.layoutAnchor.y === t.y && e.layoutAnchor.selectedAt !== Jy());
 }(t, R)) {
 var M = function(e, t, r, o, n) {
 var i, s;
@@ -35232,7 +35236,7 @@ if (function(e) {
 if (!e.allowPerimeter || e.rcl < 2) return !1;
 if (e.existingSites.length >= 8) return !1;
 var t = e.existingSites.some(function(e) {
-return Qy.has(e.structureType);
+return Zy.has(e.structureType);
 });
 return e.danger >= 1 || !t;
 }({
@@ -35241,7 +35245,7 @@ rcl: f,
 danger: t.danger,
 existingSites: p
 })) {
-var P = Jy(f) ? 2 : 3, I = y.capRequested(P);
+var P = ev(f) ? 2 : 3, I = y.capRequested(P);
 I > 0 && (N = function(e, t, r, o, n, c) {
 var u, l, m, d, p, f;
 if (void 0 === n && (n = 3), void 0 === c && (c = []), o < 2) return {
@@ -35930,16 +35934,16 @@ return null;
 if (H && y.canPlace({
 bypassRoomLimit: !0
 })) {
-Zy(t, H.anchor, H.blueprint.name, f);
+$y(t, H.anchor, H.blueprint.name, f);
 var K = e.createConstructionSite(H.anchor.x, H.anchor.y, STRUCTURE_SPAWN);
 y.recordResult(K, STRUCTURE_SPAWN);
 }
 }
 }
 }, e;
-}(), rv = new tv;
+}(), nv = new ov;
 
-function ov(e) {
+function av(e) {
 var t;
 switch (e.posture) {
 case "defensive":
@@ -35961,7 +35965,7 @@ siege: e.pheromones.siege
 };
 }
 
-var nv = {
+var iv = {
 info: function(e, t) {
 return U.info(e, t);
 },
@@ -35974,10 +35978,10 @@ return U.error(e, t);
 debug: function(e, t) {
 return U.debug(e, t);
 }
-}, av = new (function() {
+}, sv = new (function() {
 function e() {
-this.manager = new hu({
-logger: nv
+this.manager = new Eu({
+logger: iv
 });
 }
 return e.prototype.getReaction = function(e) {
@@ -35987,23 +35991,23 @@ return this.manager.calculateReactionChain(e, t);
 }, e.prototype.hasResourcesForReaction = function(e, t, r) {
 return void 0 === r && (r = 100), this.manager.hasResourcesForReaction(e, t, r);
 }, e.prototype.planReactions = function(e, t) {
-var r = ov(t);
+var r = av(t);
 return this.manager.planReactions(e, r);
 }, e.prototype.scheduleCompoundProduction = function(e, t) {
-var r = ov(t);
+var r = av(t);
 return this.manager.scheduleCompoundProduction(e, r);
 }, e.prototype.executeReaction = function(e, t) {
 this.manager.executeReaction(e, t);
 }, e;
-}()), iv = {
-labManager: Pu,
-boostManager: Mu,
-chemistryPlanner: av,
-labConfigManager: _u,
-logger: ll
-}, sv = function() {
+}()), cv = {
+labManager: Gu,
+boostManager: Uu,
+chemistryPlanner: sv,
+labConfigManager: Pu,
+logger: dl
+}, uv = function() {
 function e(e) {
-void 0 === e && (e = iv), this.deps = e;
+void 0 === e && (e = cv), this.deps = e;
 }
 return e.prototype.run = function(e, t) {
 var r = {
@@ -36042,9 +36046,9 @@ room: e.name
 var r, o = null === (r = this.deps.labConfigManager.getConfig(e)) || void 0 === r ? void 0 : r.activeReaction;
 return (null == o ? void 0 : o.input1) === t.input1 && o.input2 === t.input2 && o.output === t.product;
 }, e;
-}(), cv = new sv, uv = function() {
+}(), lv = new uv, mv = function() {
 function e(e) {
-void 0 === e && (e = cv), this.labWorkflow = e;
+void 0 === e && (e = lv), this.labWorkflow = e;
 }
 return e.prototype.getRoomEconomyIntent = function(e, t) {
 var r, o, n = null !== (o = null === (r = e.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 0, a = t.links.length;
@@ -36067,30 +36071,30 @@ o.processing.labs && this.labWorkflow.run(e, t), o.processing.powerSpawn && this
 }, e.prototype.runPowerSpawn = function(e, t) {
 t && t.store.getUsedCapacity(RESOURCE_POWER) >= 1 && t.store.getUsedCapacity(RESOURCE_ENERGY) >= 50 && t.processPower();
 }, e;
-}(), lv = new uv, mv = {
+}(), dv = new mv, pv = {
 enablePheromones: !0,
 enableEvolution: !0,
 enableSpawning: !0,
 enableConstruction: !0,
 enableTowers: !0,
 enableProcessing: !0
-}, dv = new Map;
+}, fv = new Map;
 
-function pv(e) {
+function yv(e) {
 return Number.isFinite(e) && e >= 1 ? Math.floor(e) : 1;
 }
 
-function fv(e) {
+function vv(e) {
 return e.constructionSchedule && "object" == typeof e.constructionSchedule || (e.constructionSchedule = {}),
 e.constructionSchedule;
 }
 
-var yv = function() {
+var gv = function() {
 function e(e, t) {
-void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, mv), t);
+void 0 === t && (t = {}), this.roomName = e, this.config = o(o({}, pv), t);
 }
 return e.prototype.run = function(e) {
-var t, r, o, n = rs.startRoom(this.roomName);
+var t, r, o, n = ns.startRoom(this.roomName);
 try {
 var i = Game.rooms[this.roomName];
 if (!i || !(null === (t = i.controller) || void 0 === t ? void 0 : t.my)) return;
@@ -36131,7 +36135,7 @@ if (t) throw t.error;
 }
 }(i);
 var c = wr.getOrInitSwarmState(this.roomName), u = function(e) {
-var t = dv.get(e.name);
+var t = fv.get(e.name);
 if (t && t.tick === Game.time) return t;
 var r = e.find(FIND_MY_STRUCTURES), o = {
 tick: Game.time,
@@ -36153,43 +36157,43 @@ return e.structureType === STRUCTURE_POWER_SPAWN;
 sources: e.find(FIND_SOURCES),
 constructionSites: e.find(FIND_MY_CONSTRUCTION_SITES)
 };
-return dv.set(e.name, o), o;
+return fv.set(e.name, o), o;
 }(i);
-this.config.enablePheromones && !s && Game.time % 5 == 0 && Iy.updateMetrics(i, c);
-var l = zy.updateThreatAssessment(i, c, {
+this.config.enablePheromones && !s && Game.time % 5 == 0 && Ly.updateMetrics(i, c);
+var l = Xy.updateThreatAssessment(i, c, {
 spawns: u.spawns,
 towers: u.towers
 });
-Si.assess(i, c, l), ki.checkSafeMode(i, c), this.config.enableEvolution && (Wy.updateEvolutionStage(c, i, e),
-s || Wy.updateMissingStructures(c, i)), Hy.updatePosture(c), this.config.enablePheromones && !s && Iy.updatePheromones(c, i),
-this.config.enableTowers && zy.runTowerControl(i, c, u.towers);
+Si.assess(i, c, l), ki.checkSafeMode(i, c), this.config.enableEvolution && (Ky.updateEvolutionStage(c, i, e),
+s || Ky.updateMissingStructures(c, i)), Yy.updatePosture(c), this.config.enablePheromones && !s && Ly.updatePheromones(c, i),
+this.config.enableTowers && Xy.runTowerControl(i, c, u.towers);
 var m = 0 === u.spawns.length || c.danger >= 2;
 if (this.config.enableConstruction && (!s || m)) {
-var d = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, p = rv.getConstructionInterval(d), f = Hy.allowsBuilding(c.posture), y = !f && c.danger >= 2 || s && m;
+var d = null !== (o = null === (r = i.controller) || void 0 === r ? void 0 : r.level) && void 0 !== o ? o : 1, p = nv.getConstructionInterval(d), f = Yy.allowsBuilding(c.posture), y = !f && c.danger >= 2 || s && m;
 (f || y) && function(e, t, r) {
-var o = pv(r), n = fv(e);
+var o = yv(r), n = vv(e);
 return "number" == typeof n.nextRunTick && Number.isFinite(n.nextRunTick) || (n.nextRunTick = t,
 n.interval = o), t >= n.nextRunTick;
-}(c, Game.time, p) && (rv.runConstruction(i, c, u.constructionSites, u.spawns, {
+}(c, Game.time, p) && (nv.runConstruction(i, c, u.constructionSites, u.spawns, {
 criticalOnly: y
 }), function(e, t, r) {
-var o = pv(r), n = fv(e);
+var o = yv(r), n = vv(e);
 n.lastRunTick = t, n.nextRunTick = t + o, n.interval = o;
 }(c, Game.time, p));
 }
-this.config.enableProcessing && !s && Game.time % 5 == 0 && lv.runResourceProcessing(i, c, {
+this.config.enableProcessing && !s && Game.time % 5 == 0 && dv.runResourceProcessing(i, c, {
 factory: u.factory,
 powerSpawn: u.powerSpawn,
 links: u.links,
 sources: u.sources
 });
 var v = Game.cpu.getUsed() - n;
-rs.recordRoom(i, v);
+ns.recordRoom(i, v);
 } finally {
-rs.endRoom(this.roomName, n);
+ns.endRoom(this.roomName, n);
 }
 }, e;
-}(), vv = function() {
+}(), hv = function() {
 function e() {
 this.nodes = new Map;
 }
@@ -36198,7 +36202,7 @@ var e, t, r, o, n, s, c, u = Ct(), l = u.length;
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-this.nodes.has(p.name) || this.nodes.set(p.name, new yv(p.name));
+this.nodes.has(p.name) || this.nodes.set(p.name, new gv(p.name));
 }
 } catch (t) {
 e = {
@@ -36234,7 +36238,7 @@ try {
 R.run(l);
 } catch (e) {
 var E = e instanceof Error ? e.message : String(e), T = e instanceof Error && e.stack ? e.stack : void 0;
-ll.error("Error in room ".concat(R.roomName, ": ").concat(E), {
+dl.error("Error in room ".concat(R.roomName, ": ").concat(E), {
 subsystem: "RoomManager",
 room: R.roomName,
 meta: {
@@ -36261,14 +36265,14 @@ return Array.from(this.nodes.values());
 }, e.prototype.runRoom = function(e) {
 var t;
 if (null === (t = e.controller) || void 0 === t ? void 0 : t.my) {
-this.nodes.has(e.name) || this.nodes.set(e.name, new yv(e.name));
+this.nodes.has(e.name) || this.nodes.set(e.name, new gv(e.name));
 var r = Ct().length;
 this.nodes.get(e.name).run(r);
 }
 }, e;
-}(), gv = new vv, hv = new Map;
+}(), Rv = new hv, Ev = new Map;
 
-function Rv(e) {
+function Tv(e) {
 var t;
 if (!(null === (t = e.controller) || void 0 === t ? void 0 : t.my)) return !1;
 if (function(e) {
@@ -36281,21 +36285,21 @@ return Array.isArray(a) && a.some(function(t) {
 return t.roomName === e && Number.isFinite(t.impactTick) && t.impactTick > Game.time;
 });
 }(e.name)) return !0;
-var r = hv.get(e.name), o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode ? 50 : 5;
+var r = Ev.get(e.name), o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode ? 50 : 5;
 if (r && Game.time - r.checkedAt < o) return r.active;
-var n = $s(e).length > 0;
-return hv.set(e.name, {
+var n = tc(e).length > 0;
+return Ev.set(e.name, {
 checkedAt: Game.time,
 active: n
 }), n;
 }
 
-function Ev(e, t) {
+function Cv(e, t) {
 var r, o = (null === (r = e.controller) || void 0 === r ? void 0 : r.my) ? " (owned)" : "", n = t ? " [nuke response]" : "";
 return "Room ".concat(e.name).concat(o).concat(n);
 }
 
-function Tv(e, t) {
+function Sv(e, t) {
 var r, o, n;
 if (t.nukeThreat || t.hostiles.length > 0) return Ie.CRITICAL;
 if (null === (r = e.controller) || void 0 === r ? void 0 : r.my) return Ie.HIGH;
@@ -36306,14 +36310,14 @@ return null !== (r = null === (t = null == n ? void 0 : n.owner) || void 0 === t
 return a && (null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.reservation) || void 0 === n ? void 0 : n.username) === a ? Ie.MEDIUM : Ie.LOW;
 }
 
-function Cv(e, t) {
+function wv(e, t) {
 var r;
 if (!(null === (r = e.controller) || void 0 === r ? void 0 : r.my)) return .02;
 var o = e.controller.level;
 return t.nukeThreat || t.hostiles.length > 0 ? .12 : o <= 3 ? .04 : o <= 6 ? .06 : .08;
 }
 
-var Sv, wv = function() {
+var xv, bv = function() {
 function e() {
 this.registeredRooms = new Set, this.lastSyncTick = -1, this.roomIndices = new Map,
 this.nextRoomIndex = 0;
@@ -36323,9 +36327,9 @@ var t = this.roomIndices.get(e);
 return void 0 === t && (t = this.nextRoomIndex++, this.roomIndices.set(e, t)), t;
 }, e.prototype.getRoomProcessDescriptor = function(e) {
 var t = {
-nukeThreat: Rv(e),
+nukeThreat: Tv(e),
 hostiles: Z(e)
-}, r = Tv(e, t), o = function(e, t, r) {
+}, r = Sv(e, t), o = function(e, t, r) {
 var o;
 return t === Ie.CRITICAL ? {
 tickModulo: void 0,
@@ -36345,9 +36349,9 @@ tickOffset: void 0
 };
 }(e, r, this.getRoomIndex(e.name));
 return {
-name: Ev(e, t.nukeThreat),
+name: Cv(e, t.nukeThreat),
 priority: r,
-cpuBudget: Cv(e, t),
+cpuBudget: wv(e, t),
 tickModulo: o.tickModulo,
 tickOffset: o.tickOffset,
 minBucket: this.getMinBucketForPriority(r)
@@ -36362,7 +36366,7 @@ var r = new Set;
 for (var o in Game.rooms) {
 var n = Game.rooms[o];
 r.add(o);
-var i = "room:".concat(o), s = Gi.getProcess(i), c = this.getRoomProcessDescriptor(n);
+var i = "room:".concat(o), s = Di.getProcess(i), c = this.getRoomProcessDescriptor(n);
 this.registeredRooms.has(o) ? s && this.hasDescriptorChanged(s, c) && this.updateRoomProcess(n, c) : this.registerRoomProcess(n, c);
 }
 try {
@@ -36383,7 +36387,7 @@ if (e) throw e.error;
 }, e.prototype.registerRoomProcess = function(e, t) {
 void 0 === t && (t = this.getRoomProcessDescriptor(e));
 var r = "room:".concat(e.name);
-Gi.registerProcess({
+Di.registerProcess({
 id: r,
 name: t.name,
 priority: t.priority,
@@ -36399,16 +36403,16 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && gv.runRoom(t);
+t && Rv.runRoom(t);
 }
 }), this.registeredRooms.add(e.name);
 var o = t.tickModulo ? "(mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset, ")") : "(every tick)";
-ll.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
+dl.debug("Registered room process: ".concat(e.name, " with priority ").concat(t.priority, " ").concat(o), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.updateRoomProcess = function(e, t) {
 var r = "room:".concat(e.name);
-Gi.unregisterProcess(r), Gi.registerProcess({
+Di.unregisterProcess(r), Di.registerProcess({
 id: r,
 name: t.name,
 priority: t.priority,
@@ -36424,17 +36428,17 @@ layer: "room"
 },
 execute: function() {
 var t = Game.rooms[e.name];
-t && gv.runRoom(t);
+t && Rv.runRoom(t);
 }
 });
 var o = t.tickModulo ? "mod=".concat(t.tickModulo, ", offset=").concat(t.tickOffset) : "every tick";
-ll.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
+dl.debug("Updated room process: ".concat(e.name, " priority=").concat(t.priority, " budget=").concat(t.cpuBudget, " (").concat(o, ")"), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.unregisterRoomProcess = function(e) {
 var t = "room:".concat(e);
-Gi.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
-hv.delete(e), ll.debug("Unregistered room process: ".concat(e), {
+Di.unregisterProcess(t), this.registeredRooms.delete(e), this.roomIndices.delete(e),
+Ev.delete(e), dl.debug("Unregistered room process: ".concat(e), {
 subsystem: "RoomProcessManager"
 });
 }, e.prototype.getMinBucketForPriority = function(e) {
@@ -36446,8 +36450,8 @@ try {
 for (var c = a(this.registeredRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
 if (m) {
-var d = Tv(m, {
-nukeThreat: Rv(m),
+var d = Sv(m, {
+nukeThreat: Tv(m),
 hostiles: Z(m)
 }), p = null !== (r = Ie[d]) && void 0 !== r ? r : "UNKNOWN";
 i[p] = (null !== (o = i[p]) && void 0 !== o ? o : 0) + 1, (null === (n = m.controller) || void 0 === n ? void 0 : n.my) && s++;
@@ -36474,12 +36478,12 @@ ownedRooms: s
 this.lastSyncTick = -1, this.syncRoomProcesses();
 }, e.prototype.reset = function() {
 this.registeredRooms.clear(), this.roomIndices.clear(), this.nextRoomIndex = 0,
-this.lastSyncTick = -1, hv.clear();
+this.lastSyncTick = -1, Ev.clear();
 }, e;
-}(), xv = new wv, bv = function() {
+}(), Ov = new bv, kv = function() {
 function e() {}
 return e.prototype.showKernelStats = function() {
-var e = Gi.getStatsSummary(), t = Gi.getConfig();
+var e = Di.getStatsSummary(), t = Di.getConfig();
 return function(e) {
 var t, r, o, n, i = [ "=== Kernel Stats ===", "Bucket Mode: ".concat(e.bucketMode.toUpperCase()), "CPU Bucket: ".concat(e.cpuBucket), "CPU Limit: ".concat(e.cpuLimit.toFixed(2), " (").concat((100 * e.targetCpuUsage).toFixed(0), "% of ").concat(e.gameCpuLimit, ")"), "Remaining CPU: ".concat(e.remainingCpu.toFixed(2)), "", "Processes: ".concat(e.stats.totalProcesses, " total (").concat(e.stats.activeProcesses, " active, ").concat(e.stats.suspendedProcesses, " suspended)"), "Total CPU Used: ".concat(e.stats.totalCpuUsed.toFixed(3)), "Avg CPU/Process: ".concat(e.stats.avgCpuPerProcess.toFixed(4)), "Avg Health Score: ".concat(e.stats.avgHealthScore.toFixed(1), "/100"), "", "Top CPU Consumers:" ];
 try {
@@ -36517,16 +36521,16 @@ if (o) throw o.error;
 }
 return i.join("\n");
 }({
-bucketMode: Gi.getBucketMode(),
+bucketMode: Di.getBucketMode(),
 cpuBucket: Game.cpu.bucket,
-cpuLimit: Gi.getCpuLimit(),
+cpuLimit: Di.getCpuLimit(),
 targetCpuUsage: t.targetCpuUsage,
 gameCpuLimit: Game.cpu.limit,
-remainingCpu: Gi.getRemainingCpu(),
+remainingCpu: Di.getRemainingCpu(),
 stats: e
 });
 }, e.prototype.listProcesses = function() {
-var e = Gi.getProcesses();
+var e = Di.getProcesses();
 return 0 === e.length ? "No processes registered with kernel." : function(e) {
 var t, r;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36553,11 +36557,11 @@ return o.join("\n") + "\n";
 }(e);
 }, e.prototype.showProcessTopology = function() {
 return function(e) {
-var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(xy(e.summary.byLayer)), "Groups: ".concat(xy(e.summary.byGroup)), "States: ".concat(xy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
+var t, r, o, n, c = [ "=== Process Architecture Topology ===", "Processes: ".concat(e.summary.total, " total, ").concat(e.summary.roots, " roots, ").concat(e.summary.edges, " edges"), "Layers: ".concat(Oy(e.summary.byLayer)), "Groups: ".concat(Oy(e.summary.byGroup)), "States: ".concat(Oy(e.summary.byState)), "", "ID | Parent | Layer | Group | Priority | Frequency | Schedule | State | Health", "-".repeat(120) ];
 try {
-for (var u = a(s([], i(e.nodes), !1).sort(by)), l = u.next(); !l.done; l = u.next()) {
+for (var u = a(s([], i(e.nodes), !1).sort(ky)), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
-c.push(Sy(m));
+c.push(xy(m));
 }
 } catch (e) {
 t = {
@@ -36594,19 +36598,19 @@ if (o) throw o.error;
 }
 }
 return c.join("\n");
-}(Gi.getProcessTopology());
+}(Di.getProcessTopology());
 }, e.prototype.suspendProcess = function(e) {
-var t = Gi.suspendProcess(e);
+var t = Di.suspendProcess(e);
 return 'Process "'.concat(e, t ? '" suspended.' : '" not found.');
 }, e.prototype.resumeProcess = function(e) {
-var t = Gi.resumeProcess(e);
+var t = Di.resumeProcess(e);
 return 'Process "'.concat(e, t ? '" resumed.' : '" not found or not suspended.');
 }, e.prototype.resetKernelStats = function() {
-return Gi.resetStats(), "Kernel statistics reset.";
+return Di.resetStats(), "Kernel statistics reset.";
 }, e.prototype.showProcessHealth = function() {
-var e = Gi.getProcesses();
+var e = Di.getProcesses();
 if (0 === e.length) return "No processes registered with kernel.";
-var t = Gi.getStatsSummary();
+var t = Di.getStatsSummary();
 return function(e, t, r) {
 var o, n;
 if (0 === e.length) return "No processes registered with kernel.";
@@ -36633,7 +36637,7 @@ return c.push("", "Average Health: ".concat(r.avgHealthScore.toFixed(1), "/100")
 c.join("\n");
 }(e, Game.time, t);
 }, e.prototype.resumeAllProcesses = function() {
-var e, t, r = Gi.getProcesses().filter(function(e) {
+var e, t, r = Di.getProcesses().filter(function(e) {
 return "suspended" === e.state;
 });
 if (0 === r.length) return "No suspended processes to resume.";
@@ -36641,7 +36645,7 @@ var o = 0;
 try {
 for (var n = a(r), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-Gi.resumeProcess(s.id) && o++;
+Di.resumeProcess(s.id) && o++;
 }
 } catch (t) {
 e = {
@@ -36656,7 +36660,7 @@ if (e) throw e.error;
 }
 return "Resumed ".concat(o, " of ").concat(r.length, " suspended processes.");
 }, e.prototype.showCreepStats = function() {
-var e, t, r = Cy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
+var e, t, r = wy.getStats(), o = "=== Creep Process Stats ===\nTotal Creeps: ".concat(r.totalCreeps, "\nRegistered Processes: ").concat(r.registeredCreeps, "\n\nCreeps by Priority:");
 try {
 for (var n = a(Object.entries(r.creepsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36675,7 +36679,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.showRoomStats = function() {
-var e, t, r = xv.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
+var e, t, r = Ov.getStats(), o = "=== Room Process Stats ===\nTotal Rooms: ".concat(r.totalRooms, "\nRegistered Processes: ").concat(r.registeredRooms, "\nOwned Rooms: ").concat(r.ownedRooms, "\n\nRooms by Priority:");
 try {
 for (var n = a(Object.entries(r.roomsByPriority)), s = n.next(); !s.done; s = n.next()) {
 var c = i(s.value, 2), u = c[0], l = c[1];
@@ -36694,7 +36698,7 @@ if (e) throw e.error;
 }
 return o;
 }, e.prototype.listCreepProcesses = function(e) {
-var t, r, o = Gi.getProcesses().filter(function(e) {
+var t, r, o = Di.getProcesses().filter(function(e) {
 return e.id.startsWith("creep:");
 });
 if (e && (o = o.filter(function(t) {
@@ -36723,7 +36727,7 @@ if (t) throw t.error;
 }
 return n + "\nTotal: ".concat(o.length, " creep processes");
 }, e.prototype.listRoomProcesses = function() {
-var e, t, r = Gi.getProcesses().filter(function(e) {
+var e, t, r = Di.getProcesses().filter(function(e) {
 return e.id.startsWith("room:");
 });
 if (0 === r.length) return "No room processes registered.";
@@ -36822,25 +36826,25 @@ usage: "listRoomProcesses()",
 examples: [ "listRoomProcesses()" ],
 category: "Kernel"
 }) ], e.prototype, "listRoomProcesses", null), e;
-}(), Ov = function() {
+}(), Mv = function() {
 function e() {}
 return e.prototype.setLogLevel = function(e) {
 var t = {
-debug: bu.DEBUG,
-info: bu.INFO,
-warn: bu.WARN,
-error: bu.ERROR,
-none: bu.NONE
+debug: ku.DEBUG,
+info: ku.INFO,
+warn: ku.WARN,
+error: ku.ERROR,
+none: ku.NONE
 }[e.toLowerCase()];
-return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (zu({
+return void 0 === t ? "Invalid log level: ".concat(e, ". Valid levels: debug, info, warn, error, none") : (Xu({
 level: t
 }), "Log level set to: ".concat(e.toUpperCase()));
 }, e.prototype.toggleDebug = function() {
 var e = !Mr().debug;
 return Ar({
 debug: e
-}), zu({
-level: e ? bu.DEBUG : bu.INFO
+}), Xu({
+level: e ? ku.DEBUG : ku.INFO
 }), "Debug mode: ".concat(e ? "ENABLED" : "DISABLED", " (Log level: ").concat(e ? "DEBUG" : "INFO", ")");
 }, n([ Zr({
 name: "setLogLevel",
@@ -36855,7 +36859,7 @@ usage: "toggleDebug()",
 examples: [ "toggleDebug()" ],
 category: "Logging"
 }) ], e.prototype, "toggleDebug", null), e;
-}(), kv = function() {
+}(), Av = function() {
 function e() {}
 return e.prototype.toNumber = function(e) {
 if ("number" == typeof e) return Number.isFinite(e) ? e : void 0;
@@ -36895,7 +36899,7 @@ hostileCount: null !== (l = null !== (u = null !== (s = this.toNumber(null === (
 var o, n, a, i, s = this.asRecord(null === (o = this.asRecord(e)) || void 0 === o ? void 0 : o.metrics), c = this.asRecord(null == s ? void 0 : s.energy);
 return null !== (i = null !== (a = null !== (n = this.toNumber(null == s ? void 0 : s[t])) && void 0 !== n ? n : this.toNumber(null == c ? void 0 : c[r])) && void 0 !== a ? a : this.toNumber(null == s ? void 0 : s[r])) && void 0 !== i ? i : 0;
 }, e.prototype.showStats = function() {
-var e = as.getLatestStats();
+var e = ss.getLatestStats();
 return e ? "=== SwarmBot Stats (Tick ".concat(e.tick, ") ===\nCPU: ").concat(e.cpuUsed.toFixed(2), "/").concat(e.cpuLimit, " (Bucket: ").concat(e.cpuBucket, ")\nGCL: ").concat(e.gclLevel, " (").concat((100 * e.gclProgress).toFixed(1), "%)\nGPL: ").concat(e.gplLevel, "\nCreeps: ").concat(e.totalCreeps, "\nRooms: ").concat(e.totalRooms, "\n").concat(e.rooms.map(function(e) {
 return "  ".concat(e.roomName, ": RCL").concat(e.rcl, " | ").concat(e.creepCount, " creeps | ").concat(e.storageEnergy, "E");
 }).join("\n")) : "No stats available yet. Wait for a few ticks.";
@@ -36939,18 +36943,18 @@ return Ee.clear(mt), "Room.find() cache cleared and statistics reset";
 var e = !Mr().profiling;
 return Ar({
 profiling: e
-}), rs.setEnabled(e), zu({
+}), ns.setEnabled(e), Xu({
 cpuLogging: e
 }), "Profiling: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.enableCpuDetails = function(e, t, r) {
 var o, n, a;
 void 0 === e && (e = 500), void 0 === t && (t = 1);
-var i = rs.enableCpuDetails(e, t, r);
+var i = ns.enableCpuDetails(e, t, r);
 return "CPU details enabled until tick ".concat(null !== (o = i.expiresTick) && void 0 !== o ? o : "unknown", " (sampleRate=").concat(null !== (n = i.sampleRate) && void 0 !== n ? n : 1, ", labels=").concat((null !== (a = i.labels) && void 0 !== a ? a : []).join(",") || "all", ")");
 }, e.prototype.disableCpuDetails = function() {
-return rs.disableCpuDetails(), "CPU details disabled";
+return ns.disableCpuDetails(), "CPU details disabled";
 }, e.prototype.cpuDetails = function() {
-var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = rs.getCpuDetailsStatus();
+var e, t, r, o, n, s, c = this, u = null === (r = Memory.stats) || void 0 === r ? void 0 : r.cpu_details, l = ns.getCpuDetailsStatus();
 if (!u) return "CPU details ".concat(l.enabled ? "enabled" : "disabled", "; no samples published yet");
 var m = Object.entries(null !== (o = u.entries) && void 0 !== o ? o : {}), d = Array.isArray(u.labels) ? u.labels.join(",") : "", p = [ "=== CPU Details ===", "Enabled: ".concat(String(u.enabled), " | Expires: ").concat(null !== (n = u.expires_tick) && void 0 !== n ? n : "n/a", " | Sample rate: ").concat(null !== (s = u.sample_rate) && void 0 !== s ? s : 1, " | Labels: ").concat(d || "all") ];
 try {
@@ -37088,7 +37092,7 @@ I.push("");
 }
 return I.join("\n");
 }, e.prototype.cpuBudget = function() {
-var e, t, r, o, n = rs.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
+var e, t, r, o, n = ns.validateBudgets(), i = "=== CPU Budget Report (Tick ".concat(n.tick, ") ===\n");
 if (i += "Rooms Evaluated: ".concat(n.roomsEvaluated, "\n"), i += "Within Budget: ".concat(n.roomsWithinBudget, "\n"),
 i += "Over Budget: ".concat(n.roomsOverBudget, "\n\n"), 0 === n.alerts.length) i += "OK All rooms within budget!\n"; else {
 i += "Alerts: ".concat(n.alerts.length, "\n");
@@ -37135,7 +37139,7 @@ if (r) throw r.error;
 }
 return i;
 }, e.prototype.cpuAnomalies = function() {
-var e, t, r, o, n = rs.detectAnomalies();
+var e, t, r, o, n = ns.detectAnomalies();
 if (0 === n.length) return "OK No CPU anomalies detected";
 var i = "=== CPU Anomalies Detected: ".concat(n.length, " ===\n\n"), s = n.filter(function(e) {
 return "spike" === e.type;
@@ -37184,7 +37188,7 @@ return i;
 }, e.prototype.cpuProfile = function(e) {
 var t, r, o, n;
 void 0 === e && (e = !1);
-var i = rs.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
+var i = ns.getCurrentSnapshot(), s = "=== CPU Profile (Tick ".concat(i.tick, ") ===\n");
 s += "Total: ".concat(i.cpu.used.toFixed(2), " / ").concat(i.cpu.limit, " (").concat(i.cpu.percent.toFixed(1), "%)\n"),
 s += "Bucket: ".concat(i.cpu.bucket, "\n"), s += "Heap: ".concat(i.cpu.heapUsed.toFixed(2), " MB\n\n");
 var c = Object.values(i.rooms).sort(function(e, t) {
@@ -37193,7 +37197,7 @@ return t.profiler.avgCpu - e.profiler.avgCpu;
 s += "Top ".concat(u.length, " Rooms by CPU:\n");
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
-var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = rs.postureCodeToName(p);
+var d = m.value, p = this.getRoomBrainMetrics(d).postureCode, f = ns.postureCodeToName(p);
 s += "  ".concat(d.name, " (RCL").concat(d.rcl, ", ").concat(f, "): avg ").concat(d.profiler.avgCpu.toFixed(3), " | peak ").concat(d.profiler.peakCpu.toFixed(3), " | samples ").concat(d.profiler.samples, "\n");
 }
 } catch (e) {
@@ -37234,7 +37238,7 @@ return s;
 var t, r, o, n;
 if (!e) return "Error: Room name required. Usage: diagnoseRoom('W16S52')";
 if (!Game.rooms[e]) return "Error: Room ".concat(e, " not visible. Make sure you have vision in this room.");
-var s = rs.getCurrentSnapshot(), c = s.rooms[e];
+var s = ns.getCurrentSnapshot(), c = s.rooms[e];
 if (!c) return "Error: No stats available for ".concat(e, ". The room may not have been processed yet.");
 var u = "room:".concat(e), l = s.processes[u], m = wr.getSwarmState(e), d = m && ("war" === m.posture || "siege" === m.posture || m.danger >= 2), p = d ? .25 : .1, f = null !== (o = null == l ? void 0 : l.tickModulo) && void 0 !== o ? o : 1, y = p * f, v = "----------------------------------------------\n";
 v += "  Room Diagnostic: ".concat(e, "\n"), v += "----------------------------------------------\n\n";
@@ -37244,7 +37248,7 @@ energyCapacityTotal: this.getRoomMetricValue(c, "energyCapacityTotal", "capacity
 constructionSites: this.getRoomMetricValue(c, "constructionSites", "construction_sites")
 };
 v += "SUMMARY Basic Info:\n", v += "  RCL: ".concat(c.rcl, "\n"), v += "  Controller Progress: ".concat(c.controller.progressPercent.toFixed(1), "%\n"),
-v += "  Posture: ".concat(rs.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
+v += "  Posture: ".concat(ns.postureCodeToName(g.postureCode), "\n"), v += "  Danger Level: ".concat(g.dangerLevel, "\n"),
 v += "  Hostiles: ".concat(g.hostileCount, "\n\n"), v += "CPU CPU Analysis:\n",
 v += "  Average CPU: ".concat(c.profiler.avgCpu.toFixed(3), "\n"), v += "  Peak CPU: ".concat(c.profiler.peakCpu.toFixed(3), "\n"),
 v += "  Samples: ".concat(c.profiler.samples, "\n"), v += "  Budget: ".concat(y.toFixed(3), " (base ").concat(p, ", modulo ").concat(f, ")\n");
@@ -37380,7 +37384,7 @@ usage: "diagnoseRoom(roomName)",
 examples: [ "diagnoseRoom('W16S52')", "diagnoseRoom('E1S1')" ],
 category: "Statistics"
 }) ], e.prototype, "diagnoseRoom", null), e;
-}(), Mv = function() {
+}(), Uv = function() {
 function e() {}
 return e.prototype.listCommands = function() {
 return Xr.generateHelp();
@@ -37399,22 +37403,22 @@ usage: "commandHelp(commandName)",
 examples: [ "commandHelp('setLogLevel')", "commandHelp('suspendProcess')" ],
 category: "System"
 }) ], e.prototype, "commandHelp", null), e;
-}(), Av = function() {
+}(), _v = function() {
 function e() {}
 return e.prototype.tasks = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? lm.describe(r) : "No visible owned room found. Pass a room name.";
+return r ? dm.describe(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.taskAssignments = function(e) {
 var t, r = null != e ? e : null === (t = Object.values(Game.rooms).find(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 })) || void 0 === t ? void 0 : t.name;
-return r ? lm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
+return r ? dm.describeAssignments(r) : "No visible owned room found. Pass a room name.";
 }, e.prototype.clearTasks = function(e) {
-return lm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
+return dm.clear(e), e ? "Cleared task board for ".concat(e) : "Cleared all task boards";
 }, n([ Zr({
 name: "tasks",
 description: "Show room creep task queue",
@@ -37434,21 +37438,21 @@ usage: "clearTasks(roomName?)",
 examples: [ "clearTasks('W1N1')", "clearTasks()" ],
 category: "Tasks"
 }) ], e.prototype, "clearTasks", null), e;
-}(), Uv = ((Sv = {})[MOVE] = 50, Sv[WORK] = 100, Sv[CARRY] = 50, Sv[ATTACK] = 80,
-Sv[RANGED_ATTACK] = 150, Sv[HEAL] = 250, Sv[CLAIM] = 600, Sv[TOUGH] = 10, Sv);
+}(), Nv = ((xv = {})[MOVE] = 50, xv[WORK] = 100, xv[CARRY] = 50, xv[ATTACK] = 80,
+xv[RANGED_ATTACK] = 150, xv[HEAL] = 250, xv[CLAIM] = 600, xv[TOUGH] = 10, xv);
 
-function _v(e, t) {
+function Pv(e, t) {
 void 0 === t && (t = {});
-var r = o(o({}, Uv), t);
+var r = o(o({}, Nv), t);
 return e.reduce(function(e, t) {
 var o;
-return e + (null !== (o = r[t]) && void 0 !== o ? o : Uv[t]);
+return e + (null !== (o = r[t]) && void 0 !== o ? o : Nv[t]);
 }, 0);
 }
 
-function Nv(e, t) {
+function Iv(e, t) {
 void 0 === t && (t = 0);
-var r = _v(e);
+var r = Pv(e);
 return {
 parts: e,
 cost: r,
@@ -37456,7 +37460,7 @@ minCapacity: t || r
 };
 }
 
-function Pv() {
+function Gv() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
 return e.flatMap(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
@@ -37464,11 +37468,11 @@ return Array(o).fill(r);
 });
 }
 
-var Iv, Gv, Lv, Dv = {
+var Lv, Dv, Bv, Fv = {
 larvaWorker: {
 role: "larvaWorker",
 family: "economy",
-bodies: [ Nv([ WORK, CARRY ], 150), Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Nv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Iv([ WORK, CARRY ], 150), Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 600), Iv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 100,
 maxPerRoom: 3,
 remoteRole: !1
@@ -37476,7 +37480,7 @@ remoteRole: !1
 pioneer: {
 role: "pioneer",
 family: "economy",
-bodies: [ Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Nv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Nv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 92,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37484,7 +37488,7 @@ remoteRole: !0
 interShardPioneer: {
 role: "interShardPioneer",
 family: "economy",
-bodies: [ Nv([ WORK, CARRY, MOVE, MOVE ], 250), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 95,
 maxPerRoom: 3,
 remoteRole: !0
@@ -37492,7 +37496,7 @@ remoteRole: !0
 harvester: {
 role: "harvester",
 family: "economy",
-bodies: [ Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Nv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Nv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
+bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, CARRY, MOVE, MOVE ], 350), Iv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 1e3) ],
 priority: 95,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37500,7 +37504,7 @@ remoteRole: !1
 hauler: {
 role: "hauler",
 family: "economy",
-bodies: [ Nv([ CARRY, CARRY, MOVE, MOVE ], 200), Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Iv([ CARRY, CARRY, MOVE, MOVE ], 200), Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 90,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37508,7 +37512,7 @@ remoteRole: !0
 upgrader: {
 role: "upgrader",
 family: "economy",
-bodies: [ Nv([ WORK, CARRY, MOVE ], 200), Nv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
+bodies: [ Iv([ WORK, CARRY, MOVE ], 200), Iv([ WORK, WORK, WORK, CARRY, MOVE, MOVE ], 450), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 1e3), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1700) ],
 priority: 85,
 maxPerRoom: 8,
 remoteRole: !1
@@ -37516,7 +37520,7 @@ remoteRole: !1
 builder: {
 role: "builder",
 family: "economy",
-bodies: [ Nv([ WORK, CARRY, MOVE, MOVE ], 250), Nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
+bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 650), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1400) ],
 priority: 70,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37524,7 +37528,7 @@ remoteRole: !1
 queenCarrier: {
 role: "queenCarrier",
 family: "economy",
-bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE ], 300), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE ], 450), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 600), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 900) ],
 priority: 85,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37532,7 +37536,7 @@ remoteRole: !1
 mineralHarvester: {
 role: "mineralHarvester",
 family: "economy",
-bodies: [ Nv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
+bodies: [ Iv([ WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE ], 550), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE ], 850) ],
 priority: 65,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37540,7 +37544,7 @@ remoteRole: !1
 labTech: {
 role: "labTech",
 family: "economy",
-bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 60,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37548,7 +37552,7 @@ remoteRole: !1
 factoryWorker: {
 role: "factoryWorker",
 family: "economy",
-bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600) ],
 priority: 35,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37556,7 +37560,7 @@ remoteRole: !1
 remoteHarvester: {
 role: "remoteHarvester",
 family: "economy",
-bodies: [ Nv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Nv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Nv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
+bodies: [ Iv([ WORK, WORK, CARRY, MOVE, MOVE, MOVE ], 400), Iv([ WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1050), Iv([ WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37564,7 +37568,7 @@ remoteRole: !0
 remoteHauler: {
 role: "remoteHauler",
 family: "economy",
-bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 80,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37572,7 +37576,7 @@ remoteRole: !0
 interRoomCarrier: {
 role: "interRoomCarrier",
 family: "economy",
-bodies: [ Nv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Nv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
+bodies: [ Iv([ CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 400), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 600), Iv([ CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 800) ],
 priority: 90,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37580,16 +37584,16 @@ remoteRole: !1
 crossShardCarrier: {
 role: "crossShardCarrier",
 family: "economy",
-bodies: [ Nv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Nv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Nv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Nv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
+bodies: [ Iv(s(s([], i(Array(4).fill(CARRY)), !1), i(Array(4).fill(MOVE)), !1), 400), Iv(s(s([], i(Array(8).fill(CARRY)), !1), i(Array(8).fill(MOVE)), !1), 800), Iv(s(s([], i(Array(12).fill(CARRY)), !1), i(Array(12).fill(MOVE)), !1), 1200), Iv(s(s([], i(Array(16).fill(CARRY)), !1), i(Array(16).fill(MOVE)), !1), 1600) ],
 priority: 85,
 maxPerRoom: 6,
 remoteRole: !0
 }
-}, Bv = {
+}, Wv = {
 guard: {
 role: "guard",
 family: "military",
-bodies: [ Nv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Nv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
+bodies: [ Iv([ TOUGH, ATTACK, ATTACK, MOVE, MOVE, MOVE ], 310), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1070), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1740) ],
 priority: 65,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37597,7 +37601,7 @@ remoteRole: !1
 remoteGuard: {
 role: "remoteGuard",
 family: "military",
-bodies: [ Nv([ TOUGH, ATTACK, MOVE, MOVE ], 190), Nv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Nv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
+bodies: [ Iv([ TOUGH, ATTACK, MOVE, MOVE ], 190), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 500), Iv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 880) ],
 priority: 65,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37605,7 +37609,7 @@ remoteRole: !0
 healer: {
 role: "healer",
 family: "military",
-bodies: [ Nv([ HEAL, MOVE, MOVE ], 350), Nv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Nv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
+bodies: [ Iv([ HEAL, MOVE, MOVE ], 350), Iv([ TOUGH, HEAL, HEAL, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1240), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 2640) ],
 priority: 55,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37613,7 +37617,7 @@ remoteRole: !1
 soldier: {
 role: "soldier",
 family: "military",
-bodies: [ Nv([ ATTACK, ATTACK, MOVE, MOVE ], 260), Nv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
+bodies: [ Iv([ ATTACK, ATTACK, MOVE, MOVE ], 260), Iv([ ATTACK, ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE, MOVE ], 520), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1340) ],
 priority: 50,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37621,7 +37625,7 @@ remoteRole: !1
 siegeUnit: {
 role: "siegeUnit",
 family: "military",
-bodies: [ Nv([ WORK, WORK, MOVE, MOVE ], 300), Nv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
+bodies: [ Iv([ WORK, WORK, MOVE, MOVE ], 300), Iv([ TOUGH, TOUGH, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 620), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !1
@@ -37629,7 +37633,7 @@ remoteRole: !1
 ranger: {
 role: "ranger",
 family: "military",
-bodies: [ Nv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Nv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Nv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Nv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
+bodies: [ Iv([ TOUGH, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE ], 360), Iv([ TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE ], 570), Iv([ TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1040), Iv([ TOUGH, TOUGH, TOUGH, TOUGH, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1480) ],
 priority: 60,
 maxPerRoom: 4,
 remoteRole: !1
@@ -37637,16 +37641,16 @@ remoteRole: !1
 harasser: {
 role: "harasser",
 family: "military",
-bodies: [ Nv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Nv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Nv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
+bodies: [ Iv([ TOUGH, ATTACK, RANGED_ATTACK, MOVE, MOVE ], 320), Iv([ TOUGH, TOUGH, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, MOVE, MOVE, MOVE, MOVE ], 640), Iv([ TOUGH, TOUGH, TOUGH, ATTACK, ATTACK, ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, HEAL, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 1200) ],
 priority: 40,
 maxPerRoom: 1,
 remoteRole: !1
 }
-}, Fv = {
+}, Hv = {
 powerHarvester: {
 role: "powerHarvester",
 family: "power",
-bodies: [ Nv(Pv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Nv(Pv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
+bodies: [ Iv(Gv([ TOUGH, 5 ], [ ATTACK, 20 ], [ MOVE, 25 ]), 2300), Iv(Gv([ TOUGH, 10 ], [ ATTACK, 20 ], [ MOVE, 20 ]), 3e3) ],
 priority: 30,
 maxPerRoom: 2,
 remoteRole: !0
@@ -37654,16 +37658,16 @@ remoteRole: !0
 powerCarrier: {
 role: "powerCarrier",
 family: "power",
-bodies: [ Nv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Nv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
+bodies: [ Iv(s(s([], i(Array(20).fill(CARRY)), !1), i(Array(20).fill(MOVE)), !1), 2e3), Iv(s(s([], i(Array(25).fill(CARRY)), !1), i(Array(25).fill(MOVE)), !1), 2500) ],
 priority: 25,
 maxPerRoom: 2,
 remoteRole: !0
 }
-}, Wv = {
+}, Kv = {
 scout: {
 role: "scout",
 family: "utility",
-bodies: [ Nv([ MOVE ], 50) ],
+bodies: [ Iv([ MOVE ], 50) ],
 priority: 30,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37671,7 +37675,7 @@ remoteRole: !0
 interShardScout: {
 role: "interShardScout",
 family: "utility",
-bodies: [ Nv([ MOVE ], 50) ],
+bodies: [ Iv([ MOVE ], 50) ],
 priority: 70,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37679,7 +37683,7 @@ remoteRole: !0
 interShardClaimer: {
 role: "interShardClaimer",
 family: "utility",
-bodies: [ Nv([ CLAIM, MOVE ], 650) ],
+bodies: [ Iv([ CLAIM, MOVE ], 650) ],
 priority: 80,
 maxPerRoom: 1,
 remoteRole: !0
@@ -37687,7 +37691,7 @@ remoteRole: !0
 claimer: {
 role: "claimer",
 family: "utility",
-bodies: [ Nv([ CLAIM, MOVE ], 650), Nv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
+bodies: [ Iv([ CLAIM, MOVE ], 650), Iv([ CLAIM, CLAIM, MOVE, MOVE ], 1300) ],
 priority: 95,
 maxPerRoom: 6,
 remoteRole: !0
@@ -37695,7 +37699,7 @@ remoteRole: !0
 engineer: {
 role: "engineer",
 family: "utility",
-bodies: [ Nv([ WORK, CARRY, MOVE, MOVE ], 250), Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
+bodies: [ Iv([ WORK, CARRY, MOVE, MOVE ], 250), Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500) ],
 priority: 55,
 maxPerRoom: 2,
 remoteRole: !1
@@ -37703,30 +37707,30 @@ remoteRole: !1
 remoteWorker: {
 role: "remoteWorker",
 family: "utility",
-bodies: [ Nv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Nv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
+bodies: [ Iv([ WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE ], 500), Iv([ WORK, WORK, WORK, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE ], 750) ],
 priority: 45,
 maxPerRoom: 4,
 remoteRole: !0
 }
-}, Hv = o(o(o(o({}, Dv), Bv), Wv), Fv);
+}, Yv = o(o(o(o({}, Fv), Wv), Kv), Hv);
 
 try {
-for (var Kv = a(Object.values(Hv)), Yv = Kv.next(); !Yv.done; Yv = Kv.next()) Yv.value.bodies.sort(function(e, t) {
+for (var Vv = a(Object.values(Yv)), qv = Vv.next(); !qv.done; qv = Vv.next()) qv.value.bodies.sort(function(e, t) {
 return e.cost - t.cost;
 });
 } catch (e) {
-Iv = {
+Lv = {
 error: e
 };
 } finally {
 try {
-Yv && !Yv.done && (Gv = Kv.return) && Gv.call(Kv);
+qv && !qv.done && (Dv = Vv.return) && Dv.call(Vv);
 } finally {
-if (Iv) throw Iv.error;
+if (Lv) throw Lv.error;
 }
 }
 
-function Vv(e) {
+function jv(e) {
 var t, r, o = [];
 try {
 for (var n = a(e), s = n.next(); !s.done; s = n.next()) for (var c = i(s.value, 2), u = c[0], l = c[1], m = 0; m < l; m++) o.push(u);
@@ -37741,11 +37745,11 @@ s && !s.done && (r = n.return) && r.call(n);
 if (t) throw t.error;
 }
 }
-return qv(o);
+return zv(o);
 }
 
-function qv(e) {
-var t = _v(e);
+function zv(e) {
+var t = Pv(e);
 return {
 parts: e,
 cost: t,
@@ -37753,16 +37757,16 @@ minCapacity: t
 };
 }
 
-function jv(e, t) {
+function Qv(e, t) {
 var r;
-return null !== (r = e.map(qv).filter(function(e) {
+return null !== (r = e.map(zv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50;
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0]) && void 0 !== r ? r : null;
 }
 
-function zv(e) {
+function Xv(e) {
 switch (e.role) {
 case "harvester":
 case "staticMiner":
@@ -37776,7 +37780,7 @@ if (n > t) for (;o > 1 && n > t; ) n = 100 * r + 50 + 50 * --o;
 for (var a = [], i = 0; i < r; i++) a.push(WORK);
 for (i = 0; i < 1; i++) a.push(CARRY);
 for (i = 0; i < o; i++) a.push(MOVE);
-var s = _v(a);
+var s = Pv(a);
 return {
 parts: a,
 cost: s,
@@ -37801,8 +37805,8 @@ for (var p = [], f = 0; f < u; f++) p.push(CARRY);
 for (f = 0; f < l; f++) p.push(MOVE);
 return {
 parts: p,
-cost: _v(p),
-minCapacity: _v(p)
+cost: Pv(p),
+minCapacity: Pv(p)
 };
 }(e);
 
@@ -37813,7 +37817,7 @@ case "remoteWorker":
 default:
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 200), o = Math.max(1, Math.min(16, r));
-return Vv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
+return jv([ [ WORK, o ], [ CARRY, o ], [ MOVE, o ] ]);
 }(e);
 
 case "interShardScout":
@@ -37834,7 +37838,7 @@ minCapacity: 650
 case "upgrader":
 return function(e) {
 var t = e.maxEnergy, r = Math.floor(t / 450), o = Math.max(1, Math.min(15, 3 * r)), n = Math.max(1, Math.ceil(o / 3)), a = Math.max(1, Math.ceil((o + n) / 2));
-return Vv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
+return jv([ [ WORK, o ], [ CARRY, n ], [ MOVE, a ] ]);
 }(e);
 
 case "guard":
@@ -37843,13 +37847,13 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 130) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(10, c)).fill(TOUGH)), !1), i(Array(c).fill(ATTACK)), !1), i(Array(c + Math.min(10, c)).fill(MOVE)), !1));
-var u = n.map(qv).filter(function(e) {
+var u = n.map(zv).filter(function(e) {
 return e.cost <= t && e.parts.length <= 50 && e.parts.includes(TOUGH);
 }).sort(function(e, t) {
 return t.cost - e.cost || t.parts.length - e.parts.length;
 })[0];
 if (u) return u;
-var l = jv(n, t);
+var l = Qv(n, t);
 if (l) return l;
 throw new Error("No affordable combat body for ".concat(t, " energy"));
 }(e);
@@ -37859,7 +37863,7 @@ return function(e) {
 for (var t = e.maxEnergy, r = e.willBoost, o = void 0 !== r && r, n = [], a = Math.min(25, Math.floor(t / 200) || 1), c = 1; c <= a; c++) n.push(s(s([], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c).fill(MOVE)), !1)),
 n.push(s(s([ TOUGH ], i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + 1).fill(MOVE)), !1)),
 o && n.push(s(s(s([], i(Array(Math.min(5, c)).fill(TOUGH)), !1), i(Array(c).fill(RANGED_ATTACK)), !1), i(Array(c + Math.min(5, c)).fill(MOVE)), !1));
-var u = jv(n, t);
+var u = Qv(n, t);
 if (u) return u;
 throw new Error("No affordable ranged body for ".concat(t, " energy"));
 }(e);
@@ -37868,14 +37872,14 @@ case "healer":
 return function(e) {
 for (var t = e.maxEnergy, r = [], o = Math.min(25, Math.floor(t / 300) || 1), n = 1; n <= o; n++) r.push(s(s([], i(Array(n).fill(HEAL)), !1), i(Array(n).fill(MOVE)), !1)),
 r.push(s(s([ TOUGH ], i(Array(n).fill(HEAL)), !1), i(Array(n + 1).fill(MOVE)), !1));
-var a = jv(r, t);
+var a = Qv(r, t);
 if (a) return a;
 throw new Error("No affordable healer body for ".concat(t, " energy"));
 }(e);
 }
 }
 
-function Qv(e) {
+function Zv(e) {
 var t = o({
 role: e.role,
 family: e.family,
@@ -37886,9 +37890,9 @@ return e.targetRoom && (t.targetRoom = e.targetRoom), e.sourceId && (t.sourceId 
 e.boostRequirements && (t.boostRequirements = e.boostRequirements), t;
 }
 
-function Xv(e, t) {
+function Jv(e, t) {
 return e.spawnCreep(t.body.parts, (r = t.role, "".concat(r, "_").concat(Game.time, "_").concat(Math.random().toString(36).substring(2, 11))), {
-memory: Qv(t)
+memory: Zv(t)
 });
 var r;
 }
@@ -37896,9 +37900,9 @@ var r;
 !function(e) {
 e[e.EMERGENCY = 1e3] = "EMERGENCY", e[e.HIGH = 500] = "HIGH", e[e.NORMAL = 100] = "NORMAL",
 e[e.LOW = 50] = "LOW";
-}(Lv || (Lv = {}));
+}(Bv || (Bv = {}));
 
-var Zv = function() {
+var $v = function() {
 function e() {
 this.queues = new Map, this.revision = 0;
 }
@@ -37996,7 +38000,7 @@ try {
 for (var u = a(i), l = u.next(); !l.done; l = u.next()) {
 var m = l.value, d = this.getNextRequest(e, c);
 if (!d) break;
-var p = Xv(m, d);
+var p = Jv(m, d);
 p === OK ? (s++, c -= d.body.cost, this.markInProgress(e, d.id, m.id), this.removeRequest(e, d.id)) : p !== ERR_NOT_ENOUGH_ENERGY && (this.removeRequest(e, d.id),
 U.warn("Spawn request failed: ".concat(d.role, " in ").concat(e, " (error: ").concat(p, ")"), {
 subsystem: "SpawnQueue"
@@ -38016,7 +38020,7 @@ if (t) throw t.error;
 return s;
 }, e.prototype.hasEmergencySpawns = function(e) {
 return this.getQueue(e).requests.some(function(e) {
-return e.priority >= Lv.EMERGENCY;
+return e.priority >= Bv.EMERGENCY;
 });
 }, e.prototype.countByPriority = function(e, t) {
 return this.getQueue(e).requests.filter(function(e) {
@@ -38034,7 +38038,7 @@ inProgress: o.inProgress.size
 try {
 for (var i = a(o.requests), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority >= Lv.EMERGENCY ? n.emergency++ : c.priority >= Lv.HIGH ? n.high++ : c.priority >= Lv.NORMAL ? n.normal++ : n.low++;
+c.priority >= Bv.EMERGENCY ? n.emergency++ : c.priority >= Bv.HIGH ? n.high++ : c.priority >= Bv.NORMAL ? n.normal++ : n.low++;
 }
 } catch (e) {
 t = {
@@ -38049,14 +38053,14 @@ if (t) throw t.error;
 }
 return n;
 }, e;
-}(), Jv = new Zv, $v = {
+}(), eg = new $v, tg = {
 getPendingTransfers: function() {
 return [];
 },
 needsCarrier: function() {
 return !1;
 }
-}, eg = {
+}, rg = {
 predictConsumption: function() {
 return 0;
 },
@@ -38075,7 +38079,7 @@ ticks: t
 getMaxAffordableInTicks: function(e) {
 return e.energyCapacityAvailable;
 }
-}, tg = {
+}, og = {
 getActivePowerBanks: function() {
 return [];
 },
@@ -38093,81 +38097,81 @@ powerCarriers: 0,
 operations: []
 };
 }
-}, rg = {
+}, ng = {
 getEmergencyState: function() {
 return null;
 }
 };
 
-function og(e, t, r, o, n) {
-return pc(e, t, r, o, n);
+function ag(e, t, r, o, n) {
+return yc(e, t, r, o, n);
 }
 
-var ng = new Map, ag = -1, ig = null, sg = null;
+var ig = new Map, sg = -1, cg = null, ug = null;
 
-function cg() {
-ag === Game.time && ig === Game.creeps || (ng.clear(), sg = null, ag = Game.time,
-ig = Game.creeps);
+function lg() {
+sg === Game.time && cg === Game.creeps || (ig.clear(), ug = null, sg = Game.time,
+cg = Game.creeps);
 }
 
-function ug(e) {
+function mg(e) {
 var t;
 return null !== (t = e.role) && void 0 !== t ? t : "unknown";
 }
 
-function lg(e, t) {
+function dg(e, t) {
 var r;
-void 0 === t && (t = !1), cg();
-var o = t ? "".concat(e, "_active") : e, n = ng.get(o);
+void 0 === t && (t = !1), lg();
+var o = t ? "".concat(e, "_active") : e, n = ig.get(o);
 if (n instanceof Map) return n;
 var a = new Map;
 for (var i in Game.creeps) {
 var s = Game.creeps[i], c = s.memory;
 if (!(c.homeRoom !== e || t && s.spawning)) {
-var u = ug(c);
+var u = mg(c);
 a.set(u, (null !== (r = a.get(u)) && void 0 !== r ? r : 0) + 1);
 }
 }
-return ng.set(o, a), a;
+return ig.set(o, a), a;
 }
 
-function mg(e, t, r) {
+function pg(e, t, r) {
 return "".concat(e).concat("").concat(t).concat("").concat(r);
 }
 
-function dg(e, t, r) {
+function fg(e, t, r) {
 var o;
 return null !== (o = function() {
 var e;
-if (cg(), sg) return sg;
+if (lg(), ug) return ug;
 var t = new Map;
 for (var r in Game.creeps) {
 var o = Game.creeps[r].memory, n = o.homeRoom, a = o.role, i = o.targetRoom;
 if (n && a && i) {
-var s = mg(n, a, i);
+var s = pg(n, a, i);
 t.set(s, (null !== (e = t.get(s)) && void 0 !== e ? e : 0) + 1);
 }
 }
-return sg = t, t;
-}().get(mg(e, t, r))) && void 0 !== o ? o : 0;
+return ug = t, t;
+}().get(pg(e, t, r))) && void 0 !== o ? o : 0;
 }
 
-function pg(e) {
+function yg(e) {
 return (e.structureType === STRUCTURE_CONTAINER || e.structureType === STRUCTURE_ROAD) && e.hits < .75 * e.hitsMax;
 }
 
-var fg = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
+var vg = [ "remoteHarvester", "remoteHauler", "remoteWorker" ];
 
-function yg(e) {
-return fg.includes(e);
+function gg(e) {
+return vg.includes(e);
 }
 
-function vg(e) {
+function hg(e) {
 var t, r, o;
 return (null !== (o = null === (r = null === (t = e.controller) || void 0 === t ? void 0 : t.reservation) || void 0 === r ? void 0 : r.ticksToEnd) && void 0 !== o ? o : 0) >= 3e3;
 }
 
-function gg(e, t, r, o) {
+function Rg(e, t, r, o) {
 switch (r) {
 case "remoteHarvester":
 return function(e) {
@@ -38180,10 +38184,10 @@ var o = function(e) {
 var t, r;
 return null !== (r = null === (t = Game.rooms[e]) || void 0 === t ? void 0 : t.energyCapacityAvailable) && void 0 !== r ? r : 800;
 }(e);
-if (r) return og(e, t, ft(r).length, o, {
-reserved: vg(r)
+if (r) return ag(e, t, ft(r).length, o, {
+reserved: hg(r)
 }).recommendedHaulers;
-var n = og(e, t, 2, o, {
+var n = ag(e, t, 2, o, {
 reserved: !1
 });
 return Math.min(2, n.recommendedHaulers);
@@ -38194,7 +38198,7 @@ return function(e) {
 if (!e) return 0;
 var t = function(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).length + e.find(FIND_STRUCTURES, {
-filter: pg
+filter: yg
 }).length;
 }(e);
 return 0 === t ? 0 : Math.min(2, Math.max(1, Math.ceil(t / 5)));
@@ -38205,7 +38209,7 @@ return 2;
 }
 }
 
-function hg(e, t) {
+function Eg(e, t) {
 var r, o;
 try {
 var n = null === (o = null === (r = Game.map) || void 0 === r ? void 0 : r.getRoomLinearDistance) || void 0 === o ? void 0 : o.call(r, e, t);
@@ -38215,13 +38219,13 @@ return null;
 }
 }
 
-function Rg() {
+function Tg() {
 var e, t = Object.values(null !== (e = Game.spawns) && void 0 !== e ? e : {});
 return t.length > 0 ? t[0].owner.username : "";
 }
 
-function Eg(e) {
-var t = Rg(), r = function(e) {
+function Cg(e) {
+var t = Tg(), r = function(e) {
 var t;
 return null === (t = e.owner) || void 0 === t ? void 0 : t.username;
 }(e);
@@ -38233,22 +38237,22 @@ return null === (t = e.reservation) || void 0 === t ? void 0 : t.username;
 return Boolean(o && o !== t);
 }
 
-function Tg(e) {
+function Sg(e) {
 var t = wr.getEmpire().knownRooms[e];
 if (!t) return !1;
-var r = Rg();
+var r = Tg();
 return !(!t.owner || t.owner === r) || !(!t.reserver || t.reserver === r) || t.threatLevel > 0 || !!t.isSK;
 }
 
-function Cg(e, t) {
+function wg(e, t) {
 return void 0 === t && (t = Z(e)), t.some(so);
 }
 
-function Sg(e) {
+function xg(e) {
 return e.find(FIND_MY_SPAWNS).length > 0;
 }
 
-function wg() {
+function bg() {
 var e, t, r, o, n, a = new Set;
 for (var c in Game.rooms) (null === (t = null === (e = Game.rooms[c]) || void 0 === e ? void 0 : e.controller) || void 0 === t ? void 0 : t.my) && a.add(c);
 for (var u in null !== (r = Game.spawns) && void 0 !== r ? r : {}) {
@@ -38258,9 +38262,9 @@ l && a.add(l);
 return s([], i(a), !1);
 }
 
-var xg = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+var Og = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function bg(e, t) {
+function kg(e, t) {
 var r, o, n = Object.values(Game.creeps).some(function(r) {
 var o = r.memory;
 return "claimer" === o.role && o.targetRoom === e && o.task === t && function(e) {
@@ -38272,8 +38276,8 @@ return e.type === CLAIM && e.hits > 0;
 });
 if (n) return !0;
 try {
-for (var i = a(wg()), s = i.next(); !s.done; s = i.next()) {
-var c = s.value, u = Jv.getPendingRequests(c).some(function(r) {
+for (var i = a(bg()), s = i.next(); !s.done; s = i.next()) {
+var c = s.value, u = eg.getPendingRequests(c).some(function(r) {
 var o;
 return "claimer" === r.role && r.targetRoom === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.task) === t && r.body.parts.includes(CLAIM);
 });
@@ -38293,7 +38297,7 @@ if (r) throw r.error;
 return !1;
 }
 
-function Og() {
+function Mg() {
 var e, t, r, o = new Set;
 try {
 for (var n = a(Object.values(null !== (r = Game.constructionSites) && void 0 !== r ? r : {})), c = n.next(); !c.done; c = n.next()) {
@@ -38314,7 +38318,7 @@ if (e) throw e.error;
 return s([], i(o), !1).sort();
 }
 
-function kg(e, t) {
+function Ag(e, t) {
 var r, o, n, c, u = wr.getEmpire(), l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
@@ -38324,15 +38328,15 @@ return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.
 }() ? function(e) {
 var t, r, o, n = null !== (t = e.recoveryRooms) && void 0 !== t ? t : {};
 return null !== (o = null === (r = Object.values(n).filter(function(e) {
-return !bg(e.roomName, "claim");
+return !kg(e.roomName, "claim");
 }).filter(function(e) {
 return function(e) {
 var t = Game.rooms[e];
 if (t) {
 var r = t.controller;
-return !(!r || r.my || r.owner || r.reservation || Cg(t));
+return !(!r || r.my || r.owner || r.reservation || wg(t));
 }
-return !Tg(e);
+return !Sg(e);
 }(e.roomName);
 }).sort(function(e, t) {
 return e.lostAt - t.lostAt || e.roomName.localeCompare(t.roomName);
@@ -38343,11 +38347,11 @@ targetRoom: p,
 task: "claim"
 };
 var f = d ? function(e, t) {
-var r, o, n = Og().filter(function(e) {
-return !bg(e, "claim");
+var r, o, n = Mg().filter(function(e) {
+return !kg(e, "claim");
 }).filter(function(e) {
 return function(e, t) {
-var r, o, n = Game.rooms[e], a = Rg();
+var r, o, n = Game.rooms[e], a = Tg();
 if (n) {
 var i = n.controller;
 if (!i) return !1;
@@ -38358,7 +38362,7 @@ var c = null === (o = i.reservation) || void 0 === o ? void 0 : o.username;
 return !(c && c !== a || function(e) {
 return Z(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && xg.has(e.type);
+return e.hits > 0 && Og.has(e.type);
 });
 });
 }(n));
@@ -38370,7 +38374,7 @@ return !(u && (u.owner && u.owner !== a || u.reserver && u.reserver !== a || u.t
 var r;
 return {
 roomName: t,
-distance: null !== (r = hg(e, t)) && void 0 !== r ? r : 999
+distance: null !== (r = Eg(e, t)) && void 0 !== r ? r : 999
 };
 }).filter(function(e) {
 return e.distance <= 10;
@@ -38385,14 +38389,14 @@ task: "claim"
 };
 var y = d ? new Set(s(s(s([], i(Object.values(null !== (c = u.recoveryRooms) && void 0 !== c ? c : {}).map(function(e) {
 return e.roomName;
-})), !1), i(Og()), !1), i(u.claimQueue.filter(function(e) {
+})), !1), i(Mg()), !1), i(u.claimQueue.filter(function(e) {
 return !e.claimed;
 }).map(function(e) {
 return e.roomName;
 })), !1)) : new Set;
 if (d) {
 var v = u.claimQueue.find(function(e) {
-return !e.claimed && !bg(e.roomName, "claim");
+return !e.claimed && !kg(e.roomName, "claim");
 });
 if (v) return {
 targetRoom: v.roomName,
@@ -38404,20 +38408,20 @@ var r, o, n, i, s, c;
 void 0 === t && (t = new Set);
 var u = null !== (n = e.remoteAssignments) && void 0 !== n ? n : [];
 if (0 === u.length) return null;
-var l = Rg();
+var l = Tg();
 try {
 for (var m = a(u), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-if (!t.has(p) && !bg(p, "claim")) {
+if (!t.has(p) && !kg(p, "claim")) {
 var f = Game.rooms[p];
 if (f) {
 var y = f.controller;
 if (!y) continue;
-if (y.owner || Eg(y)) continue;
-if (Cg(f)) continue;
+if (y.owner || Cg(y)) continue;
+if (wg(f)) continue;
 var v = (null === (i = y.reservation) || void 0 === i ? void 0 : i.username) === l, g = null !== (c = null === (s = y.reservation) || void 0 === s ? void 0 : s.ticksToEnd) && void 0 !== c ? c : 0;
-if ((!v || g < 3e3) && !bg(p, "reserve")) return p;
-} else if (!Tg(p) && !bg(p, "reserve")) return p;
+if ((!v || g < 3e3) && !kg(p, "reserve")) return p;
+} else if (!Sg(p) && !kg(p, "reserve")) return p;
 }
 }
 } catch (e) {
@@ -38439,22 +38443,22 @@ task: "reserve"
 } : null;
 }
 
-var Mg, Ag, Ug = new Map;
+var Ug, _g, Ng = new Map;
 
-function _g(e) {
+function Pg(e) {
 var t, r = null === (t = e.store) || void 0 === t ? void 0 : t.getUsedCapacity(RESOURCE_ENERGY);
 if ("number" == typeof r) return r;
 var o = e.energy;
 return "number" == typeof o ? o : 0;
 }
 
-function Ng(e) {
+function Ig(e) {
 var t, r;
-r = Game.time, Mg === Game && Ag === r || (Ug.clear(), Mg = Game, Ag = r);
+r = Game.time, Ug === Game && _g === r || (Ng.clear(), Ug = Game, _g = r);
 var o = function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.structureEnergyFallback);
-}(), n = Ug.get(e.name);
+}(), n = Ng.get(e.name);
 if (n && n.fallbackEnabled === o) return n.value;
 var i = null !== (t = e.energyAvailable) && void 0 !== t ? t : 0, s = o ? Math.max(i, function(e) {
 var t, r, o, n, i = 0;
@@ -38465,7 +38469,7 @@ return e.find(FIND_MY_SPAWNS);
 } catch (e) {
 return [];
 }
-}(e)), c = s.next(); !c.done; c = s.next()) i += _g(c.value);
+}(e)), c = s.next(); !c.done; c = s.next()) i += Pg(c.value);
 } catch (e) {
 t = {
 error: e
@@ -38486,7 +38490,7 @@ return e.structureType === STRUCTURE_EXTENSION;
 } catch (e) {
 return [];
 }
-}(e)), l = u.next(); !l.done; l = u.next()) i += _g(l.value);
+}(e)), l = u.next(); !l.done; l = u.next()) i += Pg(l.value);
 } catch (e) {
 o = {
 error: e
@@ -38500,20 +38504,20 @@ if (o) throw o.error;
 }
 return i;
 }(e)) : i;
-return Ug.set(e.name, {
+return Ng.set(e.name, {
 fallbackEnabled: o,
 value: s
 }), s;
 }
 
-var Pg, Ig, Gg, Lg = new Map;
+var Gg, Lg, Dg, Bg = new Map;
 
-function Dg(e, t) {
+function Fg(e, t) {
 var r;
-return null !== (r = hg(e, t)) && void 0 !== r ? r : 999;
+return null !== (r = Eg(e, t)) && void 0 !== r ? r : 999;
 }
 
-function Bg(e) {
+function Wg(e) {
 try {
 return e.find(FIND_MY_SPAWNS).filter(function(e) {
 return !e.spawning;
@@ -38523,16 +38527,16 @@ return 0;
 }
 }
 
-function Fg(e, t) {
+function Hg(e, t) {
 var r, o = null !== (r = e.energyCapacityAvailable) && void 0 !== r ? r : 0;
 if (o < 200) return null;
 var n, a, i = function(e, t) {
 var r, o;
-Pg === Game && Ig === Game.map && Gg === Game.time || (Lg.clear(), Pg = Game, Ig = Game.map,
-Gg = Game.time);
+Gg === Game && Lg === Game.map && Dg === Game.time || (Bg.clear(), Gg = Game, Lg = Game.map,
+Dg = Game.time);
 var n = "".concat(e, "->").concat(t);
-if (Lg.has(n)) return null !== (r = Lg.get(n)) && void 0 !== r ? r : null;
-var a = Dg(e, t);
+if (Bg.has(n)) return null !== (r = Bg.get(n)) && void 0 !== r ? r : null;
+var a = Fg(e, t);
 try {
 if ("function" == typeof (null === (o = Game.map) || void 0 === o ? void 0 : o.findRoute)) {
 var i = Game.map.findRoute(e, t, {
@@ -38541,79 +38545,79 @@ return function(e, t) {
 var r;
 if (e === t) return 1;
 var o = Game.rooms[e];
-return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && Eg(o.controller) || Tg(e) || o && Cg(o) ? 1 / 0 : 1;
+return (null === (r = null == o ? void 0 : o.controller) || void 0 === r ? void 0 : r.my) ? 1 : (null == o ? void 0 : o.controller) && Cg(o.controller) || Sg(e) || o && wg(o) ? 1 / 0 : 1;
 }(e, t);
 }
 });
 a = i === ERR_NO_PATH ? null : i.length;
 }
 } catch (r) {
-a = Dg(e, t);
+a = Fg(e, t);
 }
-return Lg.set(n, a), a;
+return Bg.set(n, a), a;
 }(e.name, t.name);
 return null === i ? null : {
 room: e,
 routeDistance: i,
-linearDistance: Dg(e.name, t.name),
-queuePressure: (n = e.name, a = t.name, Jv.getPendingRequests(n).reduce(function(e, t) {
+linearDistance: Fg(e.name, t.name),
+queuePressure: (n = e.name, a = t.name, eg.getPendingRequests(n).reduce(function(e, t) {
 var r;
-return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Lv.EMERGENCY;
+return "pioneer" === t.role && t.targetRoom === a && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task) ? e : e + 1 + Math.max(0, t.priority) / Bv.EMERGENCY;
 }, 0)),
 energyCapacity: o,
-hasAvailableSpawn: Bg(e) > 0,
-hasReadyEnergy: Ng(e) >= 200
+hasAvailableSpawn: Wg(e) > 0,
+hasReadyEnergy: Ig(e) >= 200
 };
 }
 
-function Wg(e, t) {
+function Kg(e, t) {
 return Number(t.hasReadyEnergy) - Number(e.hasReadyEnergy) || Number(t.hasAvailableSpawn) - Number(e.hasAvailableSpawn) || e.queuePressure - t.queuePressure || t.energyCapacity - e.energyCapacity || e.routeDistance - t.routeDistance || e.linearDistance - t.linearDistance || e.room.name.localeCompare(t.room.name);
 }
 
-function Hg(e) {
+function Yg(e) {
 return e.find(FIND_MY_CONSTRUCTION_SITES).some(function(e) {
 return e.structureType === STRUCTURE_SPAWN;
 });
 }
 
-function Kg(e) {
-return Hg(e) ? Lv.EMERGENCY : Lv.HIGH;
+function Vg(e) {
+return Yg(e) ? Bv.EMERGENCY : Bv.HIGH;
 }
 
-function Yg(e, t, r) {
+function qg(e, t, r) {
 var o, n;
 if (!(null === (o = e.controller) || void 0 === o ? void 0 : o.my)) return !1;
-if (!Sg(e)) return !1;
+if (!xg(e)) return !1;
 var a = e.name === t ? r : wr.getSwarmState(e.name);
 return !((null !== (n = null == a ? void 0 : a.danger) && void 0 !== n ? n : 0) >= 2) && "war" !== (null == a ? void 0 : a.posture) && "siege" !== (null == a ? void 0 : a.posture) && "evacuate" !== (null == a ? void 0 : a.posture);
 }
 
-function Vg(e, t, r) {
+function jg(e, t, r) {
 var o, n;
 return null !== (n = null === (o = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e.name;
 }).filter(function(e) {
-return Yg(e, t, r);
+return qg(e, t, r);
 }).map(function(t) {
-return Fg(t, e);
+return Hg(t, e);
 }).filter(function(e) {
 return null !== e;
-}).sort(Wg)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
+}).sort(Kg)[0]) || void 0 === o ? void 0 : o.room.name) && void 0 !== n ? n : null;
 }
 
-function qg(e, t) {
+function zg(e, t) {
 var r, o, n = Game.rooms[e];
-if (!n || !Yg(n, e, t)) return null;
+if (!n || !qg(n, e, t)) return null;
 var i = Object.values(Game.rooms).filter(function(t) {
 return t.name !== e;
 }).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).filter(function(e) {
-return !Sg(e);
+return !xg(e);
 }).filter(function(e) {
 var t = Z(e);
-return !Cg(e, t) || mo(e, t);
+return !wg(e, t) || mo(e, t);
 }).filter(function(e) {
 return function(e) {
 var t, r, o, n, i = 0;
@@ -38634,9 +38638,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var l = a(wg()), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(bg()), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-i += Jv.getPendingRequests(d).filter(function(t) {
+i += eg.getPendingRequests(d).filter(function(t) {
 var r;
 return "pioneer" === t.role && t.targetRoom === e && "bootstrapSpawn" === (null === (r = t.additionalMemory) || void 0 === r ? void 0 : r.task);
 }).length;
@@ -38653,11 +38657,11 @@ if (o) throw o.error;
 }
 }
 return i;
-}(e.name) < (Hg(e) ? 3 : 1);
+}(e.name) < (Yg(e) ? 3 : 1);
 }).map(function(e) {
 return {
 room: e,
-homeScore: Fg(n, e)
+homeScore: Hg(n, e)
 };
 }).filter(function(e) {
 return null !== e.homeScore;
@@ -38667,10 +38671,10 @@ return e.homeScore.routeDistance - t.homeScore.routeDistance || e.homeScore.line
 try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (Vg(u.room, e, t) === e) return {
+if (jg(u.room, e, t) === e) return {
 targetRoom: u.room.name,
 task: "bootstrapSpawn",
-priority: Kg(u.room)
+priority: Vg(u.room)
 };
 }
 } catch (e) {
@@ -38687,10 +38691,10 @@ if (r) throw r.error;
 return null;
 }
 
-function jg(e, t) {
+function Qg(e, t) {
 if (t <= 0) return null;
 try {
-var r = zv({
+var r = Xv({
 maxEnergy: t,
 role: e
 });
@@ -38700,36 +38704,36 @@ return null;
 }
 }
 
-function zg(e, t, r) {
-return "healer" === e || "ranger" === e && Po(r) ? null : jg(e, t);
+function Xg(e, t, r) {
+return "healer" === e || "ranger" === e && Po(r) ? null : Qg(e, t);
 }
 
-function Qg(e) {
+function Zg(e) {
 return Boolean(e && "object" == typeof e && "string" == typeof e.roomName);
 }
 
-function Xg(e) {
+function Jg(e) {
 var t, r = Game.rooms[e.roomName];
 return r ? Z(r).length > 0 : Game.time - (null !== (t = e.createdAt) && void 0 !== t ? t : 0) <= 500;
 }
 
-function Zg(e) {
+function $g(e) {
 var t = e.defenseRequests;
-return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Qg);
+return (Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(Zg);
 }
 
-var Jg = [ "guard", "ranger", "healer" ];
+var eh = [ "guard", "ranger", "healer" ];
 
-function $g(e, t) {
+function th(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : "healer" === t ? Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0) : 0;
 }
 
-var eh = null;
+var rh = null;
 
-function th() {
-var e = Jv.getRevision();
-return eh && eh.game === Game && eh.creeps === Game.creeps && eh.tick === Game.time && eh.queueRevision === e ? eh : eh = {
+function oh() {
+var e = eg.getRevision();
+return rh && rh.game === Game && rh.creeps === Game.creeps && rh.tick === Game.time && rh.queueRevision === e ? rh : rh = {
 game: Game,
 creeps: Game.creeps,
 tick: Game.time,
@@ -38742,8 +38746,8 @@ canSpawn: new Map
 };
 }
 
-function rh(e) {
-var t = th(), r = Game.rooms[e], o = t.threats.get(e);
+function nh(e) {
+var t = oh(), r = Game.rooms[e], o = t.threats.get(e);
 if (o && o.room === r) return o.threatProfile;
 var n = Mo(e);
 return t.threats.set(e, {
@@ -38752,27 +38756,27 @@ threatProfile: n
 }), n;
 }
 
-function oh(e) {
-return Game.rooms[e.roomName] ? null !== rh(e.roomName) : Xg(e);
+function ah(e) {
+return Game.rooms[e.roomName] ? null !== nh(e.roomName) : Jg(e);
 }
 
-function nh(e) {
+function ih(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function ah(e, t) {
+function sh(e, t) {
 var r, o;
 return (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.assistTarget) === t || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task) === vi && e.targetRoom === t;
 }
 
-function ih(e, t, r) {
+function ch(e, t, r) {
 var o = wo(r), n = e[t];
 e[t] = n ? bo(n, o) : o;
 }
 
-function sh(e) {
-var t = th(), r = t.assigned.get(e);
+function uh(e) {
+var t = oh(), r = t.assigned.get(e);
 if (r) return r;
 var o = function(e) {
 var t, r, o, n, i, s, c = {
@@ -38783,12 +38787,12 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.creeps)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value, p = d.memory, f = null !== (i = p.role) && void 0 !== i ? i : "";
-if (Bo(f) && nh(p) === e) {
+if (Bo(f) && ih(p) === e) {
 c[f]++;
 var y = (null !== (s = d.body) && void 0 !== s ? s : []).filter(function(e) {
 return e.hits > 0;
 });
-y.length > 0 && ih(u, f, y);
+y.length > 0 && ch(u, f, y);
 }
 }
 } catch (e) {
@@ -38803,9 +38807,9 @@ if (t) throw t.error;
 }
 }
 for (var v in Game.rooms) try {
-for (var g = (o = void 0, a(Jv.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
+for (var g = (o = void 0, a(eg.getPendingRequests(v))), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-Bo(R.role) && ah(R, e) && (c[R.role]++, ih(u, R.role, R.body.parts));
+Bo(R.role) && sh(R, e) && (c[R.role]++, ch(u, R.role, R.body.parts));
 }
 } catch (e) {
 o = {
@@ -38826,8 +38830,8 @@ power: u
 return t.assigned.set(e, o), o;
 }
 
-function ch(e) {
-var t = th(), r = t.canSpawn.get(e.name);
+function lh(e) {
+var t = oh(), r = t.canSpawn.get(e.name);
 if (r && r.room === e) return r.value;
 var o = function(e) {
 var t;
@@ -38839,20 +38843,20 @@ value: o
 }), o;
 }
 
-function uh(e, t) {
-var r, o, n = th(), i = function(e, t) {
+function mh(e, t) {
+var r, o, n = oh(), i = function(e, t) {
 var r, o, n, a, i;
 return [ t.name, e.roomName, t.energyCapacityAvailable, Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0), Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0), null !== (a = e.urgency) && void 0 !== a ? a : "", null !== (i = e.createdAt) && void 0 !== i ? i : "" ].join(":");
 }(e, t), s = n.helperPlans.get(i);
 if (s) return s;
-var c = rh(e.roomName), u = sh(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Do(d, c, function(e, t) {
+var c = nh(e.roomName), u = uh(e.roomName), l = u.counts, m = u.power, d = t.energyCapacityAvailable, p = Do(d, c, function(e, t) {
 return {
-guard: Math.max(0, $g(e, "guard") - t.guard),
-ranger: Math.max(0, $g(e, "ranger") - t.ranger),
-healer: Math.max(0, $g(e, "healer") - t.healer)
+guard: Math.max(0, th(e, "guard") - t.guard),
+ranger: Math.max(0, th(e, "ranger") - t.ranger),
+healer: Math.max(0, th(e, "healer") - t.healer)
 };
 }(e, l), m), f = function(e, t) {
-var r, o, n, i, s = th(), c = s.capableHelpers.get(e);
+var r, o, n, i, s = oh(), c = s.capableHelpers.get(e);
 if (c) return c;
 var u = {
 guard: 0,
@@ -38862,8 +38866,8 @@ healer: 0
 try {
 for (var l = a(Object.values(Game.rooms)), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d.name !== e && ch(d)) try {
-for (var p = (n = void 0, a(Jg)), f = p.next(); !f.done; f = p.next()) {
+if (d.name !== e && lh(d)) try {
+for (var p = (n = void 0, a(eh)), f = p.next(); !f.done; f = p.next()) {
 var y = f.value;
 Io(y, d.energyCapacityAvailable, t) && u[y]++;
 }
@@ -38893,7 +38897,7 @@ if (r) throw r.error;
 return s.capableHelpers.set(e, u), u;
 }(e.roomName, c), y = {};
 try {
-for (var v = a(Jg), g = v.next(); !g.done; g = v.next()) {
+for (var v = a(eh), g = v.next(); !g.done; g = v.next()) {
 var h = g.value;
 y[h] = Io(h, d, c);
 }
@@ -38920,8 +38924,8 @@ helperBodies: y
 return n.helperPlans.set(i, R), R;
 }
 
-function lh(e, t, r) {
-var o = $g(e, t);
+function dh(e, t, r) {
+var o = th(e, t);
 if (!Bo(t)) return o;
 if (!r.threatProfile) return o;
 var n = r.assignedCounts[t] + r.aggregatePlan.counts[t], a = o > 0 ? function(e, t, r) {
@@ -38936,27 +38940,27 @@ return Math.min(8, Math.max(1, i, s, u, l));
 return Math.max(o, n, a, i);
 }
 
-function mh(e, t, r) {
-void 0 === r && (r = uh(e, t));
+function ph(e, t, r) {
+void 0 === r && (r = mh(e, t));
 var o = r.aggregatePlan.counts.guard + r.aggregatePlan.counts.ranger + r.aggregatePlan.counts.healer;
 if (o > 0) return o;
-var n = Jg.filter(function(t) {
-return !(lh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
+var n = eh.filter(function(t) {
+return !(dh(e, t, r) <= 0) && Boolean(r.helperBodies[t]);
 });
 return Math.max(1, n.length);
 }
 
-function dh(e, t, r, o) {
+function fh(e, t, r, o) {
 var n;
-return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : zg("guard", Ng(r), o) ? 1 : 0;
+return "guard" !== t || (null !== (n = e.urgency) && void 0 !== n ? n : 1) < 2 ? 0 : Xg("guard", Ig(r), o) ? 1 : 0;
 }
 
-function ph(e, t) {
+function yh(e, t) {
 if (!function(e) {
 return Bo(e);
 }(t)) return null;
 var r = Game.rooms[e];
-if (!r || !ch(r)) return null;
+if (!r || !lh(r)) return null;
 var o = Memory;
 !function(e) {
 var t, r, o = Memory, n = o.defenseAssistWaves;
@@ -38983,15 +38987,15 @@ if (t) throw t.error;
 var n = function(e, t) {
 var r;
 void 0 === t && (t = {});
-var o = Zg(e), n = function(e) {
+var o = $g(e), n = function(e) {
 return e.map(function(e) {
 var t, r, o, n, a;
 return [ e.roomName, Math.max(0, null !== (t = e.guardsNeeded) && void 0 !== t ? t : 0), Math.max(0, null !== (r = e.rangersNeeded) && void 0 !== r ? r : 0), Math.max(0, null !== (o = e.healersNeeded) && void 0 !== o ? o : 0), null !== (n = e.urgency) && void 0 !== n ? n : "", null !== (a = e.createdAt) && void 0 !== a ? a : "" ].join(":");
 }).join("|");
-}(o), a = th();
+}(o), a = oh();
 if ((null === (r = a.activeRequests) || void 0 === r ? void 0 : r.signature) === n) return t.prune && Array.isArray(e.defenseRequests) && a.activeRequests.requests.length !== o.length && (e.defenseRequests = a.activeRequests.requests),
 a.activeRequests.requests;
-var i = o.filter(oh);
+var i = o.filter(ah);
 return a.activeRequests = {
 signature: n,
 requests: i
@@ -39002,17 +39006,17 @@ prune: !0
 }).filter(function(t) {
 return t.roomName !== e;
 }).map(function(e) {
-var o = uh(e, r);
+var o = mh(e, r);
 return {
 request: e,
 plan: o,
-helperNeed: Math.max(lh(e, t, o), dh(e, t, r, o.threatProfile))
+helperNeed: Math.max(dh(e, t, o), fh(e, t, r, o.threatProfile))
 };
 }).filter(function(e) {
 return e.helperNeed > 0;
 }).filter(function(e) {
 return function(e, t) {
-return Bo(t) ? sh(e).counts[t] : 0;
+return Bo(t) ? uh(e).counts[t] : 0;
 }(e.request.roomName, t) < e.helperNeed;
 }).sort(function(t, r) {
 var o, n, a, i, s, c, u, l, m, d, p = (null !== (o = r.request.urgency) && void 0 !== o ? o : 1) - (null !== (n = t.request.urgency) && void 0 !== n ? n : 1);
@@ -39022,7 +39026,7 @@ return f !== y ? f - y : (null !== (m = t.request.createdAt) && void 0 !== m ? m
 }), s = n[0];
 return s ? function(e, t, r, o) {
 var n;
-void 0 === o && (o = uh(r, t));
+void 0 === o && (o = mh(r, t));
 var a = function(e, t) {
 var r = function() {
 var e, t = Memory;
@@ -39040,28 +39044,28 @@ return r[o] = s, s;
 return {
 targetRoom: r.roomName,
 task: vi,
-priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Lv.EMERGENCY : Lv.HIGH,
+priority: (null !== (n = r.urgency) && void 0 !== n ? n : 1) >= 2 ? Bv.EMERGENCY : Bv.HIGH,
 defenseSquadId: gi(e, r.roomName, a.createdAt),
-defenseSquadSize: mh(r, t, o),
+defenseSquadSize: ph(r, t, o),
 defenseSquadCreatedAt: a.createdAt
 };
 }(e, r, s.request, s.plan) : null;
 }
 
-var fh = "defenseRefuel", yh = {
+var vh = "defenseRefuel", gh = {
 parts: [ CARRY, MOVE ],
 cost: 100,
 minCapacity: 100
 };
 
-function vh(e, t) {
+function hh(e, t) {
 if ("hauler" !== t) return null;
 var r = Game.rooms[e];
 if (!r || !function(e) {
 var t;
-return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || Z(e).length > 0 || e.energyCapacityAvailable < yh.cost);
+return !(!(null === (t = e.controller) || void 0 === t ? void 0 : t.my) || 0 === e.find(FIND_MY_SPAWNS).length || Z(e).length > 0 || e.energyCapacityAvailable < gh.cost);
 }(r)) return null;
-if (Ng(r) >= 200) return null;
+if (Ig(r) >= 200) return null;
 var o = function(e) {
 return (t = Memory.defenseRequests, Array.isArray(t) ? t : Object.values(null != t ? t : {})).filter(function(t) {
 var r, o;
@@ -39094,7 +39098,7 @@ var t, r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
 var l = u.value.memory;
-"hauler" === l.role && l.homeRoom === e && l.task === fh && s++;
+"hauler" === l.role && l.homeRoom === e && l.task === vh && s++;
 }
 } catch (e) {
 t = {
@@ -39108,9 +39112,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Jv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(eg.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === fh && s++;
+"hauler" === p.role && f === vh && s++;
 }
 } catch (e) {
 o = {
@@ -39143,9 +39147,9 @@ if (t) throw t.error;
 }
 }
 try {
-for (var m = a(Jv.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(eg.getPendingRequests(e)), d = m.next(); !d.done; d = m.next()) {
 var p = d.value, f = null === (i = p.additionalMemory) || void 0 === i ? void 0 : i.task;
-"hauler" === p.role && f === fh && s++;
+"hauler" === p.role && f === vh && s++;
 }
 } catch (e) {
 o = {
@@ -39161,24 +39165,24 @@ if (o) throw o.error;
 return s;
 }(e);
 return i >= (n ? 4 : 2) ? null : {
-task: fh,
-priority: Lv.EMERGENCY,
-body: yh
+task: vh,
+priority: Bv.EMERGENCY,
+body: gh
 };
 }
 
-function gh(e) {
+function Rh(e) {
 var t = Game.rooms[e];
-return t ? !!t.controller && !Eg(t.controller) && !Cg(t) : !Tg(e);
+return t ? !!t.controller && !Cg(t.controller) && !wg(t) : !Sg(e);
 }
 
-function hh(e) {
+function Eh(e) {
 var t = Game.rooms[e];
-return (null == t ? void 0 : t.controller) ? !Eg(t.controller) : !Tg(e);
+return (null == t ? void 0 : t.controller) ? !Cg(t.controller) : !Sg(e);
 }
 
-function Rh(e, t, r) {
-var o = Hv[t];
+function Th(e, t, r) {
+var o = Yv[t];
 if (!o) return 0;
 var n = o.maxPerRoom, a = Game.rooms[e];
 if ("upgrader" === t && (null == a ? void 0 : a.controller)) {
@@ -39189,7 +39193,7 @@ var i = wr.getCluster(r.clusterId);
 }
 (function(e) {
 return function(e) {
-var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = Vs(null == e ? void 0 : e.storage), s = Vs(null == e ? void 0 : e.terminal), c = a && i < Ys, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
+var t, r, o, n = null !== (r = null === (t = null == e ? void 0 : e.controller) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 0, a = Boolean((null === (o = null == e ? void 0 : e.controller) || void 0 === o ? void 0 : o.my) && n >= 4 && e.storage), i = js(null == e ? void 0 : e.storage), s = js(null == e ? void 0 : e.terminal), c = a && i < qs, u = a && n >= 6 && Boolean(null == e ? void 0 : e.terminal) && s < 2e4;
 return {
 controllerLevel: n,
 isMatureOwnedRoom: a,
@@ -39206,13 +39210,13 @@ return "queenCarrier" === t && (n = (null == a ? void 0 : a.storage) && a.contro
 n;
 }
 
-function Eh(e, t, r) {
+function Ch(e, t, r) {
 var o, n, i, s = null !== (i = r.remoteAssignments) && void 0 !== i ? i : [];
 if (0 === s.length) return null;
 try {
 for (var c = a(s), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-if (gh(l) && dg(e, t, l) < gg(e, l, t, Game.rooms[l])) return l;
+if (Rh(l) && fg(e, t, l) < Rg(e, l, t, Game.rooms[l])) return l;
 }
 } catch (e) {
 o = {
@@ -39228,10 +39232,10 @@ if (o) throw o.error;
 return null;
 }
 
-function Th(e, t, r, o) {
+function Sh(e, t, r, o) {
 var n, s, c, u, l, m, d;
 void 0 === o && (o = !1);
-var p = Hv[t];
+var p = Yv[t];
 if (!p) return !1;
 var f = Game.rooms[e];
 if (function(e, t) {
@@ -39245,36 +39249,36 @@ if (!function(e, t, r) {
 return void 0 === r && (r = 1), !(r <= 0 || function(e) {
 return Array.from(e.entries()).filter(function(e) {
 var t, r, o = i(e, 1)[0];
-return "military" === (null === (t = Hv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Hv[o]) || void 0 === r ? void 0 : r.remoteRole);
+return "military" === (null === (t = Yv[o]) || void 0 === t ? void 0 : t.family) && !(null === (r = Yv[o]) || void 0 === r ? void 0 : r.remoteRole);
 }).reduce(function(e, t) {
 return e + i(t, 2)[1];
 }, 0);
 }(t) >= r || "guard" !== e);
-}(t, lg(e), y)) return !1;
+}(t, dg(e), y)) return !1;
 }
 if ("larvaWorker" === t && !o) return !1;
-if (yg(t)) return !("remoteWorker" === t && function(e, t) {
-cg();
-var r = "".concat(e, ":").concat(t), o = ng.get(r);
+if (gg(t)) return !("remoteWorker" === t && function(e, t) {
+lg();
+var r = "".concat(e, ":").concat(t), o = ig.get(r);
 if ("number" == typeof o) return o;
 var n = 0;
 for (var a in Game.creeps) {
 var i = Game.creeps[a].memory;
 i.homeRoom === e && i.role === t && n++;
 }
-return ng.set(r, n), n;
-}(e, t) >= Rh(e, t, r)) && null !== Eh(e, t, r);
+return ig.set(r, n), n;
+}(e, t) >= Th(e, t, r)) && null !== Ch(e, t, r);
 if ("remoteGuard" === t) {
 var v = null !== (c = r.remoteAssignments) && void 0 !== c ? c : [];
 if (0 === v.length) return !1;
 try {
 for (var g = a(v), h = g.next(); !h.done; h = g.next()) {
 var R = h.value;
-if (hh(R)) {
+if (Eh(R)) {
 var E = Game.rooms[R];
 if (E) {
 var T = Z(E).filter(so);
-if (T.length > 0 && dg(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
+if (T.length > 0 && fg(e, t, R) < Math.min(p.maxPerRoom, Math.ceil(T.length / 2))) return !0;
 }
 }
 }
@@ -39291,9 +39295,9 @@ if (n) throw n.error;
 }
 return !1;
 }
-var C = null !== (u = lg(e).get(t)) && void 0 !== u ? u : 0;
-if ("pioneer" === t) return null !== qg(e, r);
-if (C >= Rh(e, t, r)) return !1;
+var C = null !== (u = dg(e).get(t)) && void 0 !== u ? u : 0;
+if ("pioneer" === t) return null !== zg(e, r);
+if (C >= Th(e, t, r)) return !1;
 if (!f) return !1;
 if ("scout" === t) {
 if (r.danger >= 1) return !1;
@@ -39305,14 +39309,14 @@ var r = wr.getEmpire();
 for (var o in r.knownRooms) {
 var n = r.knownRooms[o];
 if (n && !n.scouted) {
-var a = hg(e, o);
+var a = Eg(e, o);
 if (null !== a && a >= 1 && a <= t && !n.owner && !n.reserver && !n.isHighway && !n.isSK) return !0;
 }
 }
 return !1;
 }(e));
 }
-if ("claimer" === t) return null !== kg(e, r);
+if ("claimer" === t) return null !== Ag(e, r);
 if ("interShardScout" === t || "interShardClaimer" === t || "interShardPioneer" === t) return !1;
 if ("mineralHarvester" === t) {
 var w = f.find(FIND_MINERALS)[0];
@@ -39348,7 +39352,7 @@ return e.amount - e.delivered > 500 && t < 2;
 if (!b) return !1;
 }
 if ("crossShardCarrier" === t) {
-var O = null !== (d = null === (m = $v.getActiveRequests) || void 0 === m ? void 0 : m.call($v)) && void 0 !== d ? d : [];
+var O = null !== (d = null === (m = tg.getActiveRequests) || void 0 === m ? void 0 : m.call(tg)) && void 0 !== d ? d : [];
 if (0 === O.length) return !1;
 if (b = O.some(function(e) {
 var t, r, o;
@@ -39376,16 +39380,16 @@ return s < i && c < 3;
 return !0;
 }
 
-function Ch(e) {
+function wh(e) {
 var t, r;
 return (null !== (t = e.get("harvester")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }
 
-function Sh(e) {
-return 0 === Ch(lg(e, !0));
+function xh(e) {
+return 0 === wh(dg(e, !0));
 }
 
-function wh(e) {
+function bh(e) {
 var t = ft(e);
 return [ {
 role: "harvester",
@@ -39408,14 +39412,14 @@ minCount: 1
 } ];
 }
 
-function xh(e, t) {
-var r, o, n, i, s = lg(e, !0);
-if (0 === Ch(s)) return !0;
+function Oh(e, t) {
+var r, o, n, i, s = dg(e, !0);
+if (0 === wh(s)) return !0;
 if (0 === function(e) {
 var t, r;
 return (null !== (t = e.get("hauler")) && void 0 !== t ? t : 0) + (null !== (r = e.get("larvaWorker")) && void 0 !== r ? r : 0);
 }(s) && (null !== (n = s.get("harvester")) && void 0 !== n ? n : 0) > 0) return !0;
-var c = lg(e, !1), u = wh(t);
+var c = dg(e, !1), u = bh(t);
 try {
 for (var l = a(u), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
@@ -39435,36 +39439,36 @@ if (r) throw r.error;
 return !1;
 }
 
-var bh = [ "guard", "ranger", "healer" ];
+var kh = [ "guard", "ranger", "healer" ];
 
-function Oh(e, t, r) {
+function Mh(e, t, r) {
 void 0 === r && (r = 1), e[t] += r, e.total += r;
 }
 
-function kh(e, t) {
+function Ah(e, t) {
 var r, o;
 return null !== (r = e.assistTarget) && void 0 !== r ? r : e.task === vi ? null !== (o = e.targetRoom) && void 0 !== o ? o : t : void 0;
 }
 
-function Mh(e) {
+function Uh(e) {
 var t;
-return Bo(e.role) && void 0 !== kh(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
+return Bo(e.role) && void 0 !== Ah(null !== (t = e.additionalMemory) && void 0 !== t ? t : {}, e.targetRoom);
 }
 
-function Ah(e, t) {
+function _h(e, t) {
 var r, o, n;
 return "guard" === t ? Math.max(0, null !== (r = e.guardsNeeded) && void 0 !== r ? r : 0) : "ranger" === t ? Math.max(0, null !== (o = e.rangersNeeded) && void 0 !== o ? o : 0) : Math.max(0, null !== (n = e.healersNeeded) && void 0 !== n ? n : 0);
 }
 
-function Uh(e, t) {
+function Nh(e, t) {
 return 0 === t.length ? e : bo(e, wo(t));
 }
 
-function _h(e, t) {
-e.assignedPower = Uh(e.assignedPower, t);
+function Ph(e, t) {
+e.assignedPower = Nh(e.assignedPower, t);
 }
 
-function Nh(e, t) {
+function Ih(e, t) {
 var r, o;
 if (void 0 !== t.defenseAssistReleasedAt) {
 var n = null !== (r = t.defenseAssistReleaseReason) && void 0 !== r ? r : "unknown";
@@ -39474,10 +39478,10 @@ e.released.lastReason = n);
 }
 }
 
-function Ph(e, t) {
+function Gh(e, t) {
 e.parityPercent = e.targetScore > 0 ? Math.min(100, t.score / e.targetScore * 100) : 0,
 e.blockReason = function(e) {
-var t = bh.filter(function(t) {
+var t = kh.filter(function(t) {
 return e.queued[t] > 0;
 });
 if (t.length > 0 && t.every(function(t) {
@@ -39489,50 +39493,50 @@ return e.requested.total > 0 && 0 === r ? "no-local-assist" : "none";
 }(e);
 }
 
-function Ih(e) {
+function Lh(e) {
 Game.rooms[e.name] || (Game.rooms[e.name] = e);
 }
 
-function Gh(e, t, r) {
-var n = Rh(e.name, r.roleName, t);
+function Dh(e, t, r) {
+var n = Th(e.name, r.roleName, t);
 return o(o({}, r), {
 target: n,
 missing: Math.max(0, n - r.current)
 });
 }
 
-function Lh(e, t, r, o, n) {
-if (n && ("larvaWorker" === r || "harvester" === r)) return Lv.EMERGENCY;
+function Bh(e, t, r, o, n) {
+if (n && ("larvaWorker" === r || "harvester" === r)) return Bv.EMERGENCY;
 if ("upgrader" === r && function() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.controllerDowngradePriority);
 }() && function(e) {
 var t = e.controller;
 return !!(null == t ? void 0 : t.my) && t.ticksToDowngrade <= 5e3;
-}(e)) return Lv.HIGH;
-if (rg.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
+}(e)) return Bv.HIGH;
+if (ng.getEmergencyState(e.name) && ("guard" === r || "ranger" === r || "healer" === r)) {
 var a = function(e, t, r) {
 var o = po(e), n = vo(e);
 return 0 === o.guards && 0 === o.rangers && 0 === o.healers ? 0 : "guard" === r && n.guards < o.guards || "ranger" === r && n.rangers < o.rangers || "healer" === r && n.healers < o.healers ? 100 * o.urgency : 0;
 }(e, 0, r);
-if (a >= 100) return Lv.EMERGENCY;
-if (a > 0) return Lv.HIGH;
+if (a >= 100) return Bv.EMERGENCY;
+if (a > 0) return Bv.HIGH;
 }
 return function(e) {
-return e >= 90 ? Lv.HIGH : e >= 60 ? Lv.NORMAL : Lv.LOW;
+return e >= 90 ? Bv.HIGH : e >= 60 ? Bv.NORMAL : Bv.LOW;
 }(o);
 }
 
-function Dh(e, t) {
+function Fh(e, t) {
 var r, o, n = function(e) {
 return s([], i(e), !1).sort(function(e, t) {
 return t.priority - e.priority;
 });
 }(function(e, t) {
 var r, o, n, s, c, u, l;
-Ih(e);
-var m = lg(e.name), d = Sh(e.name), p = [], f = vh(e.name, "hauler");
-if (f && (R = Hv.hauler)) return [ {
+Lh(e);
+var m = dg(e.name), d = xh(e.name), p = [], f = hh(e.name, "hauler");
+if (f && (R = Yv.hauler)) return [ {
 roleName: "hauler",
 def: R,
 current: E = null !== (n = m.get("hauler")) && void 0 !== n ? n : 0,
@@ -39542,14 +39546,14 @@ priority: f.priority,
 task: f.task,
 bodyOverride: f.body
 } ];
-if (xh(e.name, e)) {
+if (Oh(e.name, e)) {
 var y = function(e, t, r) {
 var o, n, i;
-if (0 === Ch(lg(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
+if (0 === wh(dg(e, !0))) return U.info("Bootstrap: Spawning larvaWorker (emergency - no active energy producers)", {
 subsystem: "spawn",
 room: e
 }), "larvaWorker";
-var s = lg(e, !1), c = wh(t);
+var s = dg(e, !1), c = bh(t);
 U.info("Bootstrap: Checking ".concat(c.length, " roles in order"), {
 subsystem: "spawn",
 room: e,
@@ -39564,7 +39568,7 @@ var m = l.value;
 if (!m.condition || m.condition(t)) {
 var d = null !== (i = s.get(m.role)) && void 0 !== i ? i : 0;
 if (d < m.minCount) {
-var p = Th(e, m.role, r, !0);
+var p = Sh(e, m.role, r, !0);
 if (U.info("Bootstrap: Role ".concat(m.role, " needs spawning (current: ").concat(d, ", min: ").concat(m.minCount, ", needsRole: ").concat(p, ")"), {
 subsystem: "spawn",
 room: e
@@ -39595,17 +39599,17 @@ subsystem: "spawn",
 room: e
 }), null;
 }(e.name, e, t);
-return y && (R = Hv[y]) && Th(e.name, y, t, !0) ? (p.push(Gh(e, t, {
+return y && (R = Yv[y]) && Sh(e.name, y, t, !0) ? (p.push(Dh(e, t, {
 roleName: y,
 def: R,
 current: null !== (s = m.get(y)) && void 0 !== s ? s : 0,
-priority: Lh(e, 0, y, R.priority, d),
+priority: Bh(e, 0, y, R.priority, d),
 bootstrap: !0
 })), p) : p;
 }
 try {
-for (var v = a(Object.entries(Hv)), g = v.next(); !g.done; g = v.next()) {
-var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (c = m.get(y)) && void 0 !== c ? c : 0, T = vh(e.name, y);
+for (var v = a(Object.entries(Yv)), g = v.next(); !g.done; g = v.next()) {
+var h = i(g.value, 2), R = (y = h[0], h[1]), E = null !== (c = m.get(y)) && void 0 !== c ? c : 0, T = hh(e.name, y);
 if (T) p.push({
 roleName: y,
 def: R,
@@ -39616,7 +39620,7 @@ priority: T.priority,
 task: T.task,
 bodyOverride: T.body
 }); else {
-var C = ph(e.name, y);
+var C = yh(e.name, y);
 if (C) p.push({
 roleName: y,
 def: R,
@@ -39630,8 +39634,8 @@ assistTarget: C.targetRoom,
 defenseSquadId: C.defenseSquadId,
 defenseSquadSize: C.defenseSquadSize,
 defenseSquadCreatedAt: C.defenseSquadCreatedAt
-}); else if (Th(e.name, y, t, d)) {
-var S = yg(y), w = S ? Eh(e.name, y, t) : null, x = "claimer" === y ? kg(e.name, t) : null, b = "pioneer" === y ? qg(e.name, t) : null;
+}); else if (Sh(e.name, y, t, d)) {
+var S = gg(y), w = S ? Ch(e.name, y, t) : null, x = "claimer" === y ? Ag(e.name, t) : null, b = "pioneer" === y ? zg(e.name, t) : null;
 S && !w || ("claimer" !== y || x) && ("pioneer" !== y || b) && (b ? p.push({
 roleName: y,
 def: R,
@@ -39641,11 +39645,11 @@ missing: 1,
 priority: b.priority,
 targetRoom: b.targetRoom,
 task: b.task
-}) : p.push(Gh(e, t, {
+}) : p.push(Dh(e, t, {
 roleName: y,
 def: R,
 current: E,
-priority: Lh(e, 0, y, R.priority, d),
+priority: Bh(e, 0, y, R.priority, d),
 targetRoom: null !== (l = null !== (u = null == x ? void 0 : x.targetRoom) && void 0 !== u ? u : w) && void 0 !== l ? l : void 0,
 task: null == x ? void 0 : x.task
 })));
@@ -39667,7 +39671,7 @@ return p;
 }(e, t)), c = [];
 try {
 for (var u = a(n), l = u.next(); !l.done; l = u.next()) {
-var m = Bh(e, l.value);
+var m = Wh(e, l.value);
 m && c.push(m);
 }
 } catch (e) {
@@ -39688,12 +39692,12 @@ requests: c
 };
 }
 
-function Bh(e, t) {
+function Wh(e, t) {
 var r, n, i, s = e.energyCapacityAvailable;
 try {
-var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = eg.getMaxAffordableInTicks(e, c), l = Ng(e), m = t.priority >= Lv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Bo(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Lv.EMERGENCY, y = t.assistTarget ? Mo(t.assistTarget) : null, v = d ? Io(d, s, y) : null, g = d && f ? function(e, t, r, o) {
+var c = 3 * Math.max(3, Math.min(50, Math.floor(s / 100))), u = rg.getMaxAffordableInTicks(e, c), l = Ig(e), m = t.priority >= Bv.EMERGENCY || t.bootstrap ? l : Math.max(s, u), d = t.assistTarget && Bo(t.roleName) ? t.roleName : null, p = Boolean(d), f = p && t.priority >= Bv.EMERGENCY, y = t.assistTarget ? Mo(t.assistTarget) : null, v = d ? Io(d, s, y) : null, g = d && f ? function(e, t, r, o) {
 var n;
-return null !== (n = [ Io(e, t, r), zg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
+return null !== (n = [ Io(e, t, r), Xg(e, t, r), o && o.cost <= t ? o : null ].find(function(t) {
 return function(e, t, r) {
 if (!t) return !1;
 if ("ranger" !== e) return !0;
@@ -39726,7 +39730,7 @@ if (r) throw r.error;
 }
 }
 return n;
-}(t.def, m)) && void 0 !== i ? i : zv({
+}(t.def, m)) && void 0 !== i ? i : Xv({
 maxEnergy: m,
 role: t.roleName
 }), E = t.bodyOverride ? s : h ? f ? l : s : m;
@@ -39762,44 +39766,44 @@ subsystem: "SpawnCoordinator"
 }
 }
 
-var Fh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Wh = new Set([ "guard", "ranger", "healer" ]);
+var Hh = new Set([ "pioneer", "remoteHarvester", "remoteHauler", "scout" ]), Kh = new Set([ "guard", "ranger", "healer" ]);
 
-function Hh() {
+function Yh() {
 var e;
 return !1 !== (null === (e = Memory.spawnSettings) || void 0 === e ? void 0 : e.claimerPreemption);
 }
 
-function Kh(e) {
+function Vh(e) {
 var t, r, o, n = null !== (r = null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task) && void 0 !== r ? r : "";
 return "".concat(e.role, ":").concat(null !== (o = e.targetRoom) && void 0 !== o ? o : "", ":").concat(n);
 }
 
-function Yh(e) {
+function qh(e) {
 var t;
-return e.priority >= Lv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Bv.HIGH && "defenseAssist" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function Vh(e) {
+function jh(e) {
 var t;
-return e.priority >= Lv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
+return e.priority >= Bv.EMERGENCY && "hauler" === e.role && "defenseRefuel" === (null === (t = e.additionalMemory) || void 0 === t ? void 0 : t.task);
 }
 
-function qh(e, t, r, n) {
-var i, s, c, u = e.energyCapacityAvailable, l = Ng(e), m = ko(Z(e)), d = function(e) {
+function zh(e, t, r, n) {
+var i, s, c, u = e.energyCapacityAvailable, l = Ig(e), m = ko(Z(e)), d = function(e) {
 var t = null == e ? void 0 : e.strongest;
 return Boolean(t && (t.partCount >= 25 || t.score >= 250));
-}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Lv.EMERGENCY : Lv.HIGH, f = d ? u : p === Lv.EMERGENCY ? l : u, y = function(e, t) {
+}(m), p = d || r.urgency >= 2 || t.danger >= 3 ? Bv.EMERGENCY : Bv.HIGH, f = d ? u : p === Bv.EMERGENCY ? l : u, y = function(e, t) {
 var r, o, n = {
 guards: 0,
 rangers: 0,
 healers: 0
 }, i = {};
 try {
-for (var s = a(Jv.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(eg.getPendingRequests(e)), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-Game.time - u.createdAt > 1500 || u.body.cost > t || jh(u, e) && ("guard" === u.role && (n.guards++,
-Qh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Qh(i, "ranger", u.body.parts)),
-"healer" === u.role && (n.healers++, Qh(i, "healer", u.body.parts)));
+Game.time - u.createdAt > 1500 || u.body.cost > t || Qh(u, e) && ("guard" === u.role && (n.guards++,
+Zh(i, "guard", u.body.parts)), "ranger" === u.role && (n.rangers++, Zh(i, "ranger", u.body.parts)),
+"healer" === u.role && (n.healers++, Zh(i, "healer", u.body.parts)));
 }
 } catch (e) {
 r = {
@@ -39827,7 +39831,7 @@ if ("guard" === u || "ranger" === u || "healer" === u) {
 var l = (null !== (o = c.body) && void 0 !== o ? o : []).filter(function(e) {
 return e.hits > 0;
 });
-0 !== l.length && Qh(n, u, l);
+0 !== l.length && Zh(n, u, l);
 }
 }
 }
@@ -39866,26 +39870,26 @@ return i;
 guard: Math.max(0, r.guards - n.guards - y.counts.guards),
 ranger: Math.max(0, r.rangers - n.rangers - y.counts.rangers),
 healer: Math.max(0, r.healers - n.healers - y.counts.healers)
-}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : zh("guard", f, m);
-if (R > 0 && E) for (var T = 0; T < R; T++) Zh(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
-var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : zh("ranger", f, m);
-if (C > 0 && S) for (T = 0; T < C; T++) Zh(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
-var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : zh("healer", f, m);
-if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) Zh(e, "healer", "military", Lv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
+}, g), R = h.counts.guard, E = null !== (i = h.bodies.guard) && void 0 !== i ? i : Xh("guard", f, m);
+if (R > 0 && E) for (var T = 0; T < R; T++) $h(e, "guard", "military", p, f, "guard_defense_".concat(Game.time, "_").concat(T), E);
+var C = h.counts.ranger, S = null !== (s = h.bodies.ranger) && void 0 !== s ? s : Xh("ranger", f, m);
+if (C > 0 && S) for (T = 0; T < C; T++) $h(e, "ranger", "military", p, f, "ranger_defense_".concat(Game.time, "_").concat(T), S);
+var w = h.counts.healer, x = null !== (c = h.bodies.healer) && void 0 !== c ? c : Xh("healer", f, m);
+if (w > 0 && x && (r.urgency >= 1.5 || h.healerFloor > 0)) for (T = 0; T < w; T++) $h(e, "healer", "military", Bv.HIGH, f, "healer_defense_".concat(Game.time, "_").concat(T), x);
 !function(e, t, r, o) {
-if (!(t < Lv.EMERGENCY || function(e, t) {
+if (!(t < Bv.EMERGENCY || function(e, t) {
 var r, o, n = e.find(FIND_MY_CREEPS).filter(function(e) {
 var t;
 if (e.spawning) return !1;
 var r = e.memory.role;
-return !(!r || !Wh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
+return !(!r || !Kh.has(r)) && (null !== (t = e.body) && void 0 !== t ? t : []).some(function(e) {
 return e.hits > 0 && (e.type === ATTACK || e.type === RANGED_ATTACK);
 });
 }).length;
 try {
-for (var i = a(Jv.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
+for (var i = a(eg.getPendingRequests(e.name)), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-c.priority < Lv.EMERGENCY || Wh.has(c.role) && jh(c, e.name) && c.body.cost <= t && n++;
+c.priority < Bv.EMERGENCY || Kh.has(c.role) && Qh(c, e.name) && c.body.cost <= t && n++;
 }
 } catch (e) {
 r = {
@@ -39902,7 +39906,7 @@ return n;
 }(e, r) >= 3)) {
 var n = function(e, t) {
 var r, o = [ "guard", "ranger" ].map(function(t) {
-var r = jg(t, e);
+var r = Qg(t, e);
 return r ? {
 role: t,
 body: r
@@ -39917,45 +39921,45 @@ var r = wo(t.body.parts).score - wo(e.body.parts).score;
 return 0 !== r ? r : (null == n ? void 0 : n.ranged) && e.role !== t.role ? "ranger" === e.role ? -1 : 1 : e.body.cost - t.body.cost;
 })[0]) && void 0 !== r ? r : null;
 }(r, o);
-n && Zh(e, n.role, "military", Lv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
+n && $h(e, n.role, "military", Bv.EMERGENCY, r, "".concat(n.role, "_defense_affordable_").concat(Game.time), n.body);
 }
 }(e, p, l, m), (R > 0 || C > 0 || w > 0) && U.info("Added defender spawn requests: ".concat(R, " guards, ").concat(C, " rangers, ").concat(w, " healers (priority: ").concat(p, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
 
-function jh(e, t) {
+function Qh(e, t) {
 var r, o;
 return !(e.targetRoom && e.targetRoom !== t || "defenseAssist" === (null === (r = e.additionalMemory) || void 0 === r ? void 0 : r.task) || (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.assistTarget));
 }
 
-function zh(e, t, r) {
+function Xh(e, t, r) {
 return r ? Io(e, t, r) : null;
 }
 
-function Qh(e, t, r) {
+function Zh(e, t, r) {
 var o = wo(r);
 e[t] = e[t] ? bo(e[t], o) : o;
 }
 
-function Xh(e, t, r) {
-return Jv.getPendingRequests(e).filter(function(e) {
+function Jh(e, t, r) {
+return eg.getPendingRequests(e).filter(function(e) {
 var o;
 return e.role === t && e.targetRoom === r && "powerBank" === (null === (o = e.additionalMemory) || void 0 === o ? void 0 : o.task);
 }).length;
 }
 
-function Zh(e, t, r, o, n, a, i, s, c) {
+function $h(e, t, r, o, n, a, i, s, c) {
 void 0 === i && (i = null);
 try {
-var u = null != i ? i : zv({
+var u = null != i ? i : Xv({
 maxEnergy: n,
 role: t
 });
 if (u.cost > n) return void U.warn("Skipping unspawnable ".concat(t, " request in ").concat(e.name, ": body cost ").concat(u.cost, " exceeds ").concat(n), {
 subsystem: "SpawnPipeline"
 });
-Jv.addRequest({
+eg.addRequest({
 id: a,
 roomName: e.name,
 role: t,
@@ -39973,34 +39977,34 @@ subsystem: "SpawnPipeline"
 }
 }
 
-function Jh(e, t, r) {
-if (void 0 === r && (r = e.energyAvailable), t.priority >= Lv.HIGH) return !1;
+function eR(e, t, r) {
+if (void 0 === r && (r = e.energyAvailable), t.priority >= Bv.HIGH) return !1;
 var o = r;
 if (o < t.body.cost) return !1;
 if ("scout" === t.role) return !1;
-if (t.priority < Lv.NORMAL) {
-if (eg.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
+if (t.priority < Bv.NORMAL) {
+if (rg.predictEnergyInTicks(e, 50).netFlow < 0) return !0;
 if (o / e.energyCapacityAvailable < .5) return !0;
 }
-return t.priority === Lv.NORMAL && o / e.energyCapacityAvailable < .3 && eg.predictEnergyInTicks(e, 25).netFlow > 0;
+return t.priority === Bv.NORMAL && o / e.energyCapacityAvailable < .3 && rg.predictEnergyInTicks(e, 25).netFlow > 0;
 }
 
-function $h(e, t) {
+function tR(e, t) {
 return function(e, t) {
 !function(e, t) {
 var r, o, n, i;
-Ih(e);
-var s = Jv.getQueueSize(e.name);
+Lh(e);
+var s = eg.getQueueSize(e.name);
 if (function(e) {
 return e.find(FIND_MY_SPAWNS).length > 0 && e.energyCapacityAvailable > 0;
 }(e)) {
-var c = xh(e.name, e), u = Sh(e.name) && !Jv.hasEmergencySpawns(e.name), l = po(e), m = vo(e);
+var c = Oh(e.name, e), u = xh(e.name) && !eg.hasEmergencySpawns(e.name), l = po(e), m = vo(e);
 if (c) {
-s > 0 && Jv.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && qh(e, t, l, m);
+s > 0 && eg.clearQueue(e.name), (l.guards > 0 || l.rangers > 0 || l.healers > 0) && zh(e, t, l, m);
 try {
-for (var d = a(Dh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
+for (var d = a(Fh(e, t).requests), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
-Jv.addRequest(f);
+eg.addRequest(f);
 }
 } catch (e) {
 r = {
@@ -40013,8 +40017,8 @@ p && !p.done && (o = d.return) && o.call(d);
 if (r) throw r.error;
 }
 }
-} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && qh(e, t, l, m), function(e) {
-var t, r, o = tg.requestSpawns(e.name), n = function(e) {
+} else if ((l.guards > 0 || l.rangers > 0 || l.healers > 0) && zh(e, t, l, m), function(e) {
+var t, r, o = og.requestSpawns(e.name), n = function(e) {
 var t;
 return (null === (t = e.operations) || void 0 === t ? void 0 : t.length) ? e.operations.filter(function(e) {
 return e.targetRoom && (e.powerHarvesters > 0 || e.healers > 0 || e.powerCarriers > 0);
@@ -40026,17 +40030,17 @@ powerCarriers: e.powerCarriers
 } ] : [];
 }(o);
 if (0 !== n.length) {
-var i = e.energyCapacityAvailable, s = Lv.NORMAL, c = 0, u = 0, l = 0;
+var i = e.energyCapacityAvailable, s = Bv.NORMAL, c = 0, u = 0, l = 0;
 try {
 for (var m = a(n), d = m.next(); !d.done; d = m.next()) {
 for (var p = d.value, f = p.targetRoom, y = {
 task: "powerBank",
 targetRoom: f
-}, v = Xh(e.name, "powerHarvester", f), g = Xh(e.name, "healer", f), h = Xh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) Zh(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+}, v = Jh(e.name, "powerHarvester", f), g = Jh(e.name, "healer", f), h = Jh(e.name, "powerCarrier", f), R = 0; R < Math.max(0, p.powerHarvesters - v); R++) $h(e, "powerHarvester", "power", s, i, "powerHarvester_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 c++;
-for (R = 0; R < Math.max(0, p.healers - g); R++) Zh(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.healers - g); R++) $h(e, "healer", "military", s, i, "healer_powerBank_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 u++;
-for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) Zh(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
+for (R = 0; R < Math.max(0, p.powerCarriers - h); R++) $h(e, "powerCarrier", "power", s, i, "powerCarrier_".concat(f, "_").concat(Game.time, "_").concat(R), null, f, y),
 l++;
 }
 } catch (e) {
@@ -40065,13 +40069,13 @@ o.spawnPipeline.lastPreemptiveReplanTickByRoom;
 }(), s = null !== (n = i[e.name]) && void 0 !== n ? n : -1 / 0;
 if (!(Game.time - s < 5)) {
 i[e.name] = Game.time;
-var c = new Set(Jv.getPendingRequests(e.name).map(Kh));
+var c = new Set(eg.getPendingRequests(e.name).map(Vh));
 try {
-for (var u = a(Dh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = "upgrader" === m.role && m.priority >= Lv.HIGH, p = "claimer" === m.role && Hh(), f = Yh(m), y = Vh(m);
-if (Fh.has(m.role) || d || p || f || y) {
-var v = Kh(m);
-c.has(v) || (Jv.addRequest(m), c.add(v));
+for (var u = a(Fh(e, t).requests), l = u.next(); !l.done; l = u.next()) {
+var m = l.value, d = "upgrader" === m.role && m.priority >= Bv.HIGH, p = "claimer" === m.role && Yh(), f = qh(m), y = jh(m);
+if (Hh.has(m.role) || d || p || f || y) {
+var v = Vh(m);
+c.has(v) || (eg.addRequest(m), c.add(v));
 }
 }
 } catch (e) {
@@ -40088,8 +40092,8 @@ if (r) throw r.error;
 }
 }(e, t); else {
 try {
-for (var y = a(Dh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
-Jv.addRequest(f);
+for (var y = a(Fh(e, t).requests), v = y.next(); !v.done; v = y.next()) f = v.value,
+eg.addRequest(f);
 } catch (e) {
 n = {
 error: e
@@ -40101,32 +40105,32 @@ v && !v.done && (i = y.return) && i.call(y);
 if (n) throw n.error;
 }
 }
-var g = Jv.getQueueStats(e.name);
+var g = eg.getQueueStats(e.name);
 U.debug("Populated spawn queue for ".concat(e.name, ": ").concat(g.total, " requests (E:").concat(g.emergency, ", H:").concat(g.high, ", N:").concat(g.normal, ", L:").concat(g.low, ")"), {
 subsystem: "SpawnPipeline"
 });
 }
-} else s > 0 && Jv.clearQueue(e.name);
+} else s > 0 && eg.clearQueue(e.name);
 }(e, t);
 var r = function(e) {
-var t, r, o = Jv.getAvailableSpawns(e.name);
+var t, r, o = eg.getAvailableSpawns(e.name);
 if (0 === o.length) return 0;
-var n = 0, i = Ng(e);
+var n = 0, i = Ig(e);
 try {
 for (var s = a(o), c = s.next(); !c.done; c = s.next()) {
-var u = c.value, l = Jv.getNextRequest(e.name, i);
+var u = c.value, l = eg.getNextRequest(e.name, i);
 if (!l) break;
-if (Jh(e, l, i)) {
+if (eR(e, l, i)) {
 U.debug("Delaying spawn of ".concat(l.role, " (priority: ").concat(l.priority, ") - waiting for better energy availability"), {
 subsystem: "SpawnPipeline"
 });
 break;
 }
-var m = Xv(u, l);
-m === OK ? (n++, i -= l.body.cost, Jv.markInProgress(e.name, l.id, u.id), Jv.removeRequest(e.name, l.id),
+var m = Jv(u, l);
+m === OK ? (n++, i -= l.body.cost, eg.markInProgress(e.name, l.id, u.id), eg.removeRequest(e.name, l.id),
 U.info("Spawned ".concat(l.role, " in ").concat(e.name, " (priority: ").concat(l.priority, ", cost: ").concat(l.body.cost, ")"), {
 subsystem: "SpawnPipeline"
-})) : m !== ERR_NOT_ENOUGH_ENERGY && (Jv.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
+})) : m !== ERR_NOT_ENOUGH_ENERGY && (eg.removeRequest(e.name, l.id), U.warn("Spawn failed for ".concat(l.role, " in ").concat(e.name, ": ").concat(m), {
 subsystem: "SpawnPipeline"
 }));
 }
@@ -40142,12 +40146,12 @@ if (t) throw t.error;
 }
 }
 return n;
-}(e), o = Jv.getQueueStats(e.name), n = function(e) {
+}(e), o = eg.getQueueStats(e.name), n = function(e) {
 var t, r, o, n, c, u, l, m, d, p, f, y, v, g, h, R, E, T = Game.rooms[e];
 if (!T) return [];
-var C = Ng(T), S = new Map, w = new Map, x = function(e, t) {
+var C = Ig(T), S = new Map, w = new Map, x = function(e, t) {
 var r;
-w.set(e, Uh(null !== (r = w.get(e)) && void 0 !== r ? r : {
+w.set(e, Nh(null !== (r = w.get(e)) && void 0 !== r ? r : {
 partCount: 0,
 attack: 0,
 ranged: 0,
@@ -40223,7 +40227,7 @@ return function(e, t, r) {
 var o, n, i, s = Mo(e.targetRoom);
 e.targetScore = null !== (i = null == s ? void 0 : s.total.score) && void 0 !== i ? i : 0;
 try {
-for (var c = a(bh), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(kh), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Io(l, t.energyCapacityAvailable, s);
 m ? (e.bodyCost[l] = m.cost, e.affordable[l] = m.cost <= r) : e.affordable[l] = !1;
 }
@@ -40243,15 +40247,15 @@ if (o) throw o.error;
 try {
 for (var O = a(function(e, t) {
 void 0 === t && (t = {});
-var r = Zg(e), o = r.filter(Xg);
+var r = $g(e), o = r.filter(Jg);
 return t.prune && Array.isArray(e.defenseRequests) && o.length !== r.length && (e.defenseRequests = o),
 o;
 }(Memory)), k = O.next(); !k.done; k = O.next()) if ((I = k.value).roomName !== e) {
 var M = b(I.roomName, null !== (f = I.urgency) && void 0 !== f ? f : 0);
 try {
-for (var A = (o = void 0, a(bh)), U = A.next(); !U.done; U = A.next()) {
+for (var A = (o = void 0, a(kh)), U = A.next(); !U.done; U = A.next()) {
 var _ = U.value;
-Oh(M.requested, _, Ah(I, _));
+Mh(M.requested, _, _h(I, _));
 }
 } catch (e) {
 o = {
@@ -40277,11 +40281,11 @@ if (t) throw t.error;
 }
 }
 try {
-for (var N = a(Jv.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
+for (var N = a(eg.getPendingRequests(e)), P = N.next(); !P.done; P = N.next()) {
 var I;
-Mh(I = P.value) && (D = kh(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Oh((M = b(D)).queued, I.role),
+Uh(I = P.value) && (D = Ah(null !== (y = I.additionalMemory) && void 0 !== y ? y : {}, I.targetRoom)) && (Mh((M = b(D)).queued, I.role),
 M.bodyCost[I.role] = Math.max(null !== (v = M.bodyCost[I.role]) && void 0 !== v ? v : 0, I.body.cost),
-M.affordable[I.role] = I.body.cost <= C, _h(M, I.body.parts));
+M.affordable[I.role] = I.body.cost <= C, Ph(M, I.body.parts));
 }
 } catch (e) {
 c = {
@@ -40297,13 +40301,13 @@ if (c) throw c.error;
 try {
 for (var G = a(Object.values(Game.creeps)), L = G.next(); !L.done; L = G.next()) {
 var D, B = L.value, F = null !== (g = B.memory) && void 0 !== g ? g : {};
-if (F.homeRoom === e && Bo(_ = null !== (h = F.role) && void 0 !== h ? h : "") && (D = kh(F))) {
+if (F.homeRoom === e && Bo(_ = null !== (h = F.role) && void 0 !== h ? h : "") && (D = Ah(F))) {
 M = b(D);
 var W = (null !== (R = B.body) && void 0 !== R ? R : []).filter(function(e) {
 return e.hits > 0;
 });
-B.spawning ? Oh(M.spawning, _) : void 0 === F.defenseAssistReleasedAt && B.room.name === e ? (Oh(M.staged, _),
-x(D, W)) : B.room.name === D ? Oh(M.arrived, _) : Oh(M.moving, _), Nh(M, F), _h(M, W);
+B.spawning ? Mh(M.spawning, _) : void 0 === F.defenseAssistReleasedAt && B.room.name === e ? (Mh(M.staged, _),
+x(D, W)) : B.room.name === D ? Mh(M.arrived, _) : Mh(M.moving, _), Ih(M, F), Ph(M, W);
 }
 }
 } catch (e) {
@@ -40319,7 +40323,7 @@ if (l) throw l.error;
 }
 var H = s([], i(S.values()), !1);
 try {
-for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) Ph(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : xo());
+for (var K = a(H), Y = K.next(); !Y.done; Y = K.next()) Gh(M = Y.value, null !== (E = w.get(M.targetRoom)) && void 0 !== E ? E : xo());
 } catch (e) {
 d = {
 error: e
@@ -40349,7 +40353,7 @@ defenseAssist: n
 }(e, t);
 }
 
-var eR = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, tR = /^(\d{1,2})\|(.+)$/, rR = M("SS2TerminalComms"), oR = function() {
+var rR = /^([\da-zA-Z]{1,3})\|([\d]{1,2})\|(.+)$/, oR = /^(\d{1,2})\|(.+)$/, nR = M("SS2TerminalComms"), aR = function() {
 function e() {}
 return e.loadStateFromMemory = function() {
 if (!this._stateInitialized) {
@@ -40409,11 +40413,11 @@ enumerable: !1,
 configurable: !0
 }), e.parseTransaction = function(e) {
 return function(e) {
-var t = e.match(eR);
+var t = e.match(rR);
 if (!t) return null;
 var r, o = t[1], n = parseInt(t[2], 10), a = t[3];
 if (0 === n) {
-var i = a.match(tR);
+var i = a.match(oR);
 i && (r = parseInt(i[1], 10), a = i[2]);
 }
 return {
@@ -40448,7 +40452,7 @@ this.markTransactionProcessed(c), this.saveStateToMemory(), this.hasAllPackets(m
 for (var p = [], f = 0; f <= m.finalPacket; f++) {
 var y = m.packets.get(f);
 if (!y) {
-rR.warn("Missing packet in multi-packet message", {
+nR.warn("Missing packet in multi-packet message", {
 meta: {
 packetId: f,
 messageId: u.msgId,
@@ -40464,7 +40468,7 @@ var v = p.join("");
 o.push({
 sender: c.sender.username,
 message: v
-}), this.messageBuffers.delete(l), this.saveStateToMemory(), rR.info("Received complete multi-packet message from ".concat(c.sender.username), {
+}), this.messageBuffers.delete(l), this.saveStateToMemory(), nR.info("Received complete multi-packet message from ".concat(c.sender.username), {
 meta: {
 messageId: u.msgId,
 packets: p.length,
@@ -40488,7 +40492,7 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-return o.length > 0 && rR.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
+return o.length > 0 && nR.debug("Processed ".concat(n.length, " terminal transactions, completed ").concat(o.length, " messages")),
 o;
 }, e.splitMessage = function(e) {
 if (0 === e.length || e.length > this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT) return [];
@@ -40500,7 +40504,7 @@ r.push(i);
 return r;
 }, e.sendMessage = function(e, t, r, o, n) {
 var a = this.splitMessage(n);
-if (0 === a.length) return rR.error("Message is empty or exceeds SS2 packet limit", {
+if (0 === a.length) return nR.error("Message is empty or exceeds SS2 packet limit", {
 meta: {
 length: n.length,
 maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
@@ -40508,14 +40512,14 @@ maxLength: this.MESSAGE_CHUNK_SIZE * this.MAX_PACKET_COUNT
 }), ERR_INVALID_ARGS;
 if (1 === a.length) return e.send(r, o, t, a[0]);
 var i = this.extractMessageId(a[0]);
-return i ? (this.queuePackets(e.id, t, r, o, a, i), rR.info("Queued ".concat(a.length, " packets for multi-packet message"), {
+return i ? (this.queuePackets(e.id, t, r, o, a, i), nR.info("Queued ".concat(a.length, " packets for multi-packet message"), {
 meta: {
 terminalId: e.id,
 messageId: i,
 packets: a.length,
 targetRoom: t
 }
-}), OK) : (rR.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
+}), OK) : (nR.error("Failed to extract message ID from first packet"), ERR_INVALID_ARGS);
 }, e.extractMessageId = function(e) {
 var t = e.match(/^([\da-zA-Z]{1,3})\|/);
 return t ? t[1] : null;
@@ -40540,7 +40544,7 @@ try {
 for (var u = a(Object.entries(Memory.ss2PacketQueue)), l = u.next(); !l.done; l = u.next()) {
 var m = i(l.value, 2), d = m[0], p = m[1];
 if (Game.cpu.getUsed() - c > 5) {
-rR.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
+nR.debug("Queue processing stopped due to CPU budget limit (".concat(5, " CPU)"));
 break;
 }
 var f = Game.getObjectById(p.terminalId);
@@ -40552,7 +40556,7 @@ var v = f.send(p.resourceType, p.amount, p.targetRoom, y);
 if (v === OK) {
 if (Memory.ss2PacketQueue[d].nextPacketIndex = p.nextPacketIndex + 1, n++, Memory.ss2PacketQueue[d].nextPacketIndex >= p.packets.length) {
 var g = this.extractMessageId(y);
-rR.info("Completed sending multi-packet message", {
+nR.info("Completed sending multi-packet message", {
 meta: {
 messageId: g,
 packets: p.packets.length,
@@ -40560,25 +40564,25 @@ targetRoom: p.targetRoom
 }
 }), s.push(d);
 }
-} else v === ERR_NOT_ENOUGH_RESOURCES ? rR.warn("Not enough resources to send packet, will retry next tick", {
+} else v === ERR_NOT_ENOUGH_RESOURCES ? nR.warn("Not enough resources to send packet, will retry next tick", {
 meta: {
 queueKey: d,
 resource: p.resourceType,
 amount: p.amount
 }
-}) : (rR.error("Failed to send packet: ".concat(v, ", removing queue item"), {
+}) : (nR.error("Failed to send packet: ".concat(v, ", removing queue item"), {
 meta: {
 queueKey: d,
 result: v
 }
 }), s.push(d));
-} else rR.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
+} else nR.warn("No packet at index ".concat(p.nextPacketIndex, ", removing queue item"), {
 meta: {
 queueKey: d
 }
 }), s.push(d);
 }
-} else rR.warn("Terminal not found for queue item, removing from queue", {
+} else nR.warn("Terminal not found for queue item, removing from queue", {
 meta: {
 queueKey: d,
 terminalId: p.terminalId
@@ -40612,7 +40616,7 @@ R && !R.done && (o = h.return) && o.call(h);
 if (r) throw r.error;
 }
 }
-return n > 0 && rR.debug("Sent ".concat(n, " queued packets this tick")), n;
+return n > 0 && nR.debug("Sent ".concat(n, " queued packets this tick")), n;
 }, e.cleanupExpiredQueue = function() {
 var e, t, r, o;
 if (Memory.ss2PacketQueue) {
@@ -40622,7 +40626,7 @@ for (var c = a(Object.entries(Memory.ss2PacketQueue)), u = c.next(); !u.done; u 
 var l = i(u.value, 2), m = l[0], d = l[1];
 if (n - d.queuedAt > this.QUEUE_TIMEOUT) {
 var p = this.extractMessageId(d.packets[0]);
-rR.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
+nR.warn("Queue item timed out after ".concat(n - d.queuedAt, " ticks"), {
 meta: {
 messageId: p,
 queueKey: m,
@@ -40713,7 +40717,7 @@ var e, t, r = Game.time;
 try {
 for (var o = a(this.messageBuffers.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = s[1];
-r - u.receivedAt > this.MESSAGE_TIMEOUT && (rR.warn("Message timed out", {
+r - u.receivedAt > this.MESSAGE_TIMEOUT && (nR.warn("Message timed out", {
 meta: {
 messageId: u.msgId,
 sender: u.sender
@@ -40735,7 +40739,7 @@ if (e) throw e.error;
 try {
 return e.startsWith("{") || e.startsWith("[") ? JSON.parse(e) : null;
 } catch (e) {
-return rR.error("Error parsing JSON", {
+return nR.error("Error parsing JSON", {
 meta: {
 error: String(e)
 }
@@ -40746,7 +40750,7 @@ return JSON.stringify(e);
 }, e.MESSAGE_CHUNK_SIZE = 91, e.MAX_PACKET_COUNT = 100, e.MESSAGE_TIMEOUT = 1e3,
 e.QUEUE_TIMEOUT = 1e3, e.MESSAGE_ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 e._messageBuffers = null, e._nextMessageId = null, e._stateInitialized = !1, e;
-}(), nR = [ {
+}(), iR = [ {
 name: "metrics"
 }, {
 name: "defense"
@@ -40766,7 +40770,7 @@ name: "militaryResources"
 name: "role"
 }, {
 name: "focusRoom"
-} ], aR = function() {
+} ], sR = function() {
 function e() {}
 return e.prototype.getEmpire = function() {
 var e = Memory;
@@ -40813,9 +40817,9 @@ return r[e];
 var t, r = null === (t = Memory.rooms) || void 0 === t ? void 0 : t[e];
 return null == r ? void 0 : r.swarm;
 }, e;
-}(), iR = new aR;
+}(), cR = new sR;
 
-function sR(e) {
+function uR(e) {
 return "from" === e.direction ? e.requests.filter(function(t) {
 return t.fromRoom === e.roomName;
 }).length : e.requests.filter(function(t) {
@@ -40823,19 +40827,19 @@ return t.toRoom === e.roomName;
 }).length;
 }
 
-function cR(e, t) {
+function lR(e, t) {
 var r = t.energyNeed - e.energyNeed;
 if (0 !== r) return r;
 var o = t.needsAmount - e.needsAmount;
 return 0 !== o ? o : e.roomName.localeCompare(t.roomName);
 }
 
-function uR(e, t) {
+function mR(e, t) {
 var r = t.canProvide - e.canProvide;
 return 0 !== r ? r : e.roomName.localeCompare(t.roomName);
 }
 
-var lR = {
+var dR = {
 minBucket: 0,
 criticalEnergyThreshold: 300,
 mediumEnergyThreshold: 1e3,
@@ -40846,9 +40850,9 @@ maxRequestsPerRoom: 3,
 requestTimeout: 500,
 focusRoomMediumThreshold: 5e3,
 focusRoomLowThreshold: 15e3
-}, mR = function() {
+}, pR = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, lR), e);
+void 0 === e && (e = {}), this.config = o(o({}, dR), e);
 }
 return e.prototype.processCluster = function(e) {
 if (!(Game.cpu.bucket < this.config.minBucket)) {
@@ -40869,7 +40873,7 @@ subsystem: "ResourceSharing"
 }), !1;
 if (!e.memberRooms.includes(r.toRoom) || !e.memberRooms.includes(r.fromRoom)) return !1;
 if (Game.rooms[r.toRoom]) {
-var o = iR.getSwarmState(r.toRoom);
+var o = cR.getSwarmState(r.toRoom);
 if (o && 0 === o.metrics.energyNeed) return U.debug("Resource request from ".concat(r.fromRoom, " to ").concat(r.toRoom, " no longer needed"), {
 subsystem: "ResourceSharing"
 }), !1;
@@ -40882,7 +40886,7 @@ try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
 var c = s.value, u = Game.rooms[c];
 if (u && (null === (o = u.controller) || void 0 === o ? void 0 : o.my)) {
-var l = iR.getSwarmState(c);
+var l = cR.getSwarmState(c);
 if (l) {
 var m = e.focusRoom === c, d = this.calculateRoomEnergy(u), p = d.energyAvailable, f = d.energyCapacity, y = this.calculateEnergyNeed(u, p, l, m), v = 0;
 m ? v = 0 : p > this.config.surplusEnergyThreshold && (v = p - this.config.mediumEnergyThreshold);
@@ -40952,9 +40956,9 @@ return !e.hasTerminal;
 return o({}, e);
 }), c = n.filter(function(e) {
 return e.energyNeed > 0;
-}).sort(cR), u = n.filter(function(e) {
+}).sort(lR), u = n.filter(function(e) {
 return e.canProvide > 0;
-}).sort(uR), l = [], m = [], d = function(t) {
+}).sort(mR), l = [], m = [], d = function(t) {
 if (e.existingRequests.filter(function(e) {
 return e.toRoom === t.roomName;
 }).length + l.filter(function(e) {
@@ -40976,11 +40980,11 @@ return r.fromRoom === e && r.toRoom === t;
 });
 }(t.roomName, e.roomName, r.existingRequests, o);
 }).filter(function(e) {
-return sR({
+return uR({
 roomName: e.roomName,
 direction: "from",
 requests: r.existingRequests
-}) + sR({
+}) + uR({
 roomName: e.roomName,
 direction: "from",
 requests: o
@@ -41079,7 +41083,7 @@ subsystem: "ResourceSharing"
 });
 }
 }, e;
-}(), dR = new mR, pR = {
+}(), fR = new pR, yR = {
 1: {
 guards: 1,
 rangers: 1,
@@ -41100,14 +41104,14 @@ siegeUnits: 1
 }
 };
 
-function fR(e) {
+function vR(e) {
 var t = {};
 return e.guards > 0 && (t.guard = e.guards), e.rangers > 0 && (t.ranger = e.rangers),
 e.healers > 0 && (t.healer = e.healers), e.siegeUnits > 0 && (t.siegeUnit = e.siegeUnits),
 t;
 }
 
-function yR(e) {
+function gR(e) {
 var t, r, o = new Set(e.members.filter(function(e) {
 return Boolean(Game.creeps[e]);
 }));
@@ -41130,9 +41134,9 @@ if (t) throw t.error;
 e.members = s([], i(o), !1);
 }
 
-function vR(e) {
+function hR(e) {
 var t, r, o;
-yR(e);
+gR(e);
 var n = {};
 try {
 for (var i = a(e.members), s = i.next(); !s.done; s = i.next()) {
@@ -41156,20 +41160,20 @@ if (t) throw t.error;
 return n;
 }
 
-function gR(e) {
+function RR(e) {
 var t;
-yR(e);
-var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = vR(e);
+gR(e);
+var r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = hR(e);
 return Object.entries(r).every(function(e) {
 var t, r = i(e, 2), n = r[0], a = r[1];
 return (null !== (t = o[n]) && void 0 !== t ? t : 0) >= (null != a ? a : 0);
 });
 }
 
-function hR(e) {
-return !!gR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
+function ER(e) {
+return !!RR(e) || Boolean(e.stagingTimeoutAt && Game.time >= e.stagingTimeoutAt && function(e) {
 var t, r, o, n, a, i, s, c, u;
-yR(e);
+gR(e);
 var l = function(e) {
 var t, r = null !== (t = e.targetComposition) && void 0 !== t ? t : {}, o = Object.values(r).reduce(function(e, t) {
 return e + (null != t ? t : 0);
@@ -41180,12 +41184,12 @@ var t = Game.creeps[e];
 return t && !t.spawning;
 });
 if (l <= 0 || m.length < Math.max(2, Math.ceil(.6 * l))) return !1;
-var d = vR(e);
+var d = hR(e);
 return !(0 === (null !== (t = d.guard) && void 0 !== t ? t : 0) + (null !== (r = d.soldier) && void 0 !== r ? r : 0) + (null !== (o = d.ranger) && void 0 !== o ? o : 0) + (null !== (n = d.harasser) && void 0 !== n ? n : 0) + (null !== (a = d.siegeUnit) && void 0 !== a ? a : 0) || (null !== (s = null === (i = e.targetComposition) || void 0 === i ? void 0 : i.healer) && void 0 !== s ? s : 0) > 0 && 0 === (null !== (c = d.healer) && void 0 !== c ? c : 0) || "siege" === e.type && 0 === (null !== (u = d.siegeUnit) && void 0 !== u ? u : 0));
 }(e));
 }
 
-function RR(e, t) {
+function TR(e, t) {
 var r, o, n = e.coreRoom, i = 1 / 0;
 try {
 for (var s = a(e.memberRooms), c = s.next(); !c.done; c = s.next()) {
@@ -41206,20 +41210,20 @@ if (r) throw r.error;
 return n;
 }
 
-function ER(e, t) {
+function CR(e, t) {
 var r = function(e) {
-var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = pR[r]) && void 0 !== t ? t : pR[2];
+var t, r = Math.min(3, Math.max(1, e.urgency)), o = null !== (t = yR[r]) && void 0 !== t ? t : yR[2];
 return {
 guards: Math.max(o.guards, e.guardsNeeded),
 rangers: Math.max(o.rangers, e.rangersNeeded),
 healers: Math.max(o.healers, e.healersNeeded),
 siegeUnits: o.siegeUnits
 };
-}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = RR(e, t.roomName), a = {
+}(t), o = "defense_".concat(t.roomName, "_").concat(Game.time), n = TR(e, t.roomName), a = {
 id: o,
 type: "defense",
 members: [],
-targetComposition: fR(r),
+targetComposition: vR(r),
 rallyRoom: n,
 targetRooms: [ t.roomName ],
 state: "gathering",
@@ -41231,7 +41235,7 @@ subsystem: "Squad"
 }), a;
 }
 
-function TR(e) {
+function SR(e) {
 var t = Game.time - e.createdAt;
 if ("gathering" === e.state && t > 300) return U.warn("Squad ".concat(e.id, " timed out during formation (").concat(t, " ticks)"), {
 subsystem: "Squad"
@@ -41251,9 +41255,9 @@ subsystem: "Squad"
 return !1;
 }
 
-function CR(e) {
+function wR(e) {
 var t = e.members.length;
-yR(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
+gR(e), e.members.length < t && U.debug("Squad ".concat(e.id, " lost ").concat(t - e.members.length, " members"), {
 subsystem: "Squad"
 });
 var r = e.members.map(function(e) {
@@ -41267,7 +41271,7 @@ if (o) switch (e.state) {
 case "gathering":
 r.every(function(t) {
 return t.room.name === e.rallyRoom;
-}) && hR(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
+}) && ER(e) && (e.state = "moving", U.info("Squad ".concat(e.id, " gathered, moving to ").concat(o), {
 subsystem: "Squad"
 }));
 break;
@@ -41296,7 +41300,7 @@ subsystem: "Squad"
 }
 }
 
-var SR = {
+var xR = {
 harassment: {
 composition: {
 harassers: 3,
@@ -41383,7 +41387,7 @@ prioritizeDefenses: !0
 }
 };
 
-function wR(e, t) {
+function bR(e, t) {
 var r, o, n, a;
 if (!t) return U.debug("No intel for ".concat(e, ", defaulting to harassment"), {
 subsystem: "Doctrine"
@@ -41398,8 +41402,8 @@ subsystem: "Doctrine"
 }), "harassment");
 }
 
-function xR(e, t) {
-var r, o, n, i = SR[t], s = 0;
+function OR(e, t) {
+var r, o, n, i = xR[t], s = 0;
 try {
 for (var c = a(e.memberRooms), u = c.next(); !u.done; u = c.next()) {
 var l = u.value, m = Game.rooms[l];
@@ -41425,7 +41429,7 @@ subsystem: "Doctrine"
 }), f;
 }
 
-var bR, OR, kR, MR = {
+var kR, MR, AR, UR = {
 move: 50,
 work: 100,
 carry: 50,
@@ -41434,11 +41438,11 @@ ranged_attack: 150,
 heal: 250,
 claim: 600,
 tough: 10
-}, AR = new Map;
+}, _R = new Map;
 
-function UR(e, t) {
+function NR(e, t) {
 var r, o, n, a, i, s, c, u, l, m = t.id;
-if (AR.has(m)) U.debug("Squad ".concat(m, " already forming"), {
+if (_R.has(m)) U.debug("Squad ".concat(m, " already forming"), {
 subsystem: "SquadFormation"
 }); else {
 var d;
@@ -41450,7 +41454,7 @@ healers: null !== (a = null === (n = t.targetComposition) || void 0 === n ? void
 siegeUnits: null !== (s = null === (i = t.targetComposition) || void 0 === i ? void 0 : i.siegeUnit) && void 0 !== s ? s : 0
 }, (null !== (u = null === (c = t.targetComposition) || void 0 === c ? void 0 : c.guard) && void 0 !== u ? u : 0) > 0 && (d.soldiers = 0); else {
 var p = "harass" === t.type ? "harassment" : t.type;
-d = SR[p].composition;
+d = xR[p].composition;
 }
 var f = Object.fromEntries(Object.entries(null !== (l = t.targetComposition) && void 0 !== l ? l : {}).filter(function(e) {
 return "number" == typeof e[1];
@@ -41465,19 +41469,19 @@ currentComposition: {},
 spawnRequests: new Set,
 formationStarted: Game.time
 }, v = Game.rooms[t.rallyRoom];
-v ? (AR.set(m, y), function(e, t, r, o) {
+v ? (_R.set(m, y), function(e, t, r, o) {
 var n, a, i = !1;
 if ("defense" !== t.type) {
 var s = "harass" === t.type ? "harassment" : t.type;
-i = SR[s].useBoosts;
+i = xR[s].useBoosts;
 }
-var c = Lv.NORMAL;
-"siege" === t.type ? c = Lv.HIGH : "defense" === t.type && (c = Lv.EMERGENCY);
+var c = Bv.NORMAL;
+"siege" === t.type ? c = Bv.HIGH : "defense" === t.type && (c = Bv.EMERGENCY);
 var u = function(r, n) {
 for (var a, s = 0; s < n; s++) {
-var u = _R(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
-return e + MR[t];
-}, 0), m = i ? PR(r) : [], d = {
+var u = PR(r, 0, e.energyCapacityAvailable), l = u.reduce(function(e, t) {
+return e + UR[t];
+}, 0), m = i ? GR(r) : [], d = {
 id: "".concat(t.id, "_").concat(r, "_").concat(s, "_").concat(Game.time),
 roomName: e.name,
 role: r,
@@ -41506,7 +41510,7 @@ return e + (null != t ? t : 0);
 }, 0)
 }
 };
-Jv.addRequest(d), o.spawnRequests.add(d.id);
+eg.addRequest(d), o.spawnRequests.add(d.id);
 }
 }, l = null !== (n = t.targetComposition) && void 0 !== n ? n : {};
 (null !== (a = l.guard) && void 0 !== a ? a : 0) > 0 && u("guard", l.guard), r.harassers > 0 && u("harasser", r.harassers),
@@ -41520,42 +41524,42 @@ subsystem: "SquadFormation"
 }
 }
 
-function _R(e, t, r) {
+function PR(e, t, r) {
 var o = Math.min(r, 3e3);
 switch (e) {
 case "harasser":
-return NR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
+return IR([ MOVE, ATTACK ], o, [ MOVE, ATTACK ]);
 
 case "guard":
-return NR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return IR([ TOUGH, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "soldier":
-return NR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
+return IR([ TOUGH, MOVE, ATTACK, MOVE, ATTACK ], o, [ TOUGH, MOVE, ATTACK ]);
 
 case "ranger":
-return NR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
+return IR([ TOUGH, MOVE, RANGED_ATTACK ], o, [ MOVE, RANGED_ATTACK ]);
 
 case "healer":
-return NR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
+return IR([ TOUGH, MOVE, HEAL ], o, [ MOVE, HEAL ]);
 
 case "siegeUnit":
-return NR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
+return IR([ TOUGH, MOVE, WORK ], o, [ TOUGH, MOVE, WORK ]);
 
 default:
 return [ MOVE, ATTACK ];
 }
 }
 
-function NR(e, t, r) {
+function IR(e, t, r) {
 for (var o = s([], i(e), !1), n = e.reduce(function(e, t) {
-return e + MR[t];
+return e + UR[t];
 }, 0), a = r.reduce(function(e, t) {
-return e + MR[t];
+return e + UR[t];
 }, 0); n + a <= t && o.length < 50; ) o.push.apply(o, s([], i(r), !1)), n += a;
 return o.slice(0, 50);
 }
 
-function PR(e) {
+function GR(e) {
 switch (e) {
 case "soldier":
 return [ {
@@ -41586,45 +41590,45 @@ return [];
 }
 }
 
-function IR(e) {
-return AR.has(e);
+function LR(e) {
+return _R.has(e);
 }
 
-function GR(e) {
-return gR(e) || hR(e);
+function DR(e) {
+return RR(e) || ER(e);
 }
 
-(bR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, bR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
-bR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (OR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
-OR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, OR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
-OR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (kR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
-kR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, kR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
-kR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, kR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
+(kR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 300, kR[RESOURCE_CATALYZED_UTRIUM_ACID] = 300,
+kR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 300, (MR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 600,
+MR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, MR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 300,
+MR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 600, (AR = {})[RESOURCE_CATALYZED_GHODIUM_ALKALIDE] = 900,
+AR[RESOURCE_CATALYZED_UTRIUM_ACID] = 600, AR[RESOURCE_CATALYZED_ZYNTHIUM_ACID] = 900,
+AR[RESOURCE_CATALYZED_KEANIUM_ALKALIDE] = 600, AR[RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE] = 900;
 
-var LR = {
+var BR = {
 0: 0,
 1: 5e3,
 2: 15e3,
 3: 5e4
 };
 
-function DR(e, t) {
-var r = LR[t], o = iR.getClusters();
+function FR(e, t) {
+var r = BR[t], o = cR.getClusters();
 for (var n in o) o[n].defenseRequests.some(function(t) {
 return t.roomName === e && t.urgency >= 2;
 }) && (r += 1e4);
 return r;
 }
 
-function BR(e, t, r) {
+function WR(e, t, r) {
 var n, a = e.memberRooms.flatMap(function(e) {
-var t, r, o, n, a = Game.rooms[e], i = iR.getSwarmState(e);
+var t, r, o, n, a = Game.rooms[e], i = cR.getSwarmState(e);
 if (!a || !i) return [];
 var s = null !== (r = null === (t = a.storage) || void 0 === t ? void 0 : t.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== r ? r : 0, c = null !== (n = null === (o = a.terminal) || void 0 === o ? void 0 : o.store.getUsedCapacity(RESOURCE_ENERGY)) && void 0 !== n ? n : 0;
 return [ {
 roomName: e,
 availableEnergy: s + c,
-reservedEnergy: DR(e, i.danger),
+reservedEnergy: FR(e, i.danger),
 hasTerminal: Boolean(a.terminal),
 terminalEnergy: c
 } ];
@@ -41714,7 +41718,7 @@ success: !1
 });
 }
 
-var FR = {
+var HR = {
 rclWeight: 10,
 resourceWeight: 5,
 strategicWeight: 3,
@@ -41724,7 +41728,7 @@ strongDefensePenalty: 15,
 warTargetBonus: 50
 };
 
-function WR(e, t, r) {
+function KR(e, t, r) {
 var o, n, a = {
 empire: r
 };
@@ -41755,7 +41759,7 @@ reason: u ? void 0 : "not a confirmed enemy target"
 };
 }
 
-function HR(e, t, r, o) {
+function YR(e, t, r, o) {
 var n, a, i = 0;
 i += e.controllerLevel * o.rclWeight, e.controllerLevel >= 6 ? i += 5 * o.resourceWeight : e.controllerLevel >= 4 && (i += 2 * o.resourceWeight),
 i += e.sources * o.strategicWeight, i -= t * o.distancePenalty;
@@ -41765,7 +41769,7 @@ r && (i += o.warTargetBonus), e.threatLevel >= 2 && !r && (i -= 10 * e.threatLev
 Math.max(0, i);
 }
 
-function KR(e, t) {
+function VR(e, t) {
 var r, o, n = 1 / 0;
 try {
 for (var i = a(e.memberRooms), s = i.next(); !s.done; s = i.next()) {
@@ -41786,19 +41790,19 @@ if (r) throw r.error;
 return n;
 }
 
-function YR() {
-var e = iR.getEmpire();
+function qR() {
+var e = cR.getEmpire();
 return e.offensiveOperations || (e.offensiveOperations = {}), e.offensiveOperations;
 }
 
-function VR(e) {
-YR()[e.id] = e;
+function jR(e) {
+qR()[e.id] = e;
 }
 
-function qR(e) {
+function zR(e) {
 e.lastUpdate = Game.time;
-var t = iR.getCluster(e.clusterId);
-if (!t) return e.state = "failed", VR(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
+var t = cR.getCluster(e.clusterId);
+if (!t) return e.state = "failed", jR(e), void U.error("Cluster ".concat(e.clusterId, " not found for operation ").concat(e.id), {
 subsystem: "Offensive"
 });
 switch (e.state) {
@@ -41808,12 +41812,12 @@ e.squadIds.every(function(e) {
 var r = t.squads.find(function(t) {
 return t.id === e;
 });
-return !!r && (GR(r) || IR(e) || UR(0, r), GR(r));
+return !!r && (DR(r) || LR(e) || NR(0, r), DR(r));
 }) && (e.state = "executing", U.info("Operation ".concat(e.id, " entering execution phase"), {
 subsystem: "Offensive"
 })), Game.time - e.createdAt > 1e3 && (e.state = "failed", U.warn("Operation ".concat(e.id, " formation timed out"), {
 subsystem: "Offensive"
-})), VR(e);
+})), jR(e);
 }(e, t);
 break;
 
@@ -41824,7 +41828,7 @@ var o = t.squads.find(function(e) {
 return e.id === r;
 });
 if (!o) return "continue";
-if (CR(o), TR(o)) {
+if (wR(o), SR(o)) {
 U.info("Squad ".concat(r, " dissolving, operation ").concat(e.id, " may complete"), {
 subsystem: "Offensive"
 });
@@ -41853,7 +41857,7 @@ return t.id === e;
 });
 });
 (function(e) {
-var t, r = iR.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
+var t, r = cR.getEmpire(), o = null === (t = r.knownRooms) || void 0 === t ? void 0 : t[e.targetRoom];
 if (o) {
 var n = Game.rooms[e.targetRoom];
 if (n && n.controller) {
@@ -41880,12 +41884,12 @@ return t.score - e.score;
 }
 })(e), 0 === c.length && (e.state = "complete", U.info("Operation ".concat(e.id, " complete"), {
 subsystem: "Offensive"
-})), VR(e);
+})), jR(e);
 }(e, t);
 }
 }
 
-function jR(e, t, r) {
+function QR(e, t, r) {
 if (function(e, t) {
 var r = t.map(function(e) {
 return "string" == typeof e ? e : e.type;
@@ -41904,11 +41908,11 @@ score: n.score + o.score
 }
 }
 
-function zR(e, t, r) {
+function XR(e, t, r) {
 return Io(e, t, r);
 }
 
-function QR(e, t) {
+function ZR(e, t) {
 switch (t) {
 case "guard":
 return Math.max(0, e.guardsNeeded);
@@ -41921,11 +41925,11 @@ return Math.max(0, e.healersNeeded);
 }
 }
 
-function XR(e) {
+function JR(e) {
 return e >= 2 ? 1e3 : 500;
 }
 
-function ZR(e, t, r) {
+function $R(e, t, r) {
 return e.memberRooms.filter(function(e) {
 return e !== r;
 }).map(function(e) {
@@ -41938,8 +41942,8 @@ return a !== i ? a - i : e.energyCapacityAvailable !== t.energyCapacityAvailable
 });
 }
 
-function JR(e, t, r) {
-var o = zR(t, e.energyCapacityAvailable, r);
+function eE(e, t, r) {
+var o = XR(t, e.energyCapacityAvailable, r);
 if (!o) return !1;
 var n = null == r ? void 0 : r.strongest;
 if (!n || n.score <= 0) return !0;
@@ -41947,16 +41951,16 @@ var a = wo(o.parts);
 return a.partCount >= n.partCount && a.score >= n.score;
 }
 
-function $R(e, t, r, o) {
+function tE(e, t, r, o) {
 return s([], i(e), !1).sort(function(e, n) {
-var a, i, s = JR(e, t, o);
-if (s !== JR(n, t, o)) return s ? -1 : 1;
+var a, i, s = eE(e, t, o);
+if (s !== eE(n, t, o)) return s ? -1 : 1;
 var c = null !== (a = e.distances[r]) && void 0 !== a ? a : 50, u = null !== (i = n.distances[r]) && void 0 !== i ? i : 50;
 return c !== u ? c - u : e.energyCapacityAvailable !== n.energyCapacityAvailable ? n.energyCapacityAvailable - e.energyCapacityAvailable : e.roomName.localeCompare(n.roomName);
 });
 }
 
-function eE(e, t) {
+function rE(e, t) {
 var r, o, n, i, s, c, u = {
 counts: {
 guard: 0,
@@ -42040,21 +42044,21 @@ if (r) throw r.error;
 return u;
 }
 
-function tE(e, t) {
+function oE(e, t) {
 return {
-guard: Math.max(0, QR(e, "guard") - t.counts.guard),
-ranger: Math.max(0, QR(e, "ranger") - t.counts.ranger),
-healer: Math.max(0, QR(e, "healer") - t.counts.healer)
+guard: Math.max(0, ZR(e, "guard") - t.counts.guard),
+ranger: Math.max(0, ZR(e, "ranger") - t.counts.ranger),
+healer: Math.max(0, ZR(e, "healer") - t.counts.healer)
 };
 }
 
-function rE(e) {
+function nE(e) {
 return "guard" === e || "ranger" === e || "healer" === e;
 }
 
-function oE(e, t) {
+function aE(e, t) {
 return t.getPendingRequests(e).filter(function(e) {
-return rE(e.role);
+return nE(e.role);
 }).map(function(e) {
 var t, r, o;
 return {
@@ -42067,12 +42071,12 @@ return e.targetRoom.length > 0;
 });
 }
 
-function nE(e) {
+function iE(e) {
 var t;
 return null !== (t = e.assistTarget) && void 0 !== t ? t : e.task === vi ? e.targetRoom : void 0;
 }
 
-function aE(e) {
+function sE(e) {
 var t, r, o, n, i = {
 counts: {
 guard: 0,
@@ -42084,7 +42088,7 @@ power: {}
 try {
 for (var s = a(Object.values(null !== (o = Game.creeps) && void 0 !== o ? o : {})), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = u.memory, m = null !== (n = l.role) && void 0 !== n ? n : "";
-rE(m) && nE(l) === e && !u.spawning && jR(i, m, u.body.filter(function(e) {
+nE(m) && iE(l) === e && !u.spawning && QR(i, m, u.body.filter(function(e) {
 return e.hits > 0;
 }));
 }
@@ -42102,7 +42106,7 @@ if (t) throw t.error;
 return i;
 }
 
-function iE(e, t, r) {
+function cE(e, t, r) {
 var o, n, i, s = Game.rooms[e];
 if (s) {
 var c = {};
@@ -42132,16 +42136,16 @@ return !e.spawning;
 }).length,
 energyCapacityAvailable: s.energyCapacityAvailable,
 distances: c,
-pendingAssist: oE(e, r)
+pendingAssist: aE(e, r)
 };
 }
 }
 
-function sE(e, t) {
+function uE(e, t) {
 var r = Game.rooms[e.roomName];
 if (!r) return !1;
 try {
-var o = zR(e.role, r.energyCapacityAvailable, e.threatProfile);
+var o = XR(e.role, r.energyCapacityAvailable, e.threatProfile);
 if (!o) return !1;
 var n = {
 id: e.id,
@@ -42162,7 +42166,7 @@ subsystem: "Cluster"
 }
 }
 
-function cE(e, t, r) {
+function lE(e, t, r) {
 var o, n, a, c = 0, u = 0, l = e.getTerrain().get(t.x, t.y);
 if (l === TERRAIN_MASK_WALL) return {
 position: t,
@@ -42204,20 +42208,20 @@ exitAccess: a
 };
 }
 
-function uE(e, t) {
+function mE(e, t) {
 return "guard" === t ? Math.max(0, e.guardsNeeded) : "ranger" === t ? Math.max(0, e.rangersNeeded) : Math.max(0, e.healersNeeded);
 }
 
-function lE(e, t, r) {
+function dE(e, t, r) {
 var o = Math.max(0, r);
 "guard" !== t ? "ranger" !== t ? e.healersNeeded = o : e.rangersNeeded = o : e.guardsNeeded = o;
 }
 
-function mE(e) {
+function pE(e) {
 return "military" !== e.family ? null : "guard" === e.role || "ranger" === e.role || "healer" === e.role ? e.role : null;
 }
 
-function dE(e, t) {
+function fE(e, t) {
 var r;
 if (e.spawning) return !1;
 var o = (null !== (r = e.body) && void 0 !== r ? r : []).filter(function(e) {
@@ -42228,7 +42232,7 @@ return e.type;
 return "guard" === t ? o.includes(ATTACK) || o.includes(RANGED_ATTACK) : "ranger" === t ? o.includes(RANGED_ATTACK) : o.includes(HEAL);
 }
 
-function pE(e, t, r) {
+function yE(e, t, r) {
 var o, n, i, s, c = [];
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
@@ -42239,8 +42243,8 @@ if (d && (!r.isRoomSafe || r.isRoomSafe(d, m))) {
 var p = d.find(FIND_MY_CREEPS);
 try {
 for (var f = (i = void 0, a(p)), y = f.next(); !y.done; y = f.next()) {
-var v = y.value, g = v.memory, h = mE(g);
-h && (Ri(g) || dE(v, h) && (t.assignedCreeps.includes(v.name) || uE(t, h) <= 0 || c.push({
+var v = y.value, g = v.memory, h = pE(g);
+h && (Ri(g) || fE(v, h) && (t.assignedCreeps.includes(v.name) || mE(t, h) <= 0 || c.push({
 creep: v,
 room: d,
 role: h,
@@ -42277,7 +42281,7 @@ return e.distance - t.distance;
 });
 }
 
-function fE(e, t) {
+function vE(e, t) {
 var r, o, n = {
 guard: Math.max(0, e.guardsNeeded),
 ranger: Math.max(0, e.rangersNeeded),
@@ -42302,21 +42306,21 @@ if (r) throw r.error;
 return i;
 }
 
-function yE(e) {
+function gE(e) {
 return Math.max(2, Math.floor(e / 2));
 }
 
-var vE = {
+var hE = {
 updateInterval: 10,
 minBucket: 0,
 resourceBalanceThreshold: 1e4,
 minTerminalEnergy: 5e4
-}, gE = function() {
+}, RE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, vE), e);
+void 0 === e && (e = {}), this.lastRun = new Map, this.config = o(o({}, hE), e);
 }
 return e.prototype.run = function() {
-var e = iR.getClusters();
+var e = cR.getClusters();
 for (var t in e) {
 var r = e[t];
 if (this.shouldRunCluster(t)) try {
@@ -42335,7 +42339,7 @@ return Game.time - r >= this.config.updateInterval;
 return function(e) {
 return {
 clusterId: e.id,
-steps: nR.map(function(t) {
+steps: iR.map(function(t) {
 return {
 name: t.name,
 statsKey: "cluster:".concat(e.id, ":").concat(t.name)
@@ -42354,7 +42358,7 @@ focusRoom: e.focusRoom
 }(e);
 }, e.prototype.runCluster = function(e) {
 var t, r, o = this, n = Game.cpu.getUsed(), i = this.getClusterOperationIntent(e), s = function(t) {
-rs.measureSubsystem(t.statsKey, function() {
+ns.measureSubsystem(t.statsKey, function() {
 o.executeClusterOperation(t.name, e);
 });
 };
@@ -42391,7 +42395,7 @@ this.balanceTerminalResources(t);
 break;
 
 case "resourceSharing":
-dR.processCluster(t);
+fR.processCluster(t);
 break;
 
 case "squads":
@@ -42423,7 +42427,7 @@ if (0 === t.length) return null;
 for (var o = r ? r.pos : t[0].pos, n = [], a = -5; a <= 5; a++) for (var i = -5; i <= 5; i++) {
 var s = o.x + a, c = o.y + i;
 if (!(s < 2 || s > 47 || c < 2 || c > 47)) {
-var u = cE(e, new RoomPosition(s, c, e.name), "defense");
+var u = lE(e, new RoomPosition(s, c, e.name), "defense");
 u.score > 0 && n.push(u);
 }
 }
@@ -42472,9 +42476,9 @@ case "militaryResources":
 var t, r;
 try {
 for (var o = a(e.memberRooms), n = o.next(); !n.done; n = o.next()) {
-var i = n.value, s = iR.getSwarmState(i);
+var i = n.value, s = cR.getSwarmState(i);
 if (s) {
-var c = DR(i, s.danger);
+var c = FR(i, s.danger);
 c > 0 && Game.time % 100 == 0 && U.debug("Military energy reservation for ".concat(i, ": ").concat(c, " (danger ").concat(s.danger, ")"), {
 subsystem: "MilitaryPool"
 });
@@ -42505,7 +42509,7 @@ this.updateFocusRoom(t);
 var t, r, o = 0, n = 0, i = 0, s = 0, c = 0;
 try {
 for (var u = a(e.memberRooms), l = u.next(); !l.done; l = u.next()) {
-var m = l.value, d = iR.getSwarmState(m);
+var m = l.value, d = cR.getSwarmState(m);
 if (d && d.metrics) {
 o += d.metrics.energyHarvested || 0, n += (d.metrics.energySpawning || 0) + (d.metrics.energyConstruction || 0) + (d.metrics.energyRepair || 0),
 i += 25 * d.danger;
@@ -42537,7 +42541,7 @@ l && (null === (o = l.controller) || void 0 === o ? void 0 : o.my) && (n += l.fi
 filter: function(e) {
 return "military" === e.memory.family;
 }
-}).length, i += yE(l.controller.level));
+}).length, i += gE(l.controller.level));
 }
 } catch (e) {
 t = {
@@ -42654,7 +42658,7 @@ var t, r;
 try {
 for (var o = a(e.squads), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-CR(i), "gathering" !== i.state || GR(i) || IR(i.id) || UR(0, i), TR(i) && (i.state = "dissolving");
+wR(i), "gathering" !== i.state || DR(i) || LR(i.id) || NR(0, i), SR(i) && (i.state = "dissolving");
 }
 } catch (e) {
 t = {
@@ -42679,7 +42683,7 @@ return !r && t.urgency >= 2;
 });
 try {
 for (var n = a(o), i = n.next(); !i.done; i = n.next()) {
-var s = i.value, c = ER(e, s);
+var s = i.value, c = CR(e, s);
 e.squads.push(c);
 }
 } catch (e) {
@@ -42696,7 +42700,7 @@ if (t) throw t.error;
 }, e.prototype.updateOffensiveOperations = function(e) {
 Game.time % 100 == 0 && function(e) {
 if ("war" === e.role || "mixed" === e.role) {
-var t = (a = e.id, Object.values(YR()).filter(function(e) {
+var t = (a = e.id, Object.values(qR()).filter(function(e) {
 return "complete" !== e.state && "failed" !== e.state;
 }).filter(function(e) {
 return e.clusterId === a;
@@ -42707,22 +42711,22 @@ subsystem: "Offensive"
 var r = function(e, t, r, n) {
 var a, i, s, c, u;
 void 0 === n && (n = {});
-var l = o(o({}, FR), n), m = [], d = iR.getEmpire(), p = d.knownRooms || {};
+var l = o(o({}, HR), n), m = [], d = cR.getEmpire(), p = d.knownRooms || {};
 for (var f in p) {
 var y = p[f];
 if (y.scouted) {
 var v = null !== (i = null === (a = Object.values(Game.spawns)[0]) || void 0 === a ? void 0 : a.owner.username) && void 0 !== i ? i : "";
 if (y.owner !== v) {
-var g = WR(f, y, d);
+var g = KR(f, y, d);
 if (g.isSafe && g.isConfirmedHostile) {
 if (!y.isHighway && !y.isSK) {
-var h = KR(e, f);
+var h = VR(e, f);
 if (!(h > 10)) {
 var R = null !== (u = null === (c = Memory.lastAttacked) || void 0 === c ? void 0 : c[f]) && void 0 !== u ? u : 0;
 if (!(Game.time - R < 5e3)) {
-var E = HR(y, h, g.isExplicitWarTarget, l), T = "neutral";
+var E = YR(y, h, g.isExplicitWarTarget, l), T = "neutral";
 y.owner && (T = g.isExplicitWarTarget ? "enemy" : "hostile");
-var C = wR(f, {
+var C = bR(f, {
 towerCount: y.towerCount,
 spawnCount: y.spawnCount,
 rcl: y.controllerLevel,
@@ -42757,29 +42761,29 @@ subsystem: "AttackTarget"
 }(e);
 if (0 !== r.length) {
 var n = r[0];
-xR(e, n.doctrine) ? function(e, t, r) {
+OR(e, n.doctrine) ? function(e, t, r) {
 if (!function(e) {
-var t, r = iR.getEmpire(), o = (r.knownRooms || {})[e];
+var t, r = cR.getEmpire(), o = (r.knownRooms || {})[e];
 if (!o) return U.warn("No intel for target ".concat(e), {
 subsystem: "AttackTarget"
 }), !1;
 if (Game.time - o.lastSeen > 5e3) return U.warn("Intel for ".concat(e, " is stale (").concat(Game.time - o.lastSeen, " ticks old)"), {
 subsystem: "AttackTarget"
 }), !1;
-var n = WR(e, o, r);
+var n = KR(e, o, r);
 return !(!n.isSafe || !n.isConfirmedHostile) || (U.warn("Refusing offensive target ".concat(e, ": ").concat(null !== (t = n.reason) && void 0 !== t ? t : "unsafe target"), {
 subsystem: "AttackTarget"
 }), !1);
 }(t)) return U.warn("Invalid target ".concat(t), {
 subsystem: "Offensive"
 }), null;
-var o = (iR.getEmpire().knownRooms || {})[t], n = null != r ? r : wR(t, {
+var o = (cR.getEmpire().knownRooms || {})[t], n = null != r ? r : bR(t, {
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount,
 rcl: null == o ? void 0 : o.controllerLevel,
 owner: null == o ? void 0 : o.owner
 });
-if (!xR(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
+if (!OR(e, n)) return U.warn("Cannot launch ".concat(n, " operation on ").concat(t, " - insufficient resources"), {
 subsystem: "Offensive"
 }), null;
 var a = "op_".concat(e.id, "_").concat(t, "_").concat(Game.time), i = {
@@ -42792,7 +42796,7 @@ state: "planning",
 createdAt: Game.time,
 lastUpdate: Game.time
 };
-VR(i);
+jR(i);
 var s, c = function(e, t, r, o) {
 var n = function(e, t) {
 var r, o, n = {
@@ -42806,13 +42810,13 @@ var a = null !== (r = t.towerCount) && void 0 !== r ? r : 0, i = null !== (o = t
 a >= 3 && (n.healers += 1), a >= 2 && i >= 2 && (n.siegeUnits += 1), i >= 2 && (n.guards += 1);
 }
 return n;
-}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = RR(e, t), s = .3;
+}(0, o), a = "".concat(r, "_").concat(t, "_").concat(Game.time), i = TR(e, t), s = .3;
 "harass" === r ? s = .5 : "raid" === r ? s = .4 : "siege" === r && (s = .3);
 var c = {
 id: a,
 type: r,
 members: [],
-targetComposition: fR(n),
+targetComposition: vR(n),
 rallyRoom: i,
 targetRooms: [ t ],
 state: "gathering",
@@ -42827,8 +42831,8 @@ subsystem: "Squad"
 towerCount: null == o ? void 0 : o.towerCount,
 spawnCount: null == o ? void 0 : o.spawnCount
 });
-e.squads.push(c), i.squadIds.push(c.id), VR(i), UR(0, c), i.state = "forming", i.lastUpdate = Game.time,
-VR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
+e.squads.push(c), i.squadIds.push(c.id), jR(i), NR(0, c), i.state = "forming", i.lastUpdate = Game.time,
+jR(i), s = t, Memory.lastAttacked || (Memory.lastAttacked = {}), Memory.lastAttacked[s] = Game.time,
 U.info("Marked ".concat(s, " as attacked at tick ").concat(Game.time), {
 subsystem: "AttackTarget"
 }), U.info("Launched ".concat(n, " operation ").concat(a, " on ").concat(t, " with squad ").concat(c.id), {
@@ -42847,11 +42851,11 @@ var a;
 !function() {
 var e, t, r = Game.time;
 try {
-for (var o = a(AR.entries()), n = o.next(); !n.done; n = o.next()) {
+for (var o = a(_R.entries()), n = o.next(); !n.done; n = o.next()) {
 var s = i(n.value, 2), c = s[0], u = r - s[1].formationStarted;
 u > 500 && (U.warn("Squad ".concat(c, " formation timed out after ").concat(u, " ticks"), {
 subsystem: "SquadFormation"
-}), AR.delete(c));
+}), _R.delete(c));
 }
 } catch (t) {
 e = {
@@ -42865,10 +42869,10 @@ if (e) throw e.error;
 }
 }
 }();
-var e = YR();
-for (var t in e) qR(e[t]);
+var e = qR();
+for (var t in e) zR(e[t]);
 !function() {
-var e = YR();
+var e = qR();
 for (var t in e) {
 var r = e[t];
 ("complete" === r.state || "failed" === r.state) && Game.time - r.createdAt > 5e3 && (delete e[t],
@@ -42946,14 +42950,14 @@ subsystem: "Cluster"
 }
 }
 }, e.prototype.createCluster = function(e) {
-var t = "cluster_".concat(e), r = iR.getCluster(t, e);
+var t = "cluster_".concat(e), r = cR.getCluster(t, e);
 if (!r) throw new Error("Failed to create cluster for ".concat(e));
 return U.info("Created cluster ".concat(t, " with core room ").concat(e), {
 subsystem: "Cluster"
 }), r;
 }, e.prototype.addRoomToCluster = function(e, t, r) {
 void 0 === r && (r = !1);
-var o = iR.getCluster(e);
+var o = cR.getCluster(e);
 o ? r ? o.remoteRooms.includes(t) || (o.remoteRooms.push(t), U.info("Added remote room ".concat(t, " to cluster ").concat(e), {
 subsystem: "Cluster"
 })) : o.memberRooms.includes(t) || (o.memberRooms.push(t), U.info("Added member room ".concat(t, " to cluster ").concat(e), {
@@ -42982,7 +42986,7 @@ for (var l = a(e.defenseRequests), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
 if (d.urgency >= 3) {
 var p = Game.rooms[d.roomName];
-p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && BR(e, d.roomName, 2e4);
+p && p.storage && p.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 1e4 && WR(e, d.roomName, 2e4);
 }
 }
 } catch (e) {
@@ -42999,7 +43003,7 @@ if (t) throw t.error;
 var f = function(t) {
 var r = Game.rooms[t];
 if (!r || !(null === (u = r.controller) || void 0 === u ? void 0 : u.my)) return "continue";
-var n, a, i = iR.getSwarmState(t);
+var n, a, i = cR.getSwarmState(t);
 if (!i) return "continue";
 if (go(r, i)) {
 var s = e.defenseRequests.find(function(e) {
@@ -43040,7 +43044,7 @@ return e.roomName;
 try {
 for (var y = a(m), v = y.next(); !v.done; v = y.next()) {
 var g = v.value;
-p[g] = Mo(g), f[g] = aE(g);
+p[g] = Mo(g), f[g] = sE(g);
 }
 } catch (e) {
 r = {
@@ -43056,7 +43060,7 @@ if (r) throw r.error;
 try {
 for (var h = a(e.memberRooms), R = h.next(); !R.done; R = h.next()) {
 var E = R.value;
-d[E] = iE(E, m, t);
+d[E] = cE(E, m, t);
 }
 } catch (e) {
 n = {
@@ -43075,13 +43079,13 @@ return e.urgency !== t.urgency ? t.urgency - e.urgency : e.createdAt - t.created
 });
 try {
 for (var y = a(f), v = y.next(); !v.done; v = y.next()) {
-var g = v.value, h = ZR(e.cluster, e.rooms, g.roomName);
+var g = v.value, h = $R(e.cluster, e.rooms, g.roomName);
 if (0 !== h.length) {
-var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = eE(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
+var R = null === (u = e.targetThreats) || void 0 === u ? void 0 : u[g.roomName], E = rE(e, g.roomName), T = Math.max.apply(Math, s([], i(h.map(function(e) {
 return e.energyCapacityAvailable;
-})), !1)), C = Do(T, R, tE(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
+})), !1)), C = Do(T, R, oE(g, E), E.power), S = Math.max(1, C.counts.guard + C.counts.ranger + C.counts.healer);
 try {
-for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = $R(h, b, g.roomName, R), M = 0; M < O; M++) {
+for (var w = (o = void 0, a([ "guard", "ranger", "healer" ])), x = w.next(); !x.done; x = w.next()) for (var b = x.value, O = C.counts[b], k = tE(h, b, g.roomName, R), M = 0; M < O; M++) {
 var A = k.find(function(e) {
 var t;
 return (null !== (t = p.get(e.roomName)) && void 0 !== t ? t : 0) < m;
@@ -43093,7 +43097,7 @@ id: "assist_".concat(b, "_").concat(g.roomName, "_").concat(A.roomName, "_").con
 roomName: A.roomName,
 role: b,
 family: "military",
-priority: XR(g.urgency),
+priority: JR(g.urgency),
 targetRoom: g.roomName,
 additionalMemory: {
 assistTarget: g.roomName,
@@ -43139,7 +43143,7 @@ targetThreats: p,
 targetAssigned: f
 }), C = 0;
 try {
-for (var S = a(T), w = S.next(); !w.done; w = S.next()) sE(w.value, t) && C++;
+for (var S = a(T), w = S.next(); !w.done; w = S.next()) uE(w.value, t) && C++;
 } catch (e) {
 u = {
 error: e
@@ -43154,7 +43158,7 @@ if (u) throw u.error;
 C > 0 && U.warn("Queued ".concat(C, " defense reinforcement spawn(s) for cluster ").concat(e.id), {
 subsystem: "Cluster"
 });
-}(e, Jv);
+}(e, eg);
 }, e.prototype.assignDefendersToRequests = function(e) {
 var t, r, o = function(e, t) {
 var r, o, n, c, u;
@@ -43166,7 +43170,7 @@ try {
 for (var d = a(m), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (t.rooms[f.roomName]) {
-var y = fE(f, pE(e, f, t)), v = y.reduce(function(e, t) {
+var y = vE(f, yE(e, f, t)), v = y.reduce(function(e, t) {
 var r;
 return e.set(t.room.name, (null !== (r = e.get(t.room.name)) && void 0 !== r ? r : 0) + 1),
 e;
@@ -43179,7 +43183,7 @@ homeRoom: R.room.name,
 targetRoom: f.roomName,
 now: t.now,
 squadSize: E
-}), f.assignedCreeps.push(R.creep.name), lE(f, R.role, uE(f, R.role) - 1), l.push({
+}), f.assignedCreeps.push(R.creep.name), dE(f, R.role, mE(f, R.role) - 1), l.push({
 creepName: R.creep.name,
 role: R.role,
 fromRoom: R.room.name,
@@ -43246,24 +43250,24 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), hE = new gE, RE = /^([WE])(\d+)([NS])(\d+)$/;
+}(), EE = new RE, TE = /^([WE])(\d+)([NS])(\d+)$/;
 
-function EE(e) {
-return RE.test(e);
+function CE(e) {
+return TE.test(e);
 }
 
-var TE = {
+var SE = {
 updateInterval: 300,
 minBucket: 6e3,
 maxCpuBudget: .01
-}, CE = function() {
+}, wE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, TE), e);
+void 0 === e && (e = {}), this.lastRun = 0, this.config = o(o({}, SE), e);
 }
 return e.prototype.run = function() {
 this.lastRun = Game.time;
-var e = Lf();
-this.updateEnemyIntelligence(e), Df(e, {
+var e = Bf();
+this.updateEnemyIntelligence(e), Ff(e, {
 updatedSections: [ "globalTargets" ]
 });
 }, e.prototype.updateEnemyIntelligence = function(e) {
@@ -43326,7 +43330,7 @@ if (n) throw n.error;
 try {
 for (var S = a(e.warTargets), w = S.next(); !w.done; w = S.next()) {
 var x = w.value;
-if (e.isAlly(x)) f.add(x); else if (EE(x)) {
+if (e.isAlly(x)) f.add(x); else if (CE(x)) {
 var b = v.get(x);
 if (!b) continue;
 if (b.includes("Source Keeper") || e.isAlly(b)) {
@@ -43391,14 +43395,14 @@ subsystem: "CrossShardIntel"
 });
 }
 }, e.prototype.getGlobalEnemies = function() {
-return Lf().globalTargets.enemies || [];
+return Bf().globalTargets.enemies || [];
 }, n([ Ze("empire:crossShardIntel", "Cross-Shard Intel", {
 priority: Ie.LOW,
 interval: 300,
 minBucket: 6e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), SE = new CE, wE = function() {
+}(), xE = new wE, bE = function() {
 function e() {}
 return e.prototype.monitorClusterHealth = function() {
 if (Game.time % 50 == 0) {
@@ -43475,9 +43479,9 @@ economyIndex: 0
 for (var o in e) r(o);
 }
 }, e;
-}(), xE = new wE, bE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
+}(), OE = new bE, kE = new Set([ ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM ]);
 
-function OE(e, t) {
+function ME(e, t) {
 var r, o;
 if (0 === t.length) return 1 / 0;
 var n = 1 / 0;
@@ -43500,22 +43504,22 @@ if (r) throw r.error;
 return n;
 }
 
-function kE(e) {
+function AE(e) {
 return !(e.owner || e.reserver || !e.scouted || e.isHighway);
 }
 
-function ME(e, t, r) {
-if (!kE(e)) return 0;
-var o = OE(e.name, t);
+function UE(e, t, r) {
+if (!AE(e)) return 0;
+var o = ME(e.name, t);
 if (o > r.maxExpansionDistance) return 0;
 var n = 0;
-return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += fc(e.mineralType),
-n -= 5 * o, n -= yc(e.name), n -= 15 * e.threatLevel, n += vc(e.terrain), gc(e.name) && (n += 10),
-n += hc(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
-n += Ec(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
+return 2 === e.sources ? n += 40 : 1 === e.sources && (n += 20), n += vc(e.mineralType),
+n -= 5 * o, n -= gc(e.name), n -= 15 * e.threatLevel, n += hc(e.terrain), Rc(e.name) && (n += 10),
+n += Ec(e.name), e.controllerLevel > 0 && !e.owner && (n += 2 * e.controllerLevel),
+n += Cc(e.name, t, o), e.isSK && (n -= 50), Math.max(0, n);
 }
 
-function AE(e, t) {
+function _E(e, t) {
 var r, o, n, a, i, s = Game.rooms[e];
 if (!s) return null;
 var c = null === (o = null === (r = s.controller) || void 0 === r ? void 0 : r.owner) || void 0 === o ? void 0 : o.username;
@@ -43525,13 +43529,13 @@ var u = null === (i = null === (a = s.controller) || void 0 === a ? void 0 : a.r
 return u && u !== t ? "reserved by ".concat(u) : function(e) {
 return Z(e).some(function(e) {
 return e.body.some(function(e) {
-return e.hits > 0 && bE.has(e.type);
+return e.hits > 0 && kE.has(e.type);
 });
 });
 }(s) ? "visible dangerous hostiles" : null;
 }
 
-function UE(e, t, r) {
+function NE(e, t, r) {
 if (!e) return null;
 if (!r) {
 if (e.owner && e.owner !== t) return "owned by ".concat(e.owner);
@@ -43541,7 +43545,7 @@ if (e.threatLevel >= 2) return "threat level ".concat(e.threatLevel);
 return e.isHighway ? "highway room" : e.isSK ? "source keeper room" : null;
 }
 
-function _E(e) {
+function PE(e) {
 return function(e) {
 var t = te(e);
 if (!t) throw new Error("Invalid room name: ".concat(e));
@@ -43552,8 +43556,8 @@ isSK: re(t.x) && re(t.y)
 }(e);
 }
 
-function NE(e) {
-var t = _E(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
+function IE(e) {
+var t = PE(e.roomName), r = e.terrain.swamps > e.terrain.plains ? "swamp" : e.terrain.plains > e.terrain.swamps ? "plains" : "mixed";
 return o(o({
 name: e.roomName,
 lastSeen: e.tick,
@@ -43572,14 +43576,14 @@ hasPortal: e.portals > 0
 });
 }
 
-var PE = {
+var GE = {
 intelRefreshInterval: 100,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, IE = function() {
+}, LE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, PE), e);
+void 0 === e && (e = {}), this.config = o(o({}, GE), e);
 }
 return e.prototype.refreshRoomIntel = function(e) {
 var t, r;
@@ -43670,7 +43674,7 @@ subsystem: "Intel"
 }
 }, e.prototype.createStubIntel = function(e) {
 return function(e) {
-var t = _E(e);
+var t = PE(e);
 return o({
 name: e,
 lastSeen: 0,
@@ -43682,14 +43686,14 @@ terrain: "mixed"
 }, t);
 }(e);
 }, e.prototype.createRoomIntel = function(e) {
-return NE(GE(e));
+return IE(DE(e));
 }, e.prototype.updateRoomIntel = function(e, t) {
 var r, n;
-Object.assign(e, (r = e, n = NE(GE(t)), o(o({}, r), n)));
+Object.assign(e, (r = e, n = IE(DE(t)), o(o({}, r), n)));
 }, e;
 }();
 
-function GE(e) {
+function DE(e) {
 for (var t, r, o, n = e.find(FIND_SOURCES), a = e.find(FIND_MINERALS)[0], i = e.controller, s = Z(e), c = J(e), u = e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_PORTAL;
@@ -43721,11 +43725,11 @@ swamps: d
 };
 }
 
-var LE = new IE, DE = /^([WE])(\d+)([NS])(\d+)$/, BE = {
+var BE = new LE, FE = /^([WE])(\d+)([NS])(\d+)$/, WE = {
 allies: []
-}, FE = function() {
+}, HE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, BE), e);
+void 0 === e && (e = {}), this.config = o(o({}, WE), e);
 }
 return e.prototype.updateWarTargets = function(e) {
 var t = this, r = this.getMyUsername();
@@ -43745,7 +43749,7 @@ var o;
 if (e === r || this.isAllyUsername(e, t)) return !1;
 var n = null === (o = t.playerPostures) || void 0 === o ? void 0 : o.players[e];
 if ("war" === (null == n ? void 0 : n.state)) return !0;
-if (!DE.test(e)) return !1;
+if (!FE.test(e)) return !1;
 var a = t.knownRooms[e];
 return !!(null == a ? void 0 : a.owner) && a.owner !== r && !this.isAllyUsername(a.owner, t);
 }, e.prototype.addPostureTargets = function(e, t) {
@@ -43853,7 +43857,7 @@ configuredAllies: this.config.allies,
 empire: t
 });
 }, e.prototype.isRoomName = function(e) {
-return DE.test(e);
+return FE.test(e);
 }, e.prototype.scoreWarCandidate = function(e, t) {
 var r, o, n;
 return Math.max(0, 80 - 6 * t) + 10 * (null !== (r = e.controllerLevel) && void 0 !== r ? r : 0) + 8 * e.threatLevel + 8 * (null !== (o = e.towerCount) && void 0 !== o ? o : 0) + 6 * (null !== (n = e.spawnCount) && void 0 !== n ? n : 0) + (e.reserver ? 6 : 0);
@@ -43880,7 +43884,7 @@ if (r) throw r.error;
 }
 return n;
 }, e;
-}(), WE = new FE, HE = {
+}(), KE = new HE, YE = {
 updateInterval: 30,
 minBucket: 0,
 maxCpuBudget: .05,
@@ -43893,9 +43897,9 @@ gclNotifyThreshold: 90,
 roomDiscoveryInterval: 100,
 maxRoomDiscoveryDistance: 5,
 maxRoomsToDiscoverPerTick: 50
-}, KE = function() {
+}, VE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.config = o(o({}, HE), e);
+void 0 === e && (e = {}), this.config = o(o({}, YE), e);
 }
 return e.prototype.run = function() {
 var e, t = this, r = Game.cpu.getUsed(), o = wr.getEmpire(), n = null !== (e = Game.cpu.bucket) && void 0 !== e ? e : 0;
@@ -43903,27 +43907,27 @@ if (n < this.config.minBucket) Game.time % 100 == 0 && U.warn("Empire manager sk
 subsystem: "Empire"
 }); else {
 var a = this.getBucketMode(n), i = this.shouldRunDegradedModeWork(a), s = this.shouldRunNormalModeWork(a), c = this.shouldRunFullModeWork(a);
-o.lastUpdate = Game.time, s && (rs.measureSubsystem("empire:expansion", function() {
+o.lastUpdate = Game.time, s && (ns.measureSubsystem("empire:expansion", function() {
 t.updateExpansionQueue(o);
-}), rs.measureSubsystem("empire:powerBanks", function() {
+}), ns.measureSubsystem("empire:powerBanks", function() {
 t.updatePowerBanks(o);
-})), rs.measureSubsystem("empire:warTargets", function() {
-WE.updateWarTargets(o);
-}), rs.measureSubsystem("empire:objectives", function() {
+})), ns.measureSubsystem("empire:warTargets", function() {
+KE.updateWarTargets(o);
+}), ns.measureSubsystem("empire:objectives", function() {
 t.updateObjectives(o);
-}), rs.measureSubsystem("empire:gclTracking", function() {
+}), ns.measureSubsystem("empire:gclTracking", function() {
 t.trackGCLProgress(o);
-}), s && rs.measureSubsystem("empire:expansionReadiness", function() {
+}), s && ns.measureSubsystem("empire:expansionReadiness", function() {
 t.checkExpansionReadiness(o);
-}), i && (rs.measureSubsystem("empire:intelRefresh", function() {
-LE.refreshRoomIntel(o);
-}), rs.measureSubsystem("empire:roomDiscovery", function() {
-LE.discoverNearbyRooms(o);
-})), s && rs.measureSubsystem("empire:nukeCandidates", function() {
+}), i && (ns.measureSubsystem("empire:intelRefresh", function() {
+BE.refreshRoomIntel(o);
+}), ns.measureSubsystem("empire:roomDiscovery", function() {
+BE.discoverNearbyRooms(o);
+})), s && ns.measureSubsystem("empire:nukeCandidates", function() {
 t.refreshNukeCandidates(o);
-}), c && (rs.measureSubsystem("empire:clusterHealth", function() {
-xE.monitorClusterHealth();
-}), rs.measureSubsystem("empire:powerBankProfitability", function() {
+}), c && (ns.measureSubsystem("empire:clusterHealth", function() {
+OE.monitorClusterHealth();
+}), ns.measureSubsystem("empire:powerBankProfitability", function() {
 t.assessPowerBankProfitability(o);
 }));
 var u = Game.cpu.getUsed() - r, l = Game.cpu.limit * this.config.maxCpuBudget;
@@ -44005,22 +44009,22 @@ return s([], i(o), !1).sort();
 }()), p = d.next(); !p.done; p = d.next()) {
 var f = p.value;
 if (!c.has(f)) {
-var y = Boolean(Game.rooms[f]), v = AE(f, u);
+var y = Boolean(Game.rooms[f]), v = _E(f, u);
 if (v) m.push({
 roomName: f,
 reason: v
 }); else {
-var g = OE(f, t);
+var g = ME(f, t);
 if (g > r.maxExpansionDistance) m.push({
 roomName: f,
 reason: "outside expansion distance (".concat(g, ")")
 }); else {
-var h = e.knownRooms[f], R = UE(h, u, y);
+var h = e.knownRooms[f], R = NE(h, u, y);
 if (R) m.push({
 roomName: f,
 reason: R
 }); else {
-var E = (null == h ? void 0 : h.scouted) ? ME(h, t, r) : 0;
+var E = (null == h ? void 0 : h.scouted) ? UE(h, t, r) : 0;
 l.push({
 roomName: f,
 score: Math.max(E, r.minExpansionScore + 100),
@@ -44064,10 +44068,10 @@ return e.roomName;
 var o = [];
 for (var n in e.knownRooms) {
 var a = e.knownRooms[n];
-if (a && kE(a)) {
-var i = OE(a.name, t);
+if (a && AE(a)) {
+var i = ME(a.name, t);
 if (!(i > r.maxExpansionDistance)) {
-var s = ME(a, t, r);
+var s = UE(a, t, r);
 s < r.minExpansionScore || o.push({
 roomName: a.name,
 score: s,
@@ -44387,13 +44391,13 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), YE = new KE;
+}(), qE = new VE;
 
-function VE(e) {
+function jE(e) {
 return e >= 25 ? 3 : e >= 10 ? 2 : e > 0 ? 1 : 0;
 }
 
-var qE = {
+var zE = {
 updateInterval: 10,
 minBucket: 2e3,
 maxCpuBudget: .02,
@@ -44401,21 +44405,21 @@ roomsPerTick: 3,
 rescanInterval: 1e3,
 allies: [],
 aggressionThreshold: 5
-}, jE = function() {
+}, QE = function() {
 function e(e) {
 void 0 === e && (e = {}), this.lastRun = 0, this.scanQueue = [], this.enemyPlayers = new Map,
-this.config = o(o({}, qE), e);
+this.config = o(o({}, zE), e);
 }
 return e.prototype.run = function() {
 var e = this, t = Game.cpu.getUsed();
 this.lastRun = Game.time, 0 === this.scanQueue.length && this.buildScanQueue(),
-rs.measureSubsystem("intel:scanning", function() {
+ns.measureSubsystem("intel:scanning", function() {
 e.scanRooms();
-}), rs.measureSubsystem("intel:enemyTracking", function() {
+}), ns.measureSubsystem("intel:enemyTracking", function() {
 e.updateEnemyTracking();
-}), rs.measureSubsystem("intel:threatDetection", function() {
+}), ns.measureSubsystem("intel:threatDetection", function() {
 e.detectThreats();
-}), rs.measureSubsystem("intel:threatUpdate", function() {
+}), ns.measureSubsystem("intel:threatUpdate", function() {
 e.updateRoomThreatLevels();
 });
 var r = Game.cpu.getUsed() - t;
@@ -44548,7 +44552,7 @@ rooms: [],
 threatLevel: 0,
 isAlly: !1
 };
-d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, VE(m.hostileBodyParts)),
+d.rooms.includes(m.roomName) || d.rooms.push(m.roomName), d.threatLevel = Math.max(d.threatLevel, jE(m.hostileBodyParts)),
 c.set(m.username, d);
 }
 }
@@ -44723,9 +44727,9 @@ interval: 10,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), zE = new jE, QE = function() {
+}(), XE = new QE, ZE = function() {
 function e(e) {
-void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new mc(o(o({}, qs), e), {
+void 0 === e && (e = {}), this.nextNukerScan = 0, this.hasNukerCache = !1, this.coordinator = new pc(o(o({}, zs), e), {
 getEmpire: function() {
 return wr.getEmpire();
 },
@@ -44761,7 +44765,7 @@ interval: 1500,
 minBucket: 5e3,
 cpuBudget: .01
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), XE = new QE, ZE = function() {
+}(), JE = new ZE, $E = function() {
 function e() {}
 return e.prototype.ensurePixelBuyingMemory = function() {
 var e = wr.getEmpire();
@@ -44779,9 +44783,9 @@ lastScan: 0
 var e = wr.getEmpire();
 if (e.market) return e.market.pixelBuying;
 }, e;
-}(), JE = new (function(e) {
+}(), eT = new (function(e) {
 function t(t) {
-return void 0 === t && (t = {}), e.call(this, t, new ZE) || this;
+return void 0 === t && (t = {}), e.call(this, t, new $E) || this;
 }
 return r(t, e), t.prototype.run = function() {
 e.prototype.run.call(this);
@@ -44791,24 +44795,24 @@ interval: 200,
 minBucket: 9e3,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ $e() ], t);
-}(Wi));
+}(Ki));
 
-function $E() {
+function tT() {
 return global;
 }
 
-function eT(e) {
+function rT(e) {
 return Boolean(e && "object" == typeof e);
 }
 
-function tT(e) {
+function oT(e) {
 return Number(null != e ? e : 0);
 }
 
-var rT = function() {
+var nT = function() {
 function e() {}
 return e.prototype.ensurePixelGenerationMemory = function() {
-var e = $E();
+var e = tT();
 e._pixelGenerationMemory || (e._pixelGenerationMemory = {
 bucketFullSince: 0,
 consecutiveFullTicks: 0,
@@ -44816,12 +44820,12 @@ totalPixelsGenerated: 0,
 lastGenerationTick: 0
 });
 }, e.prototype.getPixelGenerationMemory = function() {
-return $E()._pixelGenerationMemory;
+return tT()._pixelGenerationMemory;
 }, e;
-}(), oT = function(e) {
+}(), aT = function(e) {
 function t(t) {
 void 0 === t && (t = {});
-var r = e.call(this, t, new rT) || this;
+var r = e.call(this, t, new nT) || this;
 return r.lastGateReason = void 0, r;
 }
 return r(t, e), t.prototype.isGenerationAllowed = function(e) {
@@ -44838,7 +44842,7 @@ var e;
 return null !== (e = globalThis.Memory) && void 0 !== e ? e : {};
 }();
 if (function(e) {
-return t = e.defenseRequests, (Array.isArray(t) ? t.filter(eT).length : Object.values(null != t ? t : {}).filter(eT).length) > 0;
+return t = e.defenseRequests, (Array.isArray(t) ? t.filter(rT).length : Object.values(null != t ? t : {}).filter(rT).length) > 0;
 var t;
 }(l)) return "active-defense-requests";
 if (function(e) {
@@ -44849,9 +44853,9 @@ var m = null === (r = l.stats) || void 0 === r ? void 0 : r.rooms;
 if (m) try {
 for (var d = a(Object.entries(m)), p = d.next(); !p.done; p = d.next()) {
 var f = i(p.value, 2), y = f[0], v = f[1];
-if (tT(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
-if (tT(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
-var g = tT(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = tT(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
+if (oT(null !== (o = null == v ? void 0 : v.hostiles) && void 0 !== o ? o : null === (n = null == v ? void 0 : v.metrics) || void 0 === n ? void 0 : n.hostile_count) > 0) return "hostile-pressure:".concat(y);
+if (oT(null === (s = null == v ? void 0 : v.spawn_queue) || void 0 === s ? void 0 : s.emergency) > 0) return "emergency-spawn:".concat(y);
+var g = oT(null === (c = null == v ? void 0 : v.taskBoard) || void 0 === c ? void 0 : c.open_tasks), h = oT(null === (u = null == v ? void 0 : v.taskBoard) || void 0 === u ? void 0 : u.assigned_tasks);
 if (g >= 80 || g - h >= 50) return "task-backlog:".concat(y);
 }
 } catch (t) {
@@ -44873,9 +44877,9 @@ interval: 1,
 minBucket: 1e4,
 cpuBudget: .01
 }) ], t.prototype, "run", null), n([ $e() ], t);
-}(Ki), nT = new oT;
+}(Vi), iT = new aT;
 
-function aT(e, t) {
+function sT(e, t) {
 var r, o;
 if ((null === (r = e.controller) || void 0 === r ? void 0 : r.owner) && !e.controller.my && !j(e.controller.owner.username)) return {
 lost: !0,
@@ -44897,7 +44901,7 @@ lost: !1
 };
 }
 
-function iT(e, t, r) {
+function cT(e, t, r) {
 var o, n = wr.getSwarmState(e);
 if (n) {
 var a = null !== (o = n.remoteAssignments) && void 0 !== o ? o : [], i = a.indexOf(t);
@@ -44911,20 +44915,20 @@ subsystem: "RemoteRoomManager"
 }
 }
 
-var sT = Mr().cpu.bucketThresholds.highMode + 1800, cT = {
+var uT = Mr().cpu.bucketThresholds.highMode + 1800, lT = {
 updateInterval: 250,
-minBucket: sT,
+minBucket: uT,
 maxSitesPerRemotePerTick: 2
 };
 
-function uT(e, t) {
+function mT(e, t) {
 var r = globalThis.cpuProfiler;
 return (null == r ? void 0 : r.measure) ? r.measure(e, t) : t();
 }
 
-var lT = function() {
+var dT = function() {
 function e(e) {
-void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, cT), e);
+void 0 === e && (e = {}), this.remoteRoadCache = new Map, this.config = o(o({}, lT), e);
 }
 return e.prototype.run = function() {
 var e, t, r, o = this, n = Object.values(Game.rooms).filter(function(e) {
@@ -44941,8 +44945,8 @@ if (0 !== i.length) try {
 for (var s = a(i), c = s.next(); !c.done; c = s.next()) {
 var u = c.value, l = Game.rooms[u];
 if (l) {
-var m = aT(l);
-m.lost && m.reason && iT(e, u, m.reason);
+var m = sT(l);
+m.lost && m.reason && cT(e, u, m.reason);
 }
 }
 } catch (e) {
@@ -44960,10 +44964,10 @@ if (t) throw t.error;
 }(e.name);
 var n = null !== (r = t.remoteAssignments) && void 0 !== r ? r : [];
 if (0 === n.length) return "continue";
-var i = uT("remoteInfrastructure.intent", function() {
+var i = mT("remoteInfrastructure.intent", function() {
 return o.getRemoteInfrastructureIntent(e, n);
 });
-uT("remoteInfrastructure.execute", function() {
+mT("remoteInfrastructure.execute", function() {
 return o.executeRemoteInfrastructureIntent(i);
 });
 };
@@ -45129,13 +45133,13 @@ skipped: o
 };
 var r, o, n, c;
 }, e.prototype.getRemoteInfrastructureSnapshot = function(e, t) {
-var r, o, n = this, c = uT("remoteInfrastructure.remoteRoadCache", function() {
+var r, o, n = this, c = mT("remoteInfrastructure.remoteRoadCache", function() {
 return n.getCachedRemoteRoads(e, t);
 }), u = {}, l = this.getMyUsername(), m = function(t) {
 var r = Game.rooms[t];
 if (!r) return "continue";
 var o = t !== e.name;
-u[t] = uT("remoteInfrastructure.roomSnapshot", function() {
+u[t] = mT("remoteInfrastructure.roomSnapshot", function() {
 var e;
 return n.getRoomSnapshot(r, null !== (e = c.get(t)) && void 0 !== e ? e : new Set, {
 includeSources: o,
@@ -45168,7 +45172,7 @@ maxRoadSitesPerRoomPerTick: 3
 }, e.prototype.getCachedRemoteRoads = function(e, t) {
 var r = this.getRemoteRoadCacheKey(e, t), o = this.remoteRoadCache.get(r);
 if (o && o.expires > Game.time) return o.roads;
-var n = uT("remoteInfrastructure.calculateRemoteRoads", function() {
+var n = mT("remoteInfrastructure.calculateRemoteRoads", function() {
 return ba(e, t);
 });
 return this.remoteRoadCache.set(r, {
@@ -45197,14 +45201,14 @@ if (e) throw e.error;
 }
 }
 }, e.prototype.getRoomSnapshot = function(e, t, r) {
-var o, n, a, c, u = this, l = uT("remoteInfrastructure.findConstructionSites", function() {
+var o, n, a, c, u = this, l = mT("remoteInfrastructure.findConstructionSites", function() {
 return e.find(FIND_CONSTRUCTION_SITES);
 }), m = {
 ownerUsername: null === (n = null === (o = e.controller) || void 0 === o ? void 0 : o.owner) || void 0 === n ? void 0 : n.username,
 reservationUsername: null === (c = null === (a = e.controller) || void 0 === a ? void 0 : a.reservation) || void 0 === c ? void 0 : c.username
 }, d = !(void 0 !== m.ownerUsername && m.ownerUsername !== r.myUsername || void 0 !== m.reservationUsername && m.reservationUsername !== r.myUsername), p = l.length < 5, f = t.size > 0 && p, y = f ? l.filter(function(e) {
 return e.structureType === STRUCTURE_ROAD;
-}) : [], v = f ? uT("remoteInfrastructure.findRoads", function() {
+}) : [], v = f ? mT("remoteInfrastructure.findRoads", function() {
 return e.find(FIND_STRUCTURES, {
 filter: function(e) {
 return e.structureType === STRUCTURE_ROAD;
@@ -45221,7 +45225,7 @@ return {
 name: e.name,
 constructionSiteCount: l.length,
 controller: m,
-sources: r.includeSources && d && p ? uT("remoteInfrastructure.sourceSnapshots", function() {
+sources: r.includeSources && d && p ? mT("remoteInfrastructure.sourceSnapshots", function() {
 return u.getSourceSnapshots(e);
 }) : void 0,
 roadPositions: h,
@@ -45239,7 +45243,7 @@ return "".concat(e.x, ",").concat(e.y);
 };
 }, e.prototype.getSourceSnapshots = function(e) {
 var t = this;
-return uT("remoteInfrastructure.findSources", function() {
+return mT("remoteInfrastructure.findSources", function() {
 return e.find(FIND_SOURCES);
 }).map(function(e) {
 return {
@@ -45336,10 +45340,10 @@ return e.length > 0 ? e[0].owner.username : "";
 }, n([ Xe("remote:infrastructure", "Remote Infrastructure Manager", {
 priority: Ie.LOW,
 interval: 1e3,
-minBucket: sT,
+minBucket: uT,
 cpuBudget: .05
 }) ], e.prototype, "run", null), n([ $e() ], e);
-}(), mT = new lT, dT = new (function(e) {
+}(), pT = new dT, fT = new (function(e) {
 function t(t) {
 return void 0 === t && (t = {}), e.call(this, t) || this;
 }
@@ -45351,7 +45355,7 @@ interval: 300,
 minBucket: 6e3,
 cpuBudget: .02
 }) ], t.prototype, "run", null), n([ $e() ], t);
-}(Vf)), pT = function() {
+}(jf)), yT = function() {
 function e() {}
 return e.prototype.cleanupMemory = function() {
 for (var e in Memory.creeps) Game.creeps[e] || delete Memory.creeps[e];
@@ -45367,13 +45371,13 @@ e = JSON.stringify(Memory).length;
 e = 0;
 }
 var o = 2097152, n = e / o * 100;
-n > 90 ? ll.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+n > 90 ? dl.error("Memory usage critical: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
-}) : n > 75 && ll.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
+}) : n > 75 && dl.warn("Memory usage high: ".concat(n.toFixed(1), "% (").concat(e, "/").concat(o, " bytes)"), {
 subsystem: "Memory"
 });
 }, e.prototype.updateMemorySegmentStats = function() {
-as.run();
+ss.run();
 }, e.prototype.runPheromoneDiffusion = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45395,7 +45399,7 @@ i && !i.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-Iy.applyDiffusion(o);
+Ly.applyDiffusion(o);
 }, e.prototype.initializeLabConfigs = function() {
 var e, t, r = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -45404,7 +45408,7 @@ return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 try {
 for (var o = a(r), n = o.next(); !n.done; n = o.next()) {
 var i = n.value;
-_u.initialize(i.name);
+Pu.initialize(i.name);
 }
 } catch (t) {
 e = {
@@ -45441,7 +45445,7 @@ cpuBudget: .01
 interval: 1e3,
 cpuBudget: .01
 }) ], e.prototype, "precacheRoomPaths", null), n([ $e() ], e);
-}(), fT = new pT, yT = new (function() {
+}(), vT = new yT, gT = new (function() {
 function e(e) {
 this.deps = e, this.processesRegistered = !1;
 }
@@ -45462,16 +45466,16 @@ this.runProcesses(), this.processQueuedEvents();
 this.processesRegistered = !1;
 }, e;
 }())({
-kernel: Gi,
+kernel: Di,
 eventBus: De,
 getCpuConfig: function() {
 return Mr().cpu;
 },
 registerProcesses: function() {
 var e;
-ll.info("Registering all processes with kernel...", {
+dl.info("Registering all processes with kernel...", {
 subsystem: "ProcessRegistry"
-}), Li(fT, Gs, Ws, fs, YE, Oc, zE, mT, Us, JE, nT, XE, su, du, dT, SE, tu, hE, _i),
+}), Bi(vT, Ds, Ks, vs, qE, Mc, XE, pT, Ns, eT, iT, JE, uu, fu, fT, xE, ou, EE, Pi),
 function() {
 var e, t, r = Mr().cpu.bucketThresholds.lowMode, o = [ {
 id: "terminal:manager",
@@ -45482,7 +45486,7 @@ interval: 20,
 minBucket: 0,
 cpuBudget: .1,
 execute: function() {
-return Gs.run();
+return Ds.run();
 }
 }, {
 id: "factory:manager",
@@ -45493,7 +45497,7 @@ interval: 30,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return Ws.run();
+return Ks.run();
 }
 }, {
 id: "link:manager",
@@ -45504,7 +45508,7 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .05,
 execute: function() {
-return fs.run();
+return vs.run();
 }
 }, {
 id: "empire:market",
@@ -45515,7 +45519,7 @@ interval: 300,
 minBucket: r,
 cpuBudget: .02,
 execute: function() {
-return Us.run();
+return Ns.run();
 }
 }, {
 id: "cluster:manager",
@@ -45526,7 +45530,7 @@ interval: 10,
 minBucket: 0,
 cpuBudget: .03,
 execute: function() {
-return hE.run();
+return EE.run();
 }
 }, {
 id: "cluster:evacuation",
@@ -45537,13 +45541,13 @@ interval: 5,
 minBucket: 0,
 cpuBudget: .02,
 execute: function() {
-return _i.run();
+return Pi.run();
 }
 } ], n = [];
 try {
 for (var i = a(o), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-Gi.getProcess(c.id) || (Gi.registerProcess(c), n.push(c.id));
+Di.getProcess(c.id) || (Di.registerProcess(c), n.push(c.id));
 }
 } catch (t) {
 e = {
@@ -45556,20 +45560,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-n.length > 0 && ll.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
+n.length > 0 && dl.warn("Registered framework package process fallbacks because decorator metadata was unavailable", {
 subsystem: "ProcessRegistry",
 meta: {
 processIds: n
 }
 });
-}(), (e = Gi.getProcess("empire:market")) && (e.interval = 300, e.minBucket = Mr().cpu.bucketThresholds.lowMode),
-ll.info("Registered ".concat(Gi.getProcesses().length, " processes with kernel"), {
+}(), (e = Di.getProcess("empire:market")) && (e.interval = 300, e.minBucket = Mr().cpu.bucketThresholds.lowMode),
+dl.info("Registered ".concat(Di.getProcesses().length, " processes with kernel"), {
 subsystem: "ProcessRegistry"
 });
 }
 });
 
-function vT(e) {
+function hT(e) {
 var t = function(e) {
 var t = Number.isFinite(e.bucket) ? e.bucket : 0;
 return t >= 8e3 ? "full" : t >= 6e3 ? "normal" : t >= 1500 ? "degraded" : t >= 500 ? "survival" : "panic";
@@ -45579,20 +45583,20 @@ bucket: e.bucket
 return e.hasCpuBudget && ("normal" === t || "full" === t);
 }
 
-var gT = cl("NativeCallsTracker");
+var RT = ll("NativeCallsTracker");
 
-function hT(e, t, r) {
+function ET(e, t, r) {
 var o = e[t];
 if (o && !o.__nativeCallsTrackerWrapped) {
 var n = Object.getOwnPropertyDescriptor(e, t);
-if (n && !1 === n.configurable) gT.warn("Cannot wrap method - property is not configurable", {
+if (n && !1 === n.configurable) RT.warn("Cannot wrap method - property is not configurable", {
 meta: {
 methodName: t
 }
 }); else try {
 var a = function() {
 for (var e = [], t = 0; t < arguments.length; t++) e[t] = arguments[t];
-return rs.recordNativeCall(r), o.apply(this, e);
+return ns.recordNativeCall(r), o.apply(this, e);
 };
 a.__nativeCallsTrackerWrapped = !0, Object.defineProperty(e, t, {
 value: a,
@@ -45601,7 +45605,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-gT.warn("Failed to wrap method", {
+RT.warn("Failed to wrap method", {
 meta: {
 methodName: t,
 error: String(e)
@@ -45611,30 +45615,30 @@ error: String(e)
 }
 }
 
-var RT, ET = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], TT = "shard1", CT = {
+var TT, CT = [ "shard0", "shard1", "shard2", "shard3", "shardX" ], ST = "shard1", wT = {
 parts: [ CLAIM, MOVE ],
 cost: 650,
 minCapacity: 650
-}, ST = {
+}, xT = {
 parts: [ WORK, CARRY, MOVE, MOVE ],
 cost: 250,
 minCapacity: 250
-}, wT = {
+}, bT = {
 parts: [ MOVE ],
 cost: 50,
 minCapacity: 50
 };
 
-function xT() {
+function OT() {
 var e, t;
 return null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0";
 }
 
-function bT() {
+function kT() {
 var e;
 return Memory.interShardOperation || (Memory.interShardOperation = {
 enabled: !0,
-targetShards: ET,
+targetShards: CT,
 launchedAt: Game.time,
 cpuFloors: {
 shard0: 5,
@@ -45644,12 +45648,12 @@ shard3: 10,
 shardX: 5
 }
 }), void 0 === Memory.interShardOperation.enabled && (Memory.interShardOperation.enabled = !0),
-(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = ET),
+(null === (e = Memory.interShardOperation.targetShards) || void 0 === e ? void 0 : e.length) || (Memory.interShardOperation.targetShards = CT),
 Memory.interShardOperation;
 }
 
-function OT() {
-return Lf({
+function MT() {
+return Bf({
 version: 1,
 shards: {},
 globalTargets: {
@@ -45662,32 +45666,32 @@ checksum: 0
 });
 }
 
-function kT(e, t) {
-void 0 === t && (t = [ "footprintOperation" ]), Df(e, {
+function AT(e, t) {
+void 0 === t && (t = [ "footprintOperation" ]), Ff(e, {
 updatedSections: t
 });
 }
 
-function MT() {
-var e, t, r, o, n, i, s, c = OT(), u = xT();
+function UT() {
+var e, t, r, o, n, i, s, c = MT(), u = OT();
 c.footprintOperation || (c.footprintOperation = {
 id: "auto-footprint-v1",
 enabled: !0,
-targetShards: ET,
+targetShards: CT,
 targets: {},
 startedAt: Game.time,
 updatedAt: Game.time
 });
 var l = c.footprintOperation;
 l.enabled = !1 !== (null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.enabled),
-l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : ET,
+l.targetShards = null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : CT,
 l.updatedAt = Game.time;
 try {
 for (var m = a(l.targetShards), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 l.targets[p] || (l.targets[p] = {
 shard: p,
-status: p === u && AT() ? "established" : "unreached",
+status: p === u && _T() ? "established" : "unreached",
 attempts: 0,
 lastUpdate: Game.time
 });
@@ -45705,7 +45709,7 @@ if (e) throw e.error;
 }
 return c.shards[u] || (c.shards[u] = {
 name: u,
-role: u === TT ? "core" : "frontier",
+role: u === ST ? "core" : "frontier",
 health: {
 cpuCategory: "low",
 cpuUsage: 0,
@@ -45722,24 +45726,24 @@ activeTasks: [],
 portals: [],
 cpuHistory: [],
 cpuLimit: null !== (s = null === (i = Game.cpu.shardLimits) || void 0 === i ? void 0 : i[u]) && void 0 !== s ? s : 0
-}), kT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
+}), AT(c, [ "footprintOperation", "shards" ]), c.footprintOperation;
 }
 
-function AT() {
+function _T() {
 return Object.values(Game.rooms).some(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 });
 }
 
-function UT() {
+function NT() {
 return Object.values(Game.rooms).filter(function(e) {
 var t;
 return (null === (t = e.controller) || void 0 === t ? void 0 : t.my) && e.find(FIND_MY_SPAWNS).length > 0;
 });
 }
 
-function _T(e, t) {
+function PT(e, t) {
 var r, o, n, i, s = 0;
 try {
 for (var c = a(Object.values(Game.creeps)), u = c.next(); !u.done; u = c.next()) {
@@ -45758,9 +45762,9 @@ if (r) throw r.error;
 }
 }
 try {
-for (var m = a(UT()), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(NT()), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
-s += Jv.getPendingRequests(p.name).filter(function(r) {
+s += eg.getPendingRequests(p.name).filter(function(r) {
 var o;
 return r.role === e && (null === (o = r.additionalMemory) || void 0 === o ? void 0 : o.targetShard) === t;
 }).length;
@@ -45779,7 +45783,7 @@ if (n) throw n.error;
 return s;
 }
 
-function NT(e) {
+function IT(e) {
 var t, r, o, n;
 try {
 for (var i = a(Object.values(Game.rooms)), s = i.next(); !s.done; s = i.next()) {
@@ -45823,7 +45827,7 @@ s && !s.done && (r = i.return) && r.call(i);
 if (t) throw t.error;
 }
 }
-var f = OT().shards[xT()], y = null == f ? void 0 : f.portals.find(function(t) {
+var f = MT().shards[OT()], y = null == f ? void 0 : f.portals.find(function(t) {
 return t.targetShard === e && t.threatRating <= 1;
 });
 return y ? {
@@ -45833,8 +45837,8 @@ targetRoom: y.targetRoom
 } : null;
 }
 
-function PT(e, t) {
-if (!(_T("scout", t) >= 1)) {
+function GT(e, t) {
+if (!(PT("scout", t) >= 1)) {
 var r = function(e) {
 var t, r, o, n, c = e.match(/^([WE])(\d+)([NS])(\d+)$/);
 if (!c) return [];
@@ -45872,13 +45876,13 @@ if (t) throw t.error;
 }
 return s([], i(p), !1);
 }(e.name)[0];
-r && Jv.addRequest({
+r && eg.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "scout",
 family: "utility",
-body: wT,
-priority: Lv.LOW + 5,
+body: bT,
+priority: Bv.LOW + 5,
 targetRoom: r,
 createdAt: Game.time,
 additionalMemory: {
@@ -45889,14 +45893,14 @@ task: "interShardPortalScout"
 }
 }
 
-function IT(e, t, r) {
-_T("interShardClaimer", t) >= 1 || Jv.addRequest({
+function LT(e, t, r) {
+PT("interShardClaimer", t) >= 1 || eg.addRequest({
 id: "interShardClaimer_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardClaimer",
 family: "utility",
-body: CT,
-priority: Lv.NORMAL + 50,
+body: wT,
+priority: Bv.NORMAL + 50,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45909,14 +45913,14 @@ workflowState: "movingToPortal"
 });
 }
 
-function GT(e, t, r) {
-_T("interShardScout", t) >= 1 || Jv.addRequest({
+function DT(e, t, r) {
+PT("interShardScout", t) >= 1 || eg.addRequest({
 id: "interShardScout_".concat(t, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardScout",
 family: "utility",
-body: wT,
-priority: Lv.NORMAL,
+body: bT,
+priority: Bv.NORMAL,
 targetRoom: r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45929,15 +45933,15 @@ workflowState: "movingToPortal"
 });
 }
 
-function LT(e, t, r) {
+function BT(e, t, r) {
 var o, n;
-(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (_T("interShardPioneer", t.shard) >= 3 || Jv.addRequest({
+(t.claimTargetRoom || "claimed" === t.status || "bootstrapping" === t.status) && (PT("interShardPioneer", t.shard) >= 3 || eg.addRequest({
 id: "interShardPioneer_".concat(t.shard, "_").concat(Game.time),
 roomName: e.name,
 role: "interShardPioneer",
 family: "economy",
-body: ST,
-priority: Lv.NORMAL + 25,
+body: xT,
+priority: Bv.NORMAL + 25,
 targetRoom: null !== (o = t.claimTargetRoom) && void 0 !== o ? o : r.targetRoom,
 createdAt: Game.time,
 additionalMemory: {
@@ -45950,19 +45954,19 @@ workflowState: "movingToPortal"
 }));
 }
 
-function DT(e) {
+function FT(e) {
 var t, r, o = null !== (r = null === (t = Game.gcl) || void 0 === t ? void 0 : t.level) && void 0 !== r ? r : 1;
 return function() {
-var e, t, r, o, n, i, s, c = xT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
+var e, t, r, o, n, i, s, c = OT(), u = new Set, l = Object.values(Game.rooms).filter(function(e) {
 var t;
 return null === (t = e.controller) || void 0 === t ? void 0 : t.my;
 }).length;
 u.add(c);
 try {
-for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : ET), d = m.next(); !d.done; d = m.next()) {
+for (var m = a(null !== (o = null === (r = Memory.interShardOperation) || void 0 === r ? void 0 : r.targetShards) && void 0 !== o ? o : CT), d = m.next(); !d.done; d = m.next()) {
 var p = d.value;
 if (!u.has(p)) try {
-var f = InterShardMemory.getRemote(p), y = f ? Uf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
+var f = InterShardMemory.getRemote(p), y = f ? Nf(f) : null, v = null === (s = null === (i = null === (n = null == y ? void 0 : y.shards) || void 0 === n ? void 0 : n[p]) || void 0 === i ? void 0 : i.health) || void 0 === s ? void 0 : s.roomCount;
 "number" == typeof v && v > 0 && (l += v), u.add(p);
 } catch (e) {}
 }
@@ -45994,9 +45998,9 @@ if (e) throw e.error;
 }
 }
 try {
-for (var c = a(UT()), u = c.next(); !u.done; u = c.next()) {
+for (var c = a(NT()), u = c.next(); !u.done; u = c.next()) {
 var l = u.value;
-n += Jv.getPendingRequests(l.name).filter(function(e) {
+n += eg.getPendingRequests(l.name).filter(function(e) {
 return "interShardClaimer" === e.role;
 }).length;
 }
@@ -46015,22 +46019,22 @@ return n;
 }() < o;
 }
 
-(RT = {
-optimizeBody: zv,
+(TT = {
+optimizeBody: Xv,
 spawnQueue: {
 addRequest: function(e) {
-return Jv.addRequest(e);
+return eg.addRequest(e);
 }
 },
 spawnPriorities: {
-LOW: Lv.LOW,
-NORMAL: Lv.NORMAL,
-HIGH: Lv.HIGH
+LOW: Bv.LOW,
+NORMAL: Bv.NORMAL,
+HIGH: Bv.HIGH
 }
-}).optimizeBody && (jf.optimizeBody = RT.optimizeBody), RT.spawnQueue && (jf.spawnQueue = RT.spawnQueue),
-RT.spawnPriorities && (jf.spawnPriorities = o(o({}, jf.spawnPriorities), RT.spawnPriorities));
+}).optimizeBody && (Qf.optimizeBody = TT.optimizeBody), TT.spawnQueue && (Qf.spawnQueue = TT.spawnQueue),
+TT.spawnPriorities && (Qf.spawnPriorities = o(o({}, Qf.spawnPriorities), TT.spawnPriorities));
 
-var BT, FT = function() {
+var WT, HT = function() {
 function e(e, t, r, o) {
 this.initialized = !1, this.logger = e, this.eventBus = t, this.pathCache = r, this.remoteMining = o;
 }
@@ -46074,7 +46078,7 @@ subsystem: "PathCacheEvents"
 }, e;
 }();
 
-function WT(e) {
+function KT(e) {
 var t, r, o = new Set;
 try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
@@ -46095,7 +46099,7 @@ if (t) throw t.error;
 return Array.from(o);
 }
 
-function HT(e, t, r) {
+function YT(e, t, r) {
 return PathFinder.search(e, {
 pos: t,
 range: 1
@@ -46161,16 +46165,16 @@ return u;
 });
 }
 
-function KT(e) {
+function VT(e) {
 return !e.incomplete && e.path.length > 0;
 }
 
 !function(e) {
 e[e.CRITICAL = 0] = "CRITICAL", e[e.HIGH = 1] = "HIGH", e[e.MEDIUM = 2] = "MEDIUM",
 e[e.LOW = 3] = "LOW";
-}(BT || (BT = {}));
+}(WT || (WT = {}));
 
-var YT = function() {
+var qT = function() {
 function e(e, t) {
 this.pathCache = e, this.logger = t;
 }
@@ -46208,8 +46212,8 @@ if (l.length > 0) {
 var h = l[0];
 try {
 for (var R = (n = void 0, a(v)), E = R.next(); !E.done; E = R.next()) {
-var T = E.value, C = HT(h.pos, T.pos, this.logger);
-if (KT(C)) {
+var T = E.value, C = YT(h.pos, T.pos, this.logger);
+if (VT(C)) {
 var S = this.pathCache.convertRoomPositionsToPathSteps(C.path);
 this.cacheRemoteMiningPath(h.pos, T.pos, S, "harvester"), m++;
 }
@@ -46236,8 +46240,8 @@ return e.pos;
 });
 try {
 for (var b = (s = void 0, a(x)), O = b.next(); !O.done; O = b.next()) {
-var k = O.value, M = HT(k, u.pos, this.logger);
-KT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
+var k = O.value, M = YT(k, u.pos, this.logger);
+VT(M) && (S = this.pathCache.convertRoomPositionsToPathSteps(M.path), this.cacheRemoteMiningPath(k, u.pos, S, "hauler"),
 m++);
 }
 } catch (e) {
@@ -46276,8 +46280,8 @@ routesCached: m
 }, e.prototype.getOrCalculateRemotePath = function(e, t, r) {
 var o = this.getRemoteMiningPath(e, t, r);
 if (o) return o;
-var n = HT(e, t, this.logger);
-if (KT(n)) {
+var n = YT(e, t, this.logger);
+if (VT(n)) {
 var a = this.pathCache.convertRoomPositionsToPathSteps(n.path);
 return this.cacheRemoteMiningPath(e, t, a, r), a;
 }
@@ -46287,7 +46291,7 @@ incomplete: n.incomplete
 }
 }), null;
 }, e;
-}(), VT = function() {
+}(), jT = function() {
 function e(e, t, r) {
 this.logger = e, this.scheduler = t, this.pathCache = r;
 }
@@ -46297,7 +46301,7 @@ try {
 for (var n = a(Object.values(Game.rooms)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
 if ((null === (r = s.controller) || void 0 === r ? void 0 : r.my) && (s.storage || 0 !== s.find(FIND_MY_SPAWNS).length)) {
-var c = WT(s);
+var c = KT(s);
 0 !== c.length && (this.pathCache.precacheRemoteRoutes(s, c), o += c.length);
 }
 }
@@ -46323,7 +46327,7 @@ void 0 === e && (e = 2), this.scheduler.scheduleTask("precache-remote-paths", 50
 return t.precacheAllRemoteRoutes();
 }, e, 5), this.logger.info("Remote path cache scheduler initialized");
 }, e;
-}(), qT = function() {
+}(), zT = function() {
 function e(e, t, r, o) {
 this.logger = e, this.pathCache = t, this.remotePaths = r, this.moveTo = o;
 }
@@ -46372,7 +46376,7 @@ stroke: "#ffffff"
 }
 });
 }, e;
-}(), jT = {
+}(), QT = {
 debug: function(e, t) {
 return M("RemoteMining").debug(e, t);
 },
@@ -46385,7 +46389,7 @@ return M("RemoteMining").warn(e, t);
 error: function(e, t) {
 return M("RemoteMining").error(e, t);
 }
-}, zT = {
+}, XT = {
 getCachedPath: function(e, t) {
 var r = ut(e, t), o = Ee.get(r, {
 namespace: ct
@@ -46412,26 +46416,26 @@ direction: a
 }
 return t;
 }
-}, QT = {
+}, ZT = {
 scheduleTask: function(e, t, r, o, n) {
 !function(e, t, r, o, n) {
-void 0 === o && (o = id.MEDIUM), gd.register({
+void 0 === o && (o = cd.MEDIUM), Rd.register({
 id: e,
 interval: t,
 execute: r,
 priority: o,
 maxCpu: n,
-skippable: o !== id.CRITICAL
+skippable: o !== cd.CRITICAL
 });
 }(e, t, r, o, n);
 }
-}, XT = new YT(zT, jT), ZT = new VT(jT, QT, XT), JT = new qT(jT, zT, XT, bl.moveTo);
+}, JT = new qT(XT, QT), $T = new jT(QT, ZT, JT), eC = new zT(QT, XT, JT, kl.moveTo);
 
-function $T(e, t, r, o) {
-return JT.moveToWithRemoteCache(e, t, r, o);
+function tC(e, t, r, o) {
+return eC.moveToWithRemoteCache(e, t, r, o);
 }
 
-var eC, tC = function() {
+var rC, oC = function() {
 function e() {
 this.logger = M("Pathfinding");
 }
@@ -46444,12 +46448,12 @@ this.logger.warn(e, t);
 }, e.prototype.error = function(e, t) {
 this.logger.error(e, t);
 }, e;
-}(), rC = function() {
+}(), nC = function() {
 function e() {}
 return e.prototype.on = function(e, t) {
 De.on(e, t);
 }, e;
-}(), oC = function() {
+}(), aC = function() {
 function e() {}
 return e.prototype.invalidateRoom = function(e) {
 !function(e) {
@@ -46494,28 +46498,28 @@ m.length > 0 && lt(n.pos, e.controller.pos, m);
 }
 }(e);
 }, e;
-}(), nC = function() {
+}(), iC = function() {
 function e() {}
 return e.prototype.getRemoteRoomsForRoom = function(e) {
 return function(e) {
-return WT(e);
+return KT(e);
 }(e);
 }, e.prototype.precacheRemoteRoutes = function(e, t) {
 !function(e, t) {
-XT.precacheRemoteRoutes(e, t);
+JT.precacheRemoteRoutes(e, t);
 }(e, t);
 }, e;
-}(), aC = new FT(new tC, new rC, new oC, new nC), iC = {
+}(), sC = new HT(new oC, new nC, new aC, new iC), cC = {
 lowBucketThreshold: 2e3,
 highBucketThreshold: 9e3,
 targetCpuUsage: .8,
 highFrequencyInterval: 1,
 mediumFrequencyInterval: 5,
 lowFrequencyInterval: 20
-}, sC = function() {
+}, uC = function() {
 function e(e) {
 void 0 === e && (e = {}), this.tasks = new Map, this.currentMode = "normal", this.tickCpuUsed = 0,
-this.config = o(o({}, iC), e);
+this.config = o(o({}, cC), e);
 }
 return e.prototype.registerTask = function(e) {
 this.tasks.set(e.name, o(o({}, e), {
@@ -46524,10 +46528,10 @@ lastRun: 0
 }, e.prototype.unregisterTask = function(e) {
 this.tasks.delete(e);
 }, e.prototype.getBucketMode = function() {
-return Gi.getBucketMode();
+return Di.getBucketMode();
 }, e.prototype.updateBucketMode = function() {
 var e = this.getBucketMode();
-e !== this.currentMode && (ll.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
+e !== this.currentMode && (dl.info("Bucket mode changed: ".concat(this.currentMode, " -> ").concat(e), {
 subsystem: "Scheduler"
 }), this.currentMode = e);
 }, e.prototype.getCpuLimit = function() {
@@ -46575,13 +46579,13 @@ try {
 i.execute(), i.lastRun = Game.time;
 } catch (e) {
 var c = e instanceof Error ? e.message : String(e);
-ll.error("Task ".concat(i.name, " failed: ").concat(c), {
+dl.error("Task ".concat(i.name, " failed: ").concat(c), {
 subsystem: "Scheduler"
 });
 }
 var u = Game.cpu.getUsed() - s;
 if (this.tickCpuUsed += u, !this.hasCpuBudget()) {
-ll.warn("CPU budget exhausted, skipping remaining tasks", {
+dl.warn("CPU budget exhausted, skipping remaining tasks", {
 subsystem: "Scheduler"
 });
 break;
@@ -46609,123 +46613,123 @@ return Array.from(this.tasks.values());
 }, e;
 }();
 
-new sC, (eC = {})[FIND_STRUCTURES] = {
+new uC, (rC = {})[FIND_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, eC[FIND_MY_STRUCTURES] = {
+}, rC[FIND_MY_STRUCTURES] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, eC[FIND_HOSTILE_STRUCTURES] = {
+}, rC[FIND_HOSTILE_STRUCTURES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, eC[FIND_SOURCES_ACTIVE] = {
+}, rC[FIND_SOURCES_ACTIVE] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, eC[FIND_SOURCES] = {
+}, rC[FIND_SOURCES] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, eC[FIND_MINERALS] = {
+}, rC[FIND_MINERALS] = {
 lowBucket: 1e4,
 normal: 5e3,
 highBucket: 1e3
-}, eC[FIND_DEPOSITS] = {
+}, rC[FIND_DEPOSITS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, eC[FIND_MY_CONSTRUCTION_SITES] = {
+}, rC[FIND_MY_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, eC[FIND_CONSTRUCTION_SITES] = {
+}, rC[FIND_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, eC[FIND_CREEPS] = {
+}, rC[FIND_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, eC[FIND_MY_CREEPS] = {
+}, rC[FIND_MY_CREEPS] = {
 lowBucket: 10,
 normal: 5,
 highBucket: 3
-}, eC[FIND_HOSTILE_CREEPS] = {
+}, rC[FIND_HOSTILE_CREEPS] = {
 lowBucket: 10,
 normal: 3,
 highBucket: 1
-}, eC[FIND_DROPPED_RESOURCES] = {
+}, rC[FIND_DROPPED_RESOURCES] = {
 lowBucket: 20,
 normal: 5,
 highBucket: 3
-}, eC[FIND_TOMBSTONES] = {
+}, rC[FIND_TOMBSTONES] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, eC[FIND_RUINS] = {
+}, rC[FIND_RUINS] = {
 lowBucket: 30,
 normal: 10,
 highBucket: 5
-}, eC[FIND_FLAGS] = {
+}, rC[FIND_FLAGS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, eC[FIND_MY_SPAWNS] = {
+}, rC[FIND_MY_SPAWNS] = {
 lowBucket: 200,
 normal: 100,
 highBucket: 50
-}, eC[FIND_HOSTILE_SPAWNS] = {
+}, rC[FIND_HOSTILE_SPAWNS] = {
 lowBucket: 100,
 normal: 50,
 highBucket: 20
-}, eC[FIND_HOSTILE_CONSTRUCTION_SITES] = {
+}, rC[FIND_HOSTILE_CONSTRUCTION_SITES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, eC[FIND_NUKES] = {
+}, rC[FIND_NUKES] = {
 lowBucket: 50,
 normal: 20,
 highBucket: 10
-}, eC[FIND_POWER_CREEPS] = {
+}, rC[FIND_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, eC[FIND_MY_POWER_CREEPS] = {
+}, rC[FIND_MY_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, eC[FIND_HOSTILE_POWER_CREEPS] = {
+}, rC[FIND_HOSTILE_POWER_CREEPS] = {
 lowBucket: 20,
 normal: 10,
 highBucket: 5
-}, eC[FIND_EXIT_TOP] = {
+}, rC[FIND_EXIT_TOP] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, eC[FIND_EXIT_RIGHT] = {
+}, rC[FIND_EXIT_RIGHT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, eC[FIND_EXIT_BOTTOM] = {
+}, rC[FIND_EXIT_BOTTOM] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, eC[FIND_EXIT_LEFT] = {
+}, rC[FIND_EXIT_LEFT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
-}, eC[FIND_EXIT] = {
+}, rC[FIND_EXIT] = {
 lowBucket: 1e3,
 normal: 500,
 highBucket: 100
 };
 
-var cC = new fe({}, wr), uC = new Nt({}, wr);
+var lC = new fe({}, wr), mC = new Nt({}, wr);
 
-function lC(e) {
+function dC(e) {
 for (var t in Game.spawns) {
 var r = Game.spawns[t];
 if (r.room.name === e.name && !r.spawning) return !0;
@@ -46733,16 +46737,16 @@ if (r.room.name === e.name && !r.spawning) return !0;
 return !1;
 }
 
-var mC = !1;
+var pC = !1;
 
-function dC() {
+function fC() {
 var e, t;
-mC || (zu({
-level: (t = Mr()).debug ? bu.DEBUG : bu.INFO,
+pC || (Xu({
+level: (t = Mr()).debug ? ku.DEBUG : ku.INFO,
 cpuLogging: t.profiling,
 enableBatching: !0,
 maxBatchSize: 50
-}), ll.info("Bot initialized", {
+}), dl.info("Bot initialized", {
 subsystem: "SwarmBot",
 meta: {
 debug: t.debug,
@@ -46752,11 +46756,11 @@ profiling: t.profiling
 var t;
 if (e.resourceTransferCoordinator) {
 var r = e.resourceTransferCoordinator;
-r.getPendingTransfers && ($v.getPendingTransfers = function(e) {
+r.getPendingTransfers && (tg.getPendingTransfers = function(e) {
 return r.getPendingTransfers(e);
-}), r.needsCarrier && ($v.needsCarrier = function(e) {
+}), r.needsCarrier && (tg.needsCarrier = function(e) {
 return r.needsCarrier(e);
-}), r.getActiveRequests && ($v.getActiveRequests = function() {
+}), r.getActiveRequests && (tg.getActiveRequests = function() {
 return r.getActiveRequests();
 });
 }
@@ -46770,66 +46774,66 @@ n.getSwarmState, n.setSwarmState, n.getCluster, n.getEmpire;
 }
 if (e.energyFlowPredictor) {
 var a = e.energyFlowPredictor;
-a.predictConsumption && (eg.predictConsumption = function(e) {
+a.predictConsumption && (rg.predictConsumption = function(e) {
 return a.predictConsumption(e);
-}), a.getEnergyAvailableForSpawning && (eg.getEnergyAvailableForSpawning = function(e) {
+}), a.getEnergyAvailableForSpawning && (rg.getEnergyAvailableForSpawning = function(e) {
 return a.getEnergyAvailableForSpawning(e);
-}), a.predictEnergyInTicks && (eg.predictEnergyInTicks = function(e, t) {
+}), a.predictEnergyInTicks && (rg.predictEnergyInTicks = function(e, t) {
 return a.predictEnergyInTicks(e, t);
-}), a.getMaxAffordableInTicks && (eg.getMaxAffordableInTicks = function(e, t) {
+}), a.getMaxAffordableInTicks && (rg.getMaxAffordableInTicks = function(e, t) {
 return a.getMaxAffordableInTicks(e, t);
 });
 }
 if (e.powerBankHarvestingManager) {
 var i = e.powerBankHarvestingManager;
-i.getActivePowerBanks && (tg.getActivePowerBanks = function() {
+i.getActivePowerBanks && (og.getActivePowerBanks = function() {
 return i.getActivePowerBanks();
-}), i.needsHarvesters && (tg.needsHarvesters = function(e) {
+}), i.needsHarvesters && (og.needsHarvesters = function(e) {
 return i.needsHarvesters(e);
-}), i.needsCarriers && (tg.needsCarriers = function(e) {
+}), i.needsCarriers && (og.needsCarriers = function(e) {
 return i.needsCarriers(e);
-}), i.requestSpawns && (tg.requestSpawns = function(e) {
+}), i.requestSpawns && (og.requestSpawns = function(e) {
 return i.requestSpawns(e);
 });
 }
 if (null === (t = e.emergencyResponseManager) || void 0 === t ? void 0 : t.getEmergencyState) {
 var s = e.emergencyResponseManager;
-rg.getEmergencyState = function(e) {
+ng.getEmergencyState = function(e) {
 return s.getEmergencyState(e);
 };
 }
 }({
 energyFlowPredictor: ro,
-powerBankHarvestingManager: su,
-resourceTransferCoordinator: Qf,
+powerBankHarvestingManager: uu,
+resourceTransferCoordinator: Zf,
 emergencyResponseManager: Si,
-kernel: Gi
+kernel: Di
 }), function(e) {
 var t, r, o, n;
-up = e ? {
-getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : cp.getLabResourceNeeds,
-getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : cp.getLabSupplyNeeds,
-getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : cp.getLabOverflow
-} : cp;
+mp = e ? {
+getLabResourceNeeds: null !== (t = e.getLabResourceNeeds) && void 0 !== t ? t : lp.getLabResourceNeeds,
+getLabSupplyNeeds: null !== (o = null !== (r = e.getLabSupplyNeeds) && void 0 !== r ? r : e.getLabResourceNeeds) && void 0 !== o ? o : lp.getLabSupplyNeeds,
+getLabOverflow: null !== (n = e.getLabOverflow) && void 0 !== n ? n : lp.getLabOverflow
+} : lp;
 }({
 getLabResourceNeeds: function(e) {
-return Pu.getLabResourceNeeds(e);
+return Gu.getLabResourceNeeds(e);
 },
 getLabSupplyNeeds: function(e) {
-return Pu.getLabResourceNeeds(e);
+return Gu.getLabResourceNeeds(e);
 },
 getLabOverflow: function(e) {
-return Pu.getLabOverflow(e);
+return Gu.getLabOverflow(e);
 }
-}), rs.initialize(), t.profiling && (function() {
+}), ns.initialize(), t.profiling && (function() {
 if (PathFinder.search && !PathFinder.search.__nativeCallsTrackerWrapped) {
 var e = Object.getOwnPropertyDescriptor(PathFinder, "search");
-if (e && !1 === e.configurable) gT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
+if (e && !1 === e.configurable) RT.warn("Cannot wrap PathFinder.search - property is not configurable"); else {
 var t = PathFinder.search;
 try {
 var r = function() {
 for (var e = [], r = 0; r < arguments.length; r++) e[r] = arguments[r];
-return rs.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
+return ns.recordNativeCall("pathfinderSearch"), t.apply(PathFinder, e);
 };
 r.__nativeCallsTrackerWrapped = !0, Object.defineProperty(PathFinder, "search", {
 value: r,
@@ -46838,7 +46842,7 @@ enumerable: !0,
 configurable: !0
 });
 } catch (e) {
-gT.warn("Failed to wrap PathFinder.search", {
+RT.warn("Failed to wrap PathFinder.search", {
 meta: {
 error: String(e)
 }
@@ -46846,11 +46850,11 @@ error: String(e)
 }
 }
 }
-}(), hT(e = Creep.prototype, "moveTo", "moveTo"), hT(e, "move", "move"), hT(e, "harvest", "harvest"),
-hT(e, "transfer", "transfer"), hT(e, "withdraw", "withdraw"), hT(e, "build", "build"),
-hT(e, "repair", "repair"), hT(e, "upgradeController", "upgradeController"), hT(e, "attack", "attack"),
-hT(e, "rangedAttack", "rangedAttack"), hT(e, "heal", "heal"), hT(e, "dismantle", "dismantle"),
-hT(e, "say", "say")), function(e) {
+}(), ET(e = Creep.prototype, "moveTo", "moveTo"), ET(e, "move", "move"), ET(e, "harvest", "harvest"),
+ET(e, "transfer", "transfer"), ET(e, "withdraw", "withdraw"), ET(e, "build", "build"),
+ET(e, "repair", "repair"), ET(e, "upgradeController", "upgradeController"), ET(e, "attack", "attack"),
+ET(e, "rangedAttack", "rangedAttack"), ET(e, "heal", "heal"), ET(e, "dismantle", "dismantle"),
+ET(e, "say", "say")), function(e) {
 void 0 === e && (e = Ue);
 var t = e.cacheManager, r = e.coherenceManager;
 r.registerCache("object", t, Ce.L1, {
@@ -47037,15 +47041,15 @@ room: e.homeRoom
 }), U.info("Pheromone event handlers initialized", {
 subsystem: "Pheromone"
 });
-}(Gi, wr, Iy), aC.initializePathCacheEvents(), ZT.initialize(id.MEDIUM), pm = $T,
-Jt.initialize(), dT.initialize(), mC = !0), wr.initialize();
-var r = yT.configureForCurrentTick();
-"critical" === r && Game.time % 10 == 0 && ll.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
+}(Di, wr, Ly), sC.initializePathCacheEvents(), $T.initialize(cd.MEDIUM), ym = tC,
+Jt.initialize(), fT.initialize(), pC = !0), wr.initialize();
+var r = gT.configureForCurrentTick();
+"critical" === r && Game.time % 10 == 0 && dl.warn("CRITICAL: CPU bucket at ".concat(Game.cpu.bucket, ", running core work and deferring optional work"), {
 subsystem: "SwarmBot"
 }), function() {
-var e, t, r = bT();
-if (!1 !== r.enabled && (r.lastRun = Game.time, MT(), function() {
-var e, t, r, o, n = OT(), a = n.footprintOperation, i = xT(), s = null == a ? void 0 : a.targets[i];
+var e, t, r = kT();
+if (!1 !== r.enabled && (r.lastRun = Game.time, UT(), function() {
+var e, t, r, o, n = MT(), a = n.footprintOperation, i = OT(), s = null == a ? void 0 : a.targets[i];
 if (a && s) {
 var c = Object.values(Game.rooms).filter(function(e) {
 var t;
@@ -47058,15 +47062,15 @@ null !== (r = s.arrivedAt) && void 0 !== r || (s.arrivedAt = Game.time), s.lastU
 var t, r;
 return null === (r = null === (t = e.memory.role) || void 0 === t ? void 0 : t.startsWith) || void 0 === r ? void 0 : r.call(t, "interShard");
 }) && ("unreached" === s.status && (s.status = "reached"), null !== (o = s.arrivedAt) && void 0 !== o || (s.arrivedAt = Game.time),
-s.lastUpdate = Game.time), a.updatedAt = Game.time, kT(n);
+s.lastUpdate = Game.time), a.updatedAt = Game.time, AT(n);
 }
 }(), function() {
-var e, t, r, n, i, s, c = bT();
+var e, t, r, n, i, s, c = kT();
 if (!1 !== c.enabled && Game.cpu.setShardLimits && Game.cpu.shardLimits && Game.time % 100 == 0) {
 var u = null !== (r = c.cpuFloors) && void 0 !== r ? r : {}, l = Game.cpu.shardLimits, m = o({}, l), d = !1;
 try {
-for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : ET), f = p.next(); !f.done; f = p.next()) {
-var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === TT ? 20 : 5;
+for (var p = a(null !== (n = c.targetShards) && void 0 !== n ? n : CT), f = p.next(); !f.done; f = p.next()) {
+var y = f.value, v = null !== (i = u[y]) && void 0 !== i ? i : y === ST ? 20 : 5;
 (null !== (s = m[y]) && void 0 !== s ? s : 0) < v && (m[y] = v, d = !0);
 }
 } catch (t) {
@@ -47084,10 +47088,10 @@ d && Game.cpu.setShardLimits(m) === OK && U.info("Applied intershard CPU floors:
 subsystem: "InterShardFootprint"
 });
 }
-}(), !AT())) try {
+}(), !_T())) try {
 for (var n = a(Object.values(Game.creeps)), i = n.next(); !i.done; i = n.next()) {
 var s = i.value, c = s.memory.role;
-"interShardClaimer" !== c && "interShardScout" !== c || my(s), "interShardPioneer" === c && ly(s);
+"interShardClaimer" !== c && "interShardScout" !== c || py(s), "interShardPioneer" === c && dy(s);
 }
 } catch (t) {
 e = {
@@ -47102,16 +47106,16 @@ if (e) throw e.error;
 }
 }();
 var n = Ct();
-if (0 === n.length) return Game.time % 100 == 0 && ll.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
+if (0 === n.length) return Game.time % 100 == 0 && dl.info("Shard idle (no owned rooms) at tick ".concat(Game.time), {
 subsystem: "SwarmBot"
-}), rs.publishIdleTick(), void ll.flush();
-Game.time % 10 == 0 && ll.info("SwarmBot loop executing at tick ".concat(Game.time), {
+}), ns.publishIdleTick(), void dl.flush();
+Game.time % 10 == 0 && dl.info("SwarmBot loop executing at tick ".concat(Game.time), {
 subsystem: "SwarmBot",
 meta: {
-systemsInitialized: mC
+systemsInitialized: pC
 }
-}), yT.ensureProcessesRegistered(), rs.startTick(), hl.clear(), yT.startEventTick(),
-rs.measureSubsystem("taskBoard", function() {
+}), gT.ensureProcessesRegistered(), ns.startTick(), El.clear(), gT.startEventTick(),
+ns.measureSubsystem("taskBoard", function() {
 var e, t, r = Mr(), o = Game.cpu.bucket >= r.cpu.bucketThresholds.highMode ? 2 : Game.cpu.bucket < r.cpu.bucketThresholds.lowMode ? 6 : 3;
 try {
 for (var i = a(function(e) {
@@ -47125,7 +47129,7 @@ rooms: n,
 interval: o
 })), s = i.next(); !s.done; s = i.next()) {
 var c = s.value;
-lm.refreshRoom(c);
+dm.refreshRoom(c);
 }
 } catch (t) {
 e = {
@@ -47138,20 +47142,20 @@ s && !s.done && (t = i.return) && t.call(i);
 if (e) throw e.error;
 }
 }
-}), rs.measureSubsystem("spawns", function() {
+}), ns.measureSubsystem("spawns", function() {
 (function() {
-var e, t, r, o = bT();
+var e, t, r, o = kT();
 if (!1 !== o.enabled && Game.time % 10 == 0) {
-var n = MT();
+var n = UT();
 !function(e) {
 var t, r, o, n, i, s, c, u;
 try {
-for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : ET), m = l.next(); !m.done; m = l.next()) {
+for (var l = a(null !== (n = null === (o = Memory.interShardOperation) || void 0 === o ? void 0 : o.targetShards) && void 0 !== n ? n : CT), m = l.next(); !m.done; m = l.next()) {
 var d = m.value;
-if (d !== xT()) try {
+if (d !== OT()) try {
 var p = InterShardMemory.getRemote(d);
 if (!p) continue;
-var f = Uf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
+var f = Nf(p), y = null === (s = null === (i = null == f ? void 0 : f.footprintOperation) || void 0 === i ? void 0 : i.targets) || void 0 === s ? void 0 : s[d];
 if (!y) continue;
 var v = e.targets[d];
 (!v || (null !== (c = y.lastUpdate) && void 0 !== c ? c : 0) > (null !== (u = v.lastUpdate) && void 0 !== u ? u : 0)) && (e.targets[d] = y);
@@ -47169,20 +47173,20 @@ if (t) throw t.error;
 }
 }
 }(n);
-var i = UT().sort(function(e, t) {
+var i = NT().sort(function(e, t) {
 return t.energyCapacityAvailable - e.energyCapacityAvailable || e.name.localeCompare(t.name);
 })[0];
 if (i) {
 try {
-for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : ET), c = s.next(); !c.done; c = s.next()) {
+for (var s = a(null !== (r = o.targetShards) && void 0 !== r ? r : CT), c = s.next(); !c.done; c = s.next()) {
 var u = c.value;
-if (u !== xT()) {
+if (u !== OT()) {
 var l = n.targets[u];
 if (l && "established" !== l.status) {
-var m = NT(u);
+var m = IT(u);
 m ? (l.portalRoom = m.room, l.portalPos = m.pos, l.destinationRoom = m.targetRoom,
-l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? LT(i, l, m) : DT() ? IT(i, u, m) : (GT(i, u, m),
-l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (PT(i, u),
+l.lastUpdate = Game.time, "claimed" === l.status || "bootstrapping" === l.status ? BT(i, l, m) : FT() ? LT(i, u, m) : (DT(i, u, m),
+l.status = "unreached" === l.status ? "unreached" : l.status, l.blockedReason = "GCL claim slots are full; sending footprint scout only until a claim slot opens")) : (GT(i, u),
 l.blockedReason = "No known safe intershard portal yet; scouting sector centers",
 l.lastUpdate = Game.time);
 }
@@ -47199,8 +47203,8 @@ c && !c.done && (t = s.return) && t.call(s);
 if (e) throw e.error;
 }
 }
-var d = OT();
-d.footprintOperation = n, kT(d);
+var d = MT();
+d.footprintOperation = n, AT(d);
 }
 }
 })(), function(e) {
@@ -47208,10 +47212,10 @@ var t, r, o = Game.cpu.bucket < Mr().cpu.bucketThresholds.lowMode;
 try {
 for (var n = a(e), i = n.next(); !i.done; i = n.next()) {
 var s = i.value;
-if (!o || lC(s)) {
-var c = $h(s, wr.getOrInitSwarmState(s.name));
-rs.recordSpawnQueue(s.name, c.stats, c.spawned), rs.recordDefenseAssist(s.name, c.defenseAssist);
-} else rs.recordDefenseAssist(s.name, []);
+if (!o || dC(s)) {
+var c = tR(s, wr.getOrInitSwarmState(s.name));
+ns.recordSpawnQueue(s.name, c.stats, c.spawned), ns.recordDefenseAssist(s.name, c.defenseAssist);
+} else ns.recordDefenseAssist(s.name, []);
 }
 } catch (e) {
 t = {
@@ -47225,21 +47229,21 @@ if (t) throw t.error;
 }
 }
 }(n);
-}), bl.preTick(), rs.measureSubsystem("processSync", function() {
-Cy.syncCreepProcesses(), xv.syncRoomProcesses();
-}), rs.measureSubsystem("kernel", function() {
-yT.runProcesses();
-}), rs.measureSubsystem("eventQueue", function() {
-yT.processQueuedEvents();
-}), rs.measureSubsystem("ss2PacketQueue", function() {
-oR.processQueue();
-}), Gi.hasCpuBudget() && rs.measureSubsystem("powerCreeps", function() {
+}), kl.preTick(), ns.measureSubsystem("processSync", function() {
+wy.syncCreepProcesses(), Ov.syncRoomProcesses();
+}), ns.measureSubsystem("kernel", function() {
+gT.runProcesses();
+}), ns.measureSubsystem("eventQueue", function() {
+gT.processQueuedEvents();
+}), ns.measureSubsystem("ss2PacketQueue", function() {
+aR.processQueue();
+}), Di.hasCpuBudget() && ns.measureSubsystem("powerCreeps", function() {
 !function() {
 var e, t;
 try {
 for (var r = a(Object.values(Game.powerCreeps)), o = r.next(); !o.done; o = r.next()) {
 var n = o.value;
-void 0 !== n.ticksToLive && dy(n);
+void 0 !== n.ticksToLive && fy(n);
 }
 } catch (t) {
 e = {
@@ -47253,18 +47257,18 @@ if (e) throw e.error;
 }
 }
 }();
-}), vT({
-hasCpuBudget: Gi.hasCpuBudget(),
+}), hT({
+hasCpuBudget: Di.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && rs.measureSubsystem("visualizations", function() {
+}) && ns.measureSubsystem("visualizations", function() {
 var e;
 !function(e, t) {
 var r, o;
 if (Mr().visualizations) {
 var n = t;
 if ("off" !== n.workload) {
-var i = cC.getConfig(), s = uC.getConfig();
-cC.setConfig(n.roomVisualizerConfig), n.renderMap && uC.setConfig(n.mapVisualizerConfig);
+var i = lC.getConfig(), s = mC.getConfig();
+lC.setConfig(n.roomVisualizerConfig), n.renderMap && mC.setConfig(n.mapVisualizerConfig);
 try {
 var c = function(e, t) {
 return t.roomRenderStride <= 1 ? e : e.filter(function(e, r) {
@@ -47275,10 +47279,10 @@ try {
 for (var u = a(c), l = u.next(); !l.done; l = u.next()) {
 var m = l.value;
 try {
-cC.draw(m);
+lC.draw(m);
 } catch (e) {
 var d = e instanceof Error ? e.message : String(e);
-ll.error("Visualization error in ".concat(m.name, ": ").concat(d), {
+dl.error("Visualization error in ".concat(m.name, ": ").concat(d), {
 subsystem: "visualizations",
 room: m.name
 });
@@ -47297,19 +47301,19 @@ if (r) throw r.error;
 }
 if (!n.renderMap) return;
 try {
-uC.draw();
+mC.draw();
 } catch (e) {
-d = e instanceof Error ? e.message : String(e), ll.error("Map visualization error: ".concat(d), {
+d = e instanceof Error ? e.message : String(e), dl.error("Map visualization error: ".concat(d), {
 subsystem: "visualizations"
 });
 }
 } finally {
-cC.setConfig(i), uC.setConfig(s);
+lC.setConfig(i), mC.setConfig(s);
 }
 }
 }
 }(n, (e = {
-hasCpuBudget: Gi.hasCpuBudget(),
+hasCpuBudget: Di.hasCpuBudget(),
 bucketMode: r,
 bucket: Game.cpu.bucket,
 ownedRoomCount: n.length
@@ -47389,19 +47393,19 @@ opacity: .5
 roomRenderStride: 1,
 renderMap: !0
 }));
-}), bl.reconcileTraffic(), vT({
-hasCpuBudget: Gi.hasCpuBudget(),
+}), kl.reconcileTraffic(), hT({
+hasCpuBudget: Di.hasCpuBudget(),
 bucket: Game.cpu.bucket
-}) && rs.measureSubsystem("scheduledTasks", function() {
+}) && ns.measureSubsystem("scheduledTasks", function() {
 var e;
-e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), gd.run(e);
-}), wr.persistHeapCache(), rs.collectProcessStats(Gi.getProcesses().reduce(function(e, t) {
+e = Math.max(0, Game.cpu.limit - Game.cpu.getUsed()), Rd.run(e);
+}), wr.persistHeapCache(), ns.collectProcessStats(Di.getProcesses().reduce(function(e, t) {
 return e.set(t.id, t), e;
-}, new Map)), rs.collectKernelBudgetStats(Gi), rs.setSkippedProcesses(Gi.getSkippedProcessesThisTick()),
-rs.finalizeTick(), ll.flush();
+}, new Map)), ns.collectKernelBudgetStats(Di), ns.setSkippedProcesses(Di.getSkippedProcessesThisTick()),
+ns.finalizeTick(), dl.flush();
 }
 
-var pC = function() {
+var yC = function() {
 function e() {}
 return e.prototype.toggleVisualizations = function() {
 var e = !Mr().visualizations;
@@ -47409,25 +47413,25 @@ return Ar({
 visualizations: e
 }), "Visualizations: ".concat(e ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleVisualization = function(e) {
-var t = cC.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = lC.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-cC.toggle(o);
-var n = cC.getConfig()[o];
+lC.toggle(o);
+var n = lC.getConfig()[o];
 return "Room visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.toggleMapVisualization = function(e) {
-var t = uC.getConfig(), r = Object.keys(t).filter(function(e) {
+var t = mC.getConfig(), r = Object.keys(t).filter(function(e) {
 return e.startsWith("show") && "boolean" == typeof t[e];
 });
 if (!r.includes(e)) return "Invalid key: ".concat(e, ". Valid keys: ").concat(r.join(", "));
 var o = e;
-uC.toggle(o);
-var n = uC.getConfig()[o];
+mC.toggle(o);
+var n = mC.getConfig()[o];
 return "Map visualization '".concat(e, "': ").concat(n ? "ENABLED" : "DISABLED");
 }, e.prototype.showMapConfig = function() {
-var e = uC.getConfig();
+var e = mC.getConfig();
 return Object.entries(e).map(function(e) {
 var t = i(e, 2), r = t[0], o = t[1];
 return "".concat(r, ": ").concat(String(o));
@@ -47550,15 +47554,15 @@ usage: "clearVisCache(roomName?)",
 examples: [ "clearVisCache()", "clearVisCache('W1N1')" ],
 category: "Visualization"
 }) ], e.prototype, "clearVisCache", null), e;
-}(), fC = function() {
+}(), vC = function() {
 function e() {}
 return e.prototype.status = function() {
-var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = dT.getCurrentShardState();
+var e, t, r = null !== (t = null === (e = Game.shard) || void 0 === e ? void 0 : e.name) && void 0 !== t ? t : "shard0", o = fT.getCurrentShardState();
 if (!o) return "No shard state found for ".concat(r);
 var n = o.health, a = [ "=== Shard Status: ".concat(r, " ==="), "Role: ".concat(o.role.toUpperCase()), "Rooms: ".concat(n.roomCount, " (Avg RCL: ").concat(n.avgRCL, ")"), "Creeps: ".concat(n.creepCount), "CPU: ".concat(n.cpuCategory.toUpperCase(), " (").concat(Math.round(100 * n.cpuUsage), "%)"), "Bucket: ".concat(n.bucketLevel), "Economy Index: ".concat(n.economyIndex, "%"), "War Index: ".concat(n.warIndex, "%"), "Portals: ".concat(o.portals.length), "Active Tasks: ".concat(o.activeTasks.length), "Last Update: ".concat(n.lastUpdate) ];
 return o.cpuLimit && a.push("CPU Limit: ".concat(o.cpuLimit)), a.join("\n");
 }, e.prototype.all = function() {
-var e, t, r = dT.getAllShards();
+var e, t, r = fT.getAllShards();
 if (0 === r.length) return "No shards tracked yet";
 var o = [ "=== All Shards ===" ];
 try {
@@ -47580,9 +47584,9 @@ if (e) throw e.error;
 return o.join("\n");
 }, e.prototype.setRole = function(e) {
 var t = [ "core", "frontier", "resource", "backup", "war" ];
-return t.includes(e) ? (dT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
+return t.includes(e) ? (fT.setShardRole(e), "Shard role set to: ".concat(e.toUpperCase())) : "Invalid role: ".concat(e, ". Valid roles: ").concat(t.join(", "));
 }, e.prototype.portals = function(e) {
-var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = dT.getCurrentShardState();
+var t, r, o, n, i, s = null !== (n = null === (o = Game.shard) || void 0 === o ? void 0 : o.name) && void 0 !== n ? n : "shard0", c = fT.getCurrentShardState();
 if (!c) return "No shard state found for ".concat(s);
 var u = c.portals;
 if (e && (u = u.filter(function(t) {
@@ -47607,19 +47611,19 @@ if (t) throw t.error;
 }
 return l.join("\n");
 }, e.prototype.bestPortal = function(e, t) {
-var r, o = dT.getOptimalPortalRoute(e, t);
+var r, o = fT.getOptimalPortalRoute(e, t);
 if (!o) return "No portal found to ".concat(e);
 var n = o.isStable ? "Stable" : "Unstable", a = o.threatRating > 0 ? " (Threat: ".concat(o.threatRating, ")") : "";
 return "Best portal to ".concat(e, ":\n") + "  Source: ".concat(o.sourceRoom, " (").concat(o.sourcePos.x, ",").concat(o.sourcePos.y, ")\n") + "  Target: ".concat(o.targetShard, "/").concat(o.targetRoom, "\n") + "  Status: ".concat(n).concat(a, "\n") + "  Traversals: ".concat(null !== (r = o.traversalCount) && void 0 !== r ? r : 0, "\n") + "  Last Scouted: ".concat(Game.time - o.lastScouted, " ticks ago");
 }, e.prototype.createTask = function(e, t, r, o) {
 void 0 === o && (o = 50);
 var n = [ "colonize", "reinforce", "transfer", "evacuate" ];
-return n.includes(e) ? (dT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
+return n.includes(e) ? (fT.createTask(e, t, r, o), "Created ".concat(e, " task to ").concat(t).concat(r ? "/".concat(r) : "", " (priority: ").concat(o, ")")) : "Invalid task type: ".concat(e, ". Valid types: ").concat(n.join(", "));
 }, e.prototype.transferResource = function(e, t, r, o, n) {
-return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (dT.createResourceTransferTask(e, t, r, o, n),
+return void 0 === n && (n = 50), !Number.isFinite(o) || o <= 0 ? "Invalid amount: ".concat(o, ". Amount must be a positive finite number.") : (fT.createResourceTransferTask(e, t, r, o, n),
 "Created resource transfer task:\n" + "  ".concat(o, " ").concat(r, " → ").concat(e, "/").concat(t, "\n") + "  Priority: ".concat(n));
 }, e.prototype.transfers = function() {
-var e, t, r = Qf.getActiveRequests();
+var e, t, r = Zf.getActiveRequests();
 if (0 === r.length) return "No active resource transfers";
 var o = [ "=== Active Resource Transfers ===" ];
 try {
@@ -47640,7 +47644,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.cpuHistory = function() {
-var e, t, r = dT.getCurrentShardState();
+var e, t, r = fT.getCurrentShardState();
 if (!r || !r.cpuHistory || 0 === r.cpuHistory.length) return "No CPU history available";
 var o = [ "=== CPU Allocation History ===" ];
 try {
@@ -47661,7 +47665,7 @@ if (e) throw e.error;
 }
 return o.join("\n");
 }, e.prototype.tasks = function() {
-var e, t, r, o = dT.getActiveTransferTasks();
+var e, t, r, o = fT.getActiveTransferTasks();
 if (0 === o.length) return "No active inter-shard tasks";
 var n = [ "=== Inter-Shard Tasks ===" ];
 try {
@@ -47682,16 +47686,16 @@ if (e) throw e.error;
 }
 return n.join("\n");
 }, e.prototype.syncStatus = function() {
-var e = dT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
-return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Pf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
+var e = fT.getSyncStatus(), t = e.isHealthy ? "✓ HEALTHY" : "⚠ DEGRADED";
+return "=== InterShardMemory Sync Status ===\n" + "Status: ".concat(t, "\n") + "Last Sync: ".concat(e.lastSync, " (").concat(e.ticksSinceSync, " ticks ago)\n") + "Memory Usage: ".concat(e.memorySize, " / ").concat(Gf, " bytes (").concat(e.sizePercent, "%)\n") + "Shards Tracked: ".concat(e.shardsTracked, "\n") + "Active Tasks: ".concat(e.activeTasks, "\n") + "Total Portals: ".concat(e.totalPortals);
 }, e.prototype.memoryStats = function() {
-var e = dT.getMemoryStats();
+var e = fT.getMemoryStats();
 return "=== InterShardMemory Usage ===\n" + "Total: ".concat(e.size, " / ").concat(e.limit, " bytes (").concat(e.percent, "%)\n") + "\nBreakdown:\n" + "  Shards: ".concat(e.breakdown.shards, " bytes\n") + "  Tasks: ".concat(e.breakdown.tasks, " bytes\n") + "  Portals: ".concat(e.breakdown.portals, " bytes\n") + "  Other: ".concat(e.breakdown.other, " bytes");
 }, e.prototype.forceSync = function() {
-return dT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
+return fT.forceSync(), "InterShardMemory sync forced. Check logs for results.";
 }, e.prototype.footprint = function() {
 return function() {
-var e, t, r, o = OT().footprintOperation;
+var e, t, r, o = MT().footprintOperation;
 if (!o) return "Intershard footprint operation has not initialized.";
 var n = [ "=== Intershard Footprint Operation ".concat(o.id, " ==="), "Enabled: ".concat(String(o.enabled)), "Started: ".concat(o.startedAt), "Updated: ".concat(o.updatedAt) ];
 try {
@@ -47797,9 +47801,9 @@ usage: "shard.footprint()",
 examples: [ "shard.footprint()" ],
 category: "Shard"
 }) ], e.prototype, "footprint", null), e;
-}(), yC = new fC;
+}(), gC = new vC;
 
-function vC(e) {
+function hC(e) {
 var t = e.match(/\((.*?)\)/);
 if (t && t[1]) {
 var r = t[1].split(",").map(function(e) {
@@ -47829,10 +47833,10 @@ title: e.metadata.description,
 describe: null === (t = e.metadata.examples) || void 0 === t ? void 0 : t[0],
 functionName: e.metadata.name,
 commandType: !(null === (r = e.metadata.usage) || void 0 === r ? void 0 : r.includes("(")),
-params: e.metadata.usage ? vC(e.metadata.usage) : void 0
+params: e.metadata.usage ? hC(e.metadata.usage) : void 0
 };
 });
-return bd({
+return kd({
 name: e,
 describe: "".concat(e, " commands"),
 api: o
@@ -47883,12 +47887,12 @@ c && !c.done && (t = n.return) && t.call(n);
 if (e) throw e.error;
 }
 }
-return bd.apply(void 0, s([], i(o), !1));
+return kd.apply(void 0, s([], i(o), !1));
 }();
 }, e.prototype.spawnForm = function(e) {
-if (!Game.rooms[e]) return Sd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!Game.rooms[e]) return xd("Room ".concat(e, " not found or not visible"), "red", !0);
 var t = JSON.stringify(e);
-return xd.form("spawnCreep", [ {
+return Od.form("spawnCreep", [ {
 type: "select",
 name: "role",
 label: "Role:",
@@ -47922,20 +47926,20 @@ command: "({role, name}) => {\n        const room = Game.rooms[".concat(t, "];\n
 });
 }, e.prototype.roomControl = function(e) {
 var t = Game.rooms[e];
-if (!t) return Sd("Room ".concat(e, " not found or not visible"), "red", !0);
+if (!t) return xd("Room ".concat(e, " not found or not visible"), "red", !0);
 var r = JSON.stringify(e), o = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return o += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Room Control: '.concat(e, "</h3>"),
-o += '<div style="margin-bottom: 10px;">', o += Sd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
-t.controller && (o += Sd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
-o += "</div>", o += xd.button({
+o += '<div style="margin-bottom: 10px;">', o += xd("Energy: ".concat(t.energyAvailable, "/").concat(t.energyCapacityAvailable), "green") + "<br>",
+t.controller && (o += xd("Controller Level: ".concat(t.controller.level, " (").concat(t.controller.progress, "/").concat(t.controller.progressTotal, ")"), "blue") + "<br>"),
+o += "</div>", o += Od.button({
 content: "🔄 Toggle Visualizations",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        global.botConfig.updateConfig({visualizations: !config.visualizations});\n        return 'Visualizations: ' + (!config.visualizations ? 'ON' : 'OFF');\n      }"
-}), o += " ", (o += xd.button({
+}), o += " ", (o += Od.button({
 content: "📊 Room Stats",
 command: "() => {\n        const room = Game.rooms[".concat(r, "];\n        if (!room) return 'Room not found';\n        let stats = '=== Room Stats ===\\n';\n        stats += 'Energy: ' + room.energyAvailable + '/' + room.energyCapacityAvailable + '\\n';\n        stats += 'Creeps: ' + Object.values(Game.creeps).filter(c => c.room.name === ").concat(r, ").length + '\\n';\n        if (room.controller) {\n          stats += 'RCL: ' + room.controller.level + '\\n';\n          stats += 'Progress: ' + room.controller.progress + '/' + room.controller.progressTotal + '\\n';\n        }\n        return stats;\n      }")
 })) + "</div>";
 }, e.prototype.logForm = function() {
-return xd.form("configureLogging", [ {
+return Od.form("configureLogging", [ {
 type: "select",
 name: "level",
 label: "Log Level:",
@@ -47960,7 +47964,7 @@ content: "Set Log Level",
 command: "({level}) => {\n        const levelMap = {\n          debug: 0,\n          info: 1,\n          warn: 2,\n          error: 3,\n          none: 4\n        };\n        const logLevel = levelMap[level];\n        global.botLogger.configureLogger({level: logLevel});\n        return 'Log level set to: ' + level.toUpperCase();\n      }"
 });
 }, e.prototype.visForm = function() {
-return xd.form("configureVisualization", [ {
+return Od.form("configureVisualization", [ {
 type: "select",
 name: "mode",
 label: "Visualization Mode:",
@@ -47984,18 +47988,18 @@ command: "({mode}) => {\n        global.botVisualizationManager.setMode(mode);\n
 }, e.prototype.quickActions = function() {
 var e = '<div style="background: #2b2b2b; padding: 10px; margin: 5px;">';
 return e += '<h3 style="color: #c5c599; margin: 0 0 10px 0;">Quick Actions</h3>',
-e += xd.button({
+e += Od.button({
 content: "🐛 Toggle Debug",
 command: "() => {\n        const config = global.botConfig.getConfig();\n        const newValue = !config.debug;\n        global.botConfig.updateConfig({debug: newValue});\n        global.botLogger.configureLogger({level: newValue ? 0 : 1});\n        return 'Debug mode: ' + (newValue ? 'ON' : 'OFF');\n      }"
-}), e += " ", (e += xd.button({
+}), e += " ", (e += Od.button({
 content: "🗑️ Clear Cache",
 command: "() => {\n        global.botCacheManager.clear();\n        return 'Cache cleared successfully';\n      }"
 })) + "</div>";
 }, e.prototype.colorDemo = function() {
 var e = "=== Console Color Demo ===\n\n";
-return e += Sd("✓ Success message", "green", !0) + "\n", e += Sd("⚠ Warning message", "yellow", !0) + "\n",
-e += Sd("✗ Error message", "red", !0) + "\n", e += Sd("ℹ Info message", "blue", !0) + "\n",
-(e += "\nNormal text: " + Sd("colored text", "green") + " normal text\n") + "Bold text: " + Sd("important", null, !0) + "\n";
+return e += xd("✓ Success message", "green", !0) + "\n", e += xd("⚠ Warning message", "yellow", !0) + "\n",
+e += xd("✗ Error message", "red", !0) + "\n", e += xd("ℹ Info message", "blue", !0) + "\n",
+(e += "\nNormal text: " + xd("colored text", "green") + " normal text\n") + "Bold text: " + xd("important", null, !0) + "\n";
 }, n([ Zr({
 name: "uiHelp",
 description: "Show interactive help interface with expandable sections",
@@ -48041,39 +48045,39 @@ category: "System"
 }) ], e.prototype, "colorDemo", null);
 }();
 
-var gC = new Ov, hC = new pC, RC = new kv, EC = new ml, TC = new bv, CC = new Mv, SC = new Av, wC = "__screepsGlobalRuntimeDiagnostics";
+var RC = new Mv, EC = new yC, TC = new Av, CC = new pl, SC = new kv, wC = new Uv, xC = new _v, bC = "__screepsGlobalRuntimeDiagnostics";
 
-function xC() {
+function OC() {
 var e, t = "string" == typeof (null === (e = Game.shard) || void 0 === e ? void 0 : e.name) ? Game.shard.name : "shard", r = Math.floor(4294967295 * Math.random()).toString(16).padStart(8, "0");
 return "".concat(t, ":").concat(Game.time, ":").concat(r);
 }
 
-function bC(e, t) {
+function kC(e, t) {
 return "number" == typeof e && Number.isFinite(e) && e >= 0 ? e : t;
 }
 
-function OC(e, t) {
+function MC(e, t) {
 return "number" == typeof e && Number.isFinite(e) ? e : t;
 }
 
-function kC(e) {
+function AC(e) {
 return "number" == typeof e && Number.isFinite(e) ? e : void 0;
 }
 
-function MC(e) {
+function UC(e) {
 var t, r, o;
 null !== (t = Memory.runtimeDiagnostics) && void 0 !== t || (Memory.runtimeDiagnostics = {});
 var n = Memory.runtimeDiagnostics.global;
 if (n && "object" == typeof n) {
 var a = {
 heapId: "string" == typeof n.heapId && n.heapId.length > 0 ? n.heapId : e,
-resetCount: bC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
-switchCount: bC(n.switchCount, 0),
-lastTick: OC(n.lastTick, Game.time),
-lastResetTick: OC(n.lastResetTick, Game.time),
-lastSwitchTick: kC(n.lastSwitchTick),
-lastSwitchPreviousTick: kC(n.lastSwitchPreviousTick),
-lastWarningTick: kC(n.lastWarningTick)
+resetCount: kC(n.resetCount, Math.max(0, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0)),
+switchCount: kC(n.switchCount, 0),
+lastTick: MC(n.lastTick, Game.time),
+lastResetTick: MC(n.lastResetTick, Game.time),
+lastSwitchTick: AC(n.lastSwitchTick),
+lastSwitchPreviousTick: AC(n.lastSwitchPreviousTick),
+lastWarningTick: AC(n.lastWarningTick)
 };
 return Memory.runtimeDiagnostics.global = a, a;
 }
@@ -48087,19 +48091,19 @@ lastResetTick: Game.time
 return Memory.runtimeDiagnostics.global = i, i;
 }
 
-var AC = cl("Main");
+var _C = ll("Main");
 
 br.register(), function(e) {
 void 0 === e && (e = !1);
 var t = function() {
-Xr.initialize(), Jr(gC), Jr(hC), Jr(RC), Jr(EC), Jr(TC), Jr(CC), Jr(SC), Jr(Du),
-Jr(Bu), Jr(Fu), Jr(yC), Jr(no), Jr(Mc), Jr(nu), global.tooangel = ru;
+Xr.initialize(), Jr(RC), Jr(EC), Jr(TC), Jr(CC), Jr(SC), Jr(wC), Jr(xC), Jr(Fu),
+Jr(Wu), Jr(Hu), Jr(gC), Jr(no), Jr(Uc), Jr(iu), global.tooangel = nu;
 var e = global;
 e.botConfig = {
 getConfig: Mr,
 updateConfig: Ar
 }, e.botLogger = {
-configureLogger: zu
+configureLogger: Xu
 }, e.botVisualizationManager = f, e.botCacheManager = Ee, Xr.exposeToGlobal();
 };
 e ? (Xr.initialize(), Xr.enableLazyLoading(t), Xr.exposeToGlobal()) : t();
@@ -48108,12 +48112,12 @@ try {
 br.run(), function(e) {
 var t, r, o;
 void 0 === e && (e = {});
-var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : xC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[wC];
+var n = globalThis, a = null !== (t = e.createHeapId) && void 0 !== t ? t : OC, i = null !== (r = e.switchLogThrottleTicks) && void 0 !== r ? r : 100, s = n[bC];
 if (!s) return s = {
 heapId: a(),
 lastTick: Game.time
-}, n[wC] = s, function(e, t) {
-var r, o = MC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
+}, n[bC] = s, function(e, t) {
+var r, o = UC(e), n = Math.max(o.resetCount, null !== (r = Memory.__globalResetCount) && void 0 !== r ? r : 0) + 1;
 return o.heapId = e, o.resetCount = n, o.lastResetTick = Game.time, o.lastTick = Game.time,
 Memory.__globalResetCount = n, null == t || t.info("Global reset detected", {
 meta: {
@@ -48131,7 +48135,7 @@ switchCount: o.switchCount
 }(s.heapId, e.logger);
 var c = s.lastTick;
 if (s.lastTick = Game.time, c + 1 !== Game.time) return function(e, t, r, o) {
-var n, a = MC(e.heapId);
+var n, a = UC(e.heapId);
 a.switchCount += 1, a.heapId = e.heapId, a.lastSwitchTick = Game.time, a.lastSwitchPreviousTick = t,
 a.lastTick = Game.time;
 var i = null !== (n = a.lastWarningTick) && void 0 !== n ? n : -1 / 0;
@@ -48152,14 +48156,14 @@ resetCount: a.resetCount,
 switchCount: a.switchCount
 };
 }(s, c, e.logger, i);
-var u = MC(s.heapId);
+var u = UC(s.heapId);
 u.heapId = s.heapId, u.lastTick = Game.time, Memory.__globalResetCount = Math.max(null !== (o = Memory.__globalResetCount) && void 0 !== o ? o : 0, u.resetCount),
 s.heapId, Game.time, u.resetCount, u.switchCount;
 }({
-logger: AC
-}), dC();
+logger: _C
+}), fC();
 } catch (e) {
-throw AC.error("Critical error in main loop: ".concat(String(e)), {
+throw _C.error("Critical error in main loop: ".concat(String(e)), {
 meta: {
 stack: e instanceof Error ? e.stack : void 0,
 tick: Game.time

--- a/packages/screeps-bot/rollup.config.js
+++ b/packages/screeps-bot/rollup.config.js
@@ -181,6 +181,10 @@ export default {
           replacement: path.resolve(__dirname, "../screeps-chemistry/src/index.ts")
         },
         {
+          find: "@ralphschuler/screeps-defense/nuke-threat-policy",
+          replacement: path.resolve(__dirname, "../screeps-defense/src/emergency/nukeThreatPolicy.ts")
+        },
+        {
           find: "@ralphschuler/screeps-defense",
           replacement: path.resolve(__dirname, "../screeps-defense/src/index.ts")
         },

--- a/packages/screeps-defense/CHANGELOG.md
+++ b/packages/screeps-defense/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Public `hasCriticalStructuresThreatened()` nuke policy and lightweight `nuke-threat-policy` package subpath
 - Framework documentation and examples
 - npm publishing workflow
 - Package marked as publishable

--- a/packages/screeps-defense/README.md
+++ b/packages/screeps-defense/README.md
@@ -258,6 +258,20 @@ Emergency manager:
 
 The bot room coordinator performs the bounded `FIND_NUKES` observation once per visible owned room/tick and passes that snapshot to threat and emergency policy. The empire nuke detector persists object-ID keyed alerts in `Memory.empire.incomingNukes`; `EvacuationManager` consumes those alerts idempotently and is the sole owner of evacuation-trigger mutation. This keeps stacked nukes distinct and prevents duplicate scans or competing evacuation state updates.
 
+Use the canonical pure predicate when deciding whether a persisted alert threatens evacuation-critical structures:
+
+```typescript
+import { hasCriticalStructuresThreatened } from "@ralphschuler/screeps-defense";
+
+if (hasCriticalStructuresThreatened(alert)) {
+  // Apply nuke evacuation policy.
+}
+```
+
+Consumers that need only this pure policy can use the lightweight
+`@ralphschuler/screeps-defense/nuke-threat-policy` subpath without loading the
+full defense package.
+
 ### Emergency helper-room refuel
 
 When a visible urgent defense request cannot afford a defender body, the spawn and

--- a/packages/screeps-defense/nuke-threat-policy/package.json
+++ b/packages/screeps-defense/nuke-threat-policy/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/emergency/nukeThreatPolicy.js",
+  "types": "../dist/emergency/nukeThreatPolicy.d.ts"
+}

--- a/packages/screeps-defense/src/emergency/evacuationManager.ts
+++ b/packages/screeps-defense/src/emergency/evacuationManager.ts
@@ -14,10 +14,11 @@
 
 import { logger } from "@ralphschuler/screeps-core";
 import { memoryManager } from "@ralphschuler/screeps-memory";
-import type { EvacuationIntentMemory, IncomingNukeAlert } from "@ralphschuler/screeps-memory";
+import type { EvacuationIntentMemory } from "@ralphschuler/screeps-memory";
 import { MediumFrequencyProcess, ProcessClass, ProcessPriority } from "@ralphschuler/screeps-kernel";
 import { getActualHostileCreeps } from "../alliance/nonAggressionPact";
 import { countActiveCombatDefenders } from "../analysis/defenderNeeds";
+import { hasCriticalStructuresThreatened } from "./nukeThreatPolicy";
 
 /**
  * Evacuation configuration
@@ -248,7 +249,7 @@ export class EvacuationManager {
           && alert.impactTick - Game.time <= this.config.nukeEvacuationLeadTime
       );
       const nearestNuke = nukeAlerts
-        .filter(alert => this.hasCriticalStructures(alert))
+        .filter(hasCriticalStructuresThreatened)
         .sort((a, b) => a.impactTick - b.impactTick)[0];
 
       if (nearestNuke) {
@@ -278,14 +279,6 @@ export class EvacuationManager {
         }
       }
     }
-  }
-
-  private hasCriticalStructures(alert: IncomingNukeAlert): boolean {
-    return (alert.threatenedStructures ?? []).some(structure =>
-      structure.includes(STRUCTURE_SPAWN)
-      || structure.includes(STRUCTURE_STORAGE)
-      || structure.includes(STRUCTURE_TERMINAL)
-    );
   }
 
   /**

--- a/packages/screeps-defense/src/emergency/nukeThreatPolicy.ts
+++ b/packages/screeps-defense/src/emergency/nukeThreatPolicy.ts
@@ -1,0 +1,23 @@
+/** Minimal persisted nuke-alert shape needed by the critical-structure policy. */
+export interface NukeStructureThreat {
+  threatenedStructures?: readonly string[];
+}
+
+const CRITICAL_NUKE_STRUCTURE_TYPES = [
+  "spawn",
+  "storage",
+  "terminal",
+] as const satisfies readonly StructureConstant[];
+
+/**
+ * Return whether a persisted nuke alert threatens evacuation-critical structures.
+ *
+ * Threat descriptors use the `<structureType>-<x>,<y>` format emitted by nuke
+ * detection. The policy is pure so detection, evacuation, and package consumers
+ * share one definition.
+ */
+export function hasCriticalStructuresThreatened(alert: NukeStructureThreat): boolean {
+  return (alert.threatenedStructures ?? []).some(structure =>
+    CRITICAL_NUKE_STRUCTURE_TYPES.some(structureType => structure.includes(structureType))
+  );
+}

--- a/packages/screeps-defense/src/index.ts
+++ b/packages/screeps-defense/src/index.ts
@@ -165,6 +165,11 @@ export {
 export { safeModeManager, SafeModeManager } from "./emergency/safeModeManager";
 
 export {
+  hasCriticalStructuresThreatened,
+  type NukeStructureThreat,
+} from "./emergency/nukeThreatPolicy";
+
+export {
   evacuationManager,
   EvacuationManager,
   type EvacuationState,

--- a/packages/screeps-defense/test/exports.test.ts
+++ b/packages/screeps-defense/test/exports.test.ts
@@ -44,7 +44,8 @@ import {
   safeModeManager,
   SafeModeManager,
   evacuationManager,
-  EvacuationManager
+  EvacuationManager,
+  hasCriticalStructuresThreatened
 } from '../src/index';
 
 describe('@ralphschuler/screeps-defense', () => {
@@ -85,6 +86,7 @@ describe('@ralphschuler/screeps-defense', () => {
     });
     
     it('should export emergency response components', () => {
+      expect(hasCriticalStructuresThreatened).to.be.a('function');
       expect(EmergencyResponseManager).to.be.a('function'); // Constructor
       expect(emergencyResponseManager).to.be.an('object');
       expect(EmergencyLevel).to.be.an('object');

--- a/packages/screeps-defense/test/nukeThreatPolicy.test.ts
+++ b/packages/screeps-defense/test/nukeThreatPolicy.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "chai";
+import { hasCriticalStructuresThreatened } from "../src/emergency/nukeThreatPolicy";
+
+describe("nuke structure threat policy", () => {
+  it("identifies persisted spawn, storage, and terminal threats", () => {
+    for (const structureType of [STRUCTURE_SPAWN, STRUCTURE_STORAGE, STRUCTURE_TERMINAL]) {
+      expect(hasCriticalStructuresThreatened({
+        threatenedStructures: [`${structureType}-25,25`],
+      })).to.equal(true);
+    }
+  });
+
+  it("ignores missing, empty, and non-critical structure threats", () => {
+    expect(hasCriticalStructuresThreatened({})).to.equal(false);
+    expect(hasCriticalStructuresThreatened({ threatenedStructures: [] })).to.equal(false);
+    expect(hasCriticalStructuresThreatened({
+      threatenedStructures: [`${STRUCTURE_TOWER}-25,25`],
+    })).to.equal(false);
+  });
+
+  it("finds a critical descriptor after non-critical entries", () => {
+    expect(hasCriticalStructuresThreatened({
+      threatenedStructures: [
+        `${STRUCTURE_TOWER}-25,25`,
+        `${STRUCTURE_STORAGE}-24,25`,
+      ],
+    })).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary

- move the evacuation-critical nuke structure predicate into `@ralphschuler/screeps-defense` as the single canonical policy
- restore the deprecated `@ralphschuler/screeps-empire` package-root and `nuke/detection` compatibility export
- publish a lightweight `@ralphschuler/screeps-defense/nuke-threat-policy` subpath so compatibility imports do not eagerly load the full CommonJS defense package
- document migration and update the generated runtime bundle

Fixes #3404

## Behavior

Valid persisted descriptors retain the previous policy: `spawn`, `storage`, or `terminal` threats are critical; missing, empty, and non-critical lists are not. `EvacuationManager` and the empire compatibility wrapper both delegate to this one implementation.

No targeting, hostility, or alliance policy changed. Permanent allies `TooAngel` and `TedRoastBeef` remain protected.

## Tests and validation

- `npm run build:framework` ✅
- `npm run build:bot` / bundle size 1.30 MB of 2 MB ✅
- `npm run check:bot-bundle-drift` ✅
- `npm run test:defense` — 114 passing ✅
- `npm run test:empire` — 11 passing ✅
- defense + empire lint ✅
- package-root and lightweight-subpath consumer TypeScript fixture: zero diagnostics ✅
- packed defense tarball includes and executes the lightweight subpath ✅
- `npm run check:no-deep-dist-imports` ✅
- `npm run check:alliance-safety` ✅
- dependency sync, docs build, duplication and complexity budgets ✅
- `npm run test:server:smoke` — passed, 47/47 assertions, 0 skipped, 2,625 ticks advanced, 0 error notifications ✅

## Risk and rollback

Low risk: package wiring plus extraction of unchanged policy semantics. Roll back by reverting `2f573579`; no Memory migration or configuration change is required.
