### PR TITLE
fix(release): align framework package publication

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -4,25 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       publish_scope:
-        description: 'Publish scope'
+        description: "Exact framework package scope (for example: empire), or all"
         required: true
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - kernel
-          - pathfinding
-          - remote-mining
-          - roles
-          - console
-          - stats
-          - spawn
-          - chemistry
-          - defense
-          - economy
-          - utils
-          - tasks
-          - posis
+        default: "all"
+        type: string
   release:
     types: [published]
 
@@ -32,38 +17,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    
-    strategy:
-      matrix:
-        package:
-          - name: '@ralphschuler/screeps-kernel'
-            path: 'packages/@ralphschuler/screeps-kernel'
-          - name: '@ralphschuler/screeps-pathfinding'
-            path: 'packages/@ralphschuler/screeps-pathfinding'
-          - name: '@ralphschuler/screeps-remote-mining'
-            path: 'packages/@ralphschuler/screeps-remote-mining'
-          - name: '@ralphschuler/screeps-roles'
-            path: 'packages/@ralphschuler/screeps-roles'
-          - name: '@ralphschuler/screeps-console'
-            path: 'packages/@ralphschuler/screeps-console'
-          - name: '@ralphschuler/screeps-stats'
-            path: 'packages/@ralphschuler/screeps-stats'
-          - name: '@ralphschuler/screeps-spawn'
-            path: 'packages/screeps-spawn'
-          - name: '@ralphschuler/screeps-chemistry'
-            path: 'packages/screeps-chemistry'
-          - name: '@ralphschuler/screeps-defense'
-            path: 'packages/screeps-defense'
-          - name: '@ralphschuler/screeps-economy'
-            path: 'packages/screeps-economy'
-          - name: '@ralphschuler/screeps-utils'
-            path: 'packages/screeps-utils'
-          - name: '@ralphschuler/screeps-posis'
-            path: 'packages/screeps-posis'
-
-    defaults:
-      run:
-        working-directory: ${{ matrix.package.path }}
 
     steps:
       - name: Checkout code
@@ -74,34 +27,48 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
 
       - name: Install workspace dependencies
         run: npm ci --ignore-scripts
-        working-directory: .
+
+      - name: Validate release package selection
+        if: github.event_name == 'release'
+        run: node scripts/publish-framework-package.mjs --list --all --json
+
+      - name: Validate manual package selection
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope != 'all'
+        run: node scripts/publish-framework-package.mjs --list --package "$PUBLISH_SCOPE" --json
+        env:
+          PUBLISH_SCOPE: ${{ inputs.publish_scope }}
+
+      - name: Validate manual all-package selection
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope == 'all'
+        run: node scripts/publish-framework-package.mjs --list --all --json
 
       - name: Build all dependencies
         run: npm run build:all
-        working-directory: .
 
-      - name: Run tests
-        run: |
-          if [ -f "package.json" ] && grep -q '"test"' package.json; then
-            npm test
-          else
-            echo "No tests defined for ${{ matrix.package.name }}"
-          fi
+      - name: Run workspace tests
+        run: npm run test:all
 
