### PR TITLE
fix(intershard): establish expansion on exact destination portals

### DIFF
--- a/packages/@ralphschuler/screeps-intershard/src/schema/compactDecoding.ts
+++ b/packages/@ralphschuler/screeps-intershard/src/schema/compactDecoding.ts
@@ -82,7 +82,8 @@ function expandPortal(portal: CompactPortal): PortalInfo {
     targetShard: portal.ts,
     targetRoom: portal.tr,
     threatRating: portal.th,
-    lastScouted: 0,
+    lastScouted: portal.ls ?? 0,
+    decayTick: portal.dt,
     isStable: portal.s === 1,
     traversalCount: portal.tc ?? 0
   };

--- a/packages/@ralphschuler/screeps-intershard/src/schema/compactEncoding.ts
+++ b/packages/@ralphschuler/screeps-intershard/src/schema/compactEncoding.ts
@@ -73,7 +73,9 @@ function toCompactPortal(portal: PortalInfo): CompactPortal {
     tr: portal.targetRoom,
     th: portal.threatRating,
     s: portal.isStable ? 1 : 0,
-    tc: portal.traversalCount ?? 0
+    tc: portal.traversalCount ?? 0,
+    ls: portal.lastScouted,
+    dt: portal.decayTick
   };
 }
 

