### PR TITLE
fix(ci): trigger framework publication from releases

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -8,8 +8,10 @@ on:
         required: true
         default: "all"
         type: string
-  release:
-    types: [published]
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 jobs:
   publish:
@@ -34,8 +36,8 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --ignore-scripts
 
-      - name: Validate release package selection
-        if: github.event_name == 'release'
+      - name: Validate trusted release package selection
+        if: github.event_name == 'workflow_call'
         run: node scripts/publish-framework-package.mjs --list --all --json
 
       - name: Validate manual package selection
@@ -54,8 +56,8 @@ jobs:
       - name: Run workspace tests
         run: npm run test:all
 
-      - name: Publish release packages to npm
-        if: github.event_name == 'release'
+      - name: Publish trusted release packages to npm
+        if: github.event_name == 'workflow_call'
         run: node scripts/publish-framework-package.mjs --all --publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             echo "Error: Not on main branch (current: $CURRENT_BRANCH)"
             exit 1
           fi
-          
+
           git add packages/screeps-bot/dist/
           if git diff --cached --quiet; then
             echo "No changes to commit"
@@ -75,3 +75,16 @@ jobs:
           allow_updates: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-framework:
+    name: Publish framework packages
+    needs: release
+    # A rerun must not make a second npm publication attempt for the same release.
+    if: >-
+      github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      needs.release.result == 'success' && github.run_attempt == 1
+    uses: ./.github/workflows/publish-framework.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write

--- a/docs/framework/contributing/release-process.md
+++ b/docs/framework/contributing/release-process.md
@@ -75,6 +75,19 @@ npm version major -w @ralphschuler/screeps-mynew
 
 ---
 
+## Automated repository release
+
+Merges to `main` run `.github/workflows/release.yml`. After the release job succeeds, that workflow calls `.github/workflows/publish-framework.yml` as a reusable workflow. The handoff is restricted to the first successful attempt of the trusted `main` release job, so a rerun does not repeat npm publication. Framework packages are selected from the repository manifest and published with npm provenance.
+
+Before changing this handoff, run the non-publishing checks locally:
+
+```bash
+npm run publish:framework:check
+npm run test:scripts -- --test-name-pattern="framework publication"
+```
+
+The manual `workflow_dispatch` path remains available for an explicit package scope. Do not select `all` for a test: publication is irreversible. If publication must be rolled back, identify the last known good release and deploy that bot bundle; do not republish an existing npm version.
+
 ## Pre-Release Checklist
 
 ### 1. Code Quality

--- a/scripts/test/framework-publication-workflow.test.mjs
+++ b/scripts/test/framework-publication-workflow.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const root = new URL("../..", import.meta.url);
+const releaseWorkflow = readFileSync(
+  new URL(".github/workflows/release.yml", root),
+  "utf8",
+);
+const publishWorkflow = readFileSync(
+  new URL(".github/workflows/publish-framework.yml", root),
+  "utf8",
+);
+
+test("release hands trusted successful runs to the reusable framework publisher", () => {
+  assert.match(releaseWorkflow, /publish-framework:\n[\s\S]*needs: release/);
+  assert.match(
+    releaseWorkflow,
+    /if: >-\n\s+github\.event_name == 'push' && github\.ref == 'refs\/heads\/main' &&\n\s+needs\.release\.result == 'success' && github\.run_attempt == 1/,
+  );
+  assert.match(
+    releaseWorkflow,
+    /uses: \.\/\.github\/workflows\/publish-framework\.yml/,
+  );
+  assert.match(releaseWorkflow, /secrets: inherit/);
+  assert.match(releaseWorkflow, /id-token: write/);
+});
+
+test("framework publication is reusable and has no token-suppressed release trigger", () => {
+  assert.match(publishWorkflow, /workflow_call:/);
+  assert.match(publishWorkflow, /NPM_TOKEN:\n\s+required: true/);
+  assert.doesNotMatch(publishWorkflow, /^\s+release:\s*$/m);
+  assert.match(publishWorkflow, /if: github\.event_name == 'workflow_call'/);
+});
+
+test("trusted publication keeps manifest selection and npm provenance", () => {
+  assert.match(
+    publishWorkflow,
+    /run: node scripts\/publish-framework-package\.mjs --list --all --json/,
+  );
+  assert.match(
+    publishWorkflow,
+    /run: node scripts\/publish-framework-package\.mjs --all --publish --access public --provenance/,
+  );
+  assert.match(
+    publishWorkflow,
+    /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/,
+  );
+});
+
+test("manual package selection remains explicit and bounded", () => {
+  assert.match(publishWorkflow, /inputs\.publish_scope != 'all'/);
+  assert.match(publishWorkflow, /--package \"\$PUBLISH_SCOPE\" --json/);
+  assert.match(
+    publishWorkflow,
+    /--package \"\$PUBLISH_SCOPE\" --publish --access public --provenance/,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #3422 by replacing the suppressed `release: published` workflow trigger with an explicit reusable-workflow handoff from the successful release job.

## Changes

- Call `.github/workflows/publish-framework.yml` after a successful trusted `main` release.
- Restrict the handoff to the first workflow attempt to avoid duplicate npm publication attempts.
- Require `NPM_TOKEN` and preserve npm provenance permissions.
- Keep manifest-driven `--all` selection and the manual exact-scope dispatch path.
- Add workflow contract tests and release-process documentation.

## Validation

- `npm run verify` — passed.
- `npm run test:scripts` — 99 passed.
- `npm run publish:framework:check` — passed.
- `npm run publish:framework:dry-run` — passed without real publication.
- `npm run build:docs` — passed.
- Private-server smoke — passed, 47/47 assertions.
- Alliance-safety and deep-dist-import checks — passed.

No live npm publication or production deployment was performed.