-      - name: Publish to npm
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.publish_scope == 'all' || contains(matrix.package.name, github.event.inputs.publish_scope)))
-        run: node scripts/publish-framework-package.mjs --package "${{ matrix.package.path }}" --publish --access public --provenance
-        working-directory: .
+      - name: Publish release packages to npm
+        if: github.event_name == 'release'
+        run: node scripts/publish-framework-package.mjs --all --publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Dry run publish (for PRs and testing)
-        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
-        run: node scripts/publish-framework-package.mjs --package "${{ matrix.package.path }}" --dry-run --access public
-        working-directory: .
+      - name: Publish all packages to npm manually
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope == 'all'
+        run: node scripts/publish-framework-package.mjs --all --publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish one exact package to npm manually
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope != 'all'
+        run: node scripts/publish-framework-package.mjs --package "$PUBLISH_SCOPE" --publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISH_SCOPE: ${{ inputs.publish_scope }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -17,31 +17,51 @@ This guide covers the complete process for publishing framework packages to npm,
 
 ## Overview
 
-The Screeps framework consists of 7 reusable packages published under the `@ralphschuler` npm scope:
+Package manifests are the publication inventory. `scripts/publish-framework-package.mjs` selects packages that:
 
-1. **@ralphschuler/screeps-kernel** - Process scheduler with CPU budget management
-2. **@ralphschuler/screeps-pathfinding** - Advanced pathfinding utilities
-3. **@ralphschuler/screeps-remote-mining** - Remote mining system
-4. **@ralphschuler/screeps-roles** - Reusable role behaviors
-5. **@ralphschuler/screeps-console** - Console command framework
-6. **@ralphschuler/screeps-stats** - Stats collection and export
-7. **@ralphschuler/screeps-visuals** - Visualization system (private, not published)
+- use the `@ralphschuler/screeps-` prefix;
+- are not marked `private`;
+- expose both `main` and `types` entry points;
+- have a publishable internal runtime-dependency closure.
+
+List the current inventory and dependency-safe publication order without staging or publishing:
+
+```bash
+node scripts/publish-framework-package.mjs --list
+node scripts/publish-framework-package.mjs --list --json
+```
 
 ## Package Status
 
-| Package | npm Published | Version | Build Status | Tests | License |
-|---------|--------------|---------|--------------|-------|---------|
-| screeps-kernel | ❌ Not yet | 0.1.0 | ✅ Working | ✅ Passing | Unlicense |
-| screeps-pathfinding | ❌ Not yet | 0.1.0 | ✅ Working | ✅ Passing | Unlicense |
-| screeps-remote-mining | ❌ Not yet | 0.1.0 | ✅ Working | ✅ Passing | Unlicense |
-| screeps-roles | ❌ Not yet | 0.1.0 | ⚠️ Broken* | ✅ Passing | Unlicense |
-| screeps-console | ❌ Not yet | 0.1.0 | ⚠️ Broken** | ✅ Passing | Unlicense |
-| screeps-stats | ❌ Not yet | 0.1.0 | ✅ Working | ✅ Passing | Unlicense |
-| screeps-visuals | N/A (private) | 0.1.0 | ✅ Working | ✅ Passing | Unlicense |
+The following tested snapshot is kept in parity with manifest discovery:
 
-*Note: screeps-roles build issues tracked in [#1010](https://github.com/ralphschuler/screeps/issues/1010)
+<!-- framework-package-inventory:start -->
 
-**Note: screeps-console has TypeScript compilation errors due to missing dependencies and type mismatches
+| Package                               | Exact dispatch scope | Version |
+| ------------------------------------- | -------------------- | ------- |
+| `@ralphschuler/screeps-core`          | `core`               | 0.1.0   |
+| `@ralphschuler/screeps-kernel`        | `kernel`             | 0.1.0   |
+| `@ralphschuler/screeps-cache`         | `cache`              | 0.1.0   |
+| `@ralphschuler/screeps-chemistry`     | `chemistry`          | 0.1.0   |
+| `@ralphschuler/screeps-console`       | `console`            | 0.1.0   |
+| `@ralphschuler/screeps-layouts`       | `layouts`            | 0.1.0   |
+| `@ralphschuler/screeps-stats`         | `stats`              | 0.2.0   |
+| `@ralphschuler/screeps-memory`        | `memory`             | 0.1.0   |
+| `@ralphschuler/screeps-defense`       | `defense`            | 0.1.0   |
+| `@ralphschuler/screeps-economy`       | `economy`            | 0.1.0   |
+| `@ralphschuler/screeps-empire`        | `empire`             | 0.1.0   |
+| `@ralphschuler/screeps-intershard`    | `intershard`         | 0.1.0   |
+| `@ralphschuler/screeps-pathfinding`   | `pathfinding`        | 0.1.0   |
+| `@ralphschuler/screeps-utils`         | `utils`              | 0.1.0   |
+| `@ralphschuler/screeps-pheromones`    | `pheromones`         | 0.1.0   |
+| `@ralphschuler/screeps-posis`         | `posis`              | 1.0.0   |
+| `@ralphschuler/screeps-remote-mining` | `remote-mining`      | 0.1.0   |
+| `@ralphschuler/screeps-roles`         | `roles`              | 0.1.0   |
+| `@ralphschuler/screeps-standards`     | `standards`          | 0.1.0   |
+
+<!-- framework-package-inventory:end -->
+
+Private packages, applications, and public packages with a private or otherwise ineligible internal runtime dependency are excluded automatically. Exact selection of an excluded package fails with the dependency reason. Do not infer npm registry status from this source inventory; verify a release with `npm view <package>`.
 
 ## Prerequisites
 
@@ -54,6 +74,7 @@ Before you can publish packages to npm, ensure you have:
 - Authentication token with publish permissions
 
 To create an npm token:
+
 ```bash
 npm login
 npm token create --read-write
@@ -72,6 +93,7 @@ Configure the following GitHub secrets:
 - `NPM_TOKEN` - npm authentication token with publish permissions
 
 To add secrets in GitHub:
+
 1. Go to repository Settings → Secrets and variables → Actions
 2. Click "New repository secret"
 3. Name: `NPM_TOKEN`, Value: your npm token
@@ -114,6 +136,7 @@ For testing or emergency releases, you can publish manually:
 #### 1. Update Version
 
 Choose the appropriate version bump:
+
 - **Patch** (0.1.0 → 0.1.1): Bug fixes, no API changes
 - **Minor** (0.1.0 → 0.2.0): New features, backward compatible
 - **Major** (0.1.0 → 1.0.0): Breaking changes
@@ -124,6 +147,7 @@ npm version patch  # or minor, or major
 ```
 
 This automatically:
+
 - Updates package.json version
 - Creates a git commit
 - Creates a git tag
@@ -136,10 +160,12 @@ Edit `CHANGELOG.md` to document changes:
 ## [0.1.1] - 2026-01-02
 
 ### Fixed
+
 - Fixed CPU budget calculation edge case
 - Corrected process priority sorting
 
 ### Added
+
 - New debug logging options
 ```
 
@@ -150,6 +176,7 @@ npm run build
 ```
 
 Verify the build output in `dist/`:
+
 ```bash
 ls -la dist/
 ```
@@ -186,6 +213,7 @@ npm install /tmp/screeps-publish-check/scope_ralphschuler__screeps-kernel/verify
 ```
 
 Verify the package works:
+
 ```bash
 node -e "const kernel = require('@ralphschuler/screeps-kernel'); console.log(kernel);"
 ```
@@ -201,11 +229,13 @@ For scoped packages (`@ralphschuler/*`), the script passes `--access public` and
 #### 8. Verify Publication
 
 Check the package on npm:
+
 ```bash
 npm view @ralphschuler/screeps-kernel
 ```
 
 Visit the npm page:
+
 ```
 https://www.npmjs.com/package/@ralphschuler/screeps-kernel
 ```
@@ -243,10 +273,12 @@ Location: `.github/workflows/publish-framework.yml`
 
 Publish specific packages on demand:
 
-1. Go to GitHub Actions → Publish Framework Packages
-2. Click "Run workflow"
-3. Select scope: `all`, `kernel`, `pathfinding`, etc.
-4. Click "Run workflow"
+1. Go to GitHub Actions → Publish Framework Packages.
+2. Click "Run workflow".
+3. Enter `all` or one exact dispatch scope from the tested inventory above.
+4. Click "Run workflow".
+
+The helper rejects unknown, partial, private, or otherwise ineligible scopes before the build. Scope matching is exact; for example, `empire` selects only `@ralphschuler/screeps-empire`.
 
 #### 2. GitHub Release
 
@@ -276,11 +308,14 @@ The automated workflow performs:
 1. ✅ Checkout code
 2. ✅ Setup Node.js 24
 3. ✅ Install dependencies
-4. ✅ Build all packages (ensures dependencies are available)
-5. ✅ Run tests
-6. ✅ Stage each package through `scripts/publish-framework-package.mjs`
-7. ✅ Normalize internal monorepo dependency ranges in the staged package manifest
-8. ✅ Publish to npm with provenance, or dry-run through the same staging path
+4. ✅ Validate the manifest-driven `all` set or one exact manual scope
+5. ✅ Build all packages
+6. ✅ Run all workspace tests once
+7. ✅ Stage selected packages in dependency-safe order
+8. ✅ Normalize internal monorepo dependency ranges in each staged manifest
+9. ✅ Publish to npm with provenance
+
+Use `npm run publish:framework:dry-run` locally for non-publishing validation; the release workflow has no unreachable PR dry-run branch.
 
 ### Workflow Security
 
@@ -309,6 +344,7 @@ We follow [Semantic Versioning 2.0.0](https://semver.org/):
 - Internal refactoring (no API changes)
 
 Examples:
+
 - Fix CPU budget calculation bug
 - Optimize pathfinding cache lookup
 - Fix typos in README
@@ -321,6 +357,7 @@ Examples:
 - New optional parameters
 
 Examples:
+
 - Add new event type to kernel
 - Add portal cache invalidation method
 - Add new behavior to roles package
@@ -334,6 +371,7 @@ Examples:
 - Renamed exports
 
 Examples:
+
 - Remove deprecated `kernel.legacy()` method
 - Change `PortalManager` constructor signature
 - Rename `execute()` to `run()` in Process interface
@@ -347,6 +385,7 @@ For alpha/beta releases:
 - **Release Candidate**: `1.0.0-rc.1`, `1.0.0-rc.2`
 
 Publish pre-releases with:
+
 ```bash
 npm publish --tag alpha
 npm publish --tag beta
@@ -358,6 +397,7 @@ npm publish --tag rc
 Current state: All packages are `0.x.y`
 
 Meaning:
+
 - APIs may change without warning
 - No guarantee of backward compatibility
 - Not recommended for production use
@@ -366,13 +406,7 @@ Once stable, promote to `1.0.0`.
 
 ### Version Compatibility
 
-Maintain this compatibility matrix in FRAMEWORK.md:
-
-| Package | Depends On | Compatible Versions |
-|---------|-----------|---------------------|
-| screeps-roles | screeps-defense | 0.1.x |
-| screeps-remote-mining | screeps-cartographer | ^1.8.13 |
-| screeps-pathfinding | screeps-cartographer | ^1.8.13 |
+Package manifests are authoritative for compatibility ranges. Inspect the current framework manifests with `npm query '[name^="@ralphschuler/screeps-"]'` and validate normalized publish artifacts with `npm run publish:framework:check`; do not duplicate a static compatibility matrix here.
 
 ## Pre-Publish Validation
 
@@ -385,6 +419,7 @@ npm run build
 ```
 
 Check for TypeScript errors:
+
 ```bash
 tsc --noEmit
 ```
@@ -408,6 +443,7 @@ npm run publish:framework:check
 This fails if any packed package manifest still contains `workspace:*` or an internal `@ralphschuler/screeps-*` wildcard dependency.
 
 Should NOT include:
+
 - `src/` (only `dist/` should be published)
 - `test/`
 - `.github/`
@@ -416,6 +452,7 @@ Should NOT include:
 - `tsconfig.json`
 
 SHOULD include:
+
 - `dist/`
 - `README.md`
 - `LICENSE`
@@ -425,6 +462,7 @@ SHOULD include:
 ### 4. Package Metadata
 
 Verify package.json has:
+
 - ✅ Correct version number
 - ✅ Complete description
 - ✅ Keywords for discoverability
@@ -445,6 +483,7 @@ Verify package.json has:
 ### 6. Dependencies
 
 Check for:
+
 - No broken dependencies
 - Peer dependencies correctly specified
 - Version ranges are appropriate
@@ -456,6 +495,7 @@ npm ls
 ### 7. License Files
 
 Each package must have:
+
 - LICENSE file (Unlicense)
 - Correct license field in package.json
 
@@ -499,6 +539,7 @@ echo "✅ Package validation complete!"
 #### Issue: "You do not have permission to publish"
 
 **Solution:**
+
 - Verify you're logged in: `npm whoami`
 - Check you have access to `@ralphschuler` scope
 - Verify `NPM_TOKEN` secret is set correctly
@@ -507,6 +548,7 @@ echo "✅ Package validation complete!"
 #### Issue: "Version already published"
 
 **Solution:**
+
 - Check current version on npm: `npm view @ralphschuler/screeps-kernel version`
 - Bump version: `npm version patch`
 - Cannot republish same version - must increment
@@ -514,6 +556,7 @@ echo "✅ Package validation complete!"
 #### Issue: "Package not found" after publishing
 
 **Solution:**
+
 - Wait 1-2 minutes for npm CDN to update
 - Check npm website directly
 - Clear npm cache: `npm cache clean --force`
@@ -521,6 +564,7 @@ echo "✅ Package validation complete!"
 #### Issue: Build fails with missing dependencies
 
 **Solution:**
+
 - Run `npm run build:all` from repository root
 - Ensure internal packages are built first
 - Check package.json `peerDependencies`
@@ -528,6 +572,7 @@ echo "✅ Package validation complete!"
 #### Issue: Tests fail in CI but pass locally
 
 **Solution:**
+
 - Check Node.js version matches CI and repository baseline (Node.js 24.x / `>=24 <25`)
 - Ensure all devDependencies are installed
 - Look for environment-specific issues
@@ -535,6 +580,7 @@ echo "✅ Package validation complete!"
 #### Issue: "ENEEDAUTH" error
 
 **Solution:**
+
 - Re-login: `npm login`
 - Regenerate token: `npm token create`
 - Update `NPM_TOKEN` secret in GitHub
@@ -542,69 +588,42 @@ echo "✅ Package validation complete!"
 ### Debug Commands
 
 Check npm configuration:
+
 ```bash
 npm config list
 ```
 
 Verify authentication:
+
 ```bash
 npm whoami
 ```
 
 Check package info:
+
 ```bash
 npm view @ralphschuler/screeps-kernel
 ```
 
 List your published packages:
+
 ```bash
 npm access ls-packages
 ```
 
 ## Package Dependencies
 
-### Dependency Graph
+### Dependency Graph and Publishing Order
 
-```
-screeps-kernel (standalone)
-├── No dependencies
+Do not maintain a second hand-written dependency graph. The publication helper reads current `dependencies`, `peerDependencies`, and `optionalDependencies` from eligible manifests, then applies a deterministic topological order. Dependencies selected in the same run are published before their dependents; cycles fail before any package is staged.
 
-screeps-pathfinding (standalone)
-├── No dependencies
+Inspect the exact current order with:
 
-screeps-remote-mining
-└── peerDependencies
-    └── screeps-cartographer: ^1.8.13
-
-screeps-roles
-├── screeps-cartographer: ^1.8.13
-└── @ralphschuler/screeps-defense: *
-
-screeps-console (standalone)
-├── No dependencies
-
-screeps-stats (standalone)
-├── No dependencies
-
-screeps-visuals (private)
-├── Not published
+```bash
+node scripts/publish-framework-package.mjs --list
 ```
 
-### Publishing Order
-
-When publishing multiple packages, follow this order to satisfy dependencies:
-
-1. **Tier 1 - Standalone Packages** (no dependencies)
-   - screeps-kernel
-   - screeps-pathfinding
-   - screeps-console
-   - screeps-stats
-
-2. **Tier 2 - Packages with external peer dependencies**
-   - screeps-remote-mining (depends on screeps-cartographer)
-
-3. **Tier 3 - Packages with internal dependencies**
-   - screeps-roles (depends on screeps-defense)
+`--all` and multiple `--package` selections use this same order. Packages with private or otherwise ineligible internal runtime dependencies are excluded from `--all` and rejected by exact selection, so a release cannot publish an unusable dependency closure. Package authors must still run `npm run publish:framework:check` before release.
 
 ### Internal Package References
 
@@ -629,10 +648,12 @@ The staging script packs the source package, extracts it, rewrites internal `@ra
 
 ### External Dependencies
 
-Current external dependencies:
-- `screeps-cartographer: ^1.8.13` (peer dependency)
+Current external framework dependency:
+
+- `screeps-cartographer: ^1.8.15` (runtime or peer dependency, depending on package)
 
 When adding new external dependencies:
+
 1. Verify package is maintained
 2. Use semantic version ranges
 3. Add to both `dependencies` and `peerDependencies` as appropriate
@@ -697,5 +718,6 @@ After initial publishing:
 ## Support
 
 For questions or issues:
+
 - GitHub Issues: https://github.com/ralphschuler/screeps/issues
 - GitHub Discussions: https://github.com/ralphschuler/screeps/discussions

--- a/scripts/publish-framework-package.mjs
+++ b/scripts/publish-framework-package.mjs
@@ -21,6 +21,11 @@ const DEPENDENCY_SECTIONS = [
   "devDependencies",
 ];
 const INTERNAL_PACKAGE_PREFIX = "@ralphschuler/screeps-";
+const PUBLISH_ORDER_DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.PUBLISH_FRAMEWORK_REPO_ROOT
@@ -32,12 +37,14 @@ const packagesRoot = process.env.PUBLISH_FRAMEWORK_PACKAGES_DIR
 
 function usage() {
   return `Usage:
-  node scripts/publish-framework-package.mjs --package <name-or-path> [--check|--dry-run|--publish]
+  node scripts/publish-framework-package.mjs --package <name-path-or-exact-scope> [--check|--dry-run|--publish]
   node scripts/publish-framework-package.mjs --all --check
+  node scripts/publish-framework-package.mjs --list [--package <name-path-or-exact-scope>] [--json]
 
 Options:
-  --package <name-or-path>  Package name or package directory to stage.
-  --all                     Stage all public framework packages with main/types entries.
+  --package <selection>     Select one exact package name, directory, or short scope.
+  --all                     Select all eligible public framework packages and dependencies.
+  --list                    List selected publishable packages without staging them.
   --check                   Pack staged package and fail on publish-time dependency issues (default).
   --dry-run                 Run npm publish --dry-run for the normalized tarball.
   --publish                 Run npm publish for the normalized tarball.
@@ -59,6 +66,7 @@ function parseArgs(argv) {
   const args = {
     packages: [],
     all: false,
+    list: false,
     mode: "check",
     access: "public",
     provenance: false,
@@ -80,6 +88,9 @@ function parseArgs(argv) {
       }
       case "--all":
         args.all = true;
+        break;
+      case "--list":
+        args.list = true;
         break;
       case "--check":
         args.mode = "check";
@@ -123,6 +134,10 @@ function parseArgs(argv) {
     }
   }
 
+  if (args.all && args.packages.length > 0) {
+    fail("Select either --all or one or more --package values, not both.");
+  }
+  if (args.list && args.packages.length === 0) args.all = true;
   if (!args.all && args.packages.length === 0) {
     fail(`Select --all or at least one --package.\n${usage()}`);
   }
@@ -174,37 +189,163 @@ function loadWorkspacePackages() {
   return packageByName;
 }
 
-function isFrameworkPublishCandidate(workspacePackage) {
-  const manifest = workspacePackage.manifest;
-  return (
-    workspacePackage.name.startsWith(INTERNAL_PACKAGE_PREFIX) &&
-    manifest.private !== true &&
-    typeof manifest.main === "string" &&
-    typeof manifest.types === "string"
-  );
+function isFrameworkPublishCandidate(workspacePackage, packageByName) {
+  return publishCandidateRejection(workspacePackage, packageByName) === null;
+}
+
+function packageScope(packageName) {
+  return packageName.startsWith(INTERNAL_PACKAGE_PREFIX)
+    ? packageName.slice(INTERNAL_PACKAGE_PREFIX.length)
+    : null;
+}
+
+function publishCandidateRejection(
+  workspacePackage,
+  packageByName,
+  visiting = new Set(),
+) {
+  if (!workspacePackage.name.startsWith(INTERNAL_PACKAGE_PREFIX)) {
+    return "package name is outside the framework scope";
+  }
+  if (workspacePackage.private) return "package is private";
+  if (typeof workspacePackage.manifest.main !== "string") {
+    return "package has no main entry point";
+  }
+  if (typeof workspacePackage.manifest.types !== "string") {
+    return "package has no types entry point";
+  }
+  if (!packageByName || visiting.has(workspacePackage.name)) return null;
+
+  const nextVisiting = new Set(visiting).add(workspacePackage.name);
+  for (const section of PUBLISH_ORDER_DEPENDENCY_SECTIONS) {
+    const dependencyNames = Object.keys(
+      workspacePackage.manifest[section] ?? {},
+    ).sort();
+    for (const dependencyName of dependencyNames) {
+      if (!dependencyName.startsWith(INTERNAL_PACKAGE_PREFIX)) continue;
+      const dependency = packageByName.get(dependencyName);
+      if (!dependency) {
+        return `dependency ${dependencyName} is not a discovered workspace package`;
+      }
+      const dependencyRejection = publishCandidateRejection(
+        dependency,
+        packageByName,
+        nextVisiting,
+      );
+      if (dependencyRejection) {
+        return `dependency ${dependencyName} is not publishable (${dependencyRejection})`;
+      }
+    }
+  }
+  return null;
+}
+
+function requirePublishCandidate(workspacePackage, selection, packageByName) {
+  const rejection = publishCandidateRejection(workspacePackage, packageByName);
+  if (rejection) {
+    fail(`Package selection ${selection} is not publishable: ${rejection}`);
+  }
+  return workspacePackage;
 }
 
 function resolvePackage(selection, packageByName) {
-  if (packageByName.has(selection)) return packageByName.get(selection);
+  const exactName = packageByName.get(selection);
+  if (exactName)
+    return requirePublishCandidate(exactName, selection, packageByName);
+
+  const exactScopeMatches = [...packageByName.values()].filter(
+    (workspacePackage) => packageScope(workspacePackage.name) === selection,
+  );
+  if (exactScopeMatches.length === 1) {
+    return requirePublishCandidate(
+      exactScopeMatches[0],
+      selection,
+      packageByName,
+    );
+  }
+  if (exactScopeMatches.length > 1) {
+    fail(`Ambiguous exact package scope: ${selection}`);
+  }
 
   const candidates = [
     path.resolve(process.cwd(), selection),
     path.resolve(repoRoot, selection),
   ];
   for (const candidate of candidates) {
-    const manifestPath = path.join(candidate, "package.json");
-    if (!existsSync(manifestPath)) continue;
-    const manifest = readJson(manifestPath);
-    return {
-      dir: candidate,
-      manifest,
-      name: manifest.name,
-      private: manifest.private === true,
-      version: manifest.version,
-    };
+    const workspacePackage = [...packageByName.values()].find(
+      (current) => path.resolve(current.dir) === candidate,
+    );
+    if (workspacePackage)
+      return requirePublishCandidate(
+        workspacePackage,
+        selection,
+        packageByName,
+      );
+    if (existsSync(path.join(candidate, "package.json"))) {
+      fail(`Package path is not a discovered workspace package: ${selection}`);
+    }
   }
 
-  fail(`Unable to resolve package selection: ${selection}`);
+  fail(`Unable to resolve exact publishable package selection: ${selection}`);
+}
+
+function orderPackagesForPublication(packages) {
+  const selectedByName = new Map(
+    packages.map((workspacePackage) => [
+      workspacePackage.name,
+      workspacePackage,
+    ]),
+  );
+  const state = new Map();
+  const stack = [];
+  const ordered = [];
+
+  function visit(workspacePackage) {
+    const currentState = state.get(workspacePackage.name);
+    if (currentState === "visited") return;
+    if (currentState === "visiting") {
+      const cycleStart = stack.indexOf(workspacePackage.name);
+      const cycle = [...stack.slice(cycleStart), workspacePackage.name];
+      fail(`Internal framework dependency cycle: ${cycle.join(" -> ")}`);
+    }
+
+    state.set(workspacePackage.name, "visiting");
+    stack.push(workspacePackage.name);
+    const dependencies = new Set();
+    for (const section of PUBLISH_ORDER_DEPENDENCY_SECTIONS) {
+      for (const dependencyName of Object.keys(
+        workspacePackage.manifest[section] ?? {},
+      )) {
+        if (selectedByName.has(dependencyName))
+          dependencies.add(dependencyName);
+      }
+    }
+    for (const dependencyName of [...dependencies].sort()) {
+      visit(selectedByName.get(dependencyName));
+    }
+    stack.pop();
+    state.set(workspacePackage.name, "visited");
+    ordered.push(workspacePackage);
+  }
+
+  for (const workspacePackage of [...selectedByName.values()].sort(
+    (left, right) => left.name.localeCompare(right.name),
+  )) {
+    visit(workspacePackage);
+  }
+  return ordered;
+}
+
+function listedPackage(workspacePackage) {
+  return {
+    name: workspacePackage.name,
+    path: path
+      .relative(repoRoot, workspacePackage.dir)
+      .split(path.sep)
+      .join("/"),
+    scope: packageScope(workspacePackage.name),
+    version: workspacePackage.version,
+  };
 }
 
 function run(command, args, options = {}) {
@@ -239,7 +380,9 @@ function parseNpmPackJson(stdout) {
     }
     return parsed[0];
   } catch (error) {
-    throw new Error(`Failed to parse npm pack JSON output: ${error.message}\n${stdout}`);
+    throw new Error(
+      `Failed to parse npm pack JSON output: ${error.message}\n${stdout}`,
+    );
   }
 }
 
@@ -247,7 +390,13 @@ function packPackage(packageDir, packDestination) {
   mkdirSync(packDestination, { recursive: true });
   const result = run(
     "npm",
-    ["pack", "--ignore-scripts", "--json", "--pack-destination", packDestination],
+    [
+      "pack",
+      "--ignore-scripts",
+      "--json",
+      "--pack-destination",
+      packDestination,
+    ],
     { cwd: packageDir },
   );
   const packInfo = parseNpmPackJson(result.stdout);
@@ -271,7 +420,11 @@ function extractPackage(tarballPath, destination) {
 }
 
 function normalizeWorkspaceVersion(specifier, concreteVersion) {
-  if (specifier === "*" || specifier === "workspace:*" || specifier === "workspace:") {
+  if (
+    specifier === "*" ||
+    specifier === "workspace:*" ||
+    specifier === "workspace:"
+  ) {
     return concreteVersion;
   }
   if (specifier === "workspace:^") return `^${concreteVersion}`;
@@ -377,7 +530,9 @@ function stageAndNormalizePackage(workspacePackage, packageByName, runRoot) {
 
   const verifyTarball = packPackage(stagedPackageDir, verifyPackDir);
   const verifiedPackageDir = extractPackage(verifyTarball, verifyExtractDir);
-  const verifiedManifest = readJson(path.join(verifiedPackageDir, "package.json"));
+  const verifiedManifest = readJson(
+    path.join(verifiedPackageDir, "package.json"),
+  );
   validatePublishManifest(verifiedManifest, packageByName);
 
   return {
@@ -392,7 +547,12 @@ function stageAndNormalizePackage(workspacePackage, packageByName, runRoot) {
 }
 
 function runPublishCommand(staged, args) {
-  const publishArgs = ["publish", staged.verifyTarball, "--access", args.access];
+  const publishArgs = [
+    "publish",
+    staged.verifyTarball,
+    "--access",
+    args.access,
+  ];
   if (args.mode === "dry-run") publishArgs.push("--dry-run");
   if (args.mode === "publish" && args.provenance) {
     publishArgs.push("--provenance");
@@ -411,36 +571,57 @@ function packageStat(packageDir) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const packageByName = loadWorkspacePackages();
-  const selections = args.all
-    ? [...packageByName.values()]
-        .filter(isFrameworkPublishCandidate)
-        .sort((left, right) => left.name.localeCompare(right.name))
-    : args.packages.map((selection) => resolvePackage(selection, packageByName));
+  const selectedPackages = args.all
+    ? [...packageByName.values()].filter((workspacePackage) =>
+        isFrameworkPublishCandidate(workspacePackage, packageByName),
+      )
+    : args.packages.map((selection) =>
+        resolvePackage(selection, packageByName),
+      );
+  const selections = orderPackagesForPublication(selectedPackages);
+
+  if (args.list) {
+    const packages = selections.map(listedPackage);
+    if (args.json)
+      console.log(JSON.stringify({ mode: "list", packages }, null, 2));
+    else
+      for (const workspacePackage of packages) {
+        console.log(
+          `${workspacePackage.scope}\t${workspacePackage.name}\t${workspacePackage.path}`,
+        );
+      }
+    return;
+  }
 
   const runRoot = createRunRoot(args);
   const summary = [];
 
   try {
     for (const workspacePackage of selections) {
-      if (!workspacePackage?.dir || !packageStat(workspacePackage.dir)?.isDirectory()) {
-        throw new Error(`Invalid package directory for ${workspacePackage?.name ?? "unknown"}`);
-      }
-
-      if (workspacePackage.private) {
-        console.log(`skip ${workspacePackage.name}: package is private`);
-        summary.push({ name: workspacePackage.name, skipped: true, reason: "private" });
-        continue;
+      if (
+        !workspacePackage?.dir ||
+        !packageStat(workspacePackage.dir)?.isDirectory()
+      ) {
+        throw new Error(
+          `Invalid package directory for ${workspacePackage?.name ?? "unknown"}`,
+        );
       }
 
       console.log(`stage ${workspacePackage.name}@${workspacePackage.version}`);
-      const staged = stageAndNormalizePackage(workspacePackage, packageByName, runRoot);
+      const staged = stageAndNormalizePackage(
+        workspacePackage,
+        packageByName,
+        runRoot,
+      );
       for (const change of staged.changes) {
         console.log(
           `normalize ${staged.packageName}: ${change.section}.${change.dependencyName} ${change.from} -> ${change.to}`,
         );
       }
       if (staged.changes.length === 0) {
-        console.log(`normalize ${staged.packageName}: no internal workspace ranges found`);
+        console.log(
+          `normalize ${staged.packageName}: no internal workspace ranges found`,
+        );
       }
 
       if (args.mode === "dry-run" || args.mode === "publish") {
@@ -462,7 +643,9 @@ function main() {
   }
 
   if (args.json) {
-    console.log(JSON.stringify({ mode: args.mode, packages: summary }, null, 2));
+    console.log(
+      JSON.stringify({ mode: args.mode, packages: summary }, null, 2),
+    );
   }
 }
 

--- a/scripts/test/publish-framework-package.test.mjs
+++ b/scripts/test/publish-framework-package.test.mjs
@@ -7,11 +7,21 @@ import test from "node:test";
 
 const repoRoot = new URL("../..", import.meta.url);
 const scriptPath = new URL("../publish-framework-package.mjs", import.meta.url);
+const workflowPath = new URL(
+  "../../.github/workflows/publish-framework.yml",
+  import.meta.url,
+);
+const publishingGuidePath = new URL("../../PUBLISHING.md", import.meta.url);
 
 function writeFrameworkPackage(
   packagesDir,
   shortName,
-  { dependencies = {}, privatePackage = false, scripts = {}, version = "0.1.0" } = {},
+  {
+    dependencies = {},
+    privatePackage = false,
+    scripts = {},
+    version = "0.1.0",
+  } = {},
 ) {
   const packageDir = path.join(packagesDir, "@ralphschuler", shortName);
   mkdirSync(path.join(packageDir, "dist"), { recursive: true });
@@ -59,7 +69,9 @@ function readJson(filePath) {
 
 function stagedManifest(stageRoot, packageName) {
   const safeName = packageName.replaceAll("/", "__").replaceAll("@", "scope_");
-  return readJson(path.join(stageRoot, safeName, "stage", "package", "package.json"));
+  return readJson(
+    path.join(stageRoot, safeName, "stage", "package", "package.json"),
+  );
 }
 
 function verifiedManifest(stageRoot, packageName) {
@@ -68,6 +80,158 @@ function verifiedManifest(stageRoot, packageName) {
     path.join(stageRoot, safeName, "verify-extract", "package", "package.json"),
   );
 }
+
+test("publish package list discovers only public framework candidates in dependency order", () => {
+  const { packagesDir } = makeFixture();
+  writeFrameworkPackage(packagesDir, "screeps-alpha", {
+    dependencies: { "@ralphschuler/screeps-beta": "*" },
+  });
+  writeFrameworkPackage(packagesDir, "screeps-beta", { version: "0.2.0" });
+  writeFrameworkPackage(packagesDir, "screeps-private", {
+    privatePackage: true,
+  });
+  writeFrameworkPackage(packagesDir, "screeps-unpublishable", {
+    dependencies: { "@ralphschuler/screeps-private": "*" },
+  });
+  const appDir = path.join(packagesDir, "application");
+  mkdirSync(path.join(appDir, "dist"), { recursive: true });
+  writeFileSync(
+    path.join(appDir, "package.json"),
+    `${JSON.stringify({ name: "application", version: "1.0.0", main: "dist/index.js", types: "dist/index.d.ts" }, null, 2)}\n`,
+  );
+
+  const result = runPublishScript(["--list", "--json"], packagesDir);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  const summary = JSON.parse(result.stdout);
+  assert.deepEqual(
+    summary.packages.map((pkg) => ({
+      name: pkg.name,
+      scope: pkg.scope,
+      version: pkg.version,
+    })),
+    [
+      { name: "@ralphschuler/screeps-beta", scope: "beta", version: "0.2.0" },
+      { name: "@ralphschuler/screeps-alpha", scope: "alpha", version: "0.1.0" },
+    ],
+  );
+});
+
+test("publish package list fails before staging cyclic internal selections", () => {
+  const { packagesDir } = makeFixture();
+  writeFrameworkPackage(packagesDir, "screeps-alpha", {
+    dependencies: { "@ralphschuler/screeps-beta": "*" },
+  });
+  writeFrameworkPackage(packagesDir, "screeps-beta", {
+    dependencies: { "@ralphschuler/screeps-alpha": "*" },
+  });
+
+  const result = runPublishScript(["--list", "--json"], packagesDir);
+
+  assert.notEqual(result.status, 0, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /Internal framework dependency cycle: @ralphschuler\/screeps-alpha -> @ralphschuler\/screeps-beta -> @ralphschuler\/screeps-alpha/,
+  );
+});
+
+test("publish package list resolves exact scopes and rejects unavailable or private scopes", () => {
+  const { packagesDir } = makeFixture();
+  writeFrameworkPackage(packagesDir, "screeps-alpha");
+  writeFrameworkPackage(packagesDir, "screeps-private", {
+    privatePackage: true,
+  });
+  writeFrameworkPackage(packagesDir, "screeps-unpublishable", {
+    dependencies: { "@ralphschuler/screeps-private": "*" },
+  });
+
+  const exact = runPublishScript(
+    ["--list", "--package", "alpha", "--json"],
+    packagesDir,
+  );
+  assert.equal(exact.status, 0, exact.stdout + exact.stderr);
+  assert.deepEqual(
+    JSON.parse(exact.stdout).packages.map((pkg) => pkg.name),
+    ["@ralphschuler/screeps-alpha"],
+  );
+
+  const substring = runPublishScript(
+    ["--list", "--package", "pha", "--json"],
+    packagesDir,
+  );
+  assert.notEqual(substring.status, 0, substring.stdout + substring.stderr);
+  assert.match(
+    substring.stderr,
+    /Unable to resolve exact publishable package selection: pha/,
+  );
+
+  const privateResult = runPublishScript(
+    ["--list", "--package", "private", "--json"],
+    packagesDir,
+  );
+  assert.notEqual(
+    privateResult.status,
+    0,
+    privateResult.stdout + privateResult.stderr,
+  );
+  assert.match(privateResult.stderr, /not publishable: package is private/);
+
+  const invalidClosure = runPublishScript(
+    ["--list", "--package", "unpublishable", "--json"],
+    packagesDir,
+  );
+  assert.notEqual(
+    invalidClosure.status,
+    0,
+    invalidClosure.stdout + invalidClosure.stderr,
+  );
+  assert.match(
+    invalidClosure.stderr,
+    /not publishable: dependency @ralphschuler\/screeps-private is not publishable \(package is private\)/,
+  );
+});
+
+test("framework publication workflow delegates all and exact scope selection to the helper", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  assert.doesNotMatch(workflow, /\bmatrix:/);
+  assert.doesNotMatch(workflow, /\bcontains\(/);
+  assert.match(workflow, /publish-framework-package\.mjs --all --publish/);
+  assert.match(
+    workflow,
+    /publish-framework-package\.mjs --package "\$PUBLISH_SCOPE" --publish/,
+  );
+});
+
+test("publishing guide inventory matches manifest-driven helper discovery", () => {
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath.pathname, "--list", "--json"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  const discoveredInventory = JSON.parse(result.stdout).packages.map(
+    ({ name, scope, version }) => ({ name, scope, version }),
+  );
+  const guide = readFileSync(publishingGuidePath, "utf8");
+  const inventory = guide.match(
+    /<!-- framework-package-inventory:start -->([\s\S]*?)<!-- framework-package-inventory:end -->/,
+  );
+  assert.ok(
+    inventory,
+    "PUBLISHING.md must contain the tested framework package inventory",
+  );
+  const documentedInventory = [
+    ...inventory[1].matchAll(
+      /\| `(@ralphschuler\/screeps-[^`]+)`\s+\| `([^`]+)`\s+\| ([^\s|]+)\s+\|/g,
+    ),
+  ].map((match) => ({ name: match[1], scope: match[2], version: match[3] }));
+
+  assert.deepEqual(documentedInventory, discoveredInventory);
+});
 
 test("publish package check normalizes internal wildcard dependencies only in staged pack output", () => {
   const { packagesDir, root } = makeFixture();
@@ -82,7 +246,14 @@ test("publish package check normalizes internal wildcard dependencies only in st
   const stageRoot = path.join(root, "stage-root");
 
   const result = runPublishScript(
-    ["--package", alphaDir, "--check", "--stage-root", stageRoot, "--keep-stage"],
+    [
+      "--package",
+      alphaDir,
+      "--check",
+      "--stage-root",
+      stageRoot,
+      "--keep-stage",
+    ],
     packagesDir,
   );
 
@@ -122,7 +293,14 @@ test("publish package check resolves workspace protocol ranges before validation
   const stageRoot = path.join(root, "stage-root");
 
   const result = runPublishScript(
-    ["--package", alphaDir, "--check", "--stage-root", stageRoot, "--keep-stage"],
+    [
+      "--package",
+      alphaDir,
+      "--check",
+      "--stage-root",
+      stageRoot,
+      "--keep-stage",
+    ],
     packagesDir,
   );
 
@@ -139,7 +317,7 @@ test("publish package dry-run publishes the verified tarball without running sta
   const { packagesDir, root } = makeFixture();
   const alphaDir = writeFrameworkPackage(packagesDir, "screeps-alpha", {
     scripts: {
-      prepublishOnly: "node -e \"process.exit(42)\"",
+      prepublishOnly: 'node -e "process.exit(42)"',
     },
   });
 
@@ -167,7 +345,13 @@ test("publish package check fails when a packed manifest still has an unresolved
   });
 
   const result = runPublishScript(
-    ["--package", alphaDir, "--check", "--stage-root", path.join(root, "stage-root")],
+    [
+      "--package",
+      alphaDir,
+      "--check",
+      "--stage-root",
+      path.join(root, "stage-root"),
+    ],
     packagesDir,
   );
 


### PR DESCRIPTION
## Overview

Closes #3415 by making workspace manifests the authoritative framework publication inventory.

## Changes

- discover eligible public framework packages from manifests
- validate exact manual dispatch scopes and reject private/invalid dependency closures
- publish all selections in deterministic dependency-safe order; reject cycles
- delegate release/manual workflow selection to the helper instead of a hand-maintained matrix
- synchronize `PUBLISHING.md` with the tested 19-package inventory
- add nine behavior-focused publication tests

## Safety

- real npm publication was not run
- package staging operates on packed temporary copies; source manifests remain unchanged
- `@ralphschuler/screeps-clusters` remains excluded because it depends on private `@ralphschuler/screeps-spawn`; tracked in #3419

## Validation

- `npm run verify`
- `npm run publish:framework:check`
- `npm run publish:framework:dry-run`
- `npm run build:docs`
- `node --test scripts/test/publish-framework-package.test.mjs` (9/9)
- Prettier on changed files
- `git diff --check`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- private-server smoke validation from `verify`: 71/71 assertions

## Rollback

Revert commit `b919dc99`; this change does not alter deployed Screeps runtime behavior or npm package versions.