--- a/packages/@ralphschuler/screeps-intershard/src/schema/compactTypes.ts
+++ b/packages/@ralphschuler/screeps-intershard/src/schema/compactTypes.ts
@@ -47,6 +47,8 @@ export interface CompactPortal {
   th: number;
   s: number;
   tc: number;
+  ls?: number;
+  dt?: number;
 }
 
 export interface CompactCpuHistory {

--- a/packages/@ralphschuler/screeps-intershard/src/shardManager.ts
+++ b/packages/@ralphschuler/screeps-intershard/src/shardManager.ts
@@ -388,18 +388,24 @@ export class ShardManager {
           const targetRoom = (destination as { room: string }).room;
 
           // Check if already tracked
+          const sourcePos = { x: portal.pos.x, y: portal.pos.y };
           const existing = shardState.portals.find(
-            p => p.sourceRoom === roomName && p.targetShard === targetShard
+            p =>
+              p.sourceRoom === roomName &&
+              p.sourcePos.x === sourcePos.x &&
+              p.sourcePos.y === sourcePos.y &&
+              p.targetShard === targetShard &&
+              p.targetRoom === targetRoom
           );
 
           if (existing) {
-            // Update existing portal
+            existing.sourcePos = sourcePos;
+            existing.targetRoom = targetRoom;
             existing.lastScouted = Game.time;
             // Determine stability: portals without decay tick are stable
             existing.isStable = portal.ticksToDecay === undefined;
-            if (portal.ticksToDecay !== undefined) {
-              existing.decayTick = Game.time + portal.ticksToDecay;
-            }
+            existing.decayTick =
+              portal.ticksToDecay === undefined ? undefined : Game.time + portal.ticksToDecay;
           } else {
             const portalInfo: PortalInfo = {
               sourceRoom: roomName,

--- a/packages/@ralphschuler/screeps-intershard/test/schema.test.ts
+++ b/packages/@ralphschuler/screeps-intershard/test/schema.test.ts
@@ -60,6 +60,7 @@ describe("InterShardMemory Schema", () => {
       targetRoom: "W9N9",
       threatRating: 2,
       lastScouted: 999,
+      decayTick: 1200,
       isStable: false,
       traversalCount: 7
     }];
@@ -112,7 +113,8 @@ describe("InterShardMemory Schema", () => {
       targetShard: "shard1",
       targetRoom: "W9N9",
       threatRating: 2,
-      lastScouted: 0,
+      lastScouted: 999,
+      decayTick: 1200,
       isStable: false,
       traversalCount: 7
     });

--- a/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
+++ b/packages/@ralphschuler/screeps-memory/src/schemas/creepSchemas.ts
@@ -103,6 +103,10 @@ export interface SwarmCreepMemory {
   targetShard?: string;
   /** Portal room for intershard operation creeps. */
   portalRoom?: string;
+  /** Exact source portal position for intershard operation creeps. */
+  portalPos?: { x: number; y: number };
+  /** Expected destination room of the source portal. */
+  portalTargetRoom?: string;
   /** Last explored room (for scouts to avoid cycling) */
   lastExploredRoom?: string;
   /** Current task */

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/economy/interShardPioneer.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/economy/interShardPioneer.ts
@@ -6,6 +6,8 @@ import { updateWorkingState } from "./common/stateManagement";
 interface InterShardMemoryFields {
   targetShard?: string;
   portalRoom?: string;
+  portalPos?: { x: number; y: number };
+  portalTargetRoom?: string;
   targetRoom?: string;
   workflowState?: string;
 }
@@ -14,19 +16,28 @@ function isDangerousHostile(hostile: Creep): boolean {
   return hostile.body.some(part => part.hits > 0 && (part.type === ATTACK || part.type === RANGED_ATTACK || part.type === WORK || part.type === HEAL));
 }
 
-function findPortal(room: Room, targetShard: string): StructurePortal | undefined {
+function findPortal(room: Room, memory: InterShardMemoryFields): StructurePortal | undefined {
+  if (!memory.targetShard) return undefined;
   const portals = room.find(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL }) as StructurePortal[];
-  return portals.find(portal => {
+  const matching = portals.filter(portal => {
     const destination = portal.destination;
-    return "shard" in destination && destination.shard === targetShard;
+    return (
+      "shard" in destination &&
+      destination.shard === memory.targetShard &&
+      (!memory.portalTargetRoom || destination.room === memory.portalTargetRoom)
+    );
   });
+  if (!memory.portalPos) return matching.length === 1 ? matching[0] : undefined;
+  return matching.find(
+    portal => portal.pos.x === memory.portalPos?.x && portal.pos.y === memory.portalPos?.y
+  );
 }
 
 function moveToPortal(ctx: CreepContext, memory: InterShardMemoryFields): CreepAction {
   if (!memory.targetShard || !memory.portalRoom) return { type: "idle" };
   if (ctx.room.name !== memory.portalRoom) return { type: "moveToRoom", roomName: memory.portalRoom };
-  const portal = findPortal(ctx.room, memory.targetShard);
-  if (!portal) return { type: "idle" };
+  const portal = findPortal(ctx.room, memory);
+  if (!portal || (portal.ticksToDecay !== undefined && portal.ticksToDecay <= 25)) return { type: "idle" };
   if (!stageInterShardCreepMemory([ctx.creep]).written) return { type: "idle" };
   // A portal only transfers a creep standing on its tile. Cartographer's
   // default target range is 1, which leaves inter-shard pioneers adjacent forever.
@@ -45,8 +56,9 @@ export function interShardPioneer(ctx: CreepContext): CreepAction {
   }
   if (Game.shard?.name !== memory.targetShard) return moveToPortal(ctx, memory);
 
-  if (!memory.targetRoom) memory.targetRoom = ctx.room.name;
+  if (!memory.targetRoom) return { type: "idle" };
   if (ctx.room.name !== memory.targetRoom) return { type: "moveToRoom", roomName: memory.targetRoom };
+  if (!ctx.room.controller?.my) return { type: "idle" };
 
   if (ctx.hostiles.some(isDangerousHostile)) return { type: "idle" };
 

--- a/packages/@ralphschuler/screeps-roles/src/behaviors/interShardClaim.ts
+++ b/packages/@ralphschuler/screeps-roles/src/behaviors/interShardClaim.ts
@@ -10,6 +10,8 @@ import type { CreepAction, CreepContext } from "./types";
 interface InterShardClaimMemory {
   targetShard?: string;
   portalRoom?: string;
+  portalPos?: { x: number; y: number };
+  portalTargetRoom?: string;
   targetRoom?: string;
   workflowState?: string;
 }
@@ -34,19 +36,28 @@ function updateFootprint(status: "reached" | "claimTargetSelected" | "claimed" |
   }
 }
 
-function findPortal(room: Room, targetShard: string): StructurePortal | undefined {
+function findPortal(room: Room, memory: InterShardClaimMemory): StructurePortal | undefined {
+  if (!memory.targetShard) return undefined;
   const portals = room.find(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL }) as StructurePortal[];
-  return portals.find(portal => {
+  const matching = portals.filter(portal => {
     const destination = portal.destination;
-    return "shard" in destination && destination.shard === targetShard;
+    return (
+      "shard" in destination &&
+      destination.shard === memory.targetShard &&
+      (!memory.portalTargetRoom || destination.room === memory.portalTargetRoom)
+    );
   });
+  if (!memory.portalPos) return matching.length === 1 ? matching[0] : undefined;
+  return matching.find(
+    portal => portal.pos.x === memory.portalPos?.x && portal.pos.y === memory.portalPos?.y
+  );
 }
 
 function moveToPortal(ctx: CreepContext, memory: InterShardClaimMemory): CreepAction {
   if (!memory.targetShard || !memory.portalRoom) return { type: "idle" };
   if (ctx.room.name !== memory.portalRoom) return { type: "moveToRoom", roomName: memory.portalRoom };
-  const portal = findPortal(ctx.room, memory.targetShard);
-  if (!portal) return { type: "idle" };
+  const portal = findPortal(ctx.room, memory);
+  if (!portal || (portal.ticksToDecay !== undefined && portal.ticksToDecay <= 25)) return { type: "idle" };
   if (!stageInterShardCreepMemory([ctx.creep]).written) return { type: "idle" };
   // A portal only transfers a creep standing on its tile. Cartographer's
   // default target range is 1, which leaves inter-shard creeps adjacent forever.

--- a/packages/@ralphschuler/screeps-roles/test/interShardPortalMovement.test.ts
+++ b/packages/@ralphschuler/screeps-roles/test/interShardPortalMovement.test.ts
@@ -119,6 +119,65 @@ describe("inter-shard portal movement", () => {
     expect(localMemory).to.equal(oversizedPayload);
   });
 
+  it("selects the persisted shard0 portal instead of another portal in the same room", () => {
+    const room = createMockRoom("W20S20");
+    const shard2Portal = {
+      structureType: STRUCTURE_PORTAL,
+      pos: new RoomPosition(28, 40, room.name),
+      destination: { shard: "shard2", room: room.name },
+    } as unknown as StructurePortal;
+    const shard0Portal = {
+      structureType: STRUCTURE_PORTAL,
+      pos: new RoomPosition(29, 12, room.name),
+      destination: { shard: "shard0", room: room.name },
+    } as unknown as StructurePortal;
+    room.find = (_type: number, options?: { filter?: (value: Structure) => boolean }) =>
+      options?.filter
+        ? [shard2Portal, shard0Portal].filter(options.filter)
+        : [shard2Portal, shard0Portal];
+    const creep = createMockCreep("interShardScout", {
+      room,
+      memory: {
+        role: "interShardScout",
+        homeRoom: "W1N1",
+        targetShard: "shard0",
+        portalRoom: room.name,
+        portalPos: { x: 29, y: 12 },
+        portalTargetRoom: room.name,
+      },
+    });
+
+    const action = interShardClaimer(createContext(creep, room));
+
+    expect(action.type).to.equal("moveTo");
+    expect((action as Extract<CreepAction, { type: "moveTo" }>).target).to.deep.equal({
+      pos: shard0Portal.pos,
+      range: 0,
+    });
+  });
+
+  it("fails closed when legacy memory cannot disambiguate duplicate target portals", () => {
+    const room = createMockRoom("W20S20");
+    const portals = [28, 29].map(x => ({
+      structureType: STRUCTURE_PORTAL,
+      pos: new RoomPosition(x, 12, room.name),
+      destination: { shard: "shard0", room: room.name },
+    })) as unknown as StructurePortal[];
+    room.find = (_type: number, options?: { filter?: (value: Structure) => boolean }) =>
+      options?.filter ? portals.filter(options.filter) : portals;
+    const creep = createMockCreep("interShardScout", {
+      room,
+      memory: {
+        role: "interShardScout",
+        homeRoom: "W1N1",
+        targetShard: "shard0",
+        portalRoom: room.name,
+      },
+    });
+
+    expect(interShardClaimer(createContext(creep, room))).to.deep.equal({ type: "idle" });
+  });
+
   it("stages pioneer memory before asking it to step onto the portal tile", () => {
     const { room, portal } = createPortalRoom();
     const creep = createMockCreep("interShardPioneer", {

--- a/packages/screeps-bot/src/intershard/footprintOperation.ts
+++ b/packages/screeps-bot/src/intershard/footprintOperation.ts
@@ -25,6 +25,13 @@ const SCOUT_BODY: BodyTemplate = { parts: [MOVE], cost: 50, minCapacity: 50 };
 const MAX_SCOUTS_PER_TARGET = 1;
 const MAX_CLAIMERS_PER_TARGET = 1;
 const MAX_PIONEERS_PER_TARGET = 3;
+const PORTAL_STALE_AFTER = 500;
+
+interface InterShardPortalTarget {
+  room: string;
+  pos: { x: number; y: number };
+  targetRoom: string;
+}
 
 interface OperationMemory {
   enabled?: boolean;
@@ -154,12 +161,16 @@ function countCreepsFor(role: string, targetShard: string): number {
   return count;
 }
 
-function getPortalForTarget(targetShard: string): { room: string; pos: { x: number; y: number }; targetRoom: string } | null {
+function getPortalForTarget(targetShard: string): InterShardPortalTarget | null {
   for (const room of Object.values(Game.rooms)) {
     const portals = room.find(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL }) as StructurePortal[];
     for (const portal of portals) {
       const destination = portal.destination;
-      if ("shard" in destination && destination.shard === targetShard) {
+      if (
+        "shard" in destination &&
+        destination.shard === targetShard &&
+        (portal.ticksToDecay === undefined || portal.ticksToDecay > 25)
+      ) {
         return { room: room.name, pos: { x: portal.pos.x, y: portal.pos.y }, targetRoom: destination.room };
       }
     }
@@ -167,7 +178,13 @@ function getPortalForTarget(targetShard: string): { room: string; pos: { x: numb
 
   const local = loadLocalInterShardMemory();
   const shard = local.shards[getCurrentShard()];
-  const known = shard?.portals.find(portal => portal.targetShard === targetShard && portal.threatRating <= 1);
+  const known = shard?.portals.find(
+    portal =>
+      portal.targetShard === targetShard &&
+      portal.threatRating <= 1 &&
+      (portal.decayTick === undefined || portal.decayTick > Game.time + 25) &&
+      Game.time - portal.lastScouted <= PORTAL_STALE_AFTER
+  );
   if (!known) return null;
   return { room: known.sourceRoom, pos: known.sourcePos, targetRoom: known.targetRoom };
 }
@@ -221,6 +238,8 @@ function requestClaimer(home: Room, targetShard: string, portal: NonNullable<Ret
     additionalMemory: {
       targetShard,
       portalRoom: portal.room,
+      portalPos: portal.pos,
+      portalTargetRoom: portal.targetRoom,
       targetRoom: portal.targetRoom,
       task: "interShardClaim",
       workflowState: "movingToPortal"
@@ -242,6 +261,8 @@ function requestFootprintScout(home: Room, targetShard: string, portal: NonNulla
     additionalMemory: {
       targetShard,
       portalRoom: portal.room,
+      portalPos: portal.pos,
+      portalTargetRoom: portal.targetRoom,
       targetRoom: portal.targetRoom,
       task: "interShardFootprint",
       workflowState: "movingToPortal"
@@ -264,6 +285,8 @@ function requestPioneer(home: Room, target: InterShardFootprintTarget, portal: N
     additionalMemory: {
       targetShard: target.shard,
       portalRoom: portal.room,
+      portalPos: portal.pos,
+      portalTargetRoom: portal.targetRoom,
       targetRoom: target.claimTargetRoom ?? portal.targetRoom,
       task: "interShardBootstrap",
       workflowState: "movingToPortal"
@@ -345,9 +368,10 @@ function updateLocalTargetStatus(): void {
   if (!op || !target) return;
 
   const ownedRooms = Object.values(Game.rooms).filter(room => room.controller?.my);
-  const operationCreepPresent = Object.values(Game.creeps).some(creep =>
-    (creep.memory as CreepMemory).role?.startsWith?.("interShard")
-  );
+  const operationCreepPresent = Object.values(Game.creeps).some(creep => {
+    const memory = creep.memory as CreepMemory & { targetShard?: string };
+    return memory.role?.startsWith?.("interShard") && memory.targetShard === currentShard;
+  });
   if (ownedRooms.length > 0) {
     target.status = ownedRooms.some(room => room.find(FIND_MY_SPAWNS).length > 0) ? "established" : "claimed";
     target.claimTargetRoom = ownedRooms[0]?.name ?? target.claimTargetRoom;


### PR DESCRIPTION
## Summary

- Bind inter-shard scouts, claimers, and pioneers to the exact source portal position and destination room.
- Fail closed when legacy memory cannot disambiguate multiple target portals.
- Preserve portal freshness/decay metadata across compact InterShardMemory writes and reject stale/expiring portal records.
- Require pioneers to bootstrap only an owned target room and count only correctly targeted destination creeps as shard presence.

## Validation

- `@ralphschuler/screeps-intershard`: 18 passing
- `@ralphschuler/screeps-roles`: 192 passing
- `screeps-bot` TypeScript typecheck: passing
- ESLint changed files: passing
- `git diff --check`: passing

## Live evidence

Read-only official API inspection confirmed the prior failure shape: shard1 expansion memories carried target shards while four destination-shard creeps had `{}` memory. Portal objects in W20S20 had distinct destinations, including shard0 and shard2. The fix persists and revalidates portal identity before range-0 traversal.

## Safety

No ally targeting changes. No deployment or npm publication performed from this branch.
